### PR TITLE
Add Discord bot integration tests

### DIFF
--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
+
+
+class DummyDiscordClient:
+    """Simple stand-in for discord.Client."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.event = lambda func: func
+        self.user = "dummy"
+
+    def get_channel(self, channel_id: int) -> None:
+        return None
+
+    async def start(self, token: str) -> None:  # pragma: no cover - not used
+        pass
+
+    async def close(self) -> None:  # pragma: no cover - not used
+        pass
+
+
+@pytest.fixture
+def simulation_bot() -> SimulationDiscordBot:
+    with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient):
+        bot = SimulationDiscordBot("token", 123)
+    return bot
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_say_command(simulation_bot: SimulationDiscordBot) -> None:
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    await say.callback(ctx, message="hello")
+    ctx.send.assert_awaited_once_with("Simulated message received: hello")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stats_command(simulation_bot: SimulationDiscordBot) -> None:
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    await stats.callback(ctx)
+    ctx.send.assert_awaited_once_with("LLM latency: 0 ms; KB size: 0")


### PR DESCRIPTION
## Summary
- add integration tests for Discord bot commands
- include placeholder `__init__` for new interface tests package

## Testing
- `pytest -m integration tests/integration/interfaces/test_discord_bot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ebb9b0cc8326bba85914689b80d3