### PR TITLE
Remove unused timeout handler

### DIFF
--- a/src/shared/async_utils.py
+++ b/src/shared/async_utils.py
@@ -98,36 +98,6 @@ class AsyncDSPyManager:
         logger.info("Shutting down AsyncDSPyManager executor.")
         self.executor.shutdown(wait=wait)
 
-    def _handle_timeout(
-        self: Self,
-        future: asyncio.Future[object],
-        default_value: object = None,
-        timeout: float | None = None,
-        dspy_callable: Callable[..., object] | None = None,
-    ) -> object:
-        """Handle a timeout by cancelling the future and logging."""
-        timeout_val = timeout if timeout is not None else self.default_timeout
-        callable_name = (
-            getattr(dspy_callable, "__name__", str(dspy_callable))
-            if dspy_callable
-            else "Unnamed DSPy call"
-        )
-
-        logger.warning(
-            "AsyncDSPyManager._handle_timeout: Timeout awaiting result for "
-            f"{callable_name} after {timeout_val:.2f}s."
-        )
-
-        if not future.done():
-            if future.cancel():
-                logger.debug(f"Cancelled underlying task for {callable_name} due to timeout.")
-            else:
-                logger.debug(
-                    "Failed to cancel underlying task for "
-                    f"{callable_name} (might have already completed or started running)."
-                )
-        return default_value
-
     async def run_with_timeout_async(
         self: Self,
         program_callable: Callable[..., object],

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -63,7 +63,9 @@ def test_update_state_node_role_change(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.unit
 def test_route_helpers() -> None:
-    out_broadcast = bag.route_broadcast_decision({"structured_output": SimpleNamespace(message_content="hi")})
+    out_broadcast = bag.route_broadcast_decision(
+        {"structured_output": SimpleNamespace(message_content="hi")}
+    )
     assert out_broadcast == "broadcast"
     out_exit = bag.route_broadcast_decision({"structured_output": None})
     assert out_exit == "exit"
@@ -72,9 +74,14 @@ def test_route_helpers() -> None:
     agent.relationships = {"b": 0.1}
     out_rel = bag.route_relationship_context({"state": agent})
     assert out_rel == "has_relationships"
-    assert bag.route_relationship_context({"state": SimpleNamespace(relationships={})}) == "no_relationships"
+    assert (
+        bag.route_relationship_context({"state": SimpleNamespace(relationships={})})
+        == "no_relationships"
+    )
 
-    intent_out = bag.route_action_intent({"structured_output": SimpleNamespace(action_intent="join_project")})
+    intent_out = bag.route_action_intent(
+        {"structured_output": SimpleNamespace(action_intent="join_project")}
+    )
     assert intent_out == "handle_join_project"
 
 


### PR DESCRIPTION
## Summary
- drop unused `_handle_timeout` logic
- format test file with Black

## Testing
- `bash scripts/lint.sh`
- `pytest -q` *(fails: `test_compile_agent_graph`, `test_update_state_node_role_change`)*

------
https://chatgpt.com/codex/tasks/task_e_68460c52c2d08326815ff826571d326c