### PR TITLE
Update ChromaDB requirement and add sqlite-web

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@ fastapi==0.105.0
 uvicorn==0.25.0
 discord.py==2.3.0
 weaviate-client==3.25.0
-chromadb==0.3.21
+chromadb==0.4.24
 dspy==0.1.4
 pydantic==2.3.0
 pydantic-settings==2.0.3
 langgraph==0.2.0
 requests==2.32.3
+sqlite-web
 
 prometheus-client==0.20.0


### PR DESCRIPTION
## Summary
- bump `chromadb` to `0.4.24`
- add `sqlite-web` to base requirements

## Testing
- `pytest -q`
- `bash scripts/lint.sh --format`

------
https://chatgpt.com/codex/tasks/task_e_684b442b84508326a44fe17ac64d3b00