### PR TITLE
Fix Windows activation in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
 2. Create and activate a virtual environment (optional but recommended):
    ```bash
    python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+   source venv/bin/activate  # On Windows: venv\Scripts\activate.bat
    ```
 
 3. Install required dependencies:
@@ -496,7 +496,7 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    # On Linux/Mac:
    source .venv/bin/activate
    # On Windows:
-   .venv\Scripts\activate
+   .venv\Scripts\activate.bat
    ```
 3. **Install dependencies:**
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,7 +3,7 @@
 This runbook outlines routine operations for working with Culture.ai.
 
 ## Starting a Simulation
-1. Activate your virtual environment.
+1. Activate your virtual environment (on Windows run `venv\Scripts\activate.bat`).
 2. Ensure dependencies are installed:
    ```bash
    pip install -r requirements.txt -r requirements-dev.txt

--- a/docs/walking_vertical_slice.md
+++ b/docs/walking_vertical_slice.md
@@ -11,7 +11,7 @@ This example demonstrates a minimal end-to-end run of the Culture.ai simulation 
 - Copy `.env.example` to `.env` and ensure the above variable is defined there
 
 ## Running the Demo
-1. Activate your virtual environment and install the requirements:
+1. Activate your virtual environment (on Windows run `venv\Scripts\activate.bat`) and install the requirements:
    ```bash
    pip install -r requirements.txt -r requirements-dev.txt
    ```


### PR DESCRIPTION
## Summary
- update README Windows activation instructions
- mention `activate.bat` in runbook and demo docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b442937088326b07f9896729c276c