### PR TITLE
Install pytest-asyncio and update pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 ruff>=0.3
 mypy==1.10.0
-pytest==7.4.0
+pytest>=8.2,<9
 pytest-cov==4.1.0
 black==23.7.0
 types-requests==2.31.0
 pytest-xdist==3.7.0
+pytest-asyncio==1.0.0


### PR DESCRIPTION
## Summary
- add pytest-asyncio to dev requirements
- bump pytest to >=8.2 as required by pytest-asyncio
- verify pytest.ini asyncio settings

## Testing
- `pip install -r requirements-dev.txt`
- `pytest --collect-only -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a01202608326aa075dd3a79fb857