### PR TITLE
Improve LLM performance logging setup

### DIFF
--- a/docs/llm_monitoring_strategies.md
+++ b/docs/llm_monitoring_strategies.md
@@ -53,13 +53,14 @@ def generate_text(prompt, model="mistral:latest", temperature=0.7):
     """Generate text completion from Ollama."""
     import time
     import logging
+    from src.shared.logging_utils import get_logger
     import uuid
     
     # Create unique request ID for correlation
     request_id = str(uuid.uuid4())[:8]
     
     # Setup logging
-    llm_logger = logging.getLogger("llm_performance")
+    llm_logger = get_logger("llm_performance")
     
     # Capture start time with high precision
     start_time = time.perf_counter()
@@ -152,6 +153,7 @@ import functools
 import time
 import logging
 import json
+from src.shared.logging_utils import get_logger
 import uuid
 from typing import Callable, Any
 
@@ -167,7 +169,7 @@ def monitor_llm_call(model_param: str = "model", context: str = None):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # Setup logging
-            llm_logger = logging.getLogger("llm_performance")
+            llm_logger = get_logger("llm_performance")
             
             # Create request ID and get start time
             request_id = str(uuid.uuid4())[:8]
@@ -270,6 +272,7 @@ import json
 import statistics
 import threading
 from typing import Dict, List, Optional
+from src.shared.logging_utils import get_logger
 from contextlib import contextmanager
 
 class LLMPerformanceMonitor:
@@ -278,7 +281,7 @@ class LLMPerformanceMonitor:
     def __init__(self, aggregation_interval: int = 60):
         self.metrics_store: List[Dict] = []
         self.lock = threading.Lock()
-        self.logger = logging.getLogger("llm_performance")
+        self.logger = get_logger("llm_performance")
         self.aggregation_interval = aggregation_interval
         self.last_aggregation = time.time()
     

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -1,13 +1,14 @@
 import functools
 import json
-import logging
 import sys
 import time
 import uuid
 from typing import Any, Callable, Optional, ParamSpec, TypeVar
 
+from src.shared.logging_utils import get_logger
+
 # Setup a dedicated logger for LLM performance metrics
-llm_perf_logger = logging.getLogger("llm_performance")
+llm_perf_logger = get_logger("llm_performance")
 
 P = ParamSpec("P")
 R = TypeVar("R")


### PR DESCRIPTION
## Summary
- initialize `llm_perf_logger` via `get_logger` helper
- update monitoring docs to recommend `get_logger`

## Testing
- `python -m pytest -q tests/unit/core/test_llm_monitoring.py`

------
https://chatgpt.com/codex/tasks/task_e_6841993e636c8326bbdba5a1b50f64e7