### PR TITLE
Remove mypy ignore directives and add typing

### DIFF
--- a/src/agents/core/agent_graph_types.py
+++ b/src/agents/core/agent_graph_types.py
@@ -2,8 +2,6 @@
 Defines common types used in the agent's LangGraph state.
 """
 
-# mypy: ignore-errors
-
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -1,4 +1,3 @@
-# mypy: ignore-errors
 # ruff: noqa: ANN101, ANN102
 import logging
 import random
@@ -195,6 +194,31 @@ class AgentStateData(BaseModel):
         default_factory=lambda: float(str(get_config("TARGETED_MESSAGE_MULTIPLIER") or "1.5"))
     )
 
+    @property
+    def positive_relationship_learning_rate(self) -> float:
+        return self._positive_relationship_learning_rate
+
+    @property
+    def negative_relationship_learning_rate(self) -> float:
+        return self._negative_relationship_learning_rate
+
+    @property
+    def neutral_relationship_learning_rate(self) -> float:
+        return self._neutral_relationship_learning_rate
+
+    @property
+    def targeted_message_multiplier(self) -> float:
+        """Multiplier applied when sending targeted messages."""
+        return self._targeted_message_multiplier
+
+    @property
+    def min_relationship_score(self) -> float:
+        return self._min_relationship_score
+
+    @property
+    def max_relationship_score(self) -> float:
+        return self._max_relationship_score
+
     @field_validator("mood_level", mode="before")
     @classmethod
     def check_mood_level_type_before(cls, v: Any) -> Any:
@@ -340,13 +364,13 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
     def get_llm_client(self) -> "LLMClient":
         if not self.llm_client:
             raise ValueError("LLMClient not initialized")
-        return cast("LLMClient", self.llm_client)
+        return cast("LLMClient", self.llm_client)  # type: ignore[no-any-unimported]
 
     def get_memory_retriever(self) -> Any:  # VectorStoreRetriever:
         """Returns the memory retriever for the agent."""
         if not self.memory_store_manager:
             raise ValueError("MemoryStoreManager not initialized")
-        return self.memory_store_manager.get_retriever()  # type: ignore
+        return self.memory_store_manager.get_retriever()
 
     # ------------------------------------------------------------------
     # Serialization helpers for tests

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -2,7 +2,6 @@
 """
 Defines the base class for all agents in the Culture simulation.
 """
-# mypy: ignore-errors
 
 import copy
 import logging
@@ -423,7 +422,7 @@ class Agent:
             "knowledge_board_content": knowledge_board_content,  # Pass the knowledge board content
             "knowledge_board": knowledge_board,  # Pass the knowledge board instance
             "scenario_description": scenario_description,  # Pass the simulation scenario
-            "current_role": self._state.role,  # Pass the agent's current role
+            "current_role": self._state.current_role,  # Pass the agent's current role
             "influence_points": int(self._state.ip),  # Cast to int for TypedDict compliance
             "steps_in_current_role": self._state.steps_in_current_role,
             # Pass the agent's steps in current role
@@ -509,7 +508,7 @@ class Agent:
                         )
                     logger.debug(  # Keep this log for state update confirmation
                         f"RUN_TURN_POST_UPDATE :: Agent {self.agent_id}: self._state updated with new "
-                        f"AgentState object (Role: {self._state.role}, Mood: {self._state.mood})."
+                        f"AgentState object (Role: {self._state.current_role}, Mood: {self._state.mood_value})."
                     )
                 else:
                     logger.warning(
@@ -568,7 +567,9 @@ class Agent:
                     and isinstance(turn_output, dict)
                     and "action_intent" in turn_output
                 ):
-                    self._state.last_action_intent = turn_output["action_intent"]
+                    self._state.last_action_intent = AgentActionIntent(
+                        turn_output["action_intent"]
+                    )
                     logger.debug(
                         f"Agent {self.agent_id} updated last_action_intent to: {self._state.last_action_intent}"
                     )
@@ -602,12 +603,12 @@ class Agent:
 
     def __str__(self: Self) -> str:
         """Returns a string representation of the agent."""
-        return f"Agent(id={self.agent_id}, role={self._state.role})"
+        return f"Agent(id={self.agent_id}, role={self._state.current_role})"
 
     def __repr__(self: Self) -> str:
         """Returns a detailed string representation for debugging."""
         return (
-            f"Agent(agent_id='{self.agent_id}', role='{self._state.role}', "
+            f"Agent(agent_id='{self.agent_id}', role='{self._state.current_role}', "
             f"ip={self._state.ip}, du={self._state.du})"
         )
 
@@ -852,17 +853,22 @@ class Agent:
             du_change -= state.du_cost_per_action
 
         # Intent-specific DU generation/costs from ACTION_DU_GENERATION_V2
-        action_du_config = config.ACTION_DU_GENERATION_V2.get(action_intent, {})
+        action_du_generation_cfg = config.get_config("ACTION_DU_GENERATION_V2")
+        action_du_config = {}
+        if isinstance(action_du_generation_cfg, dict):
+            action_du_config = action_du_generation_cfg.get(action_intent, {})
         base_du_generation = action_du_config.get("base_amount", 0.0)
         role_bonus_factor = action_du_config.get("role_bonus_factor", 0.0)
 
         # Get the role-specific generation dictionary (e.g., {"base": 1.0, "bonus_factor": 0.2})
-        role_specific_generation_dict = config.ROLE_DU_GENERATION.get(state.role, {})
+        role_specific_generation_dict = config.ROLE_DU_GENERATION.get(state.current_role, {})
         # Extract the 'base' DU generation for the role, to be multiplied by the action's role_bonus_factor
         role_base_generation_for_action_bonus = role_specific_generation_dict.get("base", 0.0)
 
         # --- Start Debug Logging ---
-        logger.debug(f"DU Calc: action_intent='{action_intent}', agent_role='{state.role}'")
+        logger.debug(
+            f"DU Calc: action_intent='{action_intent}', agent_role='{state.current_role}'"
+        )
         logger.debug(f"DU Calc: action_du_config='{action_du_config}'")
         logger.debug(
             f"DU Calc: base_du_generation (type: {type(base_du_generation)})='{base_du_generation}'"
@@ -935,7 +941,9 @@ class Agent:
         logger.debug(
             f"BaseAgent ({self.agent_id}): id(self.state) before process_perceived_messages: {id(self.state)}"
         )
-        AgentController(self.state).process_perceived_messages(enriched_messages_for_state_update)
+        AgentController(self.state).process_perceived_messages(
+            cast(list[dict[str, Any]], enriched_messages_for_state_update)
+        )
         logger.info(
             f"Agent {self.agent_id} processed {len(enriched_messages_for_state_update)} messages directly in perceive_messages, updating mood/relationships."
         )

--- a/src/agents/dspy_programs/action_intent_selector.py
+++ b/src/agents/dspy_programs/action_intent_selector.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101
-# mypy: ignore-errors
 """
 DSPy-powered Action Intent Selector Module
 

