### PR TITLE
Fix outdated doc paths

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,7 +353,7 @@ All DSPy program modules in `src/agents/dspy_programs/` are strictly compliant w
 
 ### Overview
 
-The `AsyncDSPyManager` (`src/utils/async_dspy_manager.py`) is a core infrastructure component that manages all DSPy program calls asynchronously using a thread pool. It provides:
+The `AsyncDSPyManager` (`src/shared/async_utils.py`) is a core infrastructure component that manages all DSPy program calls asynchronously using a thread pool. It provides:
 - **Non-blocking execution** of DSPy programs, improving simulation responsiveness and throughput.
 - **Timeout handling**: If a DSPy call exceeds the allowed time, the manager returns a failsafe output.
 - **Graceful error recovery**: Exceptions in DSPy calls are caught, logged, and replaced with safe fallback results.

--- a/docs/onboarding_report.md
+++ b/docs/onboarding_report.md
@@ -34,7 +34,7 @@ Culture.ai employs a modular architecture. The main components are:
     *   The agent's turn is a graph with nodes for perception analysis, memory retrieval (RAG), thought generation, action selection, and state updates.
     *   DSPy is increasingly used for core logic within these nodes, such as `L1SummaryGenerator` and `action_intent_selector`.
 *   **Simulation Environment (`src/sim/simulation.py`):** Manages the overall simulation, agent scheduling, and interactions with shared resources like the `KnowledgeBoard`.
-*   **Infrastructure (`src/infra/`):** Contains supporting modules for configuration (`config.py`), LLM client interaction (`llm_client.py`, `dspy_ollama_integration.py`), logging (`logging_config.py`), and LLM mocking for tests (`llm_mock_helper.py`).
+*   **Infrastructure (`src/infra/`):** Contains supporting modules for configuration (`config.py`), LLM client interaction (`llm_client.py`, `dspy_ollama_integration.py`), logging (`logging_config.py`), and LLM mocking for tests (`llm_mocks.py`).
 *   **DSPy Programs (`src/agents/dspy_programs/`):** Houses DSPy programs for various agent tasks like summary generation, thought generation, and action/intent selection. Compiled/optimized versions are often used.
 
 ## 4. Coding Standards & Practices
@@ -67,7 +67,7 @@ Adherence to coding standards is crucial for maintaining a clean and collaborati
 *   **Testing:**
     *   Unit tests (`tests/unit/`) and integration tests (`tests/integration/`) are vital.
     *   Follow naming conventions like `test_{feature}_{scenario}`.
-    *   `unittest` is the primary framework, with mocking utilities in `tests/utils/mock_llm.py` and `src/infra/llm_mock_helper.py`.
+    *   `unittest` is the primary framework, with mocking utilities in `tests/utils/mock_llm.py` and `src/shared/llm_mocks.py`.
 *   **Git & Version Control:** (Assumed standard practices, but a `code_review_process.md` exists in `docs/`)
 
 ## 5. Key Files & Directories

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -21,9 +21,9 @@ except Exception:  # pragma: no cover - optional dependency
 
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
-import requests  # type: ignore
+import requests
 from pydantic import BaseModel, ValidationError
-from requests.exceptions import RequestException  # type: ignore
+from requests.exceptions import RequestException
 
 from src.shared.decorator_utils import monitor_llm_call
 

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -49,7 +49,7 @@ async def test_dspy_call_timeout_in_graph(
     simple_agent: Agent, async_manager: AsyncDSPyManager, caplog: LogCaptureFixture
 ) -> None:
     caplog.set_level(
-        logging.WARNING, logger="src.utils.async_dspy_manager"
+        logging.WARNING, logger="src.shared.async_utils"
     )  # For timeout test, we expect WARNING
     caplog.set_level(logging.DEBUG)  # General debug for other logs if needed
 


### PR DESCRIPTION
## Summary
- fix AsyncDSPyManager file path in architecture docs
- update llm mock helper path in onboarding docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6843087df0648326879c45b0a7fc9dba