### PR TITLE
Add memory role history tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,3 +122,19 @@ def ensure_dspy_predict(monkeypatch: MonkeyPatch) -> None:
             return type("Result", (), {"intent": "CONTINUE_COLLABORATION"})()
 
     monkeypatch.setattr(dspy, "Predict", DummyPredict, raising=False)
+
+@pytest.fixture(autouse=True)
+def ensure_langgraph(monkeypatch: MonkeyPatch) -> None:
+    """Provide minimal langgraph stubs when the package is missing."""
+    if "langgraph" in sys.modules:
+        return
+    import types
+
+    langgraph_mod = types.ModuleType("langgraph")
+    graph_mod = types.ModuleType("langgraph.graph")
+    graph_mod.StateGraph = object
+    graph_mod.START = "START"
+    graph_mod.END = "END"
+    langgraph_mod.graph = graph_mod
+    sys.modules["langgraph"] = langgraph_mod
+    sys.modules["langgraph.graph"] = graph_mod

--- a/tests/unit/memory/test_role_history.py
+++ b/tests/unit/memory/test_role_history.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tests.utils.dummy_chromadb import setup_dummy_chromadb
+
+
+@pytest.fixture(autouse=True)
+def _install_dummy_chromadb() -> None:
+    setup_dummy_chromadb()
+
+
+@pytest.mark.unit
+def test_get_role_history_builds_periods(tmp_path) -> None:
+    from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+    manager = ChromaVectorStoreManager(persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]])
+
+    manager.record_role_change("agent", 1, "R0", "R1")
+    manager.record_role_change("agent", 5, "R1", "R2")
+    manager.record_role_change("agent", 10, "R2", "R3")
+
+    history = manager.get_role_history("agent")
+    assert history == [
+        {"role": "R1", "start_step": 1, "end_step": 4},
+        {"role": "R2", "start_step": 5, "end_step": 9},
+        {"role": "R3", "start_step": 10, "end_step": None},
+    ]
+
+
+@pytest.mark.unit
+def test_retrieve_role_specific_memories_without_query(monkeypatch, tmp_path) -> None:
+    from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+    manager = ChromaVectorStoreManager(persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]])
+
+    monkeypatch.setattr(
+        manager,
+        "get_role_history",
+        lambda agent_id: [
+            {"role": "Analyst", "start_step": 0, "end_step": 2},
+            {"role": "Analyst", "start_step": 5, "end_step": 6},
+        ],
+    )
+
+    calls = []
+
+    def fake_retrieve(agent_id, filters=None, limit=None, include_usage_stats=False):
+        calls.append(filters)
+        return [{"id": len(calls)}]
+
+    monkeypatch.setattr(manager, "retrieve_filtered_memories", fake_retrieve)
+
+    memories = manager.retrieve_role_specific_memories("agent", role="Analyst", query=None, k=3)
+
+    assert len(memories) == 2
+    assert calls[0]["step"] == {"$gte": 0, "$lte": 2}
+    assert calls[1]["step"] == {"$gte": 5, "$lte": 6}
+

--- a/tests/utils/dummy_chromadb.py
+++ b/tests/utils/dummy_chromadb.py
@@ -1,0 +1,66 @@
+import sys
+import types
+
+
+def setup_dummy_chromadb() -> None:
+    """Install a lightweight stub of the ``chromadb`` package into ``sys.modules``."""
+
+    chromadb = types.ModuleType("chromadb")
+    utils = types.ModuleType("chromadb.utils")
+    emb = types.ModuleType("chromadb.utils.embedding_functions")
+
+    class SentenceTransformerEmbeddingFunction:
+        def __init__(self, model_name: str | None = None) -> None:  # pragma: no cover - simple stub
+            pass
+
+    emb.SentenceTransformerEmbeddingFunction = SentenceTransformerEmbeddingFunction
+    utils.embedding_functions = emb
+    chromadb.utils = utils
+
+    class DummyCollection:
+        def __init__(self) -> None:
+            self.docs: list[dict[str, object]] = []
+
+        def add(self, documents: list[str], metadatas: list[dict[str, object]], ids: list[str]) -> None:
+            for doc, meta, _id in zip(documents, metadatas, ids):
+                self.docs.append({"id": _id, "metadata": meta, "document": doc})
+
+        def get(self, where: dict | None = None, include: list[str] | None = None) -> dict:
+            ids: list[str] = []
+            metas: list[dict[str, object]] = []
+            conditions = where.get("$and", [where]) if where else []
+            for item in self.docs:
+                meta = item["metadata"]
+                match = True
+                for cond in conditions:
+                    for key, value in cond.items():
+                        if meta.get(key) != value:
+                            match = False
+                            break
+                    if not match:
+                        break
+                if match:
+                    ids.append(item["id"])
+                    metas.append(meta)
+            return {"ids": ids, "metadatas": metas}
+
+    class DummyClient:
+        def __init__(self, path: str | None = None) -> None:
+            self.collections: dict[str, DummyCollection] = {}
+
+        def get_or_create_collection(self, name: str, embedding_function: object | None = None) -> DummyCollection:
+            if name not in self.collections:
+                self.collections[name] = DummyCollection()
+            return self.collections[name]
+
+    chromadb.PersistentClient = DummyClient
+    chromadb.__version__ = "0.0"
+
+    exc = types.ModuleType("chromadb.exceptions")
+    exc.ChromaDBException = Exception
+    chromadb.exceptions = exc
+
+    sys.modules["chromadb"] = chromadb
+    sys.modules["chromadb.utils"] = utils
+    sys.modules["chromadb.utils.embedding_functions"] = emb
+    sys.modules["chromadb.exceptions"] = exc


### PR DESCRIPTION
## Summary
- add a dummy `chromadb` module for lightweight unit tests
- add langgraph stub fixture so graph tests run without the package
- test role history reconstruction logic

## Testing
- `ruff check tests/unit/memory/test_role_history.py tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684767eb166c832699d41a2d358034ca