### PR TITLE
Fix fallback when requests not installed

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -42,7 +42,6 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 
 from pydantic import BaseModel, ValidationError
-from requests.exceptions import RequestException
 
 from src.shared.decorator_utils import monitor_llm_call
 


### PR DESCRIPTION
## Summary
- fix optional requests import to avoid failures when the `requests` library is missing

## Testing
- `ruff check --diff`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f8966af48326b63c346ca9480107