### PR TITLE
Add CLI flags for warning control

### DIFF
--- a/docs/warning_management.md
+++ b/docs/warning_management.md
@@ -86,8 +86,21 @@ To add a new warning filter:
 3. Document it in this file
 4. Verify the filter works by running the tests
 
+## Command-Line Control
+
+You can enable or disable these filters when running the simulation:
+
+```bash
+python -m src.app --no-warning-filters        # show all warnings
+python -m src.app --log-suppressed-warnings   # keep filters but log them
+```
+
+Use `--no-warning-filters` for debugging noisy dependencies, and
+`--log-suppressed-warnings` to record suppressed messages without
+polluting the console.
+
 ## Potential Future Improvements
 
 - Add command-line flag to enable/disable warning filtering for debugging
 - Implement more granular filtering by module or specific warning location
-- Add warning reporting tools to collect statistics on suppressed warnings 
+- Add warning reporting tools to collect statistics on suppressed warnings

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.infra.config import get_config
 from src.infra.llm_client import get_ollama_client
+from src.infra.warning_filters import configure_warning_filters
 from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.simulation import Simulation
 
@@ -48,7 +49,7 @@ def create_simulation(
             else:
                 logging.warning("Discord bot not ready, running without integration.")
 
-    agents = [Agent(agent_id=f"agent_{i+1}", name=f"Agent_{i+1}") for i in range(num_agents)]
+    agents = [Agent(agent_id=f"agent_{i + 1}", name=f"Agent_{i + 1}") for i in range(num_agents)]
 
     sim = Simulation(
         agents=agents,
@@ -80,12 +81,27 @@ def parse_args() -> argparse.Namespace:
         default="./chroma_db",
         help="Directory for vector store persistence.",
     )
+    parser.add_argument(
+        "--no-warning-filters",
+        action="store_true",
+        help="Disable default warning filters.",
+    )
+    parser.add_argument(
+        "--log-suppressed-warnings",
+        action="store_true",
+        help="Log warnings that would otherwise be suppressed.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
     args = parse_args()
+
+    configure_warning_filters(
+        apply_filters=not args.no_warning_filters,
+        log_suppressed=args.log_suppressed_warnings,
+    )
 
     sim = create_simulation(
         num_agents=args.agents,


### PR DESCRIPTION
## Summary
- add command-line options to disable warning filters or log suppressed warnings
- implement logging option in warning_filters
- document command-line control for warning management

## Testing
- `ruff format src/infra/warning_filters.py src/app.py`
- `ruff check src/infra/warning_filters.py src/app.py`
- `mypy --config-file=pyproject.toml src/infra/warning_filters.py src/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197c1fc2883268c5774233776ef4e