### PR TITLE
Remove Any from llm_client

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -8,15 +8,17 @@ import json
 import logging
 import time
 from collections.abc import Iterable
-from typing import Any, Callable, Optional, ParamSpec, Protocol, TypeVar, cast
+from typing import Callable, Optional, ParamSpec, Protocol, TypeVar, cast
 
 from src.shared.typing import (
     ChatOptions,
+    JSONDict,
     LLMChatResponse,
     LLMClientMockResponses,
     LLMMessage,
     OllamaGenerateResponse,
     SentimentAnalysisResponse,
+    StructuredOutputMock,
 )
 
 try:
@@ -51,6 +53,8 @@ except Exception:  # pragma: no cover - fallback when requests missing
 
 
 from pydantic import BaseModel, ValidationError
+from pydantic.fields import FieldInfo
+from pydantic.v1.fields import ModelField
 
 from src.shared.decorator_utils import monitor_llm_call
 
@@ -477,9 +481,9 @@ def generate_structured_output(
             if not issubclass(response_model, BaseModel):
                 raise TypeError("response_model must be a subclass of BaseModel")
             if model_name in _MOCK_RESPONSES:
-                mock_data = cast(dict[str, Any], _MOCK_RESPONSES).get(model_name)
+                mock_data = cast(StructuredOutputMock | str | None, _MOCK_RESPONSES.get(model_name))
                 if isinstance(mock_data, dict):
-                    field_dict: dict[str, Any] = {}
+                    mocked_fields: JSONDict = {}
                     mock_fields = getattr(response_model, "model_fields", None)
                     if mock_fields is None:
                         base_fields = getattr(response_model, "__fields__", None)
@@ -489,70 +493,65 @@ def generate_structured_output(
                     for field_name, field in mock_fields.items():
                         if field.is_required():
                             if field.annotation is str:
-                                field_dict[field_name] = str(
+                                mocked_fields[field_name] = str(
                                     mock_data.get(field_name, f"Mock {field_name}")
                                 )
                             elif field.annotation is int:
                                 val = mock_data.get(field_name, 1)
-                                field_dict[field_name] = int(val) if isinstance(val, int) else 1
+                                mocked_fields[field_name] = int(val) if isinstance(val, int) else 1
                             elif field.annotation is float:
                                 val = mock_data.get(field_name, 1.0)
-                                field_dict[field_name] = (
+                                mocked_fields[field_name] = (
                                     float(val) if isinstance(val, float) else 1.0
                                 )
                             elif field.annotation is bool:
                                 val = mock_data.get(field_name, False)
-                                field_dict[field_name] = (
+                                mocked_fields[field_name] = (
                                     bool(val) if isinstance(val, bool) else False
                                 )
                             elif field.annotation is list:
                                 val = mock_data.get(field_name, [])
-                                field_dict[field_name] = val if isinstance(val, list) else []
+                                mocked_fields[field_name] = val if isinstance(val, list) else []
                             elif field.annotation is dict:
                                 val = mock_data.get(field_name, {})
-                                field_dict[field_name] = val if isinstance(val, dict) else {}
-                    return response_model(**field_dict)
+                                mocked_fields[field_name] = val if isinstance(val, dict) else {}
+                    return response_model(**mocked_fields)
                 else:
                     try:
                         mock_dict = json.loads(str(mock_data))
                         return response_model(**mock_dict)
                     except json.JSONDecodeError:
                         pass
-            # Only define field_dict if not already defined
-            field_dict = {}
+            # Only define field_defaults if not already defined
+            field_defaults: JSONDict = {}
             if hasattr(response_model, "model_fields"):
-                fields: Iterable[tuple[str, Any]] = response_model.model_fields.items()
-
-                def is_required(f: Any) -> bool:
-                    return bool(f.is_required())
-
+                fields: Iterable[tuple[str, FieldInfo]] = response_model.model_fields.items()
             else:
                 base_fields = getattr(response_model, "__fields__", None)
                 if callable(base_fields):
                     base_fields = base_fields()
-                if base_fields is None:
-                    fields = []
-                else:
-                    fields = base_fields.items()
+                fields = base_fields.items() if base_fields is not None else []
 
-                def is_required(f: Any) -> bool:
-                    return bool(cast("Any", f).required)
+            def is_required(f: FieldInfo | ModelField) -> bool:
+                if isinstance(f, FieldInfo):
+                    return bool(f.is_required())
+                return bool(f.required)
 
             for field_name, field in fields:
                 if is_required(field):
                     if field.annotation is str:
-                        field_dict[field_name] = f"Mock {field_name}"
+                        field_defaults[field_name] = f"Mock {field_name}"
                     elif field.annotation is int:
-                        field_dict[field_name] = 1
+                        field_defaults[field_name] = 1
                     elif field.annotation is float:
-                        field_dict[field_name] = 1.0
+                        field_defaults[field_name] = 1.0
                     elif field.annotation is bool:
-                        field_dict[field_name] = False
+                        field_defaults[field_name] = False
                     elif field.annotation is list:
-                        field_dict[field_name] = []
+                        field_defaults[field_name] = []
                     elif field.annotation is dict:
-                        field_dict[field_name] = {}
-            return response_model(**field_dict)
+                        field_defaults[field_name] = {}
+            return response_model(**field_defaults)
         except (ValidationError, json.JSONDecodeError, TypeError) as e:
             logger.error(f"Error generating mock structured output: {e}")
             return None
@@ -568,7 +567,7 @@ def generate_structured_output(
         schema_json = json.dumps(response_model.model_json_schema(), indent=2)
     else:
         schema_json = json.dumps(response_model.schema(), indent=2)
-    example: dict[str, Any] = {}
+    example: JSONDict = {}
     example_fields = getattr(response_model, "model_fields", None)
     if example_fields is None:
         base_fields = getattr(response_model, "__fields__", None)
@@ -613,7 +612,7 @@ def generate_structured_output(
         try:
             logger.debug(f"Received potential JSON response from Ollama: {response_text}")
             if response_model:
-                json_data: dict[str, Any] = json.loads(str(response_text))
+                json_data: JSONDict = json.loads(str(response_text))
                 parsed_output: BaseModel = response_model(**json_data)
                 logger.debug(f"Successfully parsed structured output: {parsed_output}")
                 return parsed_output

--- a/src/shared/llm_mocks.py
+++ b/src/shared/llm_mocks.py
@@ -72,7 +72,7 @@ class MockLLMResponse:
             "message_content": "Mock message for testing",
             "action_intent": "idle",
         }
-        self.message: dict[str, str] = {"content": content}
+        self.message: dict[str, str] = {"role": "assistant", "content": content}
 
 
 def create_mock_ollama_client() -> MagicMock:
@@ -102,6 +102,7 @@ def create_mock_ollama_client() -> MagicMock:
                 logger.debug("Mock ollama.Client.chat: returning -0.7 sentiment for disagreement")
                 return {
                     "message": {
+                        "role": "assistant",
                         "content": '{"sentiment_score": -0.7, "sentiment_label": "negative"}'
                     }
                 }
@@ -112,6 +113,7 @@ def create_mock_ollama_client() -> MagicMock:
                 logger.debug("Mock ollama.Client.chat: returning 0.2 sentiment for facilitation")
                 return {
                     "message": {
+                        "role": "assistant",
                         "content": '{"sentiment_score": 0.2, "sentiment_label": "neutral"}'
                     }
                 }
@@ -121,6 +123,7 @@ def create_mock_ollama_client() -> MagicMock:
                 )
                 return {
                     "message": {
+                        "role": "assistant",
                         "content": '{"sentiment_score": 0.0, "sentiment_label": "neutral"}'
                     }
                 }
@@ -133,7 +136,7 @@ def create_mock_ollama_client() -> MagicMock:
         )
         # Ensure this default response is what other direct .chat() users might expect if not sentiment.
         # The original code had "This is a mock Ollama response". Let's stick to that for non-sentiment.
-        return {"message": {"content": "This is a mock Ollama response"}}
+        return {"message": {"role": "assistant", "content": "This is a mock Ollama response"}}
 
     mock_client.chat.side_effect = mock_chat_for_sentiment_and_general
 

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -4,6 +4,7 @@ from typing import Optional, TypedDict
 class LLMMessage(TypedDict):
     """Minimal shape for a chat message from Ollama."""
 
+    role: str
     content: str
 
 
@@ -11,6 +12,14 @@ class LLMChatResponse(TypedDict):
     """Return type for Ollama chat calls."""
 
     message: LLMMessage
+
+
+class ChatOptions(TypedDict, total=False):
+    """Options for Ollama chat calls."""
+
+    temperature: float
+    top_p: float
+    num_predict: int
 
 
 class OllamaGenerateResponse(TypedDict, total=False):

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -1,4 +1,13 @@
-from typing import Optional, TypedDict
+from __future__ import annotations
+
+from typing import TypedDict, Union
+
+# Basic JSON-compatible types used throughout the codebase
+JSONValue = Union[str, int, float, bool, None, dict[str, "JSONValue"], list["JSONValue"]]
+
+# Simple alias for a JSON-compatible dictionary
+JSONDict = dict[str, JSONValue]
+
 
 
 class LLMMessage(TypedDict):
@@ -61,6 +70,6 @@ class SimulationMessage(TypedDict):
 
     step: int
     sender_id: str
-    recipient_id: Optional[str]
+    recipient_id: str | None
     content: str
-    action_intent: Optional[str]
+    action_intent: str | None


### PR DESCRIPTION
## Summary
- add structured chat message and options types
- use ParamSpec-based _retry_with_backoff
- update llm client to use these types
- fix LLM mocks for new message structure
- simplify redundant casting

## Testing
- `ruff check src/infra/llm_client.py src/shared/typing.py src/shared/llm_mocks.py`
- `mypy src/infra/llm_client.py src/shared/llm_mocks.py`
- `mypy`
- `pytest -q` *(fails: unrecognized arguments -n)*

------
https://chatgpt.com/codex/tasks/task_e_68498adecbc08326bd1d7e1543cfcbba