### PR TITLE
Add coverage artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
         shell: bash
         run: pytest -m "integration" --disable-warnings -q
 
+      - name: Upload coverage artifact
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage.xml
+          path: coverage.xml
+
       - name: Run Black (Formatter)
         if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -561,6 +561,8 @@ Generate a coverage report:
 python -m pytest --cov=src --cov-report=term-missing tests/
 ```
 CI enforces `--cov-fail-under=90` for overall coverage.
+CI also uploads `coverage.xml` as a GitHub Actions artifact. Open the workflow run
+and download the file from the **Artifacts** section.
 
 ### Project Structure (Key Directories)
 - `src/` — Main source code (agents, graphs, memory, infra, simulation)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -67,6 +67,7 @@ Culture.ai uses [pytest-xdist](https://pytest-xdist.readthedocs.io/) for paralle
 - Full suite runs nightly and on main branch merges
 - See `.github/workflows/ci.yml` for details
 - Pushes that only modify Markdown files or documentation paths are ignored by CI
+- After tests complete, the `coverage.xml` file is uploaded as a GitHub Actions artifact. In the workflow run summary, look under **Artifacts** to download it.
 
 ## Adding/Updating Markers
 


### PR DESCRIPTION
## Summary
- upload `coverage.xml` from CI as artifact
- document where to find coverage report artifact in docs and README

## Testing
- `ruff check . --output-format=full`
- `mypy src/ --strict` *(fails: 52 errors)*
- `pytest --maxfail=1 --disable-warnings -q` *(fails: unrecognized arguments -n)*
- `black --check .` *(fails: would reformat 7 files)*

------
https://chatgpt.com/codex/tasks/task_e_684a0662bd9883269a7eb57c0b44c2cd