### PR TITLE
Implement docs-only workflow skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Detect non-comment code changes
+        id: changes
+        shell: bash
+        run: |
+          bash scripts/check_code_changes.sh
+
+      - name: Skip workflow if only docs or comments changed
+        if: steps.changes.outputs.CODE_CHANGES == 'false'
+        run: |
+          echo "No non-comment code changes detected. Skipping remaining steps."
+          exit 0
+
       - name: Set up Python
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - name: Install dependencies
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: |
           python -m pip install --upgrade pip
@@ -30,22 +44,27 @@ jobs:
           pip install chromadb weaviate-client langgraph
 
       - name: Run Ruff (Lint)
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: ruff check . --output-format=full
 
       - name: Run Mypy (Type Check)
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: mypy src/ --strict
 
       - name: Run Tests & Coverage
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: |
           pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=90
 
       - name: Run Integration Tests
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: pytest -m "integration" --disable-warnings -q
 
       - name: Run Black (Formatter)
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: black --check .

--- a/scripts/check_code_changes.sh
+++ b/scripts/check_code_changes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Determine base commit for diff
+BASE_SHA="${GITHUB_BASE_SHA:-${GITHUB_EVENT_BEFORE}}"
+if [ -z "$BASE_SHA" ]; then
+  BASE_SHA=$(git rev-parse HEAD~1)
+fi
+
+git fetch --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 || true
+
+# List changed files between base and HEAD
+CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD)
+
+# Filter out documentation files
+CODE_FILES=$(echo "$CHANGED_FILES" | grep -vE '\.md$|^docs/' || true)
+
+if [ -z "$CODE_FILES" ]; then
+  echo "Only documentation files changed."
+  echo "CODE_CHANGES=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Check for non-comment additions
+NON_COMMENT_LINES=$(git diff "$BASE_SHA" HEAD -- $CODE_FILES | grep -E '^\+' | grep -vE '^\+\+' | sed 's/^+//' | grep -vE '^\s*(#|//|\*|"""|$)' || true)
+
+if [ -z "$NON_COMMENT_LINES" ]; then
+  echo "Only comments changed."
+  echo "CODE_CHANGES=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Code changes detected."
+echo "CODE_CHANGES=true" >> "$GITHUB_OUTPUT"

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -552,9 +552,7 @@ class ChromaVectorStoreManager(MemoryStore):
             # Query the role changes collection using proper where clause format
             where_clause = {"$and": [{"agent_id": agent_id}, {"event_type": "role_change"}]}
 
-            results = self.roles_collection.get(
-                where=where_clause, include=["metadatas"]
-            )
+            results = self.roles_collection.get(where=where_clause, include=["metadatas"])
 
             # Support both dict-like and attribute-based responses
             if hasattr(results, "get"):

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -82,7 +82,8 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[dict[str, str]],
         options: Optional[dict[str, Any]] = None,
-    ) -> LLMChatResponse: ...
+    ) -> LLMChatResponse:
+        ...
 
 
 # Mock implementation variables and functions

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -45,5 +45,5 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
 
 
 @app.get("/health")
-async def health() -> JSONResponse:  # type: ignore[no-any-unimported]
+async def health() -> JSONResponse:
     return JSONResponse({"status": "ok"})

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -65,11 +65,15 @@ def monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data["error_message"] = "Function returned None, indicating an error"
+                        metrics_data[
+                            "error_message"
+                        ] = "Function returned None, indicating an error"
                 else:
                     metrics_data["success"] = True
                     if result is not None and hasattr(result, "usage"):
-                        metrics_data["prompt_tokens"] = getattr(result.usage, "prompt_tokens", None)
+                        metrics_data["prompt_tokens"] = getattr(
+                            result.usage, "prompt_tokens", None
+                        )
                         metrics_data["completion_tokens"] = getattr(
                             result.usage, "completion_tokens", None
                         )

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -248,7 +248,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {len(self.messages_to_perceive_this_round)} messages from pending_messages_for_next_round."
@@ -369,9 +371,9 @@ class Simulation:
             logger.info(f"  - DU: {current_agent_state.du:.1f} (from {current_agent_state.du})")
 
             # Update the agent state in the simulation's list of agents
-            self.agents[agent_to_run_index] = (
-                agent  # Ensure the agent object itself is updated if it was replaced
-            )
+            self.agents[
+                agent_to_run_index
+            ] = agent  # Ensure the agent object itself is updated if it was replaced
             self.agents[agent_to_run_index].update_state(current_agent_state)
 
             # Determine next agent index based on role change event this turn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ def ensure_dspy_predict(monkeypatch: MonkeyPatch) -> None:
 
     monkeypatch.setattr(dspy, "Predict", DummyPredict, raising=False)
 
+
 @pytest.fixture(autouse=True)
 def ensure_langgraph(monkeypatch: MonkeyPatch) -> None:
     """Provide minimal langgraph stubs when the package is missing."""

