### PR TITLE
Add Grafana metrics panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ python -m src.http_app
 
 ### Prometheus Metrics
 The simulation exposes Prometheus metrics on port 8000 when `src.interfaces.metrics` is imported.
-Metrics include `llm_latency_ms` and `knowledge_board_size`. You can scrape them with a Prometheus server and
+Metrics include `llm_latency_ms`, `llm_calls_total`, `knowledge_board_size`, and `active_agent_count`. You can scrape them with a Prometheus server and
 check the latest values with the `!stats` Discord command.
 
 For routine operations and troubleshooting, see [docs/runbook.md](docs/runbook.md).

--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -23,7 +23,61 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+      "y": 0
+      }
+    },
+    {
+      "type": "graph",
+      "title": "Knowledge Board Size",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "knowledge_board_size",
+          "legendFormat": "KB Size",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "type": "graph",
+      "title": "Active Agent Count",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "active_agent_count",
+          "legendFormat": "Agents",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "type": "graph",
+      "title": "LLM Query Rate (QPS)",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(llm_calls_total[1m])",
+          "legendFormat": "QPS",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
       }
     }
   ]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -13,7 +13,7 @@ This guide explains how to configure basic monitoring for Culture.ai using Grafa
 2. Upload `docs/grafana_dashboard.json` from this repository.
 3. Select your Prometheus data source when prompted and click **Import**.
 
-The dashboard provides a starter panel showing CPU usage for Culture.ai processes. Extend it with additional panels as needed.
+The imported dashboard includes panels for CPU usage, Knowledge Board size, active agent count, and the LLM query rate (QPS).
 
 ## 3. Running Grafana Locally
 


### PR DESCRIPTION
## Summary
- expand `docs/grafana_dashboard.json` with new panels for Knowledge Board size, active agent count and LLM query rate (QPS)
- describe the dashboard panels in `docs/observability.md`
- document available metrics in README

## Testing
- `jq '.' docs/grafana_dashboard.json`

------
https://chatgpt.com/codex/tasks/task_e_68498adf3474832694326d655d63ed1f