### PR TITLE
Resolve lints and clean warnings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -625,7 +625,9 @@ async def test_case_4_broadcast_vs_targeted(use_discord: bool = False) -> None:
 
         # Verify that the targeted multiplier is working correctly
         if abs(observed_multiplier - targeted_multiplier) < 0.1:
-            logging.info("✅ VERIFICATION PASSED: Targeted message multiplier is working correctly")
+            logging.info(
+                "✅ VERIFICATION PASSED: Targeted message multiplier is working correctly"
+            )
         else:
             logging.info(
                 "❌ VERIFICATION FAILED: Targeted message multiplier not applying correctly"

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -21,7 +21,7 @@ try:
 
     BaseLM = dspy.LM
     DSPY_AVAILABLE = True
-except Exception as e:  # pragma: no cover - optional dependency
+except Exception:  # pragma: no cover - optional dependency
     logging.getLogger(__name__).warning("DSPy not available; using stub implementations")
 
     class BaseLM:

--- a/src/infra/llm_mock_helper.py
+++ b/src/infra/llm_mock_helper.py
@@ -140,10 +140,6 @@ def create_mock_ollama_client() -> MagicMock:
     # Mock the generate method - this is often used by DSPy
     # Keep the existing heuristic for generate, but ensure it returns a dict with "response" key
     # as ollama.Client.generate does.
-    mock_thought_response_str_for_generate = (
-        '{"thought": "As a MockRole, this is a generic mocked thought for generate."}'
-    )
-    mock_action_intent_response_str_for_generate = '{"action_intent": "idle", "message_content": "Mocked action intent message for generate.", "thought": "Mocked thought for action intent for generate."}'
 
     def mock_generate(*args: Any, **kwargs: Any) -> dict[str, Any]:
         prompt_content = str(kwargs.get("prompt", ""))  # Ensure prompt_content is a string

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -93,9 +93,9 @@ class Simulation:
         logger.info("Simulation initialized with Knowledge Board.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
         logger.info("Simulation initialized with project tracking system.")
 
         # --- NEW: Initialize Collective Metrics ---
@@ -129,9 +129,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[dict[str, Any]] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            dict[str, Any]
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[dict[str, Any]] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -387,9 +387,9 @@ class Simulation:
             logger.info(f"  - DU: {current_agent_state.du:.1f} (from {current_agent_state.du})")
 
             # Update the agent state in the simulation's list of agents
-            self.agents[
-                agent_to_run_index
-            ] = agent  # Ensure the agent object itself is updated if it was replaced
+            self.agents[agent_to_run_index] = (
+                agent  # Ensure the agent object itself is updated if it was replaced
+            )
             self.agents[agent_to_run_index].update_state(current_agent_state)
 
             # Determine next agent index based on role change event this turn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,9 @@ configure_warning_filters()  # Apply filters
 def is_ollama_running() -> Optional[bool]:
     """Check if Ollama server is running by attempting to connect to localhost:11434"""
     try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(0.1)  # Short timeout for quick check
-        s.connect(("localhost", 11434))
-        s.close()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.1)  # Short timeout for quick check
+            s.connect(("localhost", 11434))
         return True
     except (OSError, socket.timeout):
         return False

--- a/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
+++ b/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
@@ -600,12 +600,6 @@ class TestConflictResolution(unittest.IsolatedAsyncioTestCase):
             )
 
             # Assertion 8: AgentC IP/DU changes
