### PR TITLE
Mark test_generate_text_failure as unit

### DIFF
--- a/tests/unit/infra/test_llm_client_failure.py
+++ b/tests/unit/infra/test_llm_client_failure.py
@@ -3,12 +3,13 @@ from unittest.mock import MagicMock
 import pytest
 
 pytest.importorskip("requests")
-import requests
-from pytest import MonkeyPatch
+import requests  # noqa: E402
+from pytest import MonkeyPatch  # noqa: E402
 
-from src.infra import llm_client
+from src.infra import llm_client  # noqa: E402
 
 
+@pytest.mark.unit
 def test_generate_text_failure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(
         llm_client,


### PR DESCRIPTION
## Summary
- ensure the failure case test is marked as a unit test

## Testing
- `pre-commit run --files tests/unit/infra/test_llm_client_failure.py`
- `pytest tests/unit/infra/test_llm_client_failure.py::test_generate_text_failure -vv`


------
https://chatgpt.com/codex/tasks/task_e_68460c55bf408326a555e4c4c910ea4a