### PR TITLE
Increase coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run Tests & Coverage
         run: |
-          pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=0
+          pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=90
 
       - name: Run Integration Tests
         run: pytest -m "integration" --disable-warnings -q


### PR DESCRIPTION
## Summary
- enforce higher coverage in CI workflow (`--cov-fail-under=90`)

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict`
- `pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=90` *(fails: Required test coverage of 90% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6844e5a11ccc83269af8c9c3558e492b