### PR TITLE
Implement MemoryStore protocol in vector store managers

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -25,6 +25,7 @@ from src.infra.config import get_config
 from src.infra.llm_client import get_ollama_client
 from src.interfaces.dashboard_backend import AgentMessage, message_sse_queue
 from src.shared.async_utils import AsyncDSPyManager
+from src.shared.memory_store import MemoryStore
 
 from .agent_controller import AgentController
 
@@ -68,7 +69,7 @@ class Agent:
         agent_id: str | None = None,
         initial_state: dict[str, Any] | None = None,
         name: str | None = None,
-        vector_store_manager: Optional[object] = None,
+        vector_store_manager: Optional[MemoryStore] = None,
         async_dspy_manager: Optional[AsyncDSPyManager] = None,
     ):
         """
@@ -81,15 +82,15 @@ class Agent:
                 If None is provided, default values will be used.
             name (str, optional): A name for the agent. If None is provided,
                 a default name based on agent_id will be used.
-            vector_store_manager (Optional[object], optional): Manager for vector-based memory
+            vector_store_manager (Optional[MemoryStore], optional): Manager for vector-based memory
                 storage and retrieval. Used to persist memory events.
             async_dspy_manager (Optional[AsyncDSPyManager], optional): Manager for DSPy program execution.
         """
         # Generate a unique ID if none provided
         self.agent_id = agent_id if agent_id else str(uuid.uuid4())
 
-        # Explicitly declare vector_store_manager as object for Mypy
-        # self.vector_store_manager: object # Declaration moved to parameter
+        # Explicitly declare vector_store_manager for Mypy
+        # self.vector_store_manager: MemoryStore | None
 
         # Initialize as empty if not provided
         if initial_state is None:
@@ -356,7 +357,8 @@ class Agent:
         self: Self,
         simulation_step: int,
         environment_perception: dict[str, Any] | None = None,
-        vector_store_manager: object = None,  # Accepts any vector store manager implementation
+        vector_store_manager: MemoryStore
+        | None = None,  # Accepts any vector store manager implementation
         knowledge_board: Optional["KnowledgeBoard"] = None,
     ) -> dict[str, Any]:
         """
@@ -366,7 +368,7 @@ class Agent:
             simulation_step (int): The current step number from the simulation.
             environment_perception (Dict[str, Any], optional): Perception data from the
                 environment.
-            vector_store_manager (Optional[object], optional): Manager for vector-based memory
+            vector_store_manager (Optional[MemoryStore], optional): Manager for vector-based memory
                 storage and retrieval. Used to persist memory events.
             knowledge_board (Optional[KnowledgeBoard], optional): Knowledge board instance
                 that agents can read from and write to.

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -21,9 +21,9 @@ except Exception:  # pragma: no cover - optional dependency
 
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
-import requests  # type: ignore[import-untyped]
+import requests
 from pydantic import BaseModel, ValidationError
-from requests.exceptions import RequestException  # type: ignore[import-untyped]
+from requests.exceptions import RequestException
 
 from src.shared.decorator_utils import monitor_llm_call
 

--- a/src/shared/memory_store.py
+++ b/src/shared/memory_store.py
@@ -2,21 +2,22 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
 
+@runtime_checkable
 class MemoryStore(Protocol):
     """Protocol for simple memory stores used in tests."""
 
-    def add_documents(self, documents: list[str], metadatas: list[dict[str, Any]]) -> None:
+    def add_documents(self: Any, documents: list[str], metadatas: list[dict[str, Any]]) -> None:
         """Add a batch of documents with associated metadata."""
 
-    def query(self, query: str, top_k: int = 1) -> list[dict[str, Any]]:
+    def query(self: Any, query: str, top_k: int = 1) -> list[dict[str, Any]]:
         """Return the ``top_k`` most relevant documents."""
 
-    def prune(self, ttl_seconds: int) -> None:
+    def prune(self: Any, ttl_seconds: int) -> None:
         """Remove entries older than ``ttl_seconds`` based on ``timestamp`` metadata."""
 
 

--- a/tests/unit/memory/test_memory_store_protocol.py
+++ b/tests/unit/memory/test_memory_store_protocol.py
@@ -1,5 +1,6 @@
+import pathlib
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,3 +41,46 @@ def test_weaviate_ttl_prune(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(time, "time", lambda: 12)
     store.prune(5)
     mock_collection.data.delete_by_id.assert_called_once_with("1")
+
+
+@pytest.mark.unit
+def test_chroma_manager_protocol(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("chromadb")
+    from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+    manager: MemoryStore = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path),
+        embedding_function=lambda texts: [[0.0] * 8 for _ in texts],
+    )
+    manager.add_documents(["doc"], [{"timestamp": 0}])
+    results = manager.query("doc", top_k=1)
+    assert results and results[0]["content"] == "doc"
+    monkeypatch.setattr(time, "time", lambda: 10)
+    manager.prune(5)
+    assert manager.query("doc", top_k=1) == []
+
+
+@pytest.mark.unit
+def test_weaviate_manager_protocol(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("weaviate")
+    pytest.importorskip("weaviate.classes")
+    from src.agents.memory.weaviate_vector_store_manager import WeaviateVectorStoreManager
+
+    mock_collection = MagicMock()
+    mock_collection.data.insert_many = MagicMock()
+    mock_collection.data.delete_by_id = MagicMock()
+    mock_collection.query.near_vector = MagicMock(return_value=MagicMock(objects=[]))
+
+    mock_collections = MagicMock()
+    mock_collections.get.return_value = mock_collection
+    mock_collections.exists.return_value = True
+    mock_client = MagicMock(collections=mock_collections)
+
+    with patch.object(WeaviateVectorStoreManager, "_connect_client", return_value=mock_client):
+        manager: MemoryStore = WeaviateVectorStoreManager(
+            url="http://x", collection_name="Test", embedding_function=lambda x: [0.0]
+        )
+    manager.add_documents(["doc"], [{"timestamp": 0}])
+    monkeypatch.setattr(time, "time", lambda: 10)
+    manager.prune(5)
+    mock_collection.data.delete_by_id.assert_called_once()


### PR DESCRIPTION
## Summary
- refactor ChromaVectorStoreManager and WeaviateVectorStoreManager to implement `MemoryStore`
- update BaseAgent and AgentController to accept protocol instances
- add runtime-checkable `MemoryStore` protocol
- expand unit tests for protocol compliance
- clean up unused ignores in `llm_client`

## Testing
- `pre-commit run --files src/shared/memory_store.py src/agents/memory/vector_store.py src/agents/memory/weaviate_vector_store_manager.py src/agents/core/base_agent.py src/agents/core/agent_controller.py src/infra/llm_client.py tests/unit/memory/test_memory_store_protocol.py`
- `pytest tests/unit/memory/test_memory_store_protocol.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68436cfdf82483269ab4b6b0687ddb50