### PR TITLE
Fix Pydantic warnings and add async manager cleanup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,6 @@
 [pytest]
 # Ignore specific deprecation warnings that come from third-party dependencies
 filterwarnings =
-    # Ignore the Pydantic Field deprecation warning from dependencies
-    ignore:Using extra keyword arguments on `Field` is deprecated:UserWarning
-    ignore:Using extra keyword arguments on `Field` is deprecated:DeprecationWarning
     # Ignore the audioop deprecation warning from discord.py
     ignore:'audioop' is deprecated and slated for removal in Python 3.13:DeprecationWarning
     # Ignore importlib-resources open_text deprecation warning
@@ -37,6 +34,7 @@ markers =
     mus: marks tests related to Memory Utility Score (MUS)
     core: marks tests related to core agent functionality
     longevity: marks tests as longevity tests (can be slow)
+    require_ollama: marks tests that require a running Ollama server
 
 log_level = DEBUG 
 
@@ -65,4 +63,3 @@ python_functions = test_*
 # Asyncio settings for pytest-asyncio
 # Options for asyncio_mode: auto, strict, legacy
 asyncio_mode = auto
-asyncio_default_fixture_loop_scope = function

--- a/src/shared/async_utils.py
+++ b/src/shared/async_utils.py
@@ -24,6 +24,28 @@ class AsyncDSPyManager:
             f"default_timeout={default_timeout}s"
         )
 
+    async def __aenter__(self: Self) -> "AsyncDSPyManager":
+        return self
+
+    async def __aexit__(
+        self: Self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.shutdown()
+
+    def __enter__(self: Self) -> "AsyncDSPyManager":
+        return self
+
+    def __exit__(
+        self: Self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.shutdown()
+
     async def submit(
         self: Self,
         dspy_callable: Callable[..., object],


### PR DESCRIPTION
## Summary
- update validators to Pydantic v2 API
- add context manager support to `AsyncDSPyManager`
- clean up `pytest.ini` warning filters and register the `require_ollama` mark

## Testing
- `ruff check src/agents/core/agent_state.py`
- `black --check src/agents/core/agent_state.py`
- `mypy src/agents/core/agent_state.py`
- `ruff check src/shared/async_utils.py`
- `black --check src/shared/async_utils.py`
- `mypy src/shared/async_utils.py`
- `pytest --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68477b013c8c8326af14efd6a9d2676b