### PR TITLE
Remove skip markers from agent graph and dspy tests

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -158,17 +158,6 @@ class AgentStateData(BaseModel):
     _targeted_message_multiplier: float = PrivateAttr(
         default_factory=lambda: float(str(get_config("TARGETED_MESSAGE_MULTIPLIER") or "1.5"))
     )
-                "AGENT_STATE_VALIDATOR_DEBUG: mood_level input is not float/int before coercion. "
-                f"Type: {type(v)}, Value: {v}"
-
-            )
-            if isinstance(v, str) and v.lower() == "neutral":
-                logger.warning(
-                    "AGENT_STATE_VALIDATOR_DEBUG: mood_level input was 'neutral', coercing to 0.0"
-                )
-                return 0.0  # Attempt to coerce common problematic string to float
-            # If it cannot be coerced, Pydantic will raise a validation error later if not a float
-        return v
 
     @validator("mood_level")
     @classmethod

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -370,10 +370,10 @@ def configure_dspy_with_ollama(
 
     # Check Ollama server availability
     try:
-# The ``AsyncDSPyManager`` class originally lived in this file as a placeholder
-# design. It now resides in ``src.shared.async_utils`` as a fully functional
-# implementation. All production code should import it from that module. The
-# commented stub below remains only for historical reference.
+        response = requests.get(f"{api_base}/api/tags")
+        if response.status_code != 200:
+            logger.error(
+                "Ollama server reachable but returned unexpected status. "
                 f"Status code: {response.status_code}. "
                 "DSPy LM cannot be configured."
             )

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -39,12 +39,6 @@ def async_manager() -> Generator[AsyncDSPyManager, None, None]:
 
 
 @pytest.mark.asyncio
-# @pytest.mark.skip( # Unskip test
-#     reason=(
-#         "No canonical graph object is exported from basic_agent_graph.py; "
-#         "test cannot run until this is resolved."
-#     )
-# )
 async def test_dspy_call_timeout_in_graph(
     simple_agent: Agent, async_manager: AsyncDSPyManager, caplog: LogCaptureFixture
 ) -> None:
@@ -135,12 +129,6 @@ async def test_dspy_call_timeout_in_graph(
 
 
 @pytest.mark.asyncio
-# @pytest.mark.skip( # Unskip test
-#     reason=(
-#         "No canonical graph object is exported from basic_agent_graph.py; "
-#         "test cannot run until this is resolved."
-#     )
-# )
 async def test_dspy_call_exception_in_graph(
     simple_agent: Agent, async_manager: AsyncDSPyManager, caplog: LogCaptureFixture
 ) -> None:

--- a/tests/unit/dspy/test_dspy_direct.py
+++ b/tests/unit/dspy/test_dspy_direct.py
@@ -19,15 +19,7 @@ logger = logging.getLogger(__name__)
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 sys.path.insert(0, project_root)
 
-pytestmark = pytest.mark.skip(reason="Requires specific local LLM configuration, deferred for now")
 
-
-@pytest.mark.skip(
-    reason=(
-        "Requires specific local LLM configuration (Ollama with mistral:latest "
-        "and correct ENV VARS), deferred for now"
-    )
-)
 @pytest.mark.unit
 @pytest.mark.dspy
 @pytest.mark.critical_path


### PR DESCRIPTION
## Summary
- enable agent graph timeout/exception tests
- enable DSPy direct call test
- fix stray strings in `AgentState`
- clean up `configure_dspy_with_ollama` indentation

## Testing
- `pytest -m "integration or dspy" tests/integration/graph/test_async_agent_graph.py::test_dspy_call_timeout_in_graph tests/integration/graph/test_async_agent_graph.py::test_dspy_call_exception_in_graph tests/unit/dspy/test_dspy_direct.py::test_direct_call -q` *(fails: google.protobuf.runtime_version.VersionError)*

------
https://chatgpt.com/codex/tasks/task_e_68435c2c38288326a5cec88aa5a765f2