### PR TITLE
Fix LLM client failure test mark

### DIFF
--- a/tests/unit/infra/test_llm_client_failure.py
+++ b/tests/unit/infra/test_llm_client_failure.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +11,7 @@ from src.infra import llm_client
 
 
 @pytest.mark.unit
+@pytest.mark.require_ollama
 def test_generate_text_failure(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(
         llm_client,


### PR DESCRIPTION
## Summary
- avoid ruff import ordering errors in LLM client failure test
- mark the failure test with `require_ollama`

## Testing
- `pre-commit run --files tests/unit/infra/test_llm_client_failure.py`
- `pytest tests/unit/infra/test_llm_client_failure.py::test_generate_text_failure -vv -m unit`

------
https://chatgpt.com/codex/tasks/task_e_68475a0c29888326a59647417fb13d6f