### PR TITLE
Add MemoryStore protocol with TTL pruning

### DIFF
--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -11,7 +11,7 @@ from src.infra.config import (
     IP_AWARD_FOR_PROPOSAL,
     IP_COST_TO_POST_IDEA,
 )
-from src.shared.memory_store import ChromaMemoryStore
+from src.shared.memory_store import MemoryStore
 
 try:
     from .basic_agent_graph import AgentTurnState
@@ -55,7 +55,7 @@ _UNLOCKED_CAPABILITY = "collaborate"
 
 
 def handle_propose_idea(
-    agent: AgentAttributes, memory_store: ChromaMemoryStore, knowledge_board: ChromaMemoryStore
+    agent: AgentAttributes, memory_store: MemoryStore, knowledge_board: MemoryStore
 ) -> None:
     """Post an idea to the knowledge board and update agent resources."""
     idea_text = f"Idea from {agent.id}"
@@ -65,7 +65,7 @@ def handle_propose_idea(
     agent.du += config.DU_AWARD_FOR_PROPOSAL
 
 
-def handle_retrieve_and_update(agent: AgentAttributes, memory_store: ChromaMemoryStore) -> None:
+def handle_retrieve_and_update(agent: AgentAttributes, memory_store: MemoryStore) -> None:
     """Retrieve latest idea and adjust relationship score."""
     results = memory_store.query("All inter-agent communications", top_k=1)
     if not results:

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 from typing_extensions import Self
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+    pass
 
 # Attempt a more standard import for SentenceTransformerEmbeddingFunction
 try:

--- a/src/shared/memory_store.py
+++ b/src/shared/memory_store.py
@@ -85,7 +85,9 @@ class WeaviateMemoryStore(MemoryStore):
             props = getattr(obj, "properties", {})
             metadata = dict(props)
             content = metadata.pop("text", "")
-            docs.append({"content": content, "metadata": metadata, "id": str(getattr(obj, "uuid", ""))})
+            docs.append(
+                {"content": content, "metadata": metadata, "id": str(getattr(obj, "uuid", ""))}
+            )
         return docs
 
     def prune(self: Self, ttl_seconds: int) -> None:

--- a/src/shared/memory_store.py
+++ b/src/shared/memory_store.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
+import time
 import uuid
-from typing import Any
+from typing import Any, Protocol
 
 from typing_extensions import Self
 
 
-class ChromaMemoryStore:
+class MemoryStore(Protocol):
+    """Protocol for simple memory stores used in tests."""
+
+    def add_documents(self, documents: list[str], metadatas: list[dict[str, Any]]) -> None:
+        """Add a batch of documents with associated metadata."""
+
+    def query(self, query: str, top_k: int = 1) -> list[dict[str, Any]]:
+        """Return the ``top_k`` most relevant documents."""
+
+    def prune(self, ttl_seconds: int) -> None:
+        """Remove entries older than ``ttl_seconds`` based on ``timestamp`` metadata."""
+
+
+class ChromaMemoryStore(MemoryStore):
     """Minimal in-memory stand-in for ChromaDB used in tests."""
 
     def __init__(self: Self, persist_directory: str | None = None) -> None:
@@ -20,3 +34,68 @@ class ChromaMemoryStore:
     def query(self: Self, query: str, top_k: int = 1) -> list[dict[str, Any]]:
         # Ignore query text for this simplified implementation
         return list(self._store[-top_k:])
+
+    def prune(self: Self, ttl_seconds: int) -> None:
+        threshold = time.time() - ttl_seconds
+        remaining: list[dict[str, Any]] = []
+        for entry in self._store:
+            ts = entry.get("metadata", {}).get("timestamp")
+            if ts is None or ts >= threshold:
+                remaining.append(entry)
+        self._store = remaining
+
+
+class WeaviateMemoryStore(MemoryStore):
+    """Very small shim around a mocked Weaviate collection for tests."""
+
+    def __init__(
+        self: Self,
+        client: Any,
+        collection_name: str = "Memory",
+    ) -> None:
+        self.client = client
+        if hasattr(client, "collections"):
+            collections = client.collections
+            if getattr(collections, "exists", lambda _name: True)(collection_name):
+                self.collection = collections.get(collection_name)
+            else:
+                self.collection = collections.create(collection_name)
+        else:
+            raise RuntimeError("Invalid Weaviate client provided")
+        self._store: list[dict[str, Any]] = []
+
+    def add_documents(self: Self, documents: list[str], metadatas: list[dict[str, Any]]) -> None:
+        objects = []
+        for doc, meta in zip(documents, metadatas):
+            uid = meta.get("uuid", str(uuid.uuid4()))
+            entry = {"content": doc, "metadata": meta, "id": uid}
+            self._store.append(entry)
+            obj = {"text": doc, **meta, "uuid": uid}
+            objects.append(obj)
+        if hasattr(self.collection.data, "insert_many"):
+            self.collection.data.insert_many(objects)
+
+    def query(self: Self, query: str, top_k: int = 1) -> list[dict[str, Any]]:
+        result = None
+        if hasattr(self.collection.query, "near_text"):
+            result = self.collection.query.near_text(query=query, limit=top_k)
+        objects = getattr(result, "objects", []) if result else []
+        docs = []
+        for obj in objects:
+            props = getattr(obj, "properties", {})
+            metadata = dict(props)
+            content = metadata.pop("text", "")
+            docs.append({"content": content, "metadata": metadata, "id": str(getattr(obj, "uuid", ""))})
+        return docs
+
+    def prune(self: Self, ttl_seconds: int) -> None:
+        threshold = time.time() - ttl_seconds
+        remaining: list[dict[str, Any]] = []
+        for entry in self._store:
+            ts = entry.get("metadata", {}).get("timestamp")
+            if ts is None or ts >= threshold:
+                remaining.append(entry)
+            else:
+                if hasattr(self.collection.data, "delete_by_id"):
+                    self.collection.data.delete_by_id(entry["id"])
+        self._store = remaining

--- a/tests/integration/agents/test_weaviate_roundtrip.py
+++ b/tests/integration/agents/test_weaviate_roundtrip.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.memory_store import WeaviateMemoryStore
+
+
+@pytest.mark.integration
+def test_weaviate_roundtrip() -> None:
+    mock_collection = MagicMock()
+    mock_collection.data.insert_many = MagicMock()
+
+    result_obj = MagicMock()
+    result_obj.properties = {"text": "hello", "author": "A", "timestamp": 0}
+    result_obj.uuid = "1"
+    result_obj.metadata = MagicMock(distance=0.1)
+
+    mock_collection.query.near_text.return_value = MagicMock(objects=[result_obj])
+
+    mock_collections = MagicMock()
+    mock_collections.get.return_value = mock_collection
+    mock_collections.exists.return_value = True
+    mock_client = MagicMock(collections=mock_collections)
+
+    store = WeaviateMemoryStore(client=mock_client, collection_name="Test")
+    store.add_documents(["hello"], [{"author": "A", "timestamp": 0, "uuid": "1"}])
+    mock_collection.data.insert_many.assert_called_once()
+
+    results = store.query("hello", top_k=1)
+    mock_collection.query.near_text.assert_called_once_with(query="hello", limit=1)
+    assert results[0]["content"] == "hello"
+    assert results[0]["metadata"]["author"] == "A"

--- a/tests/unit/memory/test_memory_store_protocol.py
+++ b/tests/unit/memory/test_memory_store_protocol.py
@@ -1,0 +1,42 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.memory_store import ChromaMemoryStore, MemoryStore, WeaviateMemoryStore
+
+
+@pytest.mark.unit
+def test_chroma_ttl_prune(monkeypatch: pytest.MonkeyPatch) -> None:
+    store: MemoryStore = ChromaMemoryStore()
+    store.add_documents(["a", "b"], [{"timestamp": 0}, {"timestamp": 10}])
+    monkeypatch.setattr(time, "time", lambda: 12)
+    store.prune(5)
+    results = store.query("", top_k=10)
+    assert len(results) == 1
+    assert results[0]["content"] == "b"
+
+
+@pytest.mark.unit
+def test_weaviate_ttl_prune(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_collection = MagicMock()
+    mock_collection.data.insert_many = MagicMock()
+    mock_collection.data.delete_by_id = MagicMock()
+    mock_collection.query.near_text = MagicMock(return_value=MagicMock(objects=[]))
+
+    mock_collections = MagicMock()
+    mock_collections.get.return_value = mock_collection
+    mock_collections.exists.return_value = True
+    mock_client = MagicMock(collections=mock_collections)
+
+    store: MemoryStore = WeaviateMemoryStore(client=mock_client, collection_name="Test")
+    store.add_documents(
+        ["a", "b"],
+        [
+            {"timestamp": 0, "uuid": "1"},
+            {"timestamp": 10, "uuid": "2"},
+        ],
+    )
+    monkeypatch.setattr(time, "time", lambda: 12)
+    store.prune(5)
+    mock_collection.data.delete_by_id.assert_called_once_with("1")


### PR DESCRIPTION
## Summary
- add a `MemoryStore` protocol with `prune` API
- implement TTL pruning in `ChromaMemoryStore`
- implement a simple `WeaviateMemoryStore`
- update interaction handlers to accept any `MemoryStore`
- add unit tests for TTL pruning and Weaviate integration test

## Testing
- `ruff check .`
- `mypy --config-file pyproject.toml src/`
- `pytest -c /dev/null tests/unit/memory/test_memory_store_protocol.py -q`
- `pytest -c /dev/null tests/integration/agents/test_weaviate_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6842fc656dfc8326829a46184887cc8f