### PR TITLE
Remove redundant mood helpers

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -319,7 +319,7 @@ class Agent:
         Args:
             sentiment_score (float): The sentiment score to apply to the mood
         """
-        from src.agents.graphs.basic_agent_graph import get_descriptive_mood, get_mood_level
+        from src.agents.core.mood_utils import get_descriptive_mood, get_mood_level
 
         # Calculate new mood value using configured decay and update rates
         current_mood_value = (

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentState
+from src.agents.core.mood_utils import get_descriptive_mood
 from src.agents.core.roles import ROLE_ANALYZER, ROLE_FACILITATOR, ROLE_INNOVATOR
 
 # Import L1SummaryGenerator for DSPy-based L1 summary generation
@@ -370,30 +371,6 @@ def _format_messages(messages: list[dict[str, Any]]) -> str:
         message_type = "(Private to you)" if recipient else "(Broadcast)"
         lines.append(f'  - {sender} {message_type}: "{content}"')
     return "\n".join(lines)
-
-
-def get_mood_level(mood_value: float) -> str:
-    if mood_value < -0.3:
-        return "unhappy"
-    elif mood_value > 0.3:
-        return "happy"
-    return "neutral"
-
-
-def get_descriptive_mood(mood_value: float) -> str:
-    if mood_value < -0.7:
-        return "very unhappy"
-    elif mood_value < -0.3:
-        return "unhappy"
-    elif mood_value < -0.1:
-        return "slightly unhappy"
-    elif mood_value <= 0.1:
-        return "neutral"
-    elif mood_value <= 0.3:
-        return "slightly happy"
-    elif mood_value <= 0.7:
-        return "happy"
-    return "very happy"
 
 
 def shorten_message(message: str) -> str:


### PR DESCRIPTION
## Summary
- drop `get_mood_level` and `get_descriptive_mood` from `basic_agent_graph`
- import mood helpers from `src.agents.core.mood_utils` in graph and agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436cfbc8708326a654dfcb724fc3f5