### PR TITLE
Update DSPy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.25.0
 discord.py==2.3.0
 weaviate-client==3.25.0
 chromadb==0.3.21
-dspy==0.1.4
+dspy-ai==0.2.9
 pydantic==2.3.0
 pydantic-settings==2.0.3
 langgraph==0.2.0

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -22,11 +22,17 @@ from typing_extensions import Self
 # Import DSPy and Ollama, providing fallbacks when unavailable
 try:
     import dspy
+except Exception:  # pragma: no cover - attempt dspy_ai fallback
+    try:
+        import dspy_ai as dspy
+    except Exception:
+        dspy = None
 
+if dspy is not None:
     # dspy lacks type hints, so LM resolves to "Any"
     BaseLM = dspy.LM
     DSPY_AVAILABLE = True
-except Exception:  # pragma: no cover - optional dependency
+else:
     logging.getLogger(__name__).warning("DSPy not available; using stub implementations")
 
     class _BaseLM:


### PR DESCRIPTION
## Summary
- bump DSPy package from `dspy==0.1.4` to `dspy-ai==0.2.9`
- support importing `dspy_ai` if the `dspy` module is unavailable

## Testing
- `pre-commit run --files requirements.txt src/infra/dspy_ollama_integration.py`
- `pytest -c /dev/null tests/test_pytest_sanity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b442e42088326ac83443a548b1385