### PR TITLE
Fix return type annotations and ruff cleanup

### DIFF
--- a/tests/unit/graphs/test_agent_graph_builder.py
+++ b/tests/unit/graphs/test_agent_graph_builder.py
@@ -2,7 +2,8 @@ import pytest
 
 pytest.importorskip("langgraph")
 
-from langgraph.graph.graph import START, END, Graph
+from langgraph.graph.graph import END, START, Graph
+
 from src.agents.graphs.agent_graph_builder import build_graph
 
 

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -1,16 +1,15 @@
-import types
 from types import SimpleNamespace
 
 import pytest
 
 from src.agents.graphs.graph_nodes import (
+    _format_knowledge_board,
+    _format_other_agents,
     analyze_perception_sentiment_node,
     finalize_message_agent_node,
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
-    _format_knowledge_board,
-    _format_other_agents,
 )
 
 
@@ -55,12 +54,16 @@ async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
 
 
 class DummyManager:
-    async def aretrieve_relevant_memories(self, agent_id: str, query: str = "", k: int = 5):
+    async def aretrieve_relevant_memories(
+        self, agent_id: str, query: str = "", k: int = 5
+    ) -> list[dict[str, str]]:
         return [{"content": "m1"}, {"content": "m2"}]
 
 
 class DummyAgent:
-    async def async_generate_l1_summary(self, role: str, memories: str, context: str):
+    async def async_generate_l1_summary(
+        self, role: str, memories: str, context: str
+    ) -> SimpleNamespace:
         return SimpleNamespace(summary="SUM")
 
 

--- a/tests/unit/graphs/test_interaction_handlers.py
+++ b/tests/unit/graphs/test_interaction_handlers.py
@@ -2,15 +2,15 @@ import pytest
 
 from src.agents.core.agent_attributes import AgentAttributes
 from src.agents.graphs.interaction_handlers import (
+    _UNLOCKED_CAPABILITY,
+    handle_ask_clarification_node,
+    handle_continue_collaboration_node,
+    handle_deep_analysis_node,
+    handle_idle_node,
     handle_propose_idea,
     handle_propose_idea_node,
-    handle_continue_collaboration_node,
-    handle_idle_node,
-    handle_ask_clarification_node,
-    handle_deep_analysis_node,
     handle_retrieve_and_update,
 )
-from src.agents.graphs.interaction_handlers import _UNLOCKED_CAPABILITY
 from src.infra.config import (
     DU_AWARD_FOR_PROPOSAL,
     DU_COST_DEEP_ANALYSIS,


### PR DESCRIPTION
## Summary
- fix missing return type hints in graph node tests
- sort imports in graph node tests

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68436e59c5e483268cf16845b3644e6e