### PR TITLE
Refactor project intent handlers

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -14,9 +14,13 @@ from .graph_nodes import (
 from .interaction_handlers import (
     handle_ask_clarification_node,
     handle_continue_collaboration_node,
+    handle_create_project_node,  # noqa: F401 - imported for future use
     handle_deep_analysis_node,
     handle_idle_node,
+    handle_join_project_node,  # noqa: F401 - imported for future use
+    handle_leave_project_node,  # noqa: F401 - imported for future use
     handle_propose_idea_node,
+    handle_send_direct_message_node,  # noqa: F401 - imported for future use
 )
 
 

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -23,6 +23,13 @@ from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
 # Import L2SummaryGenerator for DSPy-based L2 summary generation
 from src.infra import config  # Import config for role change parameters
 
+from .interaction_handlers import (  # noqa: F401 - imported for re-export
+    handle_create_project_node,
+    handle_join_project_node,
+    handle_leave_project_node,
+    handle_send_direct_message_node,
+)
+
 # Module logger
 logger = logging.getLogger(__name__)
 
@@ -413,22 +420,6 @@ def route_relationship_context(state: AgentTurnState) -> str:
     if agent_state_obj and agent_state_obj.relationships:
         return "has_relationships"
     return "no_relationships"
-
-
-def handle_create_project_node(state: AgentTurnState) -> dict[str, Any]:
-    return dict(state)
-
-
-def handle_join_project_node(state: AgentTurnState) -> dict[str, Any]:
-    return dict(state)
-
-
-def handle_leave_project_node(state: AgentTurnState) -> dict[str, Any]:
-    return dict(state)
-
-
-def handle_send_direct_message_node(state: AgentTurnState) -> dict[str, Any]:
-    return dict(state)
 
 
 def route_action_intent(state: AgentTurnState) -> str:

--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -46,6 +46,22 @@ def handle_ask_clarification_node(state: AgentTurnState) -> dict[str, Any]:
     return dict(state)
 
 
+def handle_create_project_node(state: AgentTurnState) -> dict[str, Any]:
+    return dict(state)
+
+
+def handle_join_project_node(state: AgentTurnState) -> dict[str, Any]:
+    return dict(state)
+
+
+def handle_leave_project_node(state: AgentTurnState) -> dict[str, Any]:
+    return dict(state)
+
+
+def handle_send_direct_message_node(state: AgentTurnState) -> dict[str, Any]:
+    return dict(state)
+
+
 # --- Simple vertical slice handlers ---
 
 _RELATIONSHIP_INCREMENT = 0.1


### PR DESCRIPTION
## Summary
- move project-related handlers to `interaction_handlers.py`
- re-export moved handlers in `basic_agent_graph`
- keep `agent_graph_builder` importing new handlers for future use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68436cfd17748326945774c250fffe06