### PR TITLE
Add memory logging for proposed ideas

### DIFF
--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -77,6 +77,7 @@ def handle_propose_idea(
     idea_text = f"Idea from {agent.id}"
     metadata = {"author": agent.id}
     knowledge_board.add_documents([idea_text], [metadata])
+    memory_store.add_documents([idea_text], [metadata])
     agent.ip -= IP_COST_TO_POST_IDEA
     agent.du += config.DU_AWARD_FOR_PROPOSAL
 

--- a/tests/unit/graphs/test_interaction_handlers.py
+++ b/tests/unit/graphs/test_interaction_handlers.py
@@ -65,8 +65,10 @@ def test_handle_propose_idea() -> None:
     agent.ip = 8
     agent.du = 0
     handle_propose_idea(agent, memory, board)
-    docs = board.query("", top_k=1)
-    assert docs[0]["metadata"]["author"] == "a"
+    docs_board = board.query("", top_k=1)
+    docs_memory = memory.query("", top_k=1)
+    assert docs_board[0]["metadata"]["author"] == "a"
+    assert docs_memory[0]["metadata"]["author"] == "a"
     assert agent.ip == 8 - IP_COST_TO_POST_IDEA
     assert agent.du == DU_AWARD_FOR_PROPOSAL
 


### PR DESCRIPTION
## Summary
- store proposed idea in both board and agent memory
- cover new behavior in unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843911ebb208326bcb264cfd381da18