### PR TITLE
Delegate mood updates to controller

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -319,38 +319,7 @@ class Agent:
         Args:
             sentiment_score (float): The sentiment score to apply to the mood
         """
-        from src.agents.graphs.basic_agent_graph import get_descriptive_mood, get_mood_level
-
-        # Calculate new mood value using configured decay and update rates
-        current_mood_value = (
-            float(self._state.mood_history[-1][1]) if self._state.mood_history else 0.0
-        )
-        new_mood_value = (
-            current_mood_value * (1 - self._state.mood_decay_rate)
-            + sentiment_score * self._state.mood_update_rate
-        )
-        new_mood_value = max(-1.0, min(1.0, new_mood_value))  # Keep within [-1, 1]
-
-        # Update mood and descriptive mood
-        new_mood = get_mood_level(new_mood_value)
-        new_descriptive_mood = get_descriptive_mood(new_mood_value)
-
-        # Track if mood changed
-        mood_changed = self._state.mood != new_mood
-
-        # Update state
-        self._state.mood = new_mood
-        self._state.mood_history.append(
-            (
-                (self._state.last_action_step if self._state.last_action_step is not None else 0),
-                new_mood,
-            )
-        )
-
-        if mood_changed:
-            logger.info(
-                f"Agent {self.agent_id} mood changed to {new_mood} ({new_descriptive_mood})"
-            )
+        AgentController(self._state).update_mood(sentiment_score)
 
     async def run_turn(
         self: Self,

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -21,9 +21,9 @@ except Exception:  # pragma: no cover - optional dependency
 
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
-import requests  # type: ignore[import-untyped]
+import requests
 from pydantic import BaseModel, ValidationError
-from requests.exceptions import RequestException  # type: ignore[import-untyped]
+from requests.exceptions import RequestException
 
 from src.shared.decorator_utils import monitor_llm_call
 

--- a/tests/unit/core/test_base_agent_mood.py
+++ b/tests/unit/core/test_base_agent_mood.py
@@ -1,0 +1,58 @@
+import sys
+import types
+
+import pytest
+from pytest import MonkeyPatch
+
+from src.agents.core.agent_controller import AgentController
+
+
+def _ensure_chromadb_stub() -> None:
+    """Insert a lightweight chromadb stub into ``sys.modules`` if missing."""
+    if "chromadb" not in sys.modules:
+        chromadb = types.ModuleType("chromadb")
+        chromadb.__version__ = "0.0"
+
+        class _DummyClient:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+        chromadb.PersistentClient = _DummyClient
+        sys.modules["chromadb"] = chromadb
+        utils_mod = types.ModuleType("chromadb.utils.embedding_functions")
+        utils_mod.SentenceTransformerEmbeddingFunction = object  # type: ignore[attr-defined]
+        sys.modules["chromadb.utils.embedding_functions"] = utils_mod
+    if "weaviate" not in sys.modules:
+        weaviate = types.ModuleType("weaviate")
+        weaviate.Client = object  # type: ignore[attr-defined]
+        sys.modules["weaviate"] = weaviate
+        classes_mod = types.ModuleType("weaviate.classes")
+        sys.modules["weaviate.classes"] = classes_mod
+    if "sse_starlette.sse" not in sys.modules:
+        sse_mod = types.ModuleType("sse_starlette.sse")
+        sse_mod.EventSourceResponse = object  # type: ignore[attr-defined]
+        sys.modules["sse_starlette.sse"] = sse_mod
+
+
+@pytest.mark.unit
+def test_update_mood_delegates(monkeypatch: MonkeyPatch) -> None:
+    _ensure_chromadb_stub()
+    from src.agents.graphs import basic_agent_graph
+
+    monkeypatch.setattr(basic_agent_graph, "compile_agent_graph", lambda: None)
+    from src.agents.core.base_agent import Agent
+
+    agent = Agent(agent_id="a3", vector_store_manager=object())
+    called: dict[str, float] = {}
+
+    def fake_update(self: AgentController, score: float) -> None:
+        called["score"] = score
+        self.state.mood_level = 0.42
+        self.state.mood_history.append((0, 0.42))
+
+    monkeypatch.setattr(AgentController, "update_mood", fake_update)
+
+    agent.update_mood(0.7)
+
+    assert called["score"] == 0.7
+    assert agent.state.mood_level == 0.42


### PR DESCRIPTION
## Summary
- delegate mood update logic from `BaseAgent` to `AgentController`
- drop unused type ignore comments in `llm_client`
- add unit test verifying `BaseAgent.update_mood` delegation

## Testing
- `ruff format tests/unit/core/test_base_agent_mood.py src/agents/core/base_agent.py`
- `ruff check tests/unit/core/test_base_agent_mood.py src/agents/core/base_agent.py`
- `mypy --config-file pyproject.toml`
- `pytest -m "unit and not dspy"`

------
https://chatgpt.com/codex/tasks/task_e_68436cfc981c8326a8c7dfb8971c2d92