### PR TITLE
Implement memory tracking manager

### DIFF
--- a/scripts/analyze_memory_usage.py
+++ b/scripts/analyze_memory_usage.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+"""Simple analysis of memory usage statistics."""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+project_root = str(Path(__file__).parent.parent)
+sys.path.append(project_root)
+
+from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger("memory_usage_analysis")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze memory usage statistics")
+    parser.add_argument("--agent_id", required=True, help="Agent ID to analyze")
+    parser.add_argument("--chroma_dir", default="./chroma_db", help="ChromaDB directory")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    vector_store = ChromaVectorStoreManager(persist_directory=args.chroma_dir)
+    tracker = MemoryTrackingManager(vector_store)
+
+    results = vector_store.retrieve_filtered_memories(
+        agent_id=args.agent_id,
+        include_usage_stats=True,
+    )
+
+    if not results:
+        logger.info("No memories found for agent %s", args.agent_id)
+        return
+
+    results.sort(key=lambda m: m.get("retrieval_count", 0), reverse=True)
+
+    for mem in results[:10]:
+        mus = tracker.calculate_mus(str(mem.get("memory_id", "")))
+        logger.info(
+            "MUS=%0.3f | retrievals=%s | content=%s",
+            mus,
+            mem.get("retrieval_count", 0),
+            str(mem.get("content", ""))[:60],
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents/memory/__init__.py
+++ b/src/agents/memory/__init__.py
@@ -5,6 +5,7 @@ This module contains components related to agent memory management,
 including persistence, retrieval, and memory utility operations.
 """
 
+from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 
-__all__ = ["ChromaVectorStoreManager"]
+__all__ = ["ChromaVectorStoreManager", "MemoryTrackingManager"]

--- a/src/agents/memory/memory_tracking_manager.py
+++ b/src/agents/memory/memory_tracking_manager.py
@@ -1,0 +1,38 @@
+import logging
+from collections.abc import Sequence
+from typing import Any, Optional
+
+from typing_extensions import Self
+
+from .vector_store import ChromaVectorStoreManager
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryTrackingManager:
+    """Manage usage tracking metadata for agent memories."""
+
+    def __init__(self: Self, vector_store: ChromaVectorStoreManager) -> None:
+        self.vector_store = vector_store
+
+    def record_retrieval(
+        self: Self, memory_ids: list[str], relevance_scores: Optional[Sequence[float]] = None
+    ) -> None:
+        """Update usage stats when memories are retrieved."""
+        self.vector_store._update_memory_usage_stats(
+            memory_ids, list(relevance_scores) if relevance_scores else None, True
+        )
+
+    def get_usage_statistics(self: Self, memory_id: str) -> dict[str, Any]:
+        """Return usage metadata for a memory."""
+        results = self.vector_store.collection.get(ids=[memory_id], include=["metadatas"])
+        if results and results.get("metadatas"):
+            return dict(results["metadatas"][0])
+        return {}
+
+    def calculate_mus(self: Self, memory_id: str) -> float:
+        """Calculate Memory Utility Score for a memory."""
+        metadata = self.get_usage_statistics(memory_id)
+        if not metadata:
+            return 0.0
+        return self.vector_store._calculate_mus(metadata)

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -1214,6 +1214,32 @@ class ChromaVectorStoreManager:
         )
         return ids_to_prune
 
+    def prune_memories_hybrid(
+        self: Self,
+        l1_mus_threshold: float = 0.2,
+        l2_mus_threshold: float = 0.3,
+        l2_age_days: int = 30,
+        l1_min_age_days: int = 0,
+        l2_min_age_days: int = 0,
+    ) -> int:
+        """Prune memories using both MUS and age-based criteria."""
+
+        ids_to_delete: list[str] = []
+
+        l1_ids = self.get_l1_memories_for_mus_pruning(l1_mus_threshold, l1_min_age_days)
+        ids_to_delete.extend(l1_ids)
+
+        l2_ids = self.get_l2_memories_for_mus_pruning(l2_mus_threshold, l2_min_age_days)
+        ids_to_delete.extend(l2_ids)
+
+        old_l2 = self.get_l2_summaries_older_than(l2_age_days)
+        ids_to_delete.extend([i for i in old_l2 if i not in ids_to_delete])
+
+        if ids_to_delete:
+            self.delete_memories_by_ids(ids_to_delete)
+
+        return len(ids_to_delete)
+
     def get_embedding(self: Self, text: str) -> list[float]:
         """
         Get the embedding for a piece of text using the embedding function.

--- a/tests/unit/memory/test_memory_tracking_manager.py
+++ b/tests/unit/memory/test_memory_tracking_manager.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""Unit tests for MemoryTrackingManager."""
+
+import unittest
+
+import pytest
+from typing_extensions import Self
+
+pytest.importorskip("chromadb")
+
+from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+
+@pytest.mark.unit
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+class TestMemoryTrackingManager(unittest.TestCase):
+    """Tests for MemoryTrackingManager."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self: Self, chroma_test_dir: str) -> None:
+        self.chroma_test_dir = chroma_test_dir
+
+    def setUp(self: Self) -> None:
+        self.vector_store = ChromaVectorStoreManager(persist_directory=self.chroma_test_dir)
+        self.manager = MemoryTrackingManager(self.vector_store)
+        self.agent_id = "tracking_test_agent"
+
+    def tearDown(self: Self) -> None:
+        if hasattr(self.vector_store, "client") and self.vector_store.client:
+            close = getattr(self.vector_store.client, "close", None)
+            if callable(close):
+                close()
+
+    def test_calculate_mus(self: Self) -> None:
+        """Calculate MUS for a retrieved memory."""
+        mem_id = self.vector_store.add_memory(
+            agent_id=self.agent_id,
+            step=1,
+            event_type="thought",
+            content="Unit test memory",
+        )
+        self.manager.record_retrieval([mem_id], [0.9])
+        mus = self.manager.calculate_mus(mem_id)
+        self.assertGreaterEqual(mus, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MemoryTrackingManager` for usage statistics
- expose new manager in memory module
- add hybrid pruning helper on `ChromaVectorStoreManager`
- provide analysis script for usage stats
- add unit test for MemoryTrackingManager
- fix mypy errors in MemoryTrackingManager

## Testing
- `ruff format`
- `ruff check`
- `mypy src`
- `python -m pytest -q tests/unit/memory/test_memory_tracking_manager.py` *(fails: ModuleNotFoundError: No module named 'chromadb_rust_bindings.chromadb_rust_...')*


------
https://chatgpt.com/codex/tasks/task_e_6841be2821448326b87dd99ce34839f1