### PR TITLE
Implement timeout handling and tests

### DIFF
--- a/src/shared/async_utils.py
+++ b/src/shared/async_utils.py
@@ -105,7 +105,30 @@ class AsyncDSPyManager:
         timeout: float | None = None,
         dspy_callable: Callable[..., object] | None = None,
     ) -> object:
-        pass
+        """Handle a timeout by cancelling the future and logging."""
+        timeout_val = timeout if timeout is not None else self.default_timeout
+        callable_name = (
+            getattr(dspy_callable, "__name__", str(dspy_callable))
+            if dspy_callable
+            else "Unnamed DSPy call"
+        )
+
+        logger.warning(
+            "AsyncDSPyManager._handle_timeout: Timeout awaiting result for "
+            f"{callable_name} after {timeout_val:.2f}s."
+        )
+
+        if not future.done():
+            if future.cancel():
+                logger.debug(
+                    f"Cancelled underlying task for {callable_name} due to timeout."
+                )
+            else:
+                logger.debug(
+                    "Failed to cancel underlying task for "
+                    f"{callable_name} (might have already completed or started running)."
+                )
+        return default_value
 
     async def run_with_timeout_async(
         self: Self,


### PR DESCRIPTION
## Summary
- implement `_handle_timeout` to cancel futures and log
- add coverage for `run_with_timeout_async`

## Testing
- `ruff check src/shared/async_utils.py tests/unit/utils/test_async_dspy_manager.py`
- `mypy src/shared/async_utils.py tests/unit/utils/test_async_dspy_manager.py`
- `pytest -m "unit and not dspy" -q`

------
https://chatgpt.com/codex/tasks/task_e_6843528822fc8326a8a42988967de98f