### PR TITLE
Refactor agent LLM client handling

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -3,7 +3,7 @@ import logging
 import random
 from collections import deque
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import (
     BaseModel,
@@ -82,13 +82,16 @@ DEFAULT_AVAILABLE_ACTIONS: list[AgentActionIntent] = [
 # Forward reference for Agent (used in RelationshipHistoryEntry)
 if TYPE_CHECKING:
     try:
-        from src.infra.llm_client import LLMClient, LLMClientConfig  # type: ignore[attr-defined]
-    except Exception:
-        LLMClient = Any
-        LLMClientConfig = Any
+        from src.infra.llm_client import (
+            OllamaClientProtocol,
+            get_default_llm_client,
+        )
+    except Exception:  # pragma: no cover - fallback when llm_client is missing
+        OllamaClientProtocol = Any  # type: ignore[misc, assignment]
+        get_default_llm_client = lambda: None
 else:  # pragma: no cover - used only for typing
-    LLMClient = Any
-    LLMClientConfig = Any
+    OllamaClientProtocol = Any  # type: ignore[misc, assignment]
+    get_default_llm_client = lambda: None
 
 
 class AgentStateData(BaseModel):
@@ -115,8 +118,8 @@ class AgentStateData(BaseModel):
     goals: list[dict[str, Any]] = Field(default_factory=list)
     projects: dict[str, dict[str, Any]] = Field(default_factory=dict)  # project_id: {details}
     current_project_id: Optional[str] = None
-    llm_client_config: Optional[Any] = None  # Optional[LLMClientConfig] - Using Any temporarily
-    llm_client: Optional[Any] = None
+    llm_client_config: Optional[Any] = None  # Configuration data for LLM client
+    llm_client: Optional[OllamaClientProtocol] = None
     memory_store_manager: Optional[Any] = None  # Optional[VectorStoreManager]
     mock_llm_client: Optional[Any] = None
 
@@ -327,9 +330,8 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
 
     def get_current_relationship_score(self, agent_name: str) -> float:
         """Returns the current relationship score with the specified agent."""
-        history = self.relationship_history.get(agent_name)
+        history = self.relationship_history.get(agent_name, [])
         if not history:
-            # Return a neutral score if no history exists
             return 0.0
         return history[-1][1]
 
@@ -348,22 +350,9 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         llm_client = model.llm_client
         mock_llm_client = model.mock_llm_client
         if llm_client_config and not llm_client:
-
-            if mock_llm_client:
-                model.llm_client = mock_llm_client
-            else:
-                config_data = llm_client_config
-                if hasattr(config_data, "model_dump"):
-                    config_data = cast(dict[str, Any], config_data.model_dump())
-                elif not isinstance(config_data, dict):
-                    raise ValueError("llm_client_config must be a Pydantic model or a dict")
-
-                if isinstance(llm_client_config, BaseModel):
-                    model.llm_client = LLMClient(config=llm_client_config)
-                else:
-                    model.llm_client = LLMClient(
-                        config=LLMClientConfig(**config_data)
-                    )
+            model.llm_client = mock_llm_client or get_default_llm_client()
+        elif not llm_client:
+            model.llm_client = mock_llm_client or get_default_llm_client()
 
         if not model.role_history:
             model.role_history = [(model.step_counter, model.current_role)]
@@ -371,9 +360,9 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             model.mood_history = [(model.step_counter, model.mood_level)]
         return model
 
-    def get_llm_client(self) -> Any:
+    def get_llm_client(self) -> OllamaClientProtocol:
         if not self.llm_client:
-            raise ValueError("LLMClient not initialized")
+            raise ValueError("LLM client not initialized")
         return self.llm_client
 
     def get_memory_retriever(self) -> Any:  # VectorStoreRetriever:

--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -23,7 +23,7 @@ from .interaction_handlers import (
 )
 
 
-def build_graph() -> StateGraph:  # type: ignore[no-any-unimported]
+def build_graph() -> StateGraph:
     graph_builder = StateGraph(AgentTurnState)
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -379,13 +379,13 @@ def get_kb_size() -> int:
     return metrics.get_kb_size()
 
 
-@bot.command(name="say")  # type: ignore[misc]
+@bot.command(name="say")
 async def say(ctx: Any, *, message: str) -> None:
     """Echo a user-provided message for smoke testing."""
     await ctx.send(f"Simulated message received: {message}")
 
 
-@bot.command(name="stats")  # type: ignore[misc]
+@bot.command(name="stats")
 async def stats(ctx: Any) -> None:
     """Return basic runtime statistics."""
     stats_text = f"LLM latency: {get_llm_latency()} ms; KB size: {get_kb_size()}"


### PR DESCRIPTION
## Summary
- use `OllamaClientProtocol` in AgentState instead of old LLMClient types
- initialise agent LLM client with `get_default_llm_client`
- fix relationship score retrieval
- remove unused type ignores

## Testing
- `ruff check .`
- `mypy src/ --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac93c11c88326b3797472ee40d629