### PR TITLE
Add persistence to test memory store

### DIFF
--- a/docs/development_notes/TASK_149_VERTICAL_SLICE.md
+++ b/docs/development_notes/TASK_149_VERTICAL_SLICE.md
@@ -3,7 +3,7 @@
 This document summarizes the minimal end-to-end pipeline implemented for Task 149. The tests exercise a simple interaction loop:
 
 1. **Agent A proposes an idea.** Influence Points are reduced and Data Units are awarded.
-2. **The Knowledge Board stores the idea.** A lightweight in-memory store stands in for ChromaDB during tests.
+2. **The Knowledge Board stores the idea.** A lightweight in-memory store stands in for ChromaDB during tests and can optionally persist to disk.
 3. **Agent B retrieves the idea.** The retrieval updates Agent B's relationship with Agent A.
 4. **Full flow validation.** Integration tests confirm the step sequence A → B succeeds.
 

--- a/src/shared/memory_store.py
+++ b/src/shared/memory_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 import time
 import uuid
 from typing import Any, Protocol, runtime_checkable
@@ -22,15 +24,32 @@ class MemoryStore(Protocol):
 
 
 class ChromaMemoryStore(MemoryStore):
-    """Minimal in-memory stand-in for ChromaDB used in tests."""
+    """Minimal in-memory stand-in for ChromaDB used in tests.
+
+    If ``persist_directory`` is provided, the store will load from and save to
+    ``chroma_memory.json`` in that directory.
+    """
 
     def __init__(self: Self, persist_directory: str | None = None) -> None:
         self._store: list[dict[str, Any]] = []
+        self._persist_path: str | None = None
+        if persist_directory is not None:
+            os.makedirs(persist_directory, exist_ok=True)
+            self._persist_path = os.path.join(persist_directory, "chroma_memory.json")
+            if os.path.exists(self._persist_path):
+                try:
+                    with open(self._persist_path, encoding="utf-8") as fh:
+                        self._store = json.load(fh)
+                except Exception:
+                    self._store = []
 
     def add_documents(self: Self, documents: list[str], metadatas: list[dict[str, Any]]) -> None:
         for doc, meta in zip(documents, metadatas):
             entry = {"content": doc, "metadata": meta, "id": str(uuid.uuid4())}
             self._store.append(entry)
+        if self._persist_path is not None:
+            with open(self._persist_path, "w", encoding="utf-8") as fh:
+                json.dump(self._store, fh)
 
     def query(self: Self, query: str, top_k: int = 1) -> list[dict[str, Any]]:
         # Ignore query text for this simplified implementation
@@ -44,6 +63,9 @@ class ChromaMemoryStore(MemoryStore):
             if ts is None or ts >= threshold:
                 remaining.append(entry)
         self._store = remaining
+        if self._persist_path is not None:
+            with open(self._persist_path, "w", encoding="utf-8") as fh:
+                json.dump(self._store, fh)
 
 
 class WeaviateMemoryStore(MemoryStore):


### PR DESCRIPTION
## Summary
- make ChromaMemoryStore persist to a JSON file when a directory is provided
- document the optional persistence in the vertical slice notes

## Testing
- `ruff check`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843911d6af48326910a200d86c19c9b