### PR TITLE
Fix ruff issues in tests

### DIFF
--- a/tests/integration/agents/test_intent_pipeline.py
+++ b/tests/integration/agents/test_intent_pipeline.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from src.agents.core.agent_attributes import AgentAttributes
+
 try:  # agent_state may fail to import due to known indentation issue
     from src.agents.core.agent_controller import AgentController
 except IndentationError:  # pragma: no cover - environment bug

--- a/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
+++ b/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
@@ -15,6 +15,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 import pytest
+
 try:
     import dspy  # pragma: no cover - optional dependency
 except Exception:

--- a/tests/integration/test_collective_metrics.py
+++ b/tests/integration/test_collective_metrics.py
@@ -7,30 +7,37 @@ This script validates that collective IP and DU are correctly:
 3. Perceived correctly by all agents
 """
 
-import unittest
 import logging
-import sys
 import os
-import uuid
-import time
+import sys
+import unittest
 from pathlib import Path
 
 # Add the project root to the Python path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
 import pytest
+
+try:
+    from tests.manual.test_relationship_cases import create_base_simulation
+except Exception:  # pragma: no cover - optional dependency may be missing
+    from typing import Any
+
+    def create_base_simulation(*args: Any, **kwargs: Any) -> None:
+        """Fallback stub used when the real helper is unavailable."""
+        raise RuntimeError("create_base_simulation not available")
+
 try:  # agent_state parsing fails in some environments
-    from src.agents.core.base_agent import Agent
-    from src.agents.core.agent_state import AgentState
+    pass
 except IndentationError:  # pragma: no cover - environment bug
     pytest.skip("agent_state module is unparsable", allow_module_level=True)
-from src.agents.core.roles import ROLE_FACILITATOR, ROLE_INNOVATOR, ROLE_ANALYZER
+from src.agents.core.roles import ROLE_ANALYZER, ROLE_FACILITATOR, ROLE_INNOVATOR
+
 try:
-    from src.sim.simulation import Simulation
+    pass
 except Exception:  # pragma: no cover - parsing or import failure
     import pytest
     pytest.skip("simulation module unavailable", allow_module_level=True)
-from src.agents.graphs.basic_agent_graph import IP_COST_TO_POST_IDEA, PROPOSE_DETAILED_IDEA_DU_COST
 from src.infra import config
 
 # Configure logging
@@ -55,14 +62,14 @@ logger.setLevel(logging.INFO)
 
 class TestCollectiveMetrics(unittest.TestCase):
     """Test suite for validating collective metrics (IP and DU) functionality."""
-    
+
     def setUp(self):
         """Set up a simulation with multiple agents for testing."""
         # Create a simulation with 3 agents, each with different roles
         self.num_agents = 3
         self.initial_ip = 10.0  # Initial IP for each agent
         self.initial_du = 15.0  # Initial DU for each agent
-        
+
         # Create a simulation with fixed agent roles for predictable testing
         self.sim = create_base_simulation(
             num_agents=self.num_agents,
@@ -71,7 +78,7 @@ class TestCollectiveMetrics(unittest.TestCase):
             # initial_du=self.initial_du,
             # randomize_roles=False  # We want fixed roles for predictable testing
         )
-        
+
         # Assign specific roles to each agent for controlled testing
         roles = [ROLE_FACILITATOR, ROLE_INNOVATOR, ROLE_ANALYZER]
         for i, agent in enumerate(self.sim.agents):
@@ -82,47 +89,49 @@ class TestCollectiveMetrics(unittest.TestCase):
             agent._state.ip = self.initial_ip
             agent._state.du = self.initial_du
             logger.info(f"Agent {agent.agent_id} assigned role: {role} with IP: {self.initial_ip}, DU: {self.initial_du}")
-        
+
         # Force update collective metrics to reflect initial values
         self.sim._update_collective_metrics()
-        
+
         # Store initial state
         self.initial_expected_collective_ip = self.num_agents * self.initial_ip
         self.initial_expected_collective_du = self.num_agents * self.initial_du
-        
+
         logger.info(f"Set up simulation with {self.num_agents} agents")
         logger.info(f"Initial expected collective IP: {self.initial_expected_collective_ip}")
         logger.info(f"Initial expected collective DU: {self.initial_expected_collective_du}")
-    
-    def get_actual_collective_ip(self):
+
+
+    def get_actual_collective_ip(self) -> float:
         """Calculate the actual collective IP by summing all agents' IP."""
         return sum(agent._state.ip for agent in self.sim.agents)
-    
-    def get_actual_collective_du(self):
+
+
+    def get_actual_collective_du(self) -> float:
         """Calculate the actual collective DU by summing all agents' DU."""
         return sum(agent._state.du for agent in self.sim.agents)
-    
+
     def test_initial_collective_metrics(self):
         """Test that collective metrics are correctly initialized."""
         # Force the simulation to calculate and update collective metrics
         self.sim._update_collective_metrics()
-        
+
         # Get the actual collective metrics from the simulation
         actual_collective_ip = self.sim.collective_ip
         actual_collective_du = self.sim.collective_du
-        
+
         # Manually calculate expected values
         expected_collective_ip = self.initial_expected_collective_ip
         expected_collective_du = self.initial_expected_collective_du
-        
+
         # Assert that collective metrics are calculated correctly
