### PR TITLE
Add asyncio settings to pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -62,6 +62,7 @@ python_classes = Test*
 # Python functions pattern
 python_functions = test_*
 
-# Asyncio mode for pytest-asyncio
-# Options: auto, strict, legacy
+# Asyncio settings for pytest-asyncio
+# Options for asyncio_mode: auto, strict, legacy
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/tests/integration/agents/test_vertical_slice_simulation.py
+++ b/tests/integration/agents/test_vertical_slice_simulation.py
@@ -76,8 +76,6 @@ def test_vertical_slice_simulation() -> None:
     asyncio.run(sim.async_run(sim.steps_to_run))
     assert len(sim.knowledge_board.get_full_entries()) >= 1
     relationships_updated = any(
-        any(score != 0.0 for score in agent.state.relationships.values())
-        for agent in sim.agents
-
+        any(score != 0.0 for score in agent.state.relationships.values()) for agent in sim.agents
     )
     assert relationships_updated


### PR DESCRIPTION
## Summary
- configure pytest-asyncio fixture loop scope
- add fastapi stub in unit test to avoid import error
- reformat vertical slice simulation test

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 5 files)*
- `mypy --config-file pyproject.toml src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459e6bad9483269257d44651730e20