### PR TITLE
Fix import cycle and LM injection fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,8 @@ To verify your local setup with actual LLM calls, run the minimal demo script:
 ```bash
 python -m examples.walking_vertical_slice
 ```
-This spins up two agents for a few steps using your local Ollama instance. See
+This spins up three agents for a few steps using your local Ollama instance and
+persists their memories to ChromaDB. See
 [docs/walking_vertical_slice.md](docs/walking_vertical_slice.md) for details.
 
 ### Running Tests

--- a/docs/walking_vertical_slice.md
+++ b/docs/walking_vertical_slice.md
@@ -23,4 +23,4 @@ This example demonstrates a minimal end-to-end run of the Culture.ai simulation 
    python -m examples.walking_vertical_slice
    ```
 
-The script spins up two agents and runs three steps of the simulation. All LLM calls go through your local Ollama instance; no mocking is applied.
+The demo now spins up **three** agents for three steps. Memories are persisted to ChromaDB and displayed on the Knowledge Board. All LLM calls go through your local Ollama instance; no mocking is applied.

--- a/examples/walking_vertical_slice.py
+++ b/examples/walking_vertical_slice.py
@@ -17,10 +17,10 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     sim = create_simulation(
-        num_agents=2,
+        num_agents=3,
         steps=3,
         scenario="Vertical slice demonstration",
-        use_vector_store=False,
+        use_vector_store=True,
     )
     asyncio.run(sim.async_run(sim.steps_to_run))
 

--- a/scripts/analyze_memory_usage.py
+++ b/scripts/analyze_memory_usage.py
@@ -5,10 +5,9 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Any
 
-project_root = str(Path(__file__).parent.parent)
-sys.path.append(project_root)
+# Add the project root to the Python path for direct script execution
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -3,17 +3,25 @@ import logging
 import random
 from collections import deque
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    PrivateAttr,
-    ValidationInfo,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, Field, PrivateAttr
+
+try:  # Support pydantic < 2 if accidentally installed
+    from pydantic import ConfigDict, ValidationInfo, field_validator, model_validator
+except ImportError:  # pragma: no cover - fallback for old pydantic
+    from typing import Any as ValidationInfo
+
+    from pydantic import validator as field_validator
+
+    ConfigDict = dict  # type: ignore[misc]
+
+    def model_validator(*_args: str, **_kwargs: str) -> Callable[[Any], Any]:  # type: ignore
+        def decorator(fn: Any) -> Any:
+            return fn
+
+        return decorator
+
 
 # Local imports (ensure these are correct and not causing cycles if possible)
 from src.agents.core.mood_utils import get_descriptive_mood, get_mood_level

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -7,14 +7,21 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from pydantic import BaseModel, Field, PrivateAttr
 
-try:  # Support pydantic < 2 if accidentally installed
+try:  # Support pydantic >= 2 if installed
     from pydantic import ConfigDict, ValidationInfo, field_validator, model_validator
 except ImportError:  # pragma: no cover - fallback for old pydantic
     from typing import Any as ValidationInfo
 
-    from pydantic import validator as field_validator
+    from pydantic import validator as _pydantic_validator
 
     ConfigDict = dict  # type: ignore[misc]
+
+    def field_validator(*fields: str, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:  # type: ignore[misc]
+        """Shim to mimic the pydantic v2 ``field_validator`` API."""
+        mode = kwargs.pop("mode", "after")
+        if mode == "before":
+            kwargs["pre"] = True
+        return _pydantic_validator(*fields, **kwargs)
 
     def model_validator(*_args: str, **_kwargs: str) -> Callable[[Any], Any]:  # type: ignore
         def decorator(fn: Any) -> Any:

--- a/src/agents/dspy_programs/intent_selector.py
+++ b/src/agents/dspy_programs/intent_selector.py
@@ -56,8 +56,10 @@ class IntentSelectorProgram:
             self.lm = _StubLM()
         elif isinstance(lm, dspy.LM):  # type: ignore[misc]
             self.lm = lm
-        else:
+        elif callable(lm):
             self.lm = _CallableLM(lm)
+        else:
+            raise TypeError("lm must be a dspy.LM instance or callable")
 
         dspy.settings.configure(lm=self.lm)
         self._predict = dspy.Predict(IntentPrompt)

--- a/src/agents/dspy_programs/relationship_updater.py
+++ b/src/agents/dspy_programs/relationship_updater.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from src.infra.dspy_ollama_integration import DSPY_AVAILABLE, dspy
+from src.infra.dspy_ollama_integration import dspy
 
 logger = logging.getLogger(__name__)
 
@@ -107,10 +107,13 @@ def get_relationship_updater() -> object:
     Returns the optimized module if available, else the base, else a failsafe.
     """
     try:
-        from src.infra.dspy_ollama_integration import configure_dspy_with_ollama, dspy
+        from src.infra import dspy_ollama_integration
 
-        if not DSPY_AVAILABLE:
+        if not getattr(dspy_ollama_integration, "DSPY_AVAILABLE", False):
             return FailsafeRelationshipUpdater()
+
+        configure_dspy_with_ollama = dspy_ollama_integration.configure_dspy_with_ollama
+        dspy = dspy_ollama_integration.dspy
 
         # Try to configure DSPy
         try:

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -14,14 +14,15 @@ import time
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
-from typing import Any, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 import chromadb
 from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
 from pydantic import ValidationError
 from typing_extensions import Self
 
-from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
 
 # Attempt a more standard import for SentenceTransformerEmbeddingFunction
 try:
@@ -135,7 +136,9 @@ class ChromaVectorStoreManager:
             f"'{persist_directory}'."
         )
 
-        # Initialize usage tracking manager
+        # Import lazily to avoid a circular dependency with memory_tracking_manager
+        from .memory_tracking_manager import MemoryTrackingManager
+
         self.tracking_manager = MemoryTrackingManager(self.collection)
 
         # For tracking memory retrieval performance

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -26,18 +26,6 @@ logging.basicConfig(
     handlers=[logging.StreamHandler(sys.stdout)],
 )
 
-# Test DSPy import
-try:
-    logging.info("SIMULATION: Attempting to import DSPy role_thought_generator as a test...")
-
-    logging.info("SIMULATION: Successfully imported DSPy role_thought_generator!")
-except ImportError as e:
-    logging.error(f"SIMULATION: Failed to import DSPy role_thought_generator: {e}")
-    import traceback
-
-    logging.error(f"SIMULATION: Import traceback: {traceback.format_exc()}")
-
-# Regular imports follow...
 
 # Configure the logger for this module
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- allow intent selector to wrap any callable LM
- check DSPy availability inside `get_relationship_updater`
- clarify lazy import of the memory tracking manager

## Testing
- `ruff check src/agents/dspy_programs/intent_selector.py src/agents/dspy_programs/relationship_updater.py src/agents/memory/vector_store.py --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f9ff88008326bf0f59612f77b2e5