--- a/src/agents/dspy_programs/intent_selector.py
+++ b/src/agents/dspy_programs/intent_selector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# mypy: ignore-errors
 from collections.abc import Callable
 
 from typing_extensions import Self

--- a/src/agents/dspy_programs/l1_summary_generator.py
+++ b/src/agents/dspy_programs/l1_summary_generator.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101
-# mypy: ignore-errors
 """
 DSPy L1 Summary Generator
 

--- a/src/agents/dspy_programs/l2_summary_generator.py
+++ b/src/agents/dspy_programs/l2_summary_generator.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101
-# mypy: ignore-errors
 """
 DSPy L2 Summary Generator
 

--- a/src/agents/dspy_programs/rag_context_synthesizer.py
+++ b/src/agents/dspy_programs/rag_context_synthesizer.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101
-# mypy: ignore-errors
 """
 DSPy RAG Context Synthesizer
 

--- a/src/agents/dspy_programs/relationship_updater.py
+++ b/src/agents/dspy_programs/relationship_updater.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101
-# mypy: ignore-errors
 import logging
 import os
 

--- a/src/agents/dspy_programs/role_thought_generator.py
+++ b/src/agents/dspy_programs/role_thought_generator.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E501, ANN101, ANN401
-# mypy: ignore-errors
 import logging
 import os
 

--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# mypy: ignore-errors
 from langgraph.graph import END, StateGraph
 
 from .basic_agent_types import AgentTurnState
@@ -24,7 +23,7 @@ from .interaction_handlers import (
 )
 
 
-def build_graph() -> StateGraph:
+def build_graph() -> StateGraph:  # type: ignore[no-any-unimported]
     graph_builder = StateGraph(AgentTurnState)
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-# mypy: ignore-errors
 import logging
-from typing import Any
+from typing import Any, cast
 
 from src.infra.llm_client import analyze_sentiment, generate_structured_output
 from src.shared.typing import SimulationMessage
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
     agent_id = state["agent_id"]
-    perceived_messages: list[SimulationMessage] = state.get("perceived_messages", [])
+    perceived_messages = cast(list[SimulationMessage], state.get("perceived_messages", []))
     total = 0
     for msg in perceived_messages:
         if msg.get("sender_id") == agent_id:
@@ -22,10 +21,11 @@ def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
         content = msg.get("content")
         if isinstance(content, str):
             sentiment = analyze_sentiment(content)
-            if sentiment == "positive":
-                total += 1
-            elif sentiment == "negative":
-                total -= 1
+            if sentiment is not None:
+                if sentiment > 0:
+                    total += 1
+                elif sentiment < 0:
+                    total -= 1
     return {"turn_sentiment_score": total}
 
 
@@ -42,9 +42,11 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     agent = state.get("agent_instance")
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)"}
-    memories = await manager.aretrieve_relevant_memories(state["agent_id"], query="", k=5)
+    memories = await manager.aretrieve_relevant_memories(  # type: ignore[attr-defined]
+        state["agent_id"], query="", k=5
+    )
     memories_content = [m.get("content", "") for m in memories]
-    summary_result = await agent.async_generate_l1_summary(
+    summary_result = await agent.async_generate_l1_summary(  # type: ignore[attr-defined]
         state.get("current_role", ""), "\n".join(memories_content), ""
     )
     summary = getattr(summary_result, "summary", "")
@@ -62,7 +64,7 @@ async def generate_thought_and_message_node(
         if result:
             action_intent = getattr(result, "chosen_action_intent", "idle")
     structured = generate_structured_output("prompt", AgentActionOutput)
-    return {"structured_output": structured or None}
+    return {"structured_output": cast(AgentActionOutput | None, structured)}
 
 
 async def finalize_message_agent_node(state: AgentTurnState) -> dict[str, Any]:

--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# mypy: ignore-errors
 import logging
 from typing import Any
 

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -3,7 +3,6 @@ Integration module for using Ollama models with DSPy.
 Provides a proper implementation of DSPy's LM interface for Ollama models.
 """
 
