### PR TITLE
Update linting workflow and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ Welcome! We're excited that you're interested in contributing to Culture.ai. Thi
 ## Getting Started
 - **Read the [README.md](README.md)** for setup, prerequisites, and quickstart instructions.
 - Install development tools:
-  - [Ruff](https://docs.astral.sh/ruff/) for linting/formatting
-  - [Mypy](http://mypy-lang.org/) for static type checking
+- [Ruff](https://docs.astral.sh/ruff/) for linting/formatting
+- [Mypy](http://mypy-lang.org/) for static type checking
+- Install dependencies from `requirements-dev.txt` (includes `pytest-xdist`) in addition to `requirements.txt`.
 - Set up your environment and dependencies as described in the README.
 
 ## Code Style Guidelines

--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ python -m pytest --cov=src --cov-report=term-missing tests/
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on code style, review, and testing.
 
 For advanced testing, parallelization, and CI details, see [docs/testing.md](docs/testing.md).
+CI workflows are skipped when a commit only modifies documentation (`*.md` files or files under `docs/`).
 
 ## Code Quality and Type Safety
 

--- a/docs/code_review_process.md
+++ b/docs/code_review_process.md
@@ -43,7 +43,7 @@ Before submitting code for review, the author should:
 
 1. **Self-Review**: Perform a self-review of the code using the same criteria a reviewer would
 2. **Follow Standards**: Ensure code adheres to `docs/coding_standards.md`
-3. **Run Linters**: Execute `scripts/lint.sh` or `scripts/lint.bat` and address all reported issues
+3. **Run Linters**: Execute `scripts/lint.sh --format` (or `scripts/lint.bat --format`) and address all reported issues
 4. **Test Coverage**: Write and execute tests for the changes, ensuring all tests pass
 5. **Clear Description**: Provide a clear description of the changes, including:
    - What problem the change solves
@@ -159,7 +159,7 @@ To support the review process, we recommend the following branching strategy:
 
 ## 7. Tools and Resources
 
-- Linting: `scripts/lint.sh` or `scripts/lint.bat`
+ - Linting: `scripts/lint.sh --format` or `scripts/lint.bat --format`
 - Code Standards: `docs/coding_standards.md`
 - Python Style Guide: [PEP 8](https://peps.python.org/pep-0008/)
 - Type Hinting Guide: [PEP 484](https://peps.python.org/pep-0484/)

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -297,15 +297,15 @@ To ensure code consistency and catch potential errors, you can run all checks an
 
 ```bash
 # On Linux/Mac:
-./scripts/lint.sh
+./scripts/lint.sh --format  # add --format to apply Ruff and Black formatting
 
 # On Windows:
-scripts\lint.bat
+scripts\lint.bat --format
 ```
 
 This script will:
 
-1. Format code using `ruff format` and Black
+1. Optionally format code using `ruff format` and Black when `--format` is supplied
 2. Lint the codebase with `ruff check`
 3. Perform static type checking using Mypy
 

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -281,10 +281,10 @@ The following tools are integrated to enforce these standards:
 
 ### 11.1. Formatting
 - **Black**: Automatic code formatter that enforces a consistent style by reformatting your code
-- **isort**: Import statement organizer that automatically sorts and groups imports
+- **Ruff**: Handles import sorting and minor formatting via `ruff format`
 
 ### 11.2. Linting
-- **Flake8**: Code style enforcement that checks your code against PEP 8 guidelines
+- **Ruff**: Fast linter covering most Flake8 rules
 - **Mypy**: Static type checker that helps catch type-related errors before runtime
 
 ### 11.3. Testing
@@ -305,10 +305,9 @@ scripts\lint.bat
 
 This script will:
 
-1. Format code using Black
-2. Sort imports using isort
-3. Check for PEP 8 compliance and other style issues using Flake8
-4. Perform static type checking using Mypy
+1. Format code using `ruff format` and Black
+2. Lint the codebase with `ruff check`
+3. Perform static type checking using Mypy
 
 It's recommended to run this script before committing changes.
 
@@ -322,16 +321,10 @@ black src/ tests/          # Format all files in src/ and tests/
 black path/to/specific.py  # Format a specific file
 ```
 
-**isort** (import sorting):
+**Ruff** (linting & import sorting):
 ```bash
-isort src/ tests/          # Sort imports in all files in src/ and tests/
-isort path/to/specific.py  # Sort imports in a specific file
-```
-
-**Flake8** (style checking):
-```bash
-flake8 src/ tests/         # Check style in all files in src/ and tests/
-flake8 path/to/specific.py # Check style in a specific file
+ruff format path/to/file.py  # Format and sort imports in a file
+ruff check src/ tests/       # Lint all files in src/ and tests/
 ```
 
 **Mypy** (type checking):

--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -310,6 +310,8 @@ This script will:
 3. Perform static type checking using Mypy
 
 It's recommended to run this script before committing changes.
+The format steps modify files in-place, so run the script prior to creating your
+commit to avoid unexpected diffs.
 
 #### Individual Tool Usage
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,6 +63,7 @@ Culture.ai uses [pytest-xdist](https://pytest-xdist.readthedocs.io/) for paralle
 - Fast unit tests run on every push/PR
 - Full suite runs nightly and on main branch merges
 - See `.github/workflows/tests.yml` for details
+- Pushes that only modify Markdown files or documentation paths are ignored by CI
 
 ## Adding/Updating Markers
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,8 +3,15 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
-echo "Running Ruff format..."
-ruff format src/ tests/
+FORMAT=0
+if [[ "$1" == "--format" || "$1" == "-f" ]]; then
+  FORMAT=1
+fi
+
+if [[ $FORMAT -eq 1 ]]; then
+  echo "Running Ruff format..."
+  ruff format src/ tests/
+fi
 
 echo "Running Ruff check..."
 ruff check src/ tests/

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,14 +3,14 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+echo "Running Ruff format..."
+ruff format src/ tests/
+
+echo "Running Ruff check..."
+ruff check src/ tests/
+
 echo "Running Black..."
 black src/ tests/
-
-echo "Running isort..."
-isort src/ tests/
-
-echo "Running Flake8..."
-flake8 src/ tests/
 
 echo "Running Mypy..."
 mypy src/ tests/

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -15,4 +15,9 @@ source "$VENV_DIR/bin/activate"
 python -m pip install --upgrade pip
 pip install -r requirements.txt -r requirements-dev.txt
 
+if ! python -c "import xdist" >/dev/null 2>&1; then
+    echo "pytest-xdist is required but not installed" >&2
+    exit 1
+fi
+
 echo "Environment ready. Run pytest with $VENV_DIR/bin/python -m pytest"

--- a/tests/unit/infra/test_config_utils.py
+++ b/tests/unit/infra/test_config_utils.py
@@ -1,5 +1,3 @@
-import importlib
-
 import pytest
 
 from src.infra import config
@@ -16,7 +14,9 @@ def test_get_relationship_label_ranges() -> None:
 def test_get_config_value_with_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(config.CONFIG_OVERRIDES, "TEST_KEY", "from_override")
     assert (
-        config.get_config_value_with_override("TEST_KEY", default="def", module_name="src.infra.config")
+        config.get_config_value_with_override(
+            "TEST_KEY", default="def", module_name="src.infra.config"
+        )
         == "from_override"
     )
 
@@ -24,6 +24,8 @@ def test_get_config_value_with_override(monkeypatch: pytest.MonkeyPatch) -> None
 @pytest.mark.unit
 def test_get_config_value_with_missing_module() -> None:
     assert (
-        config.get_config_value_with_override("MISSING", default="def", module_name="nonexistent.module")
+        config.get_config_value_with_override(
+            "MISSING", default="def", module_name="nonexistent.module"
+        )
         == "def"
     )

--- a/tests/unit/shared/test_llm_mocks.py
+++ b/tests/unit/shared/test_llm_mocks.py
@@ -34,7 +34,9 @@ def test_create_mock_ollama_client_chat_and_generate() -> None:
     )
     assert json.loads(neg["message"]["content"])["sentiment_score"] == -0.7
 
-    gen = client.generate(prompt="Your output fields are: `l1_summary` (str)\nrecent_events")
+    gen = client.generate(
+        prompt="Your output fields are: `l1_summary` (str)\n`recent_events` (str)\n`agent_role` (str)"
+    )
     assert "l1_summary" in json.loads(gen["response"])
 
     fallback = client.generate(prompt="something else")

--- a/tests/unit/shared/test_llm_mocks.py
+++ b/tests/unit/shared/test_llm_mocks.py
@@ -11,10 +11,13 @@ def test_is_ollama_running_false(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummySocket:
         def __init__(self, *args: object, **kwargs: object) -> None:
             pass
-        def settimeout(self, *args: object) -> None:  # noqa: D401 - thin wrapper
+
+        def settimeout(self, *args: object) -> None:
             pass
+
         def connect(self, addr: tuple[str, int]) -> None:
             raise OSError()
+
         def close(self) -> None:
             pass
 
@@ -26,7 +29,9 @@ def test_is_ollama_running_false(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_create_mock_ollama_client_chat_and_generate() -> None:
     client = llm_mocks.create_mock_ollama_client()
 
-    neg = client.chat(messages=[{"content": "Analyze the sentiment of the following message. Strongly disagree"}])
+    neg = client.chat(
+        messages=[{"content": "Analyze the sentiment of the following message. Strongly disagree"}]
+    )
     assert json.loads(neg["message"]["content"])["sentiment_score"] == -0.7
 
     gen = client.generate(prompt="Your output fields are: `l1_summary` (str)\nrecent_events")


### PR DESCRIPTION
## Summary
- clean Ruff errors in tests
- modernize lint script and CI to ignore docs-only pushes
- document running tests and skip behavior
- enforce pytest-xdist check in setup script

## Testing
- `ruff check tests/unit/infra/test_config_utils.py tests/unit/shared/test_llm_mocks.py`
- `bash scripts/lint.sh` *(fails: reformatted multiple files)*
- `python -m pytest tests/` *(fails: TypeError: unsupported operand type(s) for *: 'dict' and 'float')*

------
https://chatgpt.com/codex/tasks/task_e_6845f82913b88326aa43fddd8f56c6ab