### PR TITLE
Add Windows runner to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- expand GitHub Actions to run tests on Windows and Linux

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_6844f8f21f1c83269408d08e145b4239