### PR TITLE
Add HTTP dashboard app and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Run a simulation with Discord integration:
 python -m src.app --discord
 ```
 
+Start the optional HTTP dashboard backend (for streaming events via SSE):
+
+```bash
+python -m src.http_app
+```
+
 ### Configuring a Simulation Scenario
 
 You can modify the `DEFAULT_SCENARIO` constant in `src/app.py` to define a specific context and goal for your agents:
@@ -489,14 +495,20 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    - Copy `.env.example` to `.env` and edit as needed:
     - `OLLAMA_API_BASE` (e.g., http://localhost:11434)
     - `OLLAMA_REQUEST_TIMEOUT` (request timeout in seconds)
-     - `WEAVIATE_URL` (e.g., http://localhost:8080)
-     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
+    - `WEAVIATE_URL` (e.g., http://localhost:8080)
+    - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
+    - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)
    - See `.env.example` and `docs/testing.md` for details.
 
 ### Running the Simulation
 Run a basic simulation (default parameters):
 ```bash
 python -m src.app --steps 5
+```
+
+Start the HTTP dashboard backend (optional):
+```bash
+python -m src.http_app
 ```
 
 ### Walking Vertical Slice

--- a/src/http_app.py
+++ b/src/http_app.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+from src.interfaces.dashboard_backend import app
+
+
+def main() -> None:
+    """Run the FastAPI application for the dashboard backend."""
+    host = os.getenv("HTTP_HOST", "0.0.0.0")
+    port_str = os.getenv("HTTP_PORT", "8000")
+    try:
+        port = int(port_str)
+    except ValueError as exc:  # pragma: no cover - simple runtime safeguard
+        raise ValueError(f"Invalid HTTP_PORT value: {port_str}") from exc
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `src/http_app.py` to run FastAPI dashboard backend
- update README Quickstart with `python -m src.http_app` and Discord env vars

## Testing
- `ruff check src/http_app.py`
- `mypy --config-file=pyproject.toml src/http_app.py` *(fails: return type becomes "Coroutine[Any, Any, Any]")*
- `pytest tests/test_pytest_sanity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844dbd467c08326a00c8b017cf1c80f