### PR TITLE
Run integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
+          pip install chromadb weaviate-client langgraph
 
       - name: Run Ruff (Lint)
         run: ruff check . --output-format=full
@@ -29,6 +30,9 @@ jobs:
       - name: Run Tests & Coverage
         run: |
           pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=0
+
+      - name: Run Integration Tests
+        run: pytest -m "integration" --disable-warnings -q
 
       - name: Run Black (Formatter)
         run: black --check . 


### PR DESCRIPTION
## Summary
- install chromadb, weaviate-client and langgraph in CI
- run integration tests in CI for full pipeline coverage

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: unrecognized arguments: -n)*


------
https://chatgpt.com/codex/tasks/task_e_6844738926648326ad66528a0c24c63c