### PR TITLE
Add CI status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines 
 
 For advanced testing, parallelization, and CI details, see [docs/testing.md](docs/testing.md).
 CI workflows are skipped when a commit only modifies documentation (`*.md` files or files under `docs/`).
+See [docs/ci_status.md](docs/ci_status.md) for tips on checking CI status with the GitHub interface or the `gh` CLI. Because this repository has no remote configured by default, you'll need to add your GitHub remote before checking statuses.
 
 ## Code Quality and Type Safety
 

--- a/docs/ci_status.md
+++ b/docs/ci_status.md
@@ -1,0 +1,28 @@
+# Checking CI Status
+
+Culture.ai uses GitHub Actions to run tests and linters on each branch. This repository does not include a remote by default, so you must add your GitHub remote to view CI results.
+
+## Adding the Remote
+
+Use the `git remote add` command to connect your local clone to the GitHub repository:
+
+```bash
+git remote add origin https://github.com/<your-username>/Culture.git
+```
+
+Replace `<your-username>` with the appropriate account or organization.
+
+## Viewing Status in the GitHub Interface
+
+Once a remote is configured and pushed, navigate to the branch on GitHub. The latest workflow status appears near the top of the pull request or commit page.
+
+## Using the `gh` CLI
+
+Alternatively, the [GitHub CLI](https://cli.github.com/) allows querying status from the terminal:
+
+```bash
+# Show the most recent workflow run for the current branch
+gh run list --limit 1
+```
+
+This displays whether the CI workflow succeeded or failed.


### PR DESCRIPTION
## Summary
- document how to check CI status in a new `docs/ci_status.md`
- mention the new doc in `README`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476350403883268210e5f3d7ff4abd