### PR TITLE
Add scheduled full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -86,3 +88,49 @@ jobs:
         if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash
         run: black --check .
+
+  full-suite:
+    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Detect non-comment code changes
+        if: github.event_name != 'schedule'
+        id: changes
+        shell: bash
+        run: |
+          bash scripts/check_code_changes.sh
+
+      - name: Skip workflow if only docs or comments changed
+        if: github.event_name != 'schedule' && steps.changes.outputs.CODE_CHANGES == 'false'
+        run: |
+          echo "No non-comment code changes detected. Skipping remaining steps."
+          exit 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run Full Test Suite
+        shell: bash
+        run: pytest -m "slow or dspy or integration" --disable-warnings -q

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -140,20 +140,33 @@ VALID_ROLES = [ROLE_FACILITATOR, ROLE_INNOVATOR, ROLE_ANALYZER]
 # --- Node Functions ---
 
 
+def _get_current_role(agent_state: AgentState) -> str:
+    return getattr(agent_state, "current_role", getattr(agent_state, "role"))
+
+
+def _set_current_role(agent_state: AgentState, role: str) -> None:
+    if hasattr(agent_state, "current_role"):
+        agent_state.current_role = role
+    else:
+        setattr(agent_state, "role", role)
+
+
 def process_role_change(agent_state: AgentState, requested_role: str) -> bool:
-    # (Implementation from original file)
     if requested_role not in VALID_ROLES:
-        logger.warning(f"Agent {agent_state.agent_id} requested invalid role: {requested_role}")
+        logger.warning(
+            f"Agent {agent_state.agent_id} requested invalid role: {requested_role}"
+        )
         return False
-    if requested_role == agent_state.current_role:
+    current_role = _get_current_role(agent_state)
+    if requested_role == current_role:
         return False
     if agent_state.steps_in_current_role < agent_state.role_change_cooldown:
         return False
     if agent_state.ip < agent_state.role_change_ip_cost:
         return False
-    old_role = agent_state.current_role
+    old_role = current_role
     agent_state.ip -= agent_state.role_change_ip_cost
-    agent_state.current_role = requested_role
+    _set_current_role(agent_state, requested_role)
     agent_state.steps_in_current_role = 0
     agent_state.role_history.append((int(agent_state.last_action_step or 0), requested_role))
     logger.info(f"Agent {agent_state.agent_id} changed role from {old_role} to {requested_role}.")
@@ -170,17 +183,19 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
     if structured_output and structured_output.requested_role_change:
         if process_role_change(agent_state_obj, structured_output.requested_role_change):
             AgentController(agent_state_obj).add_memory(
+                sim_step,
+                "role_change",
                 f"Changed role to {structured_output.requested_role_change}",
-                {"step": sim_step, "type": "role_change"},
             )  # type: ignore[arg-type]
         else:
             AgentController(agent_state_obj).add_memory(
+                sim_step,
+                "resource_constraint",
                 "Failed role change attempt",
-                {"step": sim_step, "type": "resource_constraint"},
             )  # type: ignore[arg-type]
 
     if action_intent != "idle":
-        role_name = agent_state_obj.current_role
+        role_name = _get_current_role(agent_state_obj)
         role_du_conf = config.ROLE_DU_GENERATION.get(role_name, {"base": 1.0})
         du_gen_rate = role_du_conf.get("base", 1.0)
 
@@ -214,7 +229,7 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
 
             # Call the dspy program
             summary_prediction = l1_gen.generate_summary(
-                agent_role=agent_state_obj.current_role,
+                agent_role=_get_current_role(agent_state_obj),
                 recent_events=recent_events_str,
                 current_mood=mood_desc,
             )
@@ -224,7 +239,7 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
                 AgentController(agent_state_obj).add_memory(
                     memory_summary,
                     {"step": sim_step, "type": "consolidated_summary"},
-                )  # type: ignore[arg-type]
+                )
                 vector_store = state.get("vector_store_manager")
                 if vector_store and hasattr(vector_store, "add_memory"):
                     vector_store.add_memory(
@@ -233,7 +248,7 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
                         "consolidated_summary",
                         memory_summary,
                         "consolidated_summary",
-                    )  # type: ignore[arg-type]
+                    )
                 logger.info(f"Agent {agent_id}: Generated L1 memory summary.")
         except Exception as e:
             logger.error(

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -21,6 +21,9 @@ def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
         content = msg.get("content")
         if isinstance(content, str):
             sentiment = analyze_sentiment(content)
+            if isinstance(sentiment, str):
+                mapping = {"positive": 1.0, "negative": -1.0, "neutral": 0.0}
+                sentiment = mapping.get(sentiment.lower(), 0.0)
             if sentiment is not None:
                 if sentiment > 0:
                     total += 1

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -6,18 +6,22 @@ Provides real-time updates about the simulation to a Discord channel.
 # ruff: noqa: ANN401
 
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from src.interfaces import metrics
 
-try:
+if TYPE_CHECKING:  # pragma: no cover - type checking only
     import discord
     from discord.ext import commands
-except Exception:  # pragma: no cover - optional dependency
-    from unittest.mock import MagicMock
+else:  # pragma: no cover - runtime import with fallback
+    try:
+        import discord  # type: ignore
+        from discord.ext import commands  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        from unittest.mock import MagicMock
 
-    discord = MagicMock()
-    commands = MagicMock()
+        discord = MagicMock()
+        commands = MagicMock()
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
@@ -52,7 +56,7 @@ class SimulationDiscordBot:
         self.client: Any = discord.Client(intents=intents)
 
         # Set up event handlers
-        @self.client.event
+        @self.client.event  # type: ignore[misc]
         async def on_ready() -> None:
             """Event handler that fires when the bot connects to Discord."""
             self.is_ready = True
@@ -376,13 +380,13 @@ def get_kb_size() -> int:
 
 
 @bot.command(name="say")
-async def say(ctx: commands.Context, *, message: str) -> None:
+async def say(ctx: commands.Context[Any], *, message: str) -> None:
     """Echo a user-provided message for smoke testing."""
     await ctx.send(f"Simulated message received: {message}")
 
 
 @bot.command(name="stats")
-async def stats(ctx: commands.Context) -> None:
+async def stats(ctx: commands.Context[Any]) -> None:
     """Return basic runtime statistics."""
     stats_text = f"LLM latency: {get_llm_latency()} ms; KB size: {get_kb_size()}"
     await ctx.send(stats_text)


### PR DESCRIPTION
## Summary
- run CI on a schedule
- run the full test suite on `main` updates and nightly schedule
- relax sentiment analysis node to accept textual results
- support legacy `role` attribute in role-change logic
- fix Discord bot typing and add missing generics

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict` *(fails: 34 errors)*
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_684a064ef5708326aa3bbaf87cc0db2a