### PR TITLE
Fix missing imports in AgentController

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import Any, cast
 
 from typing_extensions import Self


### PR DESCRIPTION
## Summary
- add `asyncio` and `time` imports to AgentController
- run `ruff` and `mypy` on the module

## Testing
- `ruff check src/agents/core/agent_controller.py`
- `mypy src/agents/core/agent_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_6844d3a9b4148326b7686e0253a0a06d