### PR TITLE
Fix pytest asyncio warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -64,5 +64,4 @@ python_functions = test_*
 
 # Asyncio mode for pytest-asyncio
 # Options: auto, strict, legacy
-asyncio_mode = auto 
-asyncio_default_fixture_loop_scope = function
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,6 @@ pytest-cov==4.1.0
 black==23.7.0
 types-requests==2.31.0
 pytest-xdist==3.7.0
-pytest-asyncio
+pytest-asyncio>=0.21
 requests
 pydantic-settings


### PR DESCRIPTION
## Summary
- pin `pytest-asyncio` version
- remove deprecated `asyncio_default_fixture_loop_scope` config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447388b3b88326996a3ce0b5b0a610