### PR TITLE
Add runbook and overview diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ Start the HTTP dashboard backend (optional):
 python -m src.http_app
 ```
 
+For routine operations and troubleshooting, see [docs/runbook.md](docs/runbook.md).
+
 ### Walking Vertical Slice
 To verify your local setup with actual LLM calls, run the minimal demo script:
 ```bash
@@ -558,7 +560,7 @@ CI enforces `--cov-fail-under=90` for overall coverage.
 ### Project Structure (Key Directories)
 - `src/` — Main source code (agents, graphs, memory, infra, simulation)
 - `tests/` — Unit and integration tests
-- `docs/` — Documentation (architecture, testing, coding standards)
+- `docs/` — Documentation (architecture, runbook, testing, coding standards)
 - `scripts/` — Utility and migration scripts
 - `examples/` — Example and experimental scripts
 - `archives/` — Historical documents (e.g., [README_archives.md](archives/README_archives.md))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,31 @@ Culture.ai is an AI Genesis Engine that simulates multi-agent interactions withi
 
 Culture.ai follows a modular design pattern, separating distinct concerns into specialized components that interact through well-defined interfaces.
 
+The diagram below provides a high-level view of how the main pieces fit together.
+
+```mermaid
+graph LR
+    subgraph Simulation
+        AGENTS[Agents]
+        ENV[Environment]
+        MEM[Memory]
+        GRAPH[Decision Graph]
+    end
+    AGENTS --> MEM
+    MEM --> AGENTS
+    AGENTS --> GRAPH
+    GRAPH --> ENV
+    ENV --> MEM
+    subgraph Infrastructure
+        LLM[(LLM Backend)]
+        VDB[(Vector Store)]
+        API[HTTP Dashboard]
+    end
+    MEM --> VDB
+    AGENTS --> LLM
+    GRAPH --> API
+```
+
 ```mermaid
 graph TD
     AC[Agent Core] --> MEM[Memory System]

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,35 @@
+# Runbook
+
+This runbook outlines routine operations for working with Culture.ai.
+
+## Starting a Simulation
+1. Activate your virtual environment.
+2. Ensure dependencies are installed:
+   ```bash
+   pip install -r requirements.txt -r requirements-dev.txt
+   ```
+3. Pull the required model and start Ollama:
+   ```bash
+   ollama pull mistral:latest
+   ```
+4. (Optional) Start the vector store:
+   ```bash
+   docker compose up -d
+   ```
+5. Run the simulation:
+   ```bash
+   python -m src.app --steps 5
+   ```
+
+## Running Tests
+Run the full suite with coverage:
+```bash
+python -m pytest --cov=src --cov-report=term-missing tests/
+```
+
+## Troubleshooting
+- **Missing environment variables**: copy `.env.example` to `.env` and update values.
+- **Vector store errors**: ensure `docker compose up -d` is running or switch to ChromaDB.
+- **LLM timeouts**: check `OLLAMA_API_BASE` and network connectivity.
+
+See the [Quickstart for Developers](../README.md#quickstart-for-developers) for additional setup details.


### PR DESCRIPTION
## Summary
- add new system overview diagram to `docs/architecture.md`
- document routine operations in `docs/runbook.md`
- link to the runbook from README and update docs directory description

## Testing
- No tests run since changes only touch documentation

------
https://chatgpt.com/codex/tasks/task_e_68477b02121c8326865634f99fd34728