### PR TITLE
Fix lint and test errors

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -344,9 +344,8 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                 last_change_step = self.role_history[-1][0] if self.role_history else 0
 
         if (
-            (current_step - last_change_step) < self._role_change_cooldown
-            and last_change_step != -1
-        ):  # Make sure last_change_step is valid
+            current_step - last_change_step
+        ) < self._role_change_cooldown and last_change_step != -1:  # Make sure last_change_step is valid
             logger.debug(
                 f"AGENT_STATE ({self.agent_id}): Role change to {new_role} denied (cooldown period). Current step: {current_step}, Last change: {last_change_step}, Cooldown: {self._role_change_cooldown}"
             )
@@ -638,5 +637,3 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         logger.debug(
             f"Agent {self.name} processed {len(messages)} messages and updated conversation history/relationships."
         )
-
-

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -23,8 +23,6 @@ from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
 from src.infra import config  # Import config for role change parameters
 from src.infra.llm_client import analyze_sentiment, generate_structured_output
 
-from .agent_graph_builder import build_graph
-
 # Module logger
 logger = logging.getLogger(__name__)
 
@@ -907,6 +905,7 @@ def _maybe_consolidate_memories(state: AgentTurnState) -> dict[str, Any]:
 
 
 # --- Graph Definition ---
+
 
 def compile_agent_graph() -> Any:
     """Compile and return the Basic Agent Graph executor."""

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -43,12 +43,16 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
         return {"rag_summary": "(No memory retrieval)"}
     memories = await manager.aretrieve_relevant_memories(state["agent_id"], query="", k=5)
     memories_content = [m.get("content", "") for m in memories]
-    summary_result = await agent.async_generate_l1_summary(state.get("current_role", ""), "\n".join(memories_content), "")
+    summary_result = await agent.async_generate_l1_summary(
+        state.get("current_role", ""), "\n".join(memories_content), ""
+    )
     summary = getattr(summary_result, "summary", "")
     return {"rag_summary": summary}
 
 
-async def generate_thought_and_message_node(state: AgentTurnState) -> dict[str, AgentActionOutput | None]:
+async def generate_thought_and_message_node(
+    state: AgentTurnState,
+) -> dict[str, AgentActionOutput | None]:
     agent = state.get("agent_instance")
     thought = "Thinking..."
     action_intent = "idle"
@@ -63,7 +67,12 @@ async def generate_thought_and_message_node(state: AgentTurnState) -> dict[str, 
 async def finalize_message_agent_node(state: AgentTurnState) -> dict[str, Any]:
     output = state.get("structured_output")
     if not output:
-        return {"message_content": None, "message_recipient_id": None, "action_intent": "idle", "updated_agent_state": state["state"]}
+        return {
+            "message_content": None,
+            "message_recipient_id": None,
+            "action_intent": "idle",
+            "updated_agent_state": state["state"],
+        }
     return {
         "message_content": output.message_content,
         "message_recipient_id": output.message_recipient_id,
@@ -75,7 +84,10 @@ async def finalize_message_agent_node(state: AgentTurnState) -> dict[str, Any]:
 
 # Helper formatters
 
-def _format_other_agents(other_agents_info: list[dict[str, Any]], relationships: dict[str, float]) -> str:
+
+def _format_other_agents(
+    other_agents_info: list[dict[str, Any]], relationships: dict[str, float]
+) -> str:
     if not other_agents_info:
         return "None"
     lines = []

--- a/src/app.py
+++ b/src/app.py
@@ -13,14 +13,13 @@ from src.sim.simulation import Simulation
 
 try:
     from src.interfaces.discord_bot import SimulationDiscordBot
+
     simulation_discord_bot_class: Optional[type[SimulationDiscordBot]] = SimulationDiscordBot
 except ImportError:  # pragma: no cover - optional dependency
     logging.warning("Discord bot module not found, running without Discord integration.")
     simulation_discord_bot_class = None
 
-DEFAULT_SCENARIO = (
-    "Agents collaborate to design a specification for a communication protocol."
-)
+DEFAULT_SCENARIO = "Agents collaborate to design a specification for a communication protocol."
 
 
 def create_simulation(
@@ -68,11 +67,18 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Culture.ai simulation.")
     parser.add_argument("--agents", type=int, default=3, help="Number of agents.")
     parser.add_argument("--steps", type=int, default=10, help="Number of steps to run.")
-    parser.add_argument("--scenario", type=str, default=DEFAULT_SCENARIO, help="Simulation scenario.")
-    parser.add_argument("--discord", action="store_true", help="Enable Discord integration.")
-    parser.add_argument("--vector-store", action="store_true", help="Use ChromaDB for agent memory.")
     parser.add_argument(
-        "--vector-dir", type=str, default="./chroma_db", help="Directory for vector store persistence."
+        "--scenario", type=str, default=DEFAULT_SCENARIO, help="Simulation scenario."
+    )
+    parser.add_argument("--discord", action="store_true", help="Enable Discord integration.")
+    parser.add_argument(
+        "--vector-store", action="store_true", help="Use ChromaDB for agent memory."
+    )
+    parser.add_argument(
+        "--vector-dir",
+        type=str,
+        default="./chroma_db",
+        help="Directory for vector store persistence.",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- update manual test to skip gracefully and avoid missing dependency imports
- tidy compile_agent_graph import logic
- apply lint fixes across agents

## Testing
- `ruff check src tests/manual/test_relationship_cases.py`
- `black --check src tests/manual/test_relationship_cases.py`
- `mypy src`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840d0afe4d4832699288de0caa29d96