### PR TITLE
Add pip cache step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Cache pip
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
         if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -16,8 +16,8 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt -r requirements-dev.txt
 
 if ! python -c "import xdist" >/dev/null 2>&1; then
-    echo "pytest-xdist is required but not installed" >&2
-    exit 1
+    echo "pytest-xdist is required but not installed; installing..." >&2
+    pip install pytest-xdist
 fi
 
 echo "Environment ready. Run pytest with $VENV_DIR/bin/python -m pytest"

--- a/src/agents/graphs/basic_agent_types.py
+++ b/src/agents/graphs/basic_agent_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Extra, Field
 
 from src.agents.core.agent_state import AgentState
 
@@ -12,7 +12,7 @@ from src.agents.core.agent_state import AgentState
 class AgentActionOutput(BaseModel):
     """Defines the expected structured output from the LLM."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra=Extra.forbid)
     thought: str = Field(
         ...,
         json_schema_extra={


### PR DESCRIPTION
## Summary
- add pip caching to `ci.yml` and use OS and requirements hash for the key
- fix mypy typing error in `basic_agent_types.py`
- install pytest-xdist automatically if missing in setup script

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_684984f8557883268179f0e7399a480d