-            ip_cost_direct_message = config.IP_COST_SEND_DIRECT_MESSAGE
-            award_ip_facilitation_attempt = config.IP_AWARD_FACILITATION_ATTEMPT
-            expected_ip_c_after_action = (
-                initial_ip_c - ip_cost_direct_message + award_ip_facilitation_attempt
-            )
-
             # Passive DU generation for Facilitator role
             du_gen_rate_c_dict = config.ROLE_DU_GENERATION.get(
                 "Facilitator", {"base": 1.2, "bonus_factor": 0.3}
@@ -1006,13 +1000,9 @@ class TestConflictResolution(unittest.IsolatedAsyncioTestCase):
         # Assertion 15: Agent B IP/DU Debit
         final_ip_b_turn2 = self.agent_b.state.ip
         final_du_b_turn2 = self.agent_b.state.du
-        du_gen_rate_b_turn2 = config.ROLE_DU_GENERATION.get(self.agent_b.state.role, 1.0)
         logger.info(f"AgentB IP after this turn: {final_ip_b_turn2}, DU: {final_du_b_turn2}")
 
         if self.agent_b.state.last_action_intent != AgentActionIntent.IDLE.value:
-            min_expected_du_b_turn2 = (
-                initial_du_b_turn2 + (0.5 * du_gen_rate_b_turn2) - 5.0
-            )  # Max possible cost for an action
             self.assertTrue(
                 final_du_b_turn2 > initial_du_b_turn2 - 5.0,
                 f"AgentB DU changed unexpectedly. From {initial_du_b_turn2} to {final_du_b_turn2}",
@@ -1373,13 +1363,9 @@ class TestConflictResolution(unittest.IsolatedAsyncioTestCase):
         # Assertion 23: Agent B IP/DU Debit
         final_ip_b_turn3 = self.agent_b.state.ip
         final_du_b_turn3 = self.agent_b.state.du
-        du_gen_rate_b_turn3 = config.ROLE_DU_GENERATION.get(self.agent_b.state.role, 1.0)
         logger.info(f"AgentB IP after third turn: {final_ip_b_turn3}, DU: {final_du_b_turn3}")
 
         if self.agent_b.state.last_action_intent != AgentActionIntent.IDLE.value:
-            min_expected_du_b_turn3 = (
-                initial_du_b_turn3 + (0.5 * du_gen_rate_b_turn3) - 5.0
-            )  # Max possible cost for an action
             self.assertTrue(
                 final_du_b_turn3 > initial_du_b_turn3 - 5.0,
                 f"AgentB DU changed unexpectedly. From {initial_du_b_turn3} to {final_du_b_turn3}",

--- a/tests/integration/test_multi_agent_collaboration.py
+++ b/tests/integration/test_multi_agent_collaboration.py
@@ -262,10 +262,6 @@ class TestMultiAgentCollaboration(unittest.IsolatedAsyncioTestCase):
 
         # --- AgentB perceives AgentA's idea and provides positive feedback (Turn 2 in Round 1) ---
         logger.info("Round 1, Turn 2: AgentB perceives and provides feedback...")
-        initial_mood_value_a_before_b_acts = self.agent_a.state.mood_value
-        initial_relationship_a_to_b_before_b_acts = self.agent_a.state.relationships.get(
-            self.agent_b.agent_id, 0.0
-        )
 
         feedback_content = "An insightful idea by @agent_a_innovator! How do you envision handling potential semantic drift in long-running decentralized systems?"
 

--- a/tests/unit/dspy/test_dspy_role_adherence.py
+++ b/tests/unit/dspy/test_dspy_role_adherence.py
@@ -160,7 +160,9 @@ def test_role_prefix_adherence() -> None:
     logger.info(f"Success rate: {success_rate:.1f}% ({success_count}/{total_tests} successful)")
 
     if success_count == total_tests:
-        logger.info("✅ All tests passed! DSPy role adherence implementation is working correctly.")
+        logger.info(
+            "✅ All tests passed! DSPy role adherence implementation is working correctly."
+        )
     else:
         logger.warning(
             f"⚠️ {total_tests - success_count} tests failed. DSPy role adherence needs improvement."


### PR DESCRIPTION
## Summary
- fix Ruff findings in various modules
- close mocked socket in tests
- format codebase with Black

## Testing
- `ruff check . --select E,W,F --extend-ignore E501`
- `mypy src/ --strict`
- `pytest -q --disable-warnings`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_68406d0d9a4c8326a13469f6ae5e292e