### PR TITLE
Add typed structures for messages and LLM responses

### DIFF
--- a/src/agents/core/agent_graph_types.py
+++ b/src/agents/core/agent_graph_types.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.shared.typing import SimulationMessage
+
 # These imports are crucial for get_type_hints to resolve forward references
 # in AgentTurnState when StateGraph is initialized.
 # from .agent_state import AgentState # REMOVE
@@ -114,7 +116,7 @@ class AgentTurnState(TypedDict):
     simulation_step: int  # The current step number from the simulation
     previous_thought: str | None  # The thought from the *last* turn
     environment_perception: dict[str, object]  # Perception data from the environment
-    perceived_messages: list[dict[str, object]]  # Messages perceived from last step
+    perceived_messages: list[SimulationMessage]  # Messages perceived from last step
     memory_history_list: list[dict[str, object]]  # Field for memory history list
     turn_sentiment_score: float  # Field for aggregated sentiment score.
     individual_message_sentiments: list[dict[str, Any]]  # For per-message sentiment scores

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -26,6 +26,7 @@ from src.infra.llm_client import get_ollama_client
 from src.interfaces.dashboard_backend import AgentMessage, message_sse_queue
 from src.shared.async_utils import AsyncDSPyManager
 from src.shared.memory_store import MemoryStore
+from src.shared.typing import SimulationMessage
 
 from .agent_controller import AgentController
 
@@ -899,7 +900,7 @@ class Agent:
         state.ip = max(0, state.ip)
         state.du = max(0, state.du)
 
-    def perceive_messages(self: Self, messages: list[dict[str, Any]]) -> None:
+    def perceive_messages(self: Self, messages: list[SimulationMessage]) -> None:
         """Allows the agent to perceive messages from other agents or the environment."""
         if not messages:
             return

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -23,6 +23,7 @@ from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
 
 # Import L2SummaryGenerator for DSPy-based L2 summary generation
 from src.infra import config  # Import config for role change parameters
+from src.shared.typing import SimulationMessage
 
 from .interaction_handlers import (  # noqa: F401 - imported for re-export
     handle_create_project_node,
@@ -229,7 +230,7 @@ class AgentTurnState(TypedDict):
     simulation_step: int  # The current step number from the simulation
     previous_thought: str | None  # The thought from the *last* turn
     environment_perception: dict[str, object]  # Perception data from the environment
-    perceived_messages: list[dict[str, object]]  # Messages perceived from last step
+    perceived_messages: list[SimulationMessage]  # Messages perceived from last step
     memory_history_list: list[dict[str, object]]  # Field for memory history list
     turn_sentiment_score: int  # Field for aggregated sentiment score
     prompt_modifier: str  # Field for relationship-based prompt adjustments

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from src.infra.llm_client import analyze_sentiment, generate_structured_output
+from src.shared.typing import SimulationMessage
 
 from .basic_agent_graph import AgentActionOutput, AgentTurnState
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
     agent_id = state["agent_id"]
-    perceived_messages = state.get("perceived_messages", [])
+    perceived_messages: list[SimulationMessage] = state.get("perceived_messages", [])
     total = 0
     for msg in perceived_messages:
         if msg.get("sender_id") == agent_id:

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -11,6 +11,8 @@ import time
 from collections.abc import Iterable
 from typing import Any, Callable, Optional, Protocol, TypeVar, cast
 
+from src.shared.typing import LLMChatResponse
+
 try:
     import ollama
 except Exception:  # pragma: no cover - optional dependency
@@ -75,7 +77,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[dict[str, str]],
         options: Optional[dict[str, Any]] = None,
-    ) -> Any: ...
+    ) -> LLMChatResponse: ...
 
 
 # Mock implementation variables and functions
