### PR TITLE
Fix CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pip install chromadb weaviate-client langgraph
 
       - name: Run Ruff (Lint)
         if: steps.changes.outputs.CODE_CHANGES == 'true'


### PR DESCRIPTION
## Summary
- remove duplicate pip install commands in CI workflow

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict` *(fails: Invalid index type "int" for "dict[str, list[tuple[int, float]]]" and others)*
- `pytest --maxfail=1 --disable-warnings -q` *(fails: stopping after 1 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe0917e083268064fb834583ebcb