-# mypy: ignore-errors
 # ruff: noqa: ANN101, ANN102
 
 import json

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -1,5 +1,4 @@
 # ruff: noqa: ANN401
-# mypy: ignore-errors
 # src/infra/llm_client.py
 """
 Provides a client for interacting with the Ollama LLM service.
@@ -82,8 +81,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[dict[str, str]],
         options: Optional[dict[str, Any]] = None,
-    ) -> LLMChatResponse:
-        ...
+    ) -> LLMChatResponse: ...
 
 
 # Mock implementation variables and functions

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -3,7 +3,6 @@ Discord bot interface for the Culture simulation.
 Provides real-time updates about the simulation to a Discord channel.
 """
 
-# mypy: ignore-errors
 # ruff: noqa: ANN401
 
 import logging

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -55,3 +55,4 @@ class SimulationMessage(TypedDict):
     recipient_id: Optional[str]
     content: str
     action_intent: Optional[str]
+    sentiment_score: Optional[float]


### PR DESCRIPTION
## Summary
- remove global `mypy: ignore-errors` directives
- adjust BaseAgent and simulation state handling
- expose relationship and message multiplier properties
- tighten graph node sentiment processing

## Testing
- `pre-commit run --files src/agents/graphs/interaction_handlers.py src/agents/graphs/graph_nodes.py src/agents/graphs/basic_agent_graph.py src/agents/graphs/agent_graph_builder.py src/agents/core/agent_state.py src/agents/core/base_agent.py src/agents/core/agent_graph_types.py src/agents/dspy_programs/l1_summary_generator.py src/agents/dspy_programs/l2_summary_generator.py src/agents/dspy_programs/action_intent_selector.py src/agents/dspy_programs/intent_selector.py src/agents/dspy_programs/role_thought_generator.py src/agents/dspy_programs/rag_context_synthesizer.py src/agents/dspy_programs/relationship_updater.py src/interfaces/discord_bot.py src/infra/dspy_ollama_integration.py src/infra/llm_client.py src/sim/simulation.py src/shared/typing.py`


------
https://chatgpt.com/codex/tasks/task_e_6849972cb9088326a1eafcea704f6b17