### PR TITLE
Add concurrency and PR trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- run CI on both push and pull_request events
- cancel in-progress runs for the same branch or PR

## Testing
- `ruff check .`
- `mypy` *(failed: Interrupted)*
- `pytest -q`
- `black --check .` *(failed)*

------
https://chatgpt.com/codex/tasks/task_e_68486c56d6f48326928dfbddfc1fc2b6