### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -1,0 +1,88 @@
+import random
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.graphs import basic_agent_graph as bag
+
+
+class DummyController:
+    def __init__(self, state: object | None = None) -> None:
+        self.state = state
+        self.added = []
+
+    def add_memory(self, *args: object) -> None:
+        self.added.append(args)
+
+
+def make_agent_state() -> SimpleNamespace:
+    return SimpleNamespace(
+        agent_id="a",
+        role="Innovator",
+        steps_in_current_role=5,
+        role_change_cooldown=3,
+        ip=10.0,
+        role_change_ip_cost=2.0,
+        role_history=[],
+        last_action_step=0,
+        short_term_memory=[],
+        du=0.0,
+    )
+
+
+@pytest.mark.unit
+def test_process_role_change_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = make_agent_state()
+    assert bag.process_role_change(state, "Analyzer") is True
+    assert state.role == "Analyzer"
+    assert state.ip == 8.0
+
+
+@pytest.mark.unit
+def test_update_state_node_role_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = make_agent_state()
+    controller = DummyController(state)
+    monkeypatch.setattr(bag, "AgentController", lambda s: controller)
+    monkeypatch.setattr(random, "random", lambda: 0.9)
+
+    output = bag.update_state_node(
+        {
+            "agent_id": "a",
+            "simulation_step": 1,
+            "structured_output": SimpleNamespace(
+                action_intent="propose_idea", requested_role_change="Analyzer"
+            ),
+            "state": state,
+        }
+    )
+
+    assert state.role == "Analyzer"
+    assert controller.added[0][2].startswith("Changed role")
+    assert output["data_units"] == int(state.du)
+
+
+@pytest.mark.unit
+def test_route_helpers() -> None:
+    out_broadcast = bag.route_broadcast_decision({"structured_output": SimpleNamespace(message_content="hi")})
+    assert out_broadcast == "broadcast"
+    out_exit = bag.route_broadcast_decision({"structured_output": None})
+    assert out_exit == "exit"
+
+    agent = make_agent_state()
+    agent.relationships = {"b": 0.1}
+    out_rel = bag.route_relationship_context({"state": agent})
+    assert out_rel == "has_relationships"
+    assert bag.route_relationship_context({"state": SimpleNamespace(relationships={})}) == "no_relationships"
+
+    intent_out = bag.route_action_intent({"structured_output": SimpleNamespace(action_intent="join_project")})
+    assert intent_out == "handle_join_project"
+
+
+@pytest.mark.unit
+def test_compile_agent_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyGraph:
+        def compile(self) -> str:
+            return "compiled"
+
+    monkeypatch.setattr(bag, "build_graph", lambda: DummyGraph())
+    assert bag.compile_agent_graph() == "compiled"

--- a/tests/unit/infra/test_config_utils.py
+++ b/tests/unit/infra/test_config_utils.py
@@ -1,0 +1,29 @@
+import importlib
+
+import pytest
+
+from src.infra import config
+
+
+@pytest.mark.unit
+def test_get_relationship_label_ranges() -> None:
+    assert config.get_relationship_label(-0.8) == "Hostile"
+    assert config.get_relationship_label(0.0) == "Neutral"
+    assert config.get_relationship_label(0.6) == "Positive"
+
+
+@pytest.mark.unit
+def test_get_config_value_with_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(config.CONFIG_OVERRIDES, "TEST_KEY", "from_override")
+    assert (
+        config.get_config_value_with_override("TEST_KEY", default="def", module_name="src.infra.config")
+        == "from_override"
+    )
+
+
+@pytest.mark.unit
+def test_get_config_value_with_missing_module() -> None:
+    assert (
+        config.get_config_value_with_override("MISSING", default="def", module_name="nonexistent.module")
+        == "def"
+    )

--- a/tests/unit/shared/test_llm_mocks.py
+++ b/tests/unit/shared/test_llm_mocks.py
@@ -1,0 +1,45 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared import llm_mocks
+
+
+@pytest.mark.unit
+def test_is_ollama_running_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummySocket:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+        def settimeout(self, *args: object) -> None:  # noqa: D401 - thin wrapper
+            pass
+        def connect(self, addr: tuple[str, int]) -> None:
+            raise OSError()
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("socket.socket", lambda *a, **k: DummySocket())
+    assert llm_mocks.is_ollama_running() is False
+
+
+@pytest.mark.unit
+def test_create_mock_ollama_client_chat_and_generate() -> None:
+    client = llm_mocks.create_mock_ollama_client()
+
+    neg = client.chat(messages=[{"content": "Analyze the sentiment of the following message. Strongly disagree"}])
+    assert json.loads(neg["message"]["content"])["sentiment_score"] == -0.7
+
+    gen = client.generate(prompt="Your output fields are: `l1_summary` (str)\nrecent_events")
+    assert "l1_summary" in json.loads(gen["response"])
+
+    fallback = client.generate(prompt="something else")
+    assert "Fallback" in json.loads(fallback["response"])["detail"]
+
+
+@pytest.mark.unit
+def test_patch_ollama_functions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.infra import llm_client
+
+    llm_mocks.patch_ollama_functions(monkeypatch)
+    assert llm_client.generate_text("test") == llm_mocks.mock_text_global
+    assert isinstance(llm_client.client.chat, MagicMock)

--- a/tests/unit/utils/test_async_dspy_manager_shutdown.py
+++ b/tests/unit/utils/test_async_dspy_manager_shutdown.py
@@ -1,0 +1,10 @@
+import pytest
+
+from src.shared.async_utils import AsyncDSPyManager
+
+
+@pytest.mark.unit
+def test_shutdown_no_errors() -> None:
+    mgr = AsyncDSPyManager(max_workers=1)
+    mgr.shutdown()
+    assert True


### PR DESCRIPTION
## Summary
- test is_ollama_running and mock client helpers
- cover config utility functions
- add basic_agent_graph helper tests
- test AsyncDSPyManager shutdown

## Testing
- `pre-commit run --files tests/unit/graphs/test_basic_agent_graph_utils.py tests/unit/infra/test_config_utils.py tests/unit/shared/test_llm_mocks.py tests/unit/utils/test_async_dspy_manager_shutdown.py`
- `pytest --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_68459e6a52308326b1a941a2bb013881