### PR TITLE
Fix query_agent_memory import

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,19 @@ python scripts/cleanup_temp_db.py --dry-run
 python scripts/cleanup_temp_db.py
 ```
 
+### `query_agent_memory.py`
+
+Queries an agent's ChromaDB memory store and synthesizes a short answer.
+
+Usage:
+```bash
+PYTHONPATH=. python scripts/query_agent_memory.py \
+    --agent_id <agent_id> \
+    --query_file path/to/query.txt \
+    [--chroma_dir ./chroma_db] [--ollama_model llama3:8b] \
+    [--max_context_items 10]
+```
+
 # Culture.ai Scripts
 
 ## Code Quality & Compliance

--- a/scripts/query_agent_memory.py
+++ b/scripts/query_agent_memory.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from src.agents.dspy_programs.rag_context_synthesizer import RAGContextSynthesizer
 from src.infra.dspy_ollama_integration import configure_dspy_with_ollama
-from src.memory.chroma_vector_store import ChromaVectorStoreManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- point `query_agent_memory.py` at new vector store path
- document how to use `query_agent_memory.py`

## Testing
- `pytest -q`
- `PYTHONPATH=$(pwd) python scripts/query_agent_memory.py --agent_id test --query_file sample_query.txt --chroma_dir ./chroma_db_temp --ollama_model foo --max_context_items 5` *(fails: The sentence_transformers python package is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840c59f61ac8326b61d86f1d71e358b