--- a/tests/manual/test_relationship_cases.py
+++ b/tests/manual/test_relationship_cases.py
@@ -403,9 +403,7 @@ async def test_case_4_broadcast_vs_targeted(use_discord: bool = False) -> None:
             f"OBSERVED MULTIPLIER: {observed_multiplier:.2f}x (Expected: {targeted_multiplier:.2f}x)"
         )
         if abs(observed_multiplier - targeted_multiplier) < 0.1:
-            logging.info(
-                "✅ VERIFICATION PASSED: Targeted message multiplier is working correctly"
-            )
+            logging.info("✅ VERIFICATION PASSED: Targeted message multiplier is working correctly")
         else:
             logging.info(
                 "❌ VERIFICATION FAILED: Targeted message multiplier not applying correctly"

--- a/tests/unit/dspy/test_dspy_role_adherence.py
+++ b/tests/unit/dspy/test_dspy_role_adherence.py
@@ -160,9 +160,7 @@ def test_role_prefix_adherence() -> None:
     logger.info(f"Success rate: {success_rate:.1f}% ({success_count}/{total_tests} successful)")
 
     if success_count == total_tests:
-        logger.info(
-            "✅ All tests passed! DSPy role adherence implementation is working correctly."
-        )
+        logger.info("✅ All tests passed! DSPy role adherence implementation is working correctly.")
     else:
         logger.warning(
             f"⚠️ {total_tests - success_count} tests failed. DSPy role adherence needs improvement."

--- a/tests/unit/memory/test_role_history.py
+++ b/tests/unit/memory/test_role_history.py
@@ -12,7 +12,9 @@ def _install_dummy_chromadb() -> None:
 def test_get_role_history_builds_periods(tmp_path) -> None:
     from src.agents.memory.vector_store import ChromaVectorStoreManager
 
-    manager = ChromaVectorStoreManager(persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]])
+    manager = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]]
+    )
 
     manager.record_role_change("agent", 1, "R0", "R1")
     manager.record_role_change("agent", 5, "R1", "R2")
@@ -30,7 +32,9 @@ def test_get_role_history_builds_periods(tmp_path) -> None:
 def test_retrieve_role_specific_memories_without_query(monkeypatch, tmp_path) -> None:
     from src.agents.memory.vector_store import ChromaVectorStoreManager
 
-    manager = ChromaVectorStoreManager(persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]])
+    manager = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path), embedding_function=lambda x: [[0.0]]
+    )
 
     monkeypatch.setattr(
         manager,
@@ -54,4 +58,3 @@ def test_retrieve_role_specific_memories_without_query(monkeypatch, tmp_path) ->
     assert len(memories) == 2
     assert calls[0]["step"] == {"$gte": 0, "$lte": 2}
     assert calls[1]["step"] == {"$gte": 5, "$lte": 6}
-

--- a/tests/utils/dummy_chromadb.py
+++ b/tests/utils/dummy_chromadb.py
@@ -10,7 +10,9 @@ def setup_dummy_chromadb() -> None:
     emb = types.ModuleType("chromadb.utils.embedding_functions")
 
     class SentenceTransformerEmbeddingFunction:
-        def __init__(self, model_name: str | None = None) -> None:  # pragma: no cover - simple stub
+        def __init__(
+            self, model_name: str | None = None
+        ) -> None:  # pragma: no cover - simple stub
             pass
 
     emb.SentenceTransformerEmbeddingFunction = SentenceTransformerEmbeddingFunction
@@ -21,7 +23,9 @@ def setup_dummy_chromadb() -> None:
         def __init__(self) -> None:
             self.docs: list[dict[str, object]] = []
 
-        def add(self, documents: list[str], metadatas: list[dict[str, object]], ids: list[str]) -> None:
+        def add(
+            self, documents: list[str], metadatas: list[dict[str, object]], ids: list[str]
+        ) -> None:
             for doc, meta, _id in zip(documents, metadatas, ids):
                 self.docs.append({"id": _id, "metadata": meta, "document": doc})
 
@@ -48,7 +52,9 @@ def setup_dummy_chromadb() -> None:
         def __init__(self, path: str | None = None) -> None:
             self.collections: dict[str, DummyCollection] = {}
 
-        def get_or_create_collection(self, name: str, embedding_function: object | None = None) -> DummyCollection:
+        def get_or_create_collection(
+            self, name: str, embedding_function: object | None = None
+        ) -> DummyCollection:
             if name not in self.collections:
                 self.collections[name] = DummyCollection()
             return self.collections[name]


### PR DESCRIPTION
## Summary
- add script to detect non-comment code changes
- exit early in CI when only docs or comments changed
- fix unused mypy ignore in dashboard backend
- format source and test files with Black

## Testing
- `ruff check src/interfaces/dashboard_backend.py --output-format=full`
- `mypy src/interfaces/dashboard_backend.py --strict`
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest -m "integration" --disable-warnings -q`
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_68486c599dac8326a29493f105557e0b