### PR TITLE
Adjust tests for current_role and numeric sentiment

### DIFF
--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -141,7 +141,9 @@ VALID_ROLES = [ROLE_FACILITATOR, ROLE_INNOVATOR, ROLE_ANALYZER]
 
 
 def _get_current_role(agent_state: AgentState) -> str:
-    return cast(str, getattr(agent_state, "current_role", getattr(agent_state, "role")))
+    if hasattr(agent_state, "current_role"):
+        return cast(str, getattr(agent_state, "current_role"))
+    return cast(str, getattr(agent_state, "role"))
 
 
 def _set_current_role(agent_state: AgentState, role: str) -> None:
@@ -153,9 +155,7 @@ def _set_current_role(agent_state: AgentState, role: str) -> None:
 
 def process_role_change(agent_state: AgentState, requested_role: str) -> bool:
     if requested_role not in VALID_ROLES:
-        logger.warning(
-            f"Agent {agent_state.agent_id} requested invalid role: {requested_role}"
-        )
+        logger.warning(f"Agent {agent_state.agent_id} requested invalid role: {requested_role}")
         return False
     current_role = _get_current_role(agent_state)
     if requested_role == current_role:

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -18,7 +18,7 @@ class DummyController:
 def make_agent_state() -> SimpleNamespace:
     return SimpleNamespace(
         agent_id="a",
-        role="Innovator",
+        current_role="Innovator",
         steps_in_current_role=5,
         role_change_cooldown=3,
         ip=10.0,
@@ -34,7 +34,7 @@ def make_agent_state() -> SimpleNamespace:
 def test_process_role_change_success(monkeypatch: pytest.MonkeyPatch) -> None:
     state = make_agent_state()
     assert bag.process_role_change(state, "Analyzer") is True
-    assert state.role == "Analyzer"
+    assert state.current_role == "Analyzer"
     assert state.ip == 8.0
 
 
@@ -56,7 +56,7 @@ def test_update_state_node_role_change(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     )
 
-    assert state.role == "Analyzer"
+    assert state.current_role == "Analyzer"
     assert controller.added[0][0].startswith("Changed role")
     assert output["data_units"] == int(state.du)
 

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -17,9 +17,9 @@ from src.agents.graphs.graph_nodes import (
 def test_analyze_perception_sentiment_node(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = []
 
-    def fake_sentiment(text: str) -> str:
+    def fake_sentiment(text: str) -> float:
         calls.append(text)
-        return "positive" if text == "good" else "negative"
+        return 1.0 if text == "good" else -1.0
 
     monkeypatch.setattr("src.agents.graphs.graph_nodes.analyze_sentiment", fake_sentiment)
 


### PR DESCRIPTION
## Summary
- update tests to use `current_role`
- expect numeric sentiments in fake sentiment analyzer
- fix `_get_current_role` to avoid attribute errors

## Testing
- `ruff check tests/unit/graphs/test_basic_agent_graph_utils.py tests/unit/graphs/test_graph_nodes.py src/agents/graphs/basic_agent_graph.py`
- `ruff format src/agents/graphs/basic_agent_graph.py tests/unit/graphs/test_basic_agent_graph_utils.py tests/unit/graphs/test_graph_nodes.py`
- `pre-commit run --files src/agents/graphs/basic_agent_graph.py tests/unit/graphs/test_basic_agent_graph_utils.py tests/unit/graphs/test_graph_nodes.py` *(fails: mypy errors)*
- `pytest -q tests/unit/graphs/test_basic_agent_graph_utils.py tests/unit/graphs/test_graph_nodes.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac93a38e88326bb6d80529d152e6a