### PR TITLE
Ensure memory store persistence

### DIFF
--- a/docs/development_notes/TASK_149_VERTICAL_SLICE.md
+++ b/docs/development_notes/TASK_149_VERTICAL_SLICE.md
@@ -3,7 +3,7 @@
 This document summarizes the minimal end-to-end pipeline implemented for Task 149. The tests exercise a simple interaction loop:
 
 1. **Agent A proposes an idea.** Influence Points are reduced and Data Units are awarded.
-2. **The Knowledge Board stores the idea.** A lightweight in-memory store stands in for ChromaDB during tests and can optionally persist to disk.
+2. **The Knowledge Board stores the idea.** A lightweight in-memory store stands in for ChromaDB during tests and can optionally persist to disk. When `persist_directory` is supplied, data is written to `chroma_memory.json` within that folder.
 3. **Agent B retrieves the idea.** The retrieval updates Agent B's relationship with Agent A.
 4. **Full flow validation.** Integration tests confirm the step sequence A → B succeeds.
 

--- a/tests/unit/memory/test_memory_store_protocol.py
+++ b/tests/unit/memory/test_memory_store_protocol.py
@@ -84,3 +84,14 @@ def test_weaviate_manager_protocol(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(time, "time", lambda: 10)
     manager.prune(5)
     mock_collection.data.delete_by_id.assert_called_once()
+
+
+@pytest.mark.unit
+def test_chroma_persistence(tmp_path: pathlib.Path) -> None:
+    """Data persists when a directory is provided."""
+    store = ChromaMemoryStore(persist_directory=str(tmp_path))
+    store.add_documents(["persist"], [{"timestamp": 0}])
+
+    reload_store = ChromaMemoryStore(persist_directory=str(tmp_path))
+    results = reload_store.query("", top_k=1)
+    assert results and results[0]["content"] == "persist"


### PR DESCRIPTION
## Summary
- document how the test memory store writes to disk
- test that ChromaMemoryStore loads persisted data

## Testing
- `pytest tests/unit/memory/test_memory_store_protocol.py::test_chroma_persistence -q`
- `pytest tests/unit -q` *(fails: AgentState validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68439f75ecf48326968cb6149c89587e