### PR TITLE
Add unit tests for graph builder and nodes

### DIFF
--- a/tests/unit/graphs/test_agent_graph_builder.py
+++ b/tests/unit/graphs/test_agent_graph_builder.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("langgraph")
+
+from langgraph.graph.graph import START, END, Graph
+from src.agents.graphs.agent_graph_builder import build_graph
+
+
+@pytest.mark.unit
+def test_build_graph_structure() -> None:
+    graph = build_graph()
+    assert isinstance(graph, Graph)
+
+    expected_nodes = {
+        "analyze_perception_sentiment",
+        "prepare_relationship_prompt",
+        "retrieve_and_summarize_memories",
+        "generate_thought_and_message",
+        "handle_propose_idea",
+        "handle_ask_clarification",
+        "handle_continue_collaboration",
+        "handle_idle",
+        "handle_deep_analysis",
+        "finalize_message_agent",
+    }
+    assert expected_nodes.issubset(graph.nodes.keys())
+
+    expected_edges = {
+        (START, "analyze_perception_sentiment"),
+        ("analyze_perception_sentiment", "prepare_relationship_prompt"),
+        ("prepare_relationship_prompt", "retrieve_and_summarize_memories"),
+        ("retrieve_and_summarize_memories", "generate_thought_and_message"),
+        ("generate_thought_and_message", "handle_idle"),
+        ("handle_idle", "finalize_message_agent"),
+        ("finalize_message_agent", END),
+    }
+    assert expected_edges.issubset(graph.edges)

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -1,0 +1,126 @@
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.graphs.graph_nodes import (
+    analyze_perception_sentiment_node,
+    finalize_message_agent_node,
+    generate_thought_and_message_node,
+    prepare_relationship_prompt_node,
+    retrieve_and_summarize_memories_node,
+    _format_knowledge_board,
+    _format_other_agents,
+)
+
+
+@pytest.mark.unit
+def test_analyze_perception_sentiment_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_sentiment(text: str) -> str:
+        calls.append(text)
+        return "positive" if text == "good" else "negative"
+
+    monkeypatch.setattr(
+        "src.agents.graphs.graph_nodes.analyze_sentiment", fake_sentiment
+    )
+
+    state = {
+        "agent_id": "a",
+        "perceived_messages": [
+            {"sender_id": "b", "content": "good"},
+            {"sender_id": "c", "content": "bad"},
+        ],
+    }
+    result = analyze_perception_sentiment_node(state)
+    assert result == {"turn_sentiment_score": 0}
+    assert calls == ["good", "bad"]
+
+
+@pytest.mark.unit
+def test_prepare_relationship_prompt_node() -> None:
+    agent_state = SimpleNamespace(relationships={"b": 0.5, "c": -0.2})
+    result = prepare_relationship_prompt_node({"state": agent_state})
+    assert "b: 0.5" in result["prompt_modifier"]
+    assert "c: -0.2" in result["prompt_modifier"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
+    state = {"agent_id": "a"}
+    out = await retrieve_and_summarize_memories_node(state)
+    assert out == {"rag_summary": "(No memory retrieval)"}
+
+
+class DummyManager:
+    async def aretrieve_relevant_memories(self, agent_id: str, query: str = "", k: int = 5):
+        return [{"content": "m1"}, {"content": "m2"}]
+
+
+class DummyAgent:
+    async def async_generate_l1_summary(self, role: str, memories: str, context: str):
+        return SimpleNamespace(summary="SUM")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_retrieve_and_summarize_memories_node_with_manager() -> None:
+    state = {
+        "agent_id": "a",
+        "vector_store_manager": DummyManager(),
+        "agent_instance": DummyAgent(),
+        "current_role": "r",
+    }
+    out = await retrieve_and_summarize_memories_node(state)
+    assert out == {"rag_summary": "SUM"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_generate_thought_and_message_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyOutput(SimpleNamespace):
+        pass
+
+    dummy = DummyOutput(
+        thought="T",
+        message_content="M",
+        message_recipient_id=None,
+        action_intent="continue_collaboration",
+    )
+
+    monkeypatch.setattr(
+        "src.agents.graphs.graph_nodes.generate_structured_output", lambda prompt, schema: dummy
+    )
+
+    out = await generate_thought_and_message_node({})
+    assert out == {"structured_output": dummy}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_finalize_message_agent_node_variants() -> None:
+    agent_state = SimpleNamespace()
+    out = await finalize_message_agent_node({"state": agent_state})
+    assert out["message_content"] is None
+    assert out["action_intent"] == "idle"
+
+    dummy = SimpleNamespace(
+        message_content="hi",
+        message_recipient_id="b",
+        action_intent="propose",
+    )
+    out2 = await finalize_message_agent_node({"state": agent_state, "structured_output": dummy})
+    assert out2["message_content"] == "hi"
+    assert out2["is_targeted"] is True
+
+
+@pytest.mark.unit
+def test_helper_formatters() -> None:
+    info = [{"agent_id": "b"}]
+    relationships = {"b": 0.2}
+    assert _format_other_agents(info, relationships) == "b: 0.2"
+    assert _format_other_agents([], relationships) == "None"
+    assert _format_knowledge_board(["a", "b"]) == "a | b"
+    assert _format_knowledge_board([]) == "(Board empty)"

--- a/tests/unit/graphs/test_interaction_handlers.py
+++ b/tests/unit/graphs/test_interaction_handlers.py
@@ -1,0 +1,121 @@
+import pytest
+
+from src.agents.core.agent_attributes import AgentAttributes
+from src.agents.graphs.interaction_handlers import (
+    handle_propose_idea,
+    handle_propose_idea_node,
+    handle_continue_collaboration_node,
+    handle_idle_node,
+    handle_ask_clarification_node,
+    handle_deep_analysis_node,
+    handle_retrieve_and_update,
+)
+from src.agents.graphs.interaction_handlers import _UNLOCKED_CAPABILITY
+from src.infra.config import (
+    DU_AWARD_FOR_PROPOSAL,
+    DU_COST_DEEP_ANALYSIS,
+    IP_AWARD_FOR_PROPOSAL,
+    IP_COST_TO_POST_IDEA,
+)
+from src.shared.memory_store import ChromaMemoryStore
+
+
+@pytest.mark.unit
+def test_handle_propose_idea_node() -> None:
+    state_obj = AgentAttributes(
+        id="a",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={},
+    )
+    state_obj.ip = 10
+    turn_state = {"state": state_obj}
+    out = handle_propose_idea_node(turn_state)
+    expected = 10 - IP_COST_TO_POST_IDEA + IP_AWARD_FOR_PROPOSAL
+    assert out["state"].ip == expected
+
+
+@pytest.mark.unit
+def test_handle_deep_analysis_node() -> None:
+    state_obj = AgentAttributes(
+        id="a",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={},
+    )
+    state_obj.du = 5
+    turn_state = {"state": state_obj}
+    out = handle_deep_analysis_node(turn_state)
+    assert out["state"].du == 5 - DU_COST_DEEP_ANALYSIS
+
+
+@pytest.mark.unit
+def test_handle_propose_idea() -> None:
+    agent = AgentAttributes(
+        id="a",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={},
+    )
+    board = ChromaMemoryStore()
+    memory = ChromaMemoryStore()
+    agent.ip = 8
+    agent.du = 0
+    handle_propose_idea(agent, memory, board)
+    docs = board.query("", top_k=1)
+    assert docs[0]["metadata"]["author"] == "a"
+    assert agent.ip == 8 - IP_COST_TO_POST_IDEA
+    assert agent.du == DU_AWARD_FOR_PROPOSAL
+
+
+@pytest.mark.unit
+def test_handle_retrieve_and_update() -> None:
+    agent = AgentAttributes(
+        id="b",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={"a": 0.4},
+    )
+    store = ChromaMemoryStore()
+    store.add_documents(["idea"], [{"author": "a"}])
+    handle_retrieve_and_update(agent, store)
+    assert agent.relationships["a"] >= 0.5
+    assert _UNLOCKED_CAPABILITY in agent.unlocked_capabilities
+    assert agent.relationship_momentum["a"] > 0
+
+
+@pytest.mark.unit
+def test_simple_passthrough_handlers() -> None:
+    agent = AgentAttributes(
+        id="x",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={},
+    )
+    ts = {"state": agent}
+    assert handle_continue_collaboration_node(ts)["state"] is agent
+    assert handle_idle_node(ts)["state"] is agent
+    assert handle_ask_clarification_node(ts)["state"] is agent
+
+
+@pytest.mark.unit
+def test_handle_retrieve_and_update_edge_cases() -> None:
+    agent = AgentAttributes(
+        id="c",
+        mood=0.0,
+        goals=[],
+        resources={},
+        relationships={},
+    )
+    store = ChromaMemoryStore()
+    # No documents -> early return
+    handle_retrieve_and_update(agent, store)
+    assert agent.relationships == {}
+    store.add_documents(["idea"], [{"metadata_only": True}])
+    handle_retrieve_and_update(agent, store)
+    assert agent.relationships == {}


### PR DESCRIPTION
## Summary
- add unit tests for agent graph builder
- add detailed tests for graph node functions
- test interaction handlers including edge cases
- ensure ≥90% coverage for graph modules

## Testing
- `pytest tests/unit/graphs tests/unit/agents/graphs -q`
- `pytest --cov=src.agents.graphs.agent_graph_builder --cov=src.agents.graphs.graph_nodes --cov=src.agents.graphs.interaction_handlers tests/unit/graphs tests/unit/agents/graphs -q`

------
https://chatgpt.com/codex/tasks/task_e_6843669a22088326891a44745b735667