### PR TITLE
Fix mypy check for dashboard backend

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -26,7 +26,7 @@ app = FastAPI()
 
 
 @app.get("/stream/messages")
-async def stream_messages(request: Request) -> EventSourceResponse:
+async def stream_messages(request: Request) -> EventSourceResponse:  # type: ignore[no-any-unimported]
     async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
         while True:
             if await request.is_disconnected():


### PR DESCRIPTION
## Summary
- ignore missing `EventSourceResponse` typing so mypy passes

## Testing
- `mypy src/ --strict`

------
https://chatgpt.com/codex/tasks/task_e_6844dbd261ac83269b27e49a62306ada