### PR TITLE
Implement simple checkpointing support

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -20,6 +20,10 @@ This runbook outlines routine operations for working with Culture.ai.
    ```bash
    python -m src.app --steps 5
    ```
+6. (Optional) Save or resume using a checkpoint:
+   ```bash
+   python -m src.app --steps 5 --checkpoint my_sim.pkl
+   ```
 
 ## Running Tests
 Run the full suite with coverage:

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -19,7 +19,11 @@ def _serialize_simulation(sim: Simulation) -> dict[str, Any]:
         "current_step": sim.current_step,
         "current_agent_index": sim.current_agent_index,
         "scenario": sim.scenario,
-        "vector_store_dir": getattr(sim.vector_store_manager, "persist_directory", None),
+        "vector_store_dir": getattr(
+            sim.vector_store_manager,
+            "persist_directory",
+            None,
+        ),
     }
 
 

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+import pickle
+from typing import Any
+
+from src.agents.core.base_agent import Agent
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.sim.knowledge_board import KnowledgeBoard
+from src.sim.simulation import Simulation
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_simulation(sim: Simulation) -> dict[str, Any]:
+    """Convert a ``Simulation`` instance into a serializable dictionary."""
+    return {
+        "agents": [agent.state.model_dump() for agent in sim.agents],
+        "current_step": sim.current_step,
+        "current_agent_index": sim.current_agent_index,
+        "scenario": sim.scenario,
+        "vector_store_dir": getattr(sim.vector_store_manager, "persist_directory", None),
+    }
+
+
+def save_checkpoint(sim: Simulation, path: str) -> None:
+    """Serialize ``sim`` to ``path`` using pickle."""
+    data = _serialize_simulation(sim)
+    with open(path, "wb") as fh:
+        pickle.dump(data, fh)
+    logger.info("Checkpoint saved to %s", path)
+
+
+def load_checkpoint(path: str) -> Simulation:
+    """Restore a ``Simulation`` instance from ``path``."""
+    with open(path, "rb") as fh:
+        data = pickle.load(fh)
+
+    vector_store_manager = None
+    vector_store_dir = data.get("vector_store_dir")
+    if vector_store_dir:
+        vector_store_manager = ChromaVectorStoreManager(persist_directory=vector_store_dir)
+
+    agents = [
+        Agent(
+            agent_id=agent_data.get("agent_id"),
+            initial_state=agent_data,
+            name=agent_data.get("name"),
+            vector_store_manager=vector_store_manager,
+        )
+        for agent_data in data.get("agents", [])
+    ]
+
+    sim = Simulation(
+        agents=agents,
+        vector_store_manager=vector_store_manager,
+        scenario=data.get("scenario", ""),
+    )
+    sim.knowledge_board = KnowledgeBoard()
+    sim.current_step = data.get("current_step", 0)
+    sim.current_agent_index = data.get("current_agent_index", 0)
+    return sim

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import pickle
+from pathlib import Path
 from typing import Any
 
 from src.agents.core.base_agent import Agent
@@ -27,17 +28,19 @@ def _serialize_simulation(sim: Simulation) -> dict[str, Any]:
     }
 
 
-def save_checkpoint(sim: Simulation, path: str) -> None:
+def save_checkpoint(sim: Simulation, path: str | Path) -> None:
     """Serialize ``sim`` to ``path`` using pickle."""
     data = _serialize_simulation(sim)
-    with open(path, "wb") as fh:
+    p = Path(path)
+    with p.open("wb") as fh:
         pickle.dump(data, fh)
-    logger.info("Checkpoint saved to %s", path)
+    logger.info("Checkpoint saved to %s", p)
 
 
-def load_checkpoint(path: str) -> Simulation:
+def load_checkpoint(path: str | Path) -> Simulation:
     """Restore a ``Simulation`` instance from ``path``."""
-    with open(path, "rb") as fh:
+    p = Path(path)
+    with p.open("rb") as fh:
         data = pickle.load(fh)
 
     vector_store_manager = None


### PR DESCRIPTION
## Summary
- add checkpoint utilities to save/load simulation state
- allow --checkpoint to resume and persist runs
- document checkpoints in the runbook

## Testing
- `pre-commit run --files src/app.py src/infra/checkpoint.py` *(fails: mypy errors)*
- `pytest -m "unit"` *(fails: ModuleNotFoundError: prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_684b442f614c8326abf0de02f7be1fb2