@@ -232,7 +234,7 @@ def generate_text(
         logger.warning("Attempted to generate text but Ollama client is unavailable.")
         return None
 
-    def call() -> object:
+    def call() -> LLMChatResponse:
         return ollama_client.chat(
             model=model,
             messages=[{"role": "user", "content": prompt}],
@@ -240,6 +242,9 @@ def generate_text(
         )
 
     response, error = _retry_with_backoff(call)
+    response = cast(Optional[LLMChatResponse], response)
+    response = cast(Optional[LLMChatResponse], response)
+    response = cast(Optional[LLMChatResponse], response)
     if error:
         logger.error(f"Failed to generate text after retries: {error}")
         return None
@@ -380,7 +385,7 @@ def analyze_sentiment(text: str, model: str = "mistral:latest") -> Optional[floa
     messages = [{"role": "user", "content": prompt}]
     logger.debug(f"LLM_CLIENT_ANALYZE_SENTIMENT --- Constructed prompt: '''{prompt}'''")
 
-    def call() -> object:
+    def call() -> LLMChatResponse:
         return ollama_client.chat(
             model=model,
             messages=messages,
@@ -388,6 +393,7 @@ def analyze_sentiment(text: str, model: str = "mistral:latest") -> Optional[floa
         )
 
     response, error = _retry_with_backoff(call)
+    response = cast(Optional[LLMChatResponse], response)
     if error:
         logger.error(f"Failed to analyze sentiment after retries: {error}")
         return None

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -35,7 +35,7 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
                 msg: AgentMessage = await message_sse_queue.get()
                 yield {
                     "event": "message",
-                    "data": msg.model_dump_json(),
+                    "data": msg.json(),
                 }
             except (RuntimeError, ValueError) as e:
                 yield {"event": "error", "data": json.dumps({"error": str(e)})}

--- a/src/shared/llm_mocks.py
+++ b/src/shared/llm_mocks.py
@@ -9,6 +9,8 @@ import socket
 from typing import Any
 from unittest.mock import MagicMock
 
+from src.shared.typing import LLMChatResponse, OllamaGenerateResponse
+
 # Handle optional Ollama dependency
 try:
     import ollama
@@ -82,9 +84,7 @@ def create_mock_ollama_client() -> MagicMock:
         mock_client = MagicMock(spec=original_client)  # Use spec for better mocking
 
     # Mock the chat method with more specific behavior for sentiment
-    def mock_chat_for_sentiment_and_general(
-        *args: Any, **kwargs: Any
-    ) -> dict[str, dict[str, str]]:
+    def mock_chat_for_sentiment_and_general(*args: Any, **kwargs: Any) -> LLMChatResponse:
         messages = kwargs.get("messages", [])
         prompt_content = ""
         if (
@@ -141,7 +141,7 @@ def create_mock_ollama_client() -> MagicMock:
     # Keep the existing heuristic for generate, but ensure it returns a dict with "response" key
     # as ollama.Client.generate does.
 
-    def mock_generate(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    def mock_generate(*args: Any, **kwargs: Any) -> OllamaGenerateResponse:
         prompt_content = str(kwargs.get("prompt", ""))  # Ensure prompt_content is a string
         logger.debug(f"MOCK_GENERATE_PROMPT_CONTENT_DEBUG: '''{prompt_content}'''")
 

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -1,0 +1,32 @@
+from typing import Optional, TypedDict
+
+
+class LLMMessage(TypedDict):
+    """Minimal shape for a chat message from Ollama."""
+
+    content: str
+
+
+class LLMChatResponse(TypedDict):
+    """Return type for Ollama chat calls."""
+
+    message: LLMMessage
+
+
+class OllamaGenerateResponse(TypedDict, total=False):
+    """Shape returned from Ollama generate calls."""
+
+    response: str
+    done: bool
+    eval_count: int
+    total_duration: int
+
+
+class SimulationMessage(TypedDict):
+    """Message exchanged between agents in the simulation."""
+
+    step: int
+    sender_id: str
+    recipient_id: Optional[str]
+    content: str
+    action_intent: Optional[str]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from typing_extensions import Self
 
 from src.infra import config  # Import to access MAX_PROJECT_MEMBERS
+from src.shared.typing import SimulationMessage
 from src.sim.knowledge_board import KnowledgeBoard
 
 # Use TYPE_CHECKING to avoid circular import issues if Agent needs Simulation later
@@ -111,13 +112,13 @@ class Simulation:
             )
 
         # --- Store broadcasts from the previous step ---
-        self.last_step_messages: list[dict[str, Any]] = []
+        self.last_step_messages: list[SimulationMessage] = []
         logger.info("Initialized storage for last step's messages.")
         # --- End NEW ---
 
-        self.pending_messages_for_next_round: list[dict[str, Any]] = []
+        self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[dict[str, Any]] = (
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
             []
         )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
@@ -272,7 +273,7 @@ class Simulation:
 
             # --- Prepare Perception Data ---
             # Use messages from the current round's perception pool
-            messages_for_this_agent_turn = list(
+            messages_for_this_agent_turn: list[SimulationMessage] = list(
                 self.messages_to_perceive_this_round
             )  # Make a copy for this agent
             perception_data = {
@@ -321,7 +322,7 @@ class Simulation:
                     f"\\'{message_content}\\'"
                 )
 
-                msg_data = {
+                msg_data: SimulationMessage = {
                     "step": self.current_step,  # Log with current global turn number
                     "sender_id": agent_id,
                     "recipient_id": message_recipient_id,


### PR DESCRIPTION
## Summary
- define new `SimulationMessage`, `LLMChatResponse` and related types
- use `SimulationMessage` throughout simulation and graph modules
- update LLM client protocol and mocks to return typed responses
- ensure dashboard backend uses `.json()` for compatibility
- refine typing in LLM client

## Testing
- `bash scripts/lint.sh`
- `mypy src/`
- `python -m pytest tests/unit/memory/test_role_history.py::test_get_role_history_builds_periods`


------
https://chatgpt.com/codex/tasks/task_e_68477b007a8c832693954399e4623d5d