### PR TITLE
Add Grafana dashboard example

### DIFF
--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -1,0 +1,30 @@
+{
+  "id": null,
+  "uid": "culture-example-dashboard",
+  "title": "Culture.ai Metrics",
+  "description": "Example Grafana dashboard for monitoring Culture.ai services.",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "5s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "process_cpu_seconds_total{job=\"culture\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    }
+  ]
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,27 @@
+# Observability Setup
+
+This guide explains how to configure basic monitoring for Culture.ai using Grafana.
+
+## 1. Requirements
+
+- A running Prometheus instance collecting metrics from Culture.ai services
+- Grafana installed and able to connect to Prometheus
+
+## 2. Import the Dashboard
+
+1. Open Grafana and navigate to **Dashboards > Import**.
+2. Upload `docs/grafana_dashboard.json` from this repository.
+3. Select your Prometheus data source when prompted and click **Import**.
+
+The dashboard provides a starter panel showing CPU usage for Culture.ai processes. Extend it with additional panels as needed.
+
+## 3. Running Grafana Locally
+
+If you want to run Grafana locally for quick testing, you can use Docker:
+
+```bash
+docker run -d -p 3000:3000 grafana/grafana
+```
+
+Once running, access Grafana at [http://localhost:3000](http://localhost:3000) and follow the import steps above.
+


### PR DESCRIPTION
## Summary
- add Grafana dashboard JSON example
- document Grafana setup steps

## Testing
- no tests run, documentation only

------
https://chatgpt.com/codex/tasks/task_e_68483471bfec8326a024d85debf73e68