### PR TITLE
Fix Extra deprecation warnings and document policy

### DIFF
--- a/docs/warning_management.md
+++ b/docs/warning_management.md
@@ -86,6 +86,19 @@ To add a new warning filter:
 3. Document it in this file
 4. Verify the filter works by running the tests
 
+## Test Suite Warning Policy
+
+Run the full test suite with warnings disabled:
+
+```bash
+pytest --disable-warnings
+```
+
+The summary will still show how many warnings were raised. If any appear,
+either fix the source (for example by updating deprecated Pydantic `Field`
+usage or closing async sessions) or extend `src/infra/warning_filters.py` and
+document the change here.
+
 ## Command-Line Control
 
 You can enable or disable these filters when running the simulation:

--- a/src/agents/graphs/basic_agent_types.py
+++ b/src/agents/graphs/basic_agent_types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict
 
-from pydantic import BaseModel, ConfigDict, Extra, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from src.agents.core.agent_state import AgentState
 
@@ -12,7 +12,7 @@ from src.agents.core.agent_state import AgentState
 class AgentActionOutput(BaseModel):
     """Defines the expected structured output from the LLM."""
 
-    model_config = ConfigDict(extra=Extra.forbid)
+    model_config = ConfigDict(extra="forbid")
     thought: str = Field(
         ...,
         json_schema_extra={


### PR DESCRIPTION
## Summary
- stop using deprecated `pydantic.Extra` enum
- describe the warning policy and test flag in `warning_management.md`

## Testing
- `bash scripts/lint.sh`
- `pytest --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68498ae0039483268a21952f5d1d49fa