-        self.assertAlmostEqual(actual_collective_ip, expected_collective_ip, 
+        self.assertAlmostEqual(actual_collective_ip, expected_collective_ip,
                               msg="Collective IP not calculated correctly at initialization")
-        self.assertAlmostEqual(actual_collective_du, expected_collective_du, 
+        self.assertAlmostEqual(actual_collective_du, expected_collective_du,
                               msg="Collective DU not calculated correctly at initialization")
-        
+
         logger.info("✅ Initial collective metrics calculated correctly")
-    
+
     def test_collective_metrics_after_direct_changes(self):
         """
         Test collective metrics are correctly updated after direct changes to agent resources.
@@ -130,52 +139,52 @@ class TestCollectiveMetrics(unittest.TestCase):
         """
         # Force the simulation to calculate and update collective metrics initially
         self.sim._update_collective_metrics()
-        
+
         # Get the actual collective metrics from the simulation before changes
         initial_actual_collective_ip = self.sim.collective_ip
         initial_actual_collective_du = self.sim.collective_du
-        
+
         logger.info(f"Initial actual collective IP: {initial_actual_collective_ip}")
         logger.info(f"Initial actual collective DU: {initial_actual_collective_du}")
-        
+
         # Directly modify agent IP/DU to simulate actions
         # Agent 0 earns 5 IP and spends 2 DU
         self.sim.agents[0]._state.ip += 5.0
         self.sim.agents[0]._state.du -= 2.0
         logger.info(f"Agent {self.sim.agents[0].agent_id} earns 5 IP and spends 2 DU")
-        
+
         # Agent 1 spends 3 IP and earns 4 DU
         self.sim.agents[1]._state.ip -= 3.0
         self.sim.agents[1]._state.du += 4.0
         logger.info(f"Agent {self.sim.agents[1].agent_id} spends 3 IP and earns 4 DU")
-        
+
         # Agent 2 doesn't change (control)
-        
+
         # Calculate expected collective metrics after changes
         expected_collective_ip_after = initial_actual_collective_ip + 5.0 - 3.0
         expected_collective_du_after = initial_actual_collective_du - 2.0 + 4.0
-        
+
         logger.info(f"Expected collective IP after changes: {expected_collective_ip_after}")
         logger.info(f"Expected collective DU after changes: {expected_collective_du_after}")
-        
+
         # Force the simulation to update collective metrics
         self.sim._update_collective_metrics()
-        
+
         # Get the actual collective metrics after changes
         actual_collective_ip_after = self.sim.collective_ip
         actual_collective_du_after = self.sim.collective_du
-        
+
         logger.info(f"Actual collective IP after changes: {actual_collective_ip_after}")
         logger.info(f"Actual collective DU after changes: {actual_collective_du_after}")
-        
+
         # Assert that collective metrics are updated correctly
-        self.assertAlmostEqual(actual_collective_ip_after, expected_collective_ip_after, 
+        self.assertAlmostEqual(actual_collective_ip_after, expected_collective_ip_after,
                               msg="Collective IP not updated correctly after changes")
-        self.assertAlmostEqual(actual_collective_du_after, expected_collective_du_after, 
+        self.assertAlmostEqual(actual_collective_du_after, expected_collective_du_after,
                               msg="Collective DU not updated correctly after changes")
-        
+
         logger.info("✅ Collective metrics updated correctly after direct changes")
-    
+
     def test_agent_perception_of_collective_metrics(self):
         """
         Test that each agent correctly perceives the collective metrics.
@@ -183,24 +192,24 @@ class TestCollectiveMetrics(unittest.TestCase):
         """
         # Force the simulation to calculate and update collective metrics initially
         self.sim._update_collective_metrics()
-        
+
         # Run a simulation step to ensure environment perception is updated
         self.sim.run_step(1)
-        
+
         # After running a step, manually calculate what the collective metrics should be
         expected_collective_ip = sum(agent._state.ip for agent in self.sim.agents)
         expected_collective_du = sum(agent._state.du for agent in self.sim.agents)
-        
+
         # Check if the simulation's collective metrics match our manual calculation
         self.assertAlmostEqual(expected_collective_ip, self.sim.collective_ip,
                                msg="Simulation's collective IP doesn't match manual calculation")
         self.assertAlmostEqual(expected_collective_du, self.sim.collective_du,
                                msg="Simulation's collective DU doesn't match manual calculation")
-        
+
         logger.info(f"Collective metrics in simulation - IP: {self.sim.collective_ip}, DU: {self.sim.collective_du}")
         logger.info(f"Manually calculated metrics - IP: {expected_collective_ip}, DU: {expected_collective_du}")
         logger.info("✅ Collective metrics properly calculated and matched manual calculation")
-    
+
     def test_multi_step_collective_metrics(self):
         """
         Test collective metrics over multiple simulation steps.
@@ -208,28 +217,28 @@ class TestCollectiveMetrics(unittest.TestCase):
         """
         # Initial calculation
         self.sim._update_collective_metrics()
-        
+
         initial_collective_ip = self.sim.collective_ip
         initial_collective_du = self.sim.collective_du
-        
+
         logger.info(f"Starting multi-step test with collective IP: {initial_collective_ip}, collective DU: {initial_collective_du}")
-        
+
         # Store role-based DU generation rates for easier calculation
         du_generation_rates = {
             ROLE_FACILITATOR: config.ROLE_DU_GENERATION.get(ROLE_FACILITATOR, 1),
             ROLE_INNOVATOR: config.ROLE_DU_GENERATION.get(ROLE_INNOVATOR, 2),
             ROLE_ANALYZER: config.ROLE_DU_GENERATION.get(ROLE_ANALYZER, 1)
         }
-        
+
         # Track expected values based on roles and passive generation
         expected_collective_ip = initial_collective_ip
         expected_collective_du = initial_collective_du
-        
+
         # Run simulation for multiple steps
         num_steps = 3
         for step in range(num_steps):
             logger.info(f"--- Step {step+1} of {num_steps} ---")
-            
+
             # Calculate expected DU increase from passive role-based generation
             expected_du_increase = 0
             for agent in self.sim.agents:
@@ -237,71 +246,71 @@ class TestCollectiveMetrics(unittest.TestCase):
                 du_rate = du_generation_rates.get(role, 0)
                 expected_du_increase += du_rate
                 logger.info(f"Agent {agent.agent_id} with role {role} will generate {du_rate} DU")
-            
+
             # Update expected values
             expected_collective_du += expected_du_increase
             logger.info(f"Expected collective DU after step {step+1}: {expected_collective_du} (increase of {expected_du_increase})")
-            
+
             # Run a simulation step
             self.sim.run_step(1)
-            
+
             # Get actual values after the step
             actual_collective_ip = self.sim.collective_ip
             actual_collective_du = self.sim.collective_du
-            
+
             logger.info(f"Actual collective IP after step {step+1}: {actual_collective_ip}")
             logger.info(f"Actual collective DU after step {step+1}: {actual_collective_du}")
-            
-            # Due to randomness in agent decisions, we should verify the collective metrics are correctly 
+
+            # Due to randomness in agent decisions, we should verify the collective metrics are correctly
             # calculated based on actual agent states rather than our predictions
             calculated_collective_ip = self.get_actual_collective_ip()
             calculated_collective_du = self.get_actual_collective_du()
-            
+
             logger.info(f"Calculated collective IP from agent states: {calculated_collective_ip}")
             logger.info(f"Calculated collective DU from agent states: {calculated_collective_du}")
-            
+
             # Verify that simulation's collective metrics match calculation from agent states
-            self.assertAlmostEqual(actual_collective_ip, calculated_collective_ip, 
+            self.assertAlmostEqual(actual_collective_ip, calculated_collective_ip,
                                   msg=f"Simulation's collective IP doesn't match calculation from agent states at step {step+1}")
-            self.assertAlmostEqual(actual_collective_du, calculated_collective_du, 
+            self.assertAlmostEqual(actual_collective_du, calculated_collective_du,
                                   msg=f"Simulation's collective DU doesn't match calculation from agent states at step {step+1}")
-            
+
             # Update expected values for next step based on actual values
             expected_collective_ip = actual_collective_ip
             expected_collective_du = actual_collective_du
-            
+
             # Force update collective metrics
             self.sim._update_collective_metrics()
-            
+
             # Get actual metrics after step
             actual_collective_ip_after = self.sim.collective_ip
             actual_collective_du_after = self.sim.collective_du
-            
+
             logger.info(f"Actual collective IP after step {step+1}: {actual_collective_ip_after}")
             logger.info(f"Actual collective DU after step {step+1}: {actual_collective_du_after}")
-            
+
             # Verify calculations in edge case scenarios
-            self.assertAlmostEqual(actual_collective_ip_after, expected_collective_ip, 
+            self.assertAlmostEqual(actual_collective_ip_after, expected_collective_ip,
                                   msg=f"Simulation's collective IP doesn't match calculation from agent states at step {step+1}")
-            self.assertAlmostEqual(actual_collective_du_after, expected_collective_du, 
+            self.assertAlmostEqual(actual_collective_du_after, expected_collective_du,
                                   msg=f"Simulation's collective DU doesn't match calculation from agent states at step {step+1}")
-        
+
         logger.info("✅ Multi-step collective metrics tracking passed")
-    
+
     def test_edge_cases(self):
         """Test collective metrics with edge cases like zero or negative resource values."""
         # Force the simulation to calculate and update collective metrics initially
         self.sim._update_collective_metrics()
-        
+
         # Get the actual collective metrics from the simulation before changes
         initial_actual_collective_ip = self.sim.collective_ip
         initial_actual_collective_du = self.sim.collective_du
-        
+
         # Edge case 1: Agent with zero IP/DU
         self.sim.agents[0]._state.ip = 0
         self.sim.agents[0]._state.du = 0
         logger.info(f"Edge case: Set Agent {self.sim.agents[0].agent_id} IP and DU to zero")
-        
+
         # Edge case 2: Agent with negative IP (if allowed by the system)
         # Some systems might clamp to zero, others might allow negative
         try:
@@ -311,32 +320,32 @@ class TestCollectiveMetrics(unittest.TestCase):
             logger.info(f"Setting negative IP failed as expected: {e}")
             # Reset to zero if negative not allowed
             self.sim.agents[1]._state.ip = 0
-        
+
         # Calculate expected collective metrics after changes
         expected_collective_ip = self.get_actual_collective_ip()
         expected_collective_du = self.get_actual_collective_du()
-        
+
         logger.info(f"Expected collective IP after edge cases: {expected_collective_ip}")
         logger.info(f"Expected collective DU after edge cases: {expected_collective_du}")
-        
+
         # Force the simulation to update collective metrics
         self.sim._update_collective_metrics()
-        
+
         # Get the actual collective metrics after changes
         actual_collective_ip = self.sim.collective_ip
         actual_collective_du = self.sim.collective_du
-        
+
         logger.info(f"Actual collective IP after edge cases: {actual_collective_ip}")
         logger.info(f"Actual collective DU after edge cases: {actual_collective_du}")
-        
+
         # Assert that collective metrics handle edge cases correctly
-        self.assertAlmostEqual(actual_collective_ip, expected_collective_ip, 
+        self.assertAlmostEqual(actual_collective_ip, expected_collective_ip,
                               msg="Collective IP not handled correctly with edge cases")
-        self.assertAlmostEqual(actual_collective_du, expected_collective_du, 
+        self.assertAlmostEqual(actual_collective_du, expected_collective_du,
                               msg="Collective DU not handled correctly with edge cases")
-        
+
         logger.info("✅ Edge cases for collective metrics handled correctly")
 
 if __name__ == "__main__":
     logger.info("Starting collective metrics tests...")
-    unittest.main() 
+    unittest.main()

--- a/tests/integration/test_full_memory_pipeline.py
+++ b/tests/integration/test_full_memory_pipeline.py
@@ -2,7 +2,7 @@
 """
 End-to-End Memory Pipeline Integration Test
 
-This test verifies the complete memory pipeline, from raw event recording through 
+This test verifies the complete memory pipeline, from raw event recording through
 multiple stages of summarization and pruning, ensuring all components work together correctly.
 
 The test simulates:
@@ -14,16 +14,15 @@ The test simulates:
 6. MUS-based memory pruning for both L1 and L2 summaries
 """
 
-import os
-import sys
-import uuid
-import math
 import logging
-import unittest
+import math
+import os
 import shutil
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+import sys
+import unittest
+import uuid
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 # Add the project root to the Python path
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -32,11 +31,10 @@ sys.path.append(project_root)
 import pytest
 
 pytest.importorskip("chromadb")
-from src.agents.core.roles import ROLE_INNOVATOR, ROLE_ANALYZER, ROLE_FACILITATOR
-from src.infra.llm_client import generate_response
+from src.agents.core.roles import ROLE_ANALYZER, ROLE_FACILITATOR, ROLE_INNOVATOR
+from src.agents.dspy_programs.role_specific_summary_generator import RoleSpecificSummaryGenerator
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.infra import config
-from src.agents.dspy_programs.role_specific_summary_generator import RoleSpecificSummaryGenerator
 
 # Configure logging
 logging.basicConfig(
@@ -56,14 +54,14 @@ class TestFullMemoryPipeline(unittest.TestCase):
     Test case to verify the end-to-end memory pipeline functionality.
     Tests all memory components working together in a longer simulation.
     """
-    
+
     @classmethod
     def setUpClass(cls):
         """
         Set up the test environment by configuring the memory system and mocking time.
         """
         logger.info("Setting up test environment for end-to-end memory pipeline tests")
-        
+
         # Adjust config settings to ensure all memory operations happen quickly
         config.CONSOLIDATION_WINDOW_STEPS = 10  # Consolidate L1 every 10 steps
         config.L2_CONSOLIDATION_WINDOW_STEPS = 20  # Consolidate L2 every 20 steps
@@ -76,28 +74,28 @@ class TestFullMemoryPipeline(unittest.TestCase):
         config.MUS_L1_THRESHOLD = 0.3
         config.MUS_L2_THRESHOLD = 0.3
         config.MIN_AGE_DAYS_FOR_CONSIDERATION = 1  # Consider memories 1+ days old for MUS pruning
-        
+
         # Create test-specific ChromaDB directory
         cls.vector_store_dir = f"./test_full_memory_pipeline_{uuid.uuid4().hex[:6]}"
         if os.path.exists(cls.vector_store_dir):
             logger.info(f"Removing previous test ChromaDB at {cls.vector_store_dir}")
             shutil.rmtree(cls.vector_store_dir)
-        
+
         cls._start_datetime = datetime(2023, 1, 1, 12, 0, 0)  # Fixed start time for testing
-        
+
         # Create a patcher for datetime.utcnow() to have controlled time progression
         cls.datetime_patcher = patch('src.agents.memory.vector_store.datetime')
         cls.mock_datetime = cls.datetime_patcher.start()
         cls.mock_datetime.utcnow.return_value = cls._start_datetime
         cls.mock_datetime.fromisoformat = datetime.fromisoformat  # Keep the real method
-        
+
         # Patch llm_client.generate_response
         cls.llm_patcher = patch('src.infra.llm_client.generate_response')
         cls.mock_llm_generate = cls.llm_patcher.start()
         cls.mock_llm_generate.return_value = "Mocked LLM response for testing."
-        
+
         # Setup is completed in the test method since we need more complex mocking
-        
+
     @classmethod
     def tearDownClass(cls):
         """Clean up after tests"""
@@ -105,7 +103,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
         cls.datetime_patcher.stop()
         # Stop the LLM patcher
         cls.llm_patcher.stop()
-        
+
         # Clean up ChromaDB directory
         if os.path.exists(cls.vector_store_dir):
             try:
@@ -113,39 +111,39 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 logger.info(f"Removed test ChromaDB directory: {cls.vector_store_dir}")
             except PermissionError as e:
                 logger.warning(f"Could not remove test directory due to permission error: {e}")
-    
+
     def setUp(self):
         """Set up each test with fresh instances"""
         # Setup vector store
         self.vector_store = ChromaVectorStoreManager(persist_directory=self.vector_store_dir)
-        
+
         # Create agent instances with different roles
         self.agents = {
             'innovator': self._create_mock_agent(ROLE_INNOVATOR),
             'analyzer': self._create_mock_agent(ROLE_ANALYZER),
             'facilitator': self._create_mock_agent(ROLE_FACILITATOR)
         }
-        
+
         # Track simulation step
         self.current_step = 0
-        
+
         # Create a role-specific summary generator
         self.role_specific_summarizer = RoleSpecificSummaryGenerator()
-        
+
         # Setup simple mock simulation
         self.simulation = MagicMock()
         self.simulation.step = self.current_step
-        
+
         # Don't create an agent graph instance since we don't need the full graph functionality
         # We'll use the role-specific summarizer and vector store directly in our tests
-    
-    def _create_mock_agent(self, role):
-        """Create a mock agent with a specific role"""
+
+    def _create_mock_agent(self, role: str) -> MagicMock:
+        """Create a mock agent with a specific role."""
         agent = MagicMock()
         agent.id = f"{role.lower()}_agent_{uuid.uuid4().hex[:4]}"
         agent.role = role
         agent.get_state.return_value = {"role": role, "current_mood": "focused"}
-        
+
         # Record the role in the vector store
         self.vector_store.record_role_change(
             agent_id=agent.id,
@@ -153,19 +151,21 @@ class TestFullMemoryPipeline(unittest.TestCase):
             previous_role="unknown",
             new_role=role
         )
-        
+
         return agent
-    
-    def _advance_time(self, days=0, hours=0, minutes=0):
-        """Advance the mocked time by the specified amount"""
+
+    def _advance_time(self, days: int = 0, hours: int = 0, minutes: int = 0) -> None:
+        """Advance the mocked time by the specified amount."""
         new_datetime = self._start_datetime + timedelta(days=days, hours=hours, minutes=minutes)
         self.mock_datetime.utcnow.return_value = new_datetime
         logger.info(f"Advanced time to {new_datetime.isoformat()}")
-    
-    def _add_test_memories_for_agent(self, agent, step_start, step_count):
-        """Add a sequence of test memories for an agent"""
-        added_memory_ids = []
-        
+
+    def _add_test_memories_for_agent(
+        self, agent: MagicMock, step_start: int, step_count: int
+    ) -> list[str]:
+        """Add a sequence of test memories for an agent."""
+        added_memory_ids: list[str] = []
+
         # Different content types based on agent role
         if agent.role == ROLE_INNOVATOR:
             contents = [
@@ -191,13 +191,13 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 "The team will be more effective if we align our goals and establish trust.",
                 "I should organize a workshop to help resolve these conflicting priorities."
             ]
-        
+
         # Add memory events for specified steps
         for i in range(step_count):
             step = step_start + i
             event_type = "thought" if i % 2 == 0 else "broadcast_sent"
             content = contents[i % len(contents)]
-            
+
             memory_id = self.vector_store.add_memory(
                 agent_id=agent.id,
                 step=step,
@@ -208,15 +208,15 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 }
             )
             added_memory_ids.append(memory_id)
-            
+
             # Every few steps, add a "reply" from another agent
             if i % 3 == 0:
                 # Another agent responds
                 responder_role = ROLE_ANALYZER if agent.role != ROLE_ANALYZER else ROLE_FACILITATOR
                 responder_agent = self.agents['analyzer'] if responder_role == ROLE_ANALYZER else self.agents['facilitator']
-                
+
                 response_content = f"Interesting point about {content.split()[3:7]}. Have you considered alternative perspectives?"
-                
+
                 self.vector_store.add_memory(
                     agent_id=agent.id,
                     step=step,
@@ -227,13 +227,15 @@ class TestFullMemoryPipeline(unittest.TestCase):
                         "simulation_step_timestamp": self.mock_datetime.utcnow().isoformat()
                     }
                 )
-        
+
         return added_memory_ids
-    
-    def _simulate_l1_consolidation(self, agent, start_step, end_step):
-        """Simulate L1 consolidation for an agent for the given step range"""
+
+    def _simulate_l1_consolidation(
+        self, agent: MagicMock, start_step: int, end_step: int
+    ) -> str | None:
+        """Simulate L1 consolidation for an agent for the given step range."""
         agent_state = agent.get_state()
-        
+
         # Get all raw memories in the step range
         # Instead of using get_memory_ids_in_step_range which has issues, query directly
         where_filter = {
@@ -243,16 +245,16 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 {"step": {"$lte": end_step}}
             ]
         }
-        
+
         results = self.vector_store.collection.get(
             where=where_filter,
             include=["documents", "metadatas"]
         )
-        
+
         if not results or not results.get("ids", []):
             logger.warning(f"No raw memories found for agent {agent.id} in step range {start_step}-{end_step}")
             return None
-        
+
         # Process the memories that were returned
         memories = []
         for i, doc in enumerate(results["documents"]):
@@ -261,17 +263,17 @@ class TestFullMemoryPipeline(unittest.TestCase):
                     "content": doc,
                     "metadata": results["metadatas"][i]
                 })
-        
+
         # Prepare the context for the summarizer
         recent_events = "\n".join([memory["content"] for memory in memories])
-        
+
         # Generate the L1 summary using the role-specific summarizer
         l1_summary = self.role_specific_summarizer.generate_l1_summary(
             agent_role=agent.role,
             recent_events=recent_events,
             current_mood=agent_state.get("current_mood", "neutral")
         )
-        
+
         # Add the consolidated summary to the vector store
         consolidated_memory_id = self.vector_store.add_memory(
             agent_id=agent.id,
@@ -285,17 +287,17 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 "simulation_step_timestamp": self.mock_datetime.utcnow().isoformat()
             }
         )
-        
+
         logger.info(f"Added L1 consolidated summary for agent {agent.id} at step {end_step}, covering steps {start_step}-{end_step}")
         return consolidated_memory_id
-    
-    def _simulate_l2_consolidation(self, agent, step):
-        """Simulate L2 consolidation for an agent at a specific step"""
+
+    def _simulate_l2_consolidation(self, agent: MagicMock, step: int) -> str | None:
+        """Simulate L2 consolidation for an agent at a specific step."""
         agent_state = agent.get_state()
-        
+
         # Calculate the window start (L2 windows are larger than L1)
         start_step = max(0, step - config.L2_CONSOLIDATION_WINDOW_STEPS)
-        
+
         # Get all L1 summaries in the step range
         where_filter = {
             "$and": [
@@ -305,16 +307,16 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 {"step": {"$lte": step}}
             ]
         }
-        
+
         results = self.vector_store.collection.get(
             where=where_filter,
             include=["documents", "metadatas"]
         )
-        
+
         if not results or not results.get("ids", []):
             logger.warning(f"No L1 summaries found for agent {agent.id} in step range {start_step}-{step}")
             return None
-        
+
         # Process the L1 summaries that were returned
         l1_summaries = []
         for i, doc in enumerate(results["documents"]):
@@ -323,11 +325,11 @@ class TestFullMemoryPipeline(unittest.TestCase):
                     "content": doc,
                     "metadata": results["metadatas"][i]
                 })
-        
+
         # Prepare the context for the L2 summarizer
-        l1_summaries_context = "\n\n".join([f"L1 Summary (Step {summary['metadata'].get('step', 'unknown')}): {summary['content']}" 
+        l1_summaries_context = "\n\n".join([f"L1 Summary (Step {summary['metadata'].get('step', 'unknown')}): {summary['content']}"
                                          for summary in l1_summaries])
-        
+
         # Generate the L2 summary using the role-specific summarizer
         l2_summary = self.role_specific_summarizer.generate_l2_summary(
             agent_role=agent.role,
@@ -335,7 +337,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
             overall_mood_trend=agent_state.get("current_mood", "neutral"),
             agent_goals=agent_state.get("goals", "Complete the task effectively")
         )
-        
+
         # Add the L2 chapter summary to the vector store
         l2_memory_id = self.vector_store.add_memory(
             agent_id=agent.id,
@@ -350,12 +352,12 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 "simulation_step_end_timestamp": self.mock_datetime.utcnow().isoformat()
             }
         )
-        
+
         logger.info(f"Added L2 chapter summary for agent {agent.id} at step {step}, covering steps {start_step}-{step}")
         return l2_memory_id
-    
-    def _simulate_memory_retrievals(self, agent, queries):
-        """Simulate RAG retrievals to build up usage statistics"""
+
+    def _simulate_memory_retrievals(self, agent: MagicMock, queries: list[str]) -> None:
+        """Simulate RAG retrievals to build up usage statistics."""
         for query in queries:
             # Perform a retrieval
             memories = self.vector_store.retrieve_relevant_memories(
@@ -363,10 +365,10 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 query=query,
                 k=3
             )
-            
+
             # Log what was retrieved
             logger.info(f"Agent {agent.id} retrieved {len(memories)} memories for query: '{query}'")
-            
+
             # Perform a targeted retrieval to ensure specific memories get retrieved often
             # This helps test the MUS scoring later
             if "innovation" in query.lower() or "creative" in query.lower():
@@ -377,7 +379,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
                     limit=2
                 )
                 logger.info(f"Agent {agent.id} made targeted retrieval of {len(targeted_memories)} memories")
-    
+
     def _perform_age_pruning(self):
         """Simulate age-based pruning for both L1 and L2 summaries"""
         # Get L1 summaries that should be pruned based on age
@@ -385,12 +387,12 @@ class TestFullMemoryPipeline(unittest.TestCase):
         for agent in self.agents.values():
             # Get all L1 summaries for the agent
             l1_where = {"$and": [{"agent_id": {"$eq": agent.id}}, {"memory_type": {"$eq": "consolidated_summary"}}]}
-            
+
             l1_results = self.vector_store.collection.get(
                 where=l1_where,
                 include=["metadatas", "documents"]
             )
-            
+
             if l1_results and "ids" in l1_results and l1_results["ids"]:
                 for idx, memory_id in enumerate(l1_results["ids"]):
                     metadata = l1_results["metadatas"][idx]
@@ -402,78 +404,77 @@ class TestFullMemoryPipeline(unittest.TestCase):
                             start_step, end_step = map(int, range_str.split("-"))
                             l2_step = end_step + config.CONSOLIDATION_WINDOW_STEPS
                             current_step = self.current_step
-                            
+
                             # If this L1 has been covered by an L2 AND the delay period has passed
                             if current_step >= l2_step + config.MEMORY_PRUNING_L1_DELAY_STEPS:
                                 l1_ids_to_prune.append(memory_id)
                         except (ValueError, TypeError):
                             logger.warning(f"Invalid consolidated_step_range format: {range_str}")
-        
+
         # Perform the actual pruning
         if l1_ids_to_prune:
             logger.info(f"Age-based pruning: Deleting {len(l1_ids_to_prune)} L1 summaries")
             self.vector_store.delete_memories_by_ids(l1_ids_to_prune)
-        
+
         # Age-based L2 pruning
         # Get L2 summaries older than MAX_AGE_DAYS
         l2_ids_to_prune = self.vector_store.get_l2_summaries_older_than(
             max_age_days=config.MEMORY_PRUNING_L2_MAX_AGE_DAYS
         )
-        
+
         # Perform the actual L2 pruning
         if l2_ids_to_prune:
             logger.info(f"Age-based pruning: Deleting {len(l2_ids_to_prune)} L2 summaries")
             self.vector_store.delete_memories_by_ids(l2_ids_to_prune)
-    
+
     def _perform_mus_pruning(self):
         """Simulate MUS-based pruning for both L1 and L2 summaries"""
-        import math
-        from datetime import datetime, timedelta
-        
+        from datetime import datetime
+
         # Instead of using get_l1_memories_for_mus_pruning, implement the logic directly
         min_age_days = config.MIN_AGE_DAYS_FOR_CONSIDERATION
         mus_threshold = config.MUS_L1_THRESHOLD
         now = self.mock_datetime.utcnow()
         l1_ids_to_prune = []
-        
+
         # Get all L1 summaries
         l1_where = {"memory_type": {"$eq": "consolidated_summary"}}
         l1_results = self.vector_store.collection.get(
             where=l1_where,
             include=["metadatas", "documents"]
         )
-        
+
         if l1_results and "ids" in l1_results and l1_results["ids"]:
             for i, memory_id in enumerate(l1_results["ids"]):
                 if i < len(l1_results.get("metadatas", [])):
                     metadata = l1_results["metadatas"][i]
-                    
+
                     # Check age
                     timestamp_str = metadata.get('simulation_step_timestamp')
                     if not timestamp_str:
                         continue
-                        
+
                     try:
                         created_dt = datetime.fromisoformat(timestamp_str)
                         age_days = (now - created_dt).days
                     except Exception as e:
                         logger.warning(f"Invalid timestamp format: {timestamp_str}")
                         continue
-                        
+
                     if age_days < min_age_days:
                         continue  # Skip memories that are too young
-                    
+
                     # Calculate MUS
                     retrieval_count = metadata.get('retrieval_count', 0)
                     accumulated_relevance = metadata.get('accumulated_relevance_score', 0.0)
                     relevance_count = metadata.get('retrieval_relevance_count', 0)
                     last_retrieved = metadata.get('last_retrieved_timestamp', "")
-                    
+
                     # Calculate components
                     rfs = math.log(1 + retrieval_count)
                     rs = (accumulated_relevance / relevance_count) if relevance_count > 0 else 0.0
                     recs = 0.0
-                    
+
                     if last_retrieved:
                         try:
                             last_dt = datetime.fromisoformat(last_retrieved)
@@ -482,62 +483,62 @@ class TestFullMemoryPipeline(unittest.TestCase):
                             recs = 1.0 / (1.0 + days_since)
                         except Exception as e:
                             logger.warning(f"Invalid last_retrieved_timestamp format: {last_retrieved}")
-                    
+
                     # Calculate MUS
                     mus = (0.4 * rfs) + (0.4 * rs) + (0.2 * recs)
-                    
+
                     # If MUS is below threshold, mark for pruning
                     if mus < mus_threshold:
                         l1_ids_to_prune.append(memory_id)
-        
+
         # Perform the actual L1 MUS pruning
         if l1_ids_to_prune:
             logger.info(f"MUS-based pruning: Deleting {len(l1_ids_to_prune)} L1 summaries with low utility scores")
             self.vector_store.delete_memories_by_ids(l1_ids_to_prune)
-        
+
         # Similar approach for L2 summaries
         l2_ids_to_prune = []
         min_age_days = config.MIN_AGE_DAYS_FOR_CONSIDERATION
         mus_threshold = config.MUS_L2_THRESHOLD
-        
+
         # Get all L2 summaries
         l2_where = {"memory_type": {"$eq": "chapter_summary"}}
         l2_results = self.vector_store.collection.get(
             where=l2_where,
             include=["metadatas", "documents"]
         )
-        
+
         if l2_results and "ids" in l2_results and l2_results["ids"]:
             for i, memory_id in enumerate(l2_results["ids"]):
                 if i < len(l2_results.get("metadatas", [])):
                     metadata = l2_results["metadatas"][i]
-                    
+
                     # Check age
                     timestamp_str = metadata.get('simulation_step_end_timestamp')
                     if not timestamp_str:
                         continue
-                        
+
                     try:
                         created_dt = datetime.fromisoformat(timestamp_str)
                         age_days = (now - created_dt).days
                     except Exception as e:
                         logger.warning(f"Invalid timestamp format: {timestamp_str}")
                         continue
-                        
+
                     if age_days < min_age_days:
                         continue  # Skip memories that are too young
-                    
+
                     # Calculate MUS (same formula as L1)
                     retrieval_count = metadata.get('retrieval_count', 0)
                     accumulated_relevance = metadata.get('accumulated_relevance_score', 0.0)
                     relevance_count = metadata.get('retrieval_relevance_count', 0)
                     last_retrieved = metadata.get('last_retrieved_timestamp', "")
-                    
+
                     # Calculate components
                     rfs = math.log(1 + retrieval_count)
                     rs = (accumulated_relevance / relevance_count) if relevance_count > 0 else 0.0
                     recs = 0.0
-                    
+
                     if last_retrieved:
                         try:
                             last_dt = datetime.fromisoformat(last_retrieved)
@@ -546,76 +547,76 @@ class TestFullMemoryPipeline(unittest.TestCase):
                             recs = 1.0 / (1.0 + days_since)
                         except Exception as e:
                             logger.warning(f"Invalid last_retrieved_timestamp format: {last_retrieved}")
-                    
+
                     # Calculate MUS
                     mus = (0.4 * rfs) + (0.4 * rs) + (0.2 * recs)
-                    
+
                     # If MUS is below threshold, mark for pruning
                     if mus < mus_threshold:
                         l2_ids_to_prune.append(memory_id)
-                        
+
         # Perform the actual L2 MUS pruning
         if l2_ids_to_prune:
             logger.info(f"MUS-based pruning: Deleting {len(l2_ids_to_prune)} L2 summaries with low utility scores")
             self.vector_store.delete_memories_by_ids(l2_ids_to_prune)
-    
+
     def test_memory_pipeline_evolution(self):
         """
         Test the end-to-end memory pipeline by simulating a sequence of agent interactions,
         memory formations, consolidations, retrievals, and pruning operations.
         """
         total_steps = 100  # Total simulation steps to run
-        
+
         # Step 1: Initialize and add raw memories for each agent
         logger.info("STEP 1: Adding initial raw memories for all agents")
         for agent_name, agent in self.agents.items():
             logger.info(f"Adding memories for {agent_name} (role: {agent.role})")
             self._add_test_memories_for_agent(agent, 1, 9)  # Add memories for steps 1-9
-        
+
         # Step 2: Run the simulation and trigger memory pipeline events
         logger.info("STEP 2: Running simulation for memory pipeline processing")
-        
+
         for step in range(1, total_steps + 1):
             self.current_step = step
             self.simulation.step = step
-            
+
             # Add new memories every 5 steps
             if step % 5 == 0:
                 for agent_name, agent in self.agents.items():
                     logger.info(f"Step {step}: Adding new memories for {agent_name}")
                     self._add_test_memories_for_agent(agent, step, 5)  # Add 5 new memories
-            
+
             # L1 Consolidation check
             if step % config.CONSOLIDATION_WINDOW_STEPS == 0:
                 logger.info(f"Step {step}: L1 Consolidation triggered")
-                
+
                 # Calculate the window for consolidation
                 start_step = max(1, step - config.CONSOLIDATION_WINDOW_STEPS + 1)
                 end_step = step
-                
+
                 for agent_name, agent in self.agents.items():
                     logger.info(f"Performing L1 consolidation for {agent_name} (steps {start_step}-{end_step})")
                     self._simulate_l1_consolidation(agent, start_step, end_step)
-                
+
                 # Advance time to simulate passage of a day
                 self._advance_time(days=1)
-            
+
             # L2 Consolidation check
             if step % config.L2_CONSOLIDATION_WINDOW_STEPS == 0:
                 logger.info(f"Step {step}: L2 Consolidation triggered")
-                
+
                 for agent_name, agent in self.agents.items():
                     logger.info(f"Performing L2 consolidation for {agent_name} at step {step}")
                     self._simulate_l2_consolidation(agent, step)
-                
+
                 # Advance time to simulate passage of another day
                 self._advance_time(days=1)
-            
+
             # Memory retrievals - simulate agents accessing memory
             if step % 7 == 0:  # Every 7 steps, do some retrievals
                 for agent_name, agent in self.agents.items():
                     logger.info(f"Step {step}: Simulating memory retrievals for {agent_name}")
-                    
+
                     if agent.role == ROLE_INNOVATOR:
                         queries = [
                             "innovative ideas for our project",
@@ -634,38 +635,38 @@ class TestFullMemoryPipeline(unittest.TestCase):
                             "resolving conflicts in the team",
                             "aligning team goals and priorities"
                         ]
-                    
+
                     self._simulate_memory_retrievals(agent, queries)
-            
+
             # Age-based pruning check
             if step % 15 == 0:  # Check for age-based pruning periodically
                 logger.info(f"Step {step}: Checking for age-based pruning")
                 self._perform_age_pruning()
-            
+
             # MUS-based pruning check
             if step % 25 == 0:  # Check for MUS-based pruning less frequently
                 logger.info(f"Step {step}: Checking for MUS-based pruning")
                 self._perform_mus_pruning()
-                
+
                 # Advance time significantly to test age effects
                 self._advance_time(days=5)
-        
+
         # Step 3: Verify the final state of memory
         logger.info("STEP 3: Verifying final memory state")
-        
+
         self._verify_final_memory_state()
-    
+
     def _verify_final_memory_state(self):
         """Verify the final state of the memory store after all operations"""
         # Check raw memory counts
         try:
             for agent_name, agent in self.agents.items():
                 agent_id = agent.id
-                raw_count = self._count_memories_of_type(agent_id, "raw") 
+                raw_count = self._count_memories_of_type(agent_id, "raw")
                 logger.info(f"Agent {agent_name} ({agent.role}) has {raw_count} raw memories")
         except Exception as e:
             logger.error(f"Error checking raw count for {agent_name}: {e}")
-        
+
         # Check L1 summary counts
         try:
             for agent_name, agent in self.agents.items():
@@ -674,7 +675,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 logger.info(f"Agent {agent_name} ({agent.role}) has {l1_count} L1 summaries")
         except Exception as e:
             logger.error(f"Error checking consolidated_summary count for {agent_name}: {e}")
-        
+
         # Check L2 summary counts
         try:
             for agent_name, agent in self.agents.items():
@@ -683,7 +684,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
                 logger.info(f"Agent {agent_name} ({agent.role}) has {l2_count} L2 summaries")
         except Exception as e:
             logger.error(f"Error checking chapter_summary count for {agent_name}: {e}")
-        
+
         # Check usage statistics are being tracked
         try:
             for agent_name, agent in self.agents.items():
@@ -695,7 +696,7 @@ class TestFullMemoryPipeline(unittest.TestCase):
                     logger.warning(f"Agent {agent_name} doesn't have memory usage statistics")
         except Exception as e:
             logger.error(f"Error checking usage statistics for {agent_name}: {e}")
-        
+
         # Check role-specific summaries have characteristics matching agent role
         try:
             for agent_name, agent in self.agents.items():
@@ -718,10 +719,10 @@ class TestFullMemoryPipeline(unittest.TestCase):
 
         logger.info("End-to-end memory pipeline test completed successfully!")
 
-    def _count_memories_of_type(self, agent_id, memory_type=None):
-        """Count memories of a specific type for an agent"""
+    def _count_memories_of_type(self, agent_id: str, memory_type: str | None = None) -> int:
+        """Count memories of a specific type for an agent."""
         where_clause = {}
-        
+
         if memory_type:
             where_clause = {
                 "$and": [
@@ -731,29 +732,29 @@ class TestFullMemoryPipeline(unittest.TestCase):
             }
         else:
             where_clause = {"agent_id": {"$eq": agent_id}}
-            
+
         results = self.vector_store.collection.get(
             where=where_clause,
             include=[]  # Don't need any content, just counting
         )
-        
+
         return len(results.get("ids", []))
-    
-    def _get_memories_of_type(self, agent_id, memory_type, limit=5):
-        """Get memories of a specific type for an agent"""
+
+    def _get_memories_of_type(self, agent_id: str, memory_type: str, limit: int = 5) -> list[dict]:
+        """Get memories of a specific type for an agent."""
         where_filter = {
             "$and": [
                 {"agent_id": {"$eq": agent_id}},
                 {"memory_type": {"$eq": memory_type}}
             ]
         }
-        
+
         results = self.vector_store.collection.get(
             where=where_filter,
             include=["documents", "metadatas"],
             limit=limit
         )
-        
+
         memories = []
         if results and "documents" in results and results["documents"]:
             for i, doc in enumerate(results["documents"]):
@@ -762,27 +763,27 @@ class TestFullMemoryPipeline(unittest.TestCase):
                         "content": doc,
                         "metadata": results["metadatas"][i]
                     })
-        
+
         return memories
-    
-    def _get_memory_with_usage_stats(self, agent_id):
-        """Check if any memories have usage statistics for an agent"""
+
+    def _get_memory_with_usage_stats(self, agent_id: str) -> dict | None:
+        """Check if any memories have usage statistics for an agent."""
         where_filter = {
             "$and": [
                 {"agent_id": {"$eq": agent_id}},
                 {"retrieval_count": {"$gt": 0}}
             ]
         }
-        
+
         results = self.vector_store.collection.get(
             where=where_filter,
             include=["metadatas"],
             limit=1
         )
-        
+
         if results and "metadatas" in results and results["metadatas"]:
             return results["metadatas"][0]
         return None
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()

--- a/tests/manual/test_relationship_cases.py
+++ b/tests/manual/test_relationship_cases.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Manual verification tests for relationship dynamics."""
+# ruff: noqa: E402
 import argparse
 import asyncio
 import logging

--- a/tests/unit/dspy/test_agent_dspy.py
+++ b/tests/unit/dspy/test_agent_dspy.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+
 import pytest
 
 pytest.skip("DSPy wrapper manual test", allow_module_level=True)

--- a/tests/unit/test_dspy_summary_generators.py
+++ b/tests/unit/test_dspy_summary_generators.py
@@ -4,14 +4,13 @@ Unit tests for DSPy-based L1 and L2 summary generators.
 These tests focus on verifying the loading of compiled programs and fallback behavior.
 """
 
-import unittest
+import json
 import os
 import sys
-import json
 import tempfile
-import logging
-from unittest.mock import patch, MagicMock, ANY
+import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 # Add the project root to the Python path
 project_root = str(Path(__file__).parent.parent.parent)
@@ -20,7 +19,7 @@ sys.path.append(project_root)
 
 class TestL1SummaryGeneratorLoading(unittest.TestCase):
     """
-    Test the L1SummaryGenerator's ability to load compiled DSPy programs 
+    Test the L1SummaryGenerator's ability to load compiled DSPy programs
     and fall back gracefully when loading fails.
     """
 
@@ -29,7 +28,7 @@ class TestL1SummaryGeneratorLoading(unittest.TestCase):
         # Create a temporary directory for test files
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_dir_name = self.temp_dir.name
-        
+
         # Sample valid output for the mocked LLM
         self.sample_summary = "This is a test summary of recent events."
 
@@ -38,7 +37,7 @@ class TestL1SummaryGeneratorLoading(unittest.TestCase):
         # Clean up the temporary directory
         self.temp_dir.cleanup()
 
-    def _create_valid_l1_compiled_file(self, filename):
+    def _create_valid_l1_compiled_file(self, filename: str) -> str:
         """
         Create a valid compiled L1 summarizer JSON file.
         This represents what dspy.Module.save() would create.
@@ -56,196 +55,202 @@ class TestL1SummaryGeneratorLoading(unittest.TestCase):
             "config": {"temperature": 0.1},
             "module_type": "dspy.Predict"
         }
-        
+
         filepath = os.path.join(self.temp_dir_name, filename)
         with open(filepath, 'w') as f:
             json.dump(compiled_data, f)
-        
+
         return filepath
 
-    def _create_corrupted_l1_compiled_file(self, filename):
+    def _create_corrupted_l1_compiled_file(self, filename: str) -> str:
         """Create an invalid/corrupted JSON file."""
         filepath = os.path.join(self.temp_dir_name, filename)
         with open(filepath, 'w') as f:
             f.write("{This is not valid JSON!")
-        
+
         return filepath
 
     @patch('src.agents.dspy_programs.l1_summary_generator.L1SummaryGenerator.generate_summary')
     @patch('src.agents.dspy_programs.l1_summary_generator.L1SummaryGenerator.__init__')
-    def test_successful_load_optimized_l1_program(self, mock_init, mock_generate):
+    def test_successful_load_optimized_l1_program(
+        self, mock_init: MagicMock, mock_generate: MagicMock
+    ) -> None:
         """Test that the L1SummaryGenerator successfully loads a valid compiled program."""
         # Configure mocks
         mock_init.return_value = None  # __init__ should return None
         mock_generate.return_value = self.sample_summary
-        
+
         # Create a valid compiled program file
         valid_file_path = self._create_valid_l1_compiled_file("optimized_l1_summarizer.json")
-        
+
         # Import here to use the patched version
         from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
-        
+
         # Instantiate the L1SummaryGenerator with the valid file path
         l1_generator = L1SummaryGenerator(compiled_program_path=valid_file_path)
-        
+
         # Assert that L1SummaryGenerator.__init__ was called with the correct path
         mock_init.assert_called_once_with(compiled_program_path=valid_file_path)
-        
+
         # Test that generate_summary works as expected
         result = l1_generator.generate_summary(
             agent_role="Innovator",
             recent_events="Event 1\nEvent 2",
             current_mood="happy"
         )
-        
+
         # Verify the mock was called with the right parameters
         mock_generate.assert_called_once_with(
-            agent_role="Innovator", 
-            recent_events="Event 1\nEvent 2", 
+            agent_role="Innovator",
+            recent_events="Event 1\nEvent 2",
             current_mood="happy"
         )
-        
+
         # Assert that the result is the mocked summary
         self.assertEqual(result, self.sample_summary)
 
     @patch('src.agents.dspy_programs.l1_summary_generator.os.path.exists')
     @patch('src.agents.dspy_programs.l1_summary_generator.logger')
-    def test_fallback_if_l1_program_missing(self, mock_logger, mock_exists):
+    def test_fallback_if_l1_program_missing(
+        self, mock_logger: MagicMock, mock_exists: MagicMock
+    ) -> None:
         """Test that the L1SummaryGenerator falls back to default predictor if file is missing."""
         # Configure the mock to make file check return False (file doesn't exist)
         mock_exists.return_value = False
-        
+
         # Import after mocking
         from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l1_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l1_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Specify a non-existent file path
             non_existent_path = os.path.join(self.temp_dir_name, "non_existent_file.json")
-            
+
             # Instantiate the L1SummaryGenerator with the non-existent file path
             l1_generator = L1SummaryGenerator(compiled_program_path=non_existent_path)
-            
+
             # Verify that load was not called since the file doesn't exist
             mock_predictor.load.assert_not_called()
-            
+
             # Verify logging indicates fallback
             mock_logger.info.assert_any_call("No compiled L1 summarizer found or path not provided. Using default predictor.")
-            
+
             # Test generate_summary with the default predictor
             result = l1_generator.generate_summary(
                 agent_role="Innovator",
                 recent_events="Event 1\nEvent 2",
                 current_mood="happy"
             )
-            
+
             # Assert that the predictor was called with the right parameters
             mock_predictor.assert_called_once_with(
                 agent_role="Innovator",
                 recent_events="Event 1\nEvent 2",
                 current_mood="happy"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l1_summary)
 
     @patch('src.agents.dspy_programs.l1_summary_generator.os.path.exists')
     @patch('src.agents.dspy_programs.l1_summary_generator.logger')
-    def test_fallback_if_l1_program_corrupted(self, mock_logger, mock_exists):
+    def test_fallback_if_l1_program_corrupted(
+        self, mock_logger: MagicMock, mock_exists: MagicMock
+    ) -> None:
         """Test that the L1SummaryGenerator falls back to default predictor if file is corrupted."""
         # Configure the mock to make file check return True
         mock_exists.return_value = True
-        
+
         # Create a corrupted JSON file
         corrupted_file_path = self._create_corrupted_l1_compiled_file("corrupted_l1_summarizer.json")
-        
+
         # Import after mocking
         from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l1_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Set up the exception when trying to load
             mock_predictor.load.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l1_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Instantiate the L1SummaryGenerator with the corrupted file path
             l1_generator = L1SummaryGenerator(compiled_program_path=corrupted_file_path)
-            
+
             # Assert that the predictor load method was called but failed
             mock_predictor.load.assert_called_once_with(corrupted_file_path)
-            
+
             # Verify logging indicates error and fallback
             mock_logger.error.assert_called_once_with(
                 f"Failed to load compiled L1 summarizer from {corrupted_file_path}: Invalid JSON: line 1 column 1 (char 0). Using default predictor."
             )
-            
+
             # Test generate_summary with the default predictor
             result = l1_generator.generate_summary(
                 agent_role="Innovator",
                 recent_events="Event 1\nEvent 2",
                 current_mood="happy"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l1_summary)
 
     @patch('src.agents.dspy_programs.l1_summary_generator.logger')
-    def test_fallback_if_l1_program_path_is_none(self, mock_logger):
+    def test_fallback_if_l1_program_path_is_none(self, mock_logger: MagicMock) -> None:
         """Test that the L1SummaryGenerator falls back to default predictor if path is None."""
         # Import after mocking
         from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l1_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l1_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Instantiate the L1SummaryGenerator with None path
             l1_generator = L1SummaryGenerator(compiled_program_path=None)
-            
+
             # Assert that load was not called
             mock_predictor.load.assert_not_called()
-            
+
             # Verify logging indicates use of default predictor
             mock_logger.info.assert_any_call("No compiled L1 summarizer found or path not provided. Using default predictor.")
-            
+
             # Test generate_summary with the default predictor
             result = l1_generator.generate_summary(
                 agent_role="Innovator",
                 recent_events="Event 1\nEvent 2",
                 current_mood="happy"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l1_summary)
 
 
 class TestL2SummaryGeneratorLoading(unittest.TestCase):
     """
-    Test the L2SummaryGenerator's ability to load compiled DSPy programs 
+    Test the L2SummaryGenerator's ability to load compiled DSPy programs
     and fall back gracefully when loading fails.
     """
 
@@ -254,7 +259,7 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
         # Create a temporary directory for test files
         self.temp_dir = tempfile.TemporaryDirectory()
         self.temp_dir_name = self.temp_dir.name
-        
+
         # Sample valid output for the mocked LLM
         self.sample_summary = "This is a test L2 summary synthesizing multiple L1 summaries."
 
@@ -263,7 +268,7 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
         # Clean up the temporary directory
         self.temp_dir.cleanup()
 
-    def _create_valid_l2_compiled_file(self, filename):
+    def _create_valid_l2_compiled_file(self, filename: str) -> str:
         """
         Create a valid compiled L2 summarizer JSON file.
         This represents what dspy.Module.save() would create.
@@ -282,41 +287,43 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
             "config": {"temperature": 0.1},
             "module_type": "dspy.Predict"
         }
-        
+
         filepath = os.path.join(self.temp_dir_name, filename)
         with open(filepath, 'w') as f:
             json.dump(compiled_data, f)
-        
+
         return filepath
 
-    def _create_corrupted_l2_compiled_file(self, filename):
+    def _create_corrupted_l2_compiled_file(self, filename: str) -> str:
         """Create an invalid/corrupted JSON file."""
         filepath = os.path.join(self.temp_dir_name, filename)
         with open(filepath, 'w') as f:
             f.write("{This is not valid JSON for L2 summarizer!")
-        
+
         return filepath
 
     @patch('src.agents.dspy_programs.l2_summary_generator.L2SummaryGenerator.generate_summary')
     @patch('src.agents.dspy_programs.l2_summary_generator.L2SummaryGenerator.__init__')
-    def test_successful_load_optimized_l2_program(self, mock_init, mock_generate):
+    def test_successful_load_optimized_l2_program(
+        self, mock_init: MagicMock, mock_generate: MagicMock
+    ) -> None:
         """Test that the L2SummaryGenerator successfully loads a valid compiled program."""
         # Configure mocks
         mock_init.return_value = None  # __init__ should return None
         mock_generate.return_value = self.sample_summary
-        
+
         # Create a valid compiled program file
         valid_file_path = self._create_valid_l2_compiled_file("optimized_l2_summarizer.json")
-        
+
         # Import here to use the patched version
         from src.agents.dspy_programs.l2_summary_generator import L2SummaryGenerator
-        
+
         # Instantiate the L2SummaryGenerator with the valid file path
         l2_generator = L2SummaryGenerator(compiled_program_path=valid_file_path)
-        
+
         # Assert that L2SummaryGenerator.__init__ was called with the correct path
         mock_init.assert_called_once_with(compiled_program_path=valid_file_path)
-        
+
         # Test that generate_summary works as expected
         result = l2_generator.generate_summary(
             agent_role="Analyzer",
@@ -324,51 +331,53 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
             overall_mood_trend="positive",
             agent_goals="Analyze complex patterns"
         )
-        
+
         # Verify the mock was called with the right parameters
         mock_generate.assert_called_once_with(
-            agent_role="Analyzer", 
-            l1_summaries_context="L1 Summary 1\nL1 Summary 2", 
+            agent_role="Analyzer",
+            l1_summaries_context="L1 Summary 1\nL1 Summary 2",
             overall_mood_trend="positive",
             agent_goals="Analyze complex patterns"
         )
-        
+
         # Assert that the result is the mocked summary
         self.assertEqual(result, self.sample_summary)
 
     @patch('src.agents.dspy_programs.l2_summary_generator.os.path.exists')
     @patch('src.agents.dspy_programs.l2_summary_generator.logger')
-    def test_fallback_if_l2_program_missing(self, mock_logger, mock_exists):
+    def test_fallback_if_l2_program_missing(
+        self, mock_logger: MagicMock, mock_exists: MagicMock
+    ) -> None:
         """Test that the L2SummaryGenerator falls back to default predictor if file is missing."""
         # Configure the mock to make file check return False (file doesn't exist)
         mock_exists.return_value = False
-        
+
         # Import after mocking
         from src.agents.dspy_programs.l2_summary_generator import L2SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l2_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l2_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Specify a non-existent file path
             non_existent_path = os.path.join(self.temp_dir_name, "non_existent_l2_file.json")
-            
+
             # Instantiate the L2SummaryGenerator with the non-existent file path
             l2_generator = L2SummaryGenerator(compiled_program_path=non_existent_path)
-            
+
             # Verify that load was not called since the file doesn't exist
             mock_predictor.load.assert_not_called()
-            
+
             # Verify logging indicates fallback
             mock_logger.info.assert_any_call("No compiled L2 summarizer found or path not provided. Using default predictor.")
-            
+
             # Test generate_summary with the default predictor
             result = l2_generator.generate_summary(
                 agent_role="Analyzer",
@@ -376,7 +385,7 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
                 overall_mood_trend="positive",
                 agent_goals="Analyze complex patterns"
             )
-            
+
             # Assert that the predictor was called with the right parameters
             mock_predictor.assert_called_once_with(
                 agent_role="Analyzer",
@@ -384,48 +393,50 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
                 overall_mood_trend="positive",
                 agent_goals="Analyze complex patterns"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l2_summary)
 
     @patch('src.agents.dspy_programs.l2_summary_generator.os.path.exists')
     @patch('src.agents.dspy_programs.l2_summary_generator.logger')
-    def test_fallback_if_l2_program_corrupted(self, mock_logger, mock_exists):
+    def test_fallback_if_l2_program_corrupted(
+        self, mock_logger: MagicMock, mock_exists: MagicMock
+    ) -> None:
         """Test that the L2SummaryGenerator falls back to default predictor if file is corrupted."""
         # Configure the mock to make file check return True
         mock_exists.return_value = True
-        
+
         # Create a corrupted JSON file
         corrupted_file_path = self._create_corrupted_l2_compiled_file("corrupted_l2_summarizer.json")
-        
+
         # Import after mocking
         from src.agents.dspy_programs.l2_summary_generator import L2SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l2_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Set up the exception when trying to load
             mock_predictor.load.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l2_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Instantiate the L2SummaryGenerator with the corrupted file path
             l2_generator = L2SummaryGenerator(compiled_program_path=corrupted_file_path)
-            
+
             # Assert that the predictor load method was called but failed
             mock_predictor.load.assert_called_once_with(corrupted_file_path)
-            
+
             # Verify logging indicates error and fallback
             mock_logger.error.assert_called_once_with(
                 f"Failed to load compiled L2 summarizer from {corrupted_file_path}: Invalid JSON: line 1 column 1 (char 0). Using default predictor."
             )
-            
+
             # Test generate_summary with the default predictor
             result = l2_generator.generate_summary(
                 agent_role="Analyzer",
@@ -433,36 +444,36 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
                 overall_mood_trend="positive",
                 agent_goals="Analyze complex patterns"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l2_summary)
 
     @patch('src.agents.dspy_programs.l2_summary_generator.logger')
-    def test_fallback_if_l2_program_path_is_none(self, mock_logger):
+    def test_fallback_if_l2_program_path_is_none(self, mock_logger: MagicMock) -> None:
         """Test that the L2SummaryGenerator falls back to default predictor if path is None."""
         # Import after mocking
         from src.agents.dspy_programs.l2_summary_generator import L2SummaryGenerator
-        
+
         # Patch the actual dspy.Predict to mock its creation and usage
         with patch('src.agents.dspy_programs.l2_summary_generator.dspy.Predict') as mock_predict:
             # Configure the predictor mock
             mock_predictor = MagicMock()
             mock_predict.return_value = mock_predictor
-            
+
             # Create a mock prediction result
             mock_prediction = MagicMock()
             mock_prediction.l2_summary = self.sample_summary
             mock_predictor.return_value = mock_prediction
-            
+
             # Instantiate the L2SummaryGenerator with None path
             l2_generator = L2SummaryGenerator(compiled_program_path=None)
-            
+
             # Assert that load was not called
             mock_predictor.load.assert_not_called()
-            
+
             # Verify logging indicates use of default predictor
             mock_logger.info.assert_any_call("No compiled L2 summarizer found or path not provided. Using default predictor.")
-            
+
             # Test generate_summary with the default predictor
             result = l2_generator.generate_summary(
                 agent_role="Analyzer",
@@ -470,10 +481,10 @@ class TestL2SummaryGeneratorLoading(unittest.TestCase):
                 overall_mood_trend="positive",
                 agent_goals="Analyze complex patterns"
             )
-            
+
             # Assert that the result is the mocked summary
             self.assertEqual(result, mock_prediction.l2_summary)
 
 
 if __name__ == "__main__":
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
## Summary
- import `create_base_simulation` safely in collective metrics tests
- add missing type hints to integration tests
- annotate helper functions in summary generator tests
- silence E402 warning in manual tests

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6843669ab8a483269734b27698b9fd3b