### PR TITLE
Restrict integration tests to Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml --cov-fail-under=90
 
       - name: Run Integration Tests
-        if: steps.changes.outputs.CODE_CHANGES == 'true'
+        if: steps.changes.outputs.CODE_CHANGES == 'true' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: pytest -m "integration" --disable-warnings -q
 

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -7,12 +7,9 @@ import json
 import logging
 import time
 from collections.abc import Iterable
-
-from typing import Any, Callable, Protocol, TypeVar, cast
-
+from typing import Any, Callable, ParamSpec, Protocol, TypeVar, cast
 
 from src.shared.typing import (
-    ChatOptions,
     JSONDict,
     LLMChatResponse,
     LLMClientMockResponses,

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -72,6 +72,6 @@ class SimulationMessage(TypedDict):
     sender_id: str
     recipient_id: str | None
     content: str
-    action_intent: Optional[str]
-    sentiment_score: Optional[float]
+    action_intent: str | None
+    sentiment_score: float | None
 


### PR DESCRIPTION
## Summary
- restrict integration tests to run only on Ubuntu runners in the CI workflow
- fix typing imports and optional types

## Testing
- `ruff check src/ tests/`
- `mypy src/ tests/`
- `pytest tests/test_pytest_sanity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a366eef483268f2d5b696c79a0a5