### PR TITLE
Fix relationships loop in simulation test

### DIFF
--- a/tests/integration/agents/test_vertical_slice_simulation.py
+++ b/tests/integration/agents/test_vertical_slice_simulation.py
@@ -76,7 +76,7 @@ def test_vertical_slice_simulation() -> None:
     asyncio.run(sim.async_run(sim.steps_to_run))
     assert len(sim.knowledge_board.get_full_entries()) >= 1
     relationships_updated = any(
-        any(score != 0.0 for score in agent.state.relationships.values()) for agent in sim.agent
-    
+        any(score != 0.0 for score in agent.state.relationships.values())
+        for agent in sim.agents
     )
     assert relationships_updated


### PR DESCRIPTION
## Summary
- fix list comprehension to iterate over `sim.agents` for relationship checks
- ensure integration test `test_vertical_slice_simulation` passes

## Testing
- `pytest -m integration tests/integration/agents/test_vertical_slice_simulation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844dbd312208326b5afac834fbc6132