### PR TITLE
Fix config_data usage in AgentState

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -3,15 +3,13 @@ import logging
 import random
 from collections import deque
 from enum import Enum
-from typing import Any, Optional
-
+from typing import Any, Optional, cast
 
 from pydantic import (
     BaseModel,
+    Extra,
     Field,
     PrivateAttr,
-    field_validator,
-    model_validator,
 )
 from typing_extensions import Self
 
@@ -27,6 +25,30 @@ from src.infra.config import get_config  # Import get_config function
 from src.infra.llm_client import LLMClient, LLMClientConfig
 
 logger = logging.getLogger(__name__)
+
+
+try:  # Support pydantic >= 2 if installed
+    from pydantic import field_validator as _field_validator  # type: ignore[attr-defined]
+    from pydantic import model_validator as _model_validator  # type: ignore[attr-defined]
+    _PYDANTIC_V2 = True
+except ImportError:  # pragma: no cover - fallback for old pydantic
+    from pydantic import root_validator as _model_validator
+    from pydantic import validator as _field_validator
+    _PYDANTIC_V2 = False
+
+
+def field_validator(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for Pydantic field validators."""
+    if not _PYDANTIC_V2:
+        kwargs.pop("mode", None)
+    return _field_validator(*args, **kwargs)
+
+
+def model_validator(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for Pydantic model validators."""
+    if not _PYDANTIC_V2:
+        kwargs.pop("mode", None)
+    return _model_validator(*args, **kwargs)
 
 
 # Helper function for the default_factory to keep the lambda clean
@@ -97,7 +119,7 @@ except Exception:  # pragma: no cover - fallback when llm_client is missing
 
 
 class AgentStateData(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra=Extra.allow)
 
     agent_id: str
     name: str
@@ -346,31 +368,60 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             return value
         raise ValueError("Invalid memory_store_manager provided")
 
-    @model_validator(mode="after")  # type: ignore[arg-type]
-    def _validate_model_after(cls, model: "AgentState") -> "AgentState":
-        llm_client_config = model.llm_client_config
-        llm_client = model.llm_client
-        mock_llm_client = model.mock_llm_client
-        if llm_client_config and not llm_client:
-            if mock_llm_client:
+    if _PYDANTIC_V2:
+        @model_validator(mode="after")
+        def _validate_model_after(cls, model: "AgentState") -> "AgentState":
+            llm_client_config = model.llm_client_config
+            llm_client = model.llm_client
+            mock_llm_client = model.mock_llm_client
+            if llm_client_config and not llm_client:
+                if mock_llm_client:
+                    model.llm_client = mock_llm_client
+                else:
+                    if isinstance(llm_client_config, BaseModel):
+                        if hasattr(llm_client_config, "model_dump"):
+                            config_data: dict[str, Any] = llm_client_config.model_dump()
+                        else:
+                            config_data = llm_client_config.dict()
+                    else:
+                        config_data = cast(dict[str, Any], llm_client_config)
 
-                model.llm_client = mock_llm_client
-            else:
+                    model.llm_client = LLMClient(config=LLMClientConfig(**config_data))
+            elif not llm_client:
                 model.llm_client = get_default_llm_client()
 
-                model.llm_client = LLMClient(config=LLMClientConfig(**config_data))
-
-                if isinstance(llm_client_config, BaseModel):
-                    model.llm_client = LLMClient(config=cast(LLMClientConfig, llm_client_config))
+            if not model.role_history:
+                model.role_history = [(model.step_counter, model.current_role)]
+            if not model.mood_history:
+                model.mood_history = [(model.step_counter, model.mood_level)]
+            return model
+    else:
+        @model_validator()
+        def _validate_model_after(cls, values: dict[str, Any]) -> dict[str, Any]:
+            llm_client_config = values.get("llm_client_config")
+            llm_client = values.get("llm_client")
+            mock_llm_client = values.get("mock_llm_client")
+            if llm_client_config and not llm_client:
+                if mock_llm_client:
+                    values["llm_client"] = mock_llm_client
                 else:
-                    model.llm_client = LLMClient(config=LLMClientConfig(**config_data))
+                    if isinstance(llm_client_config, BaseModel):
+                        if hasattr(llm_client_config, "model_dump"):
+                            config_data = llm_client_config.model_dump()
+                        else:
+                            config_data = llm_client_config.dict()
+                    else:
+                        config_data = cast(dict[str, Any], llm_client_config)
 
+                    values["llm_client"] = LLMClient(config=LLMClientConfig(**config_data))
+            elif not llm_client:
+                values["llm_client"] = get_default_llm_client()
 
-        if not model.role_history:
-            model.role_history = [(model.step_counter, model.current_role)]
-        if not model.mood_history:
-            model.mood_history = [(model.step_counter, model.mood_level)]
-        return model
+            if not values.get("role_history"):
+                values["role_history"] = [(values.get("step_counter"), values.get("current_role"))]
+            if not values.get("mood_history"):
+                values["mood_history"] = [(values.get("step_counter"), values.get("mood_level"))]
+            return values
 
     def get_llm_client(self) -> Any:
         if not self.llm_client:
@@ -388,7 +439,7 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
     # ------------------------------------------------------------------
     def to_dict(self: Self) -> dict[str, Any]:
         """Return a dictionary representation of the agent state."""
-        return self.model_dump()
+        return self.dict()
 
     @classmethod
     def from_dict(cls: type[Self], data: dict[str, Any]) -> "AgentState":

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -31,8 +31,8 @@ except Exception:  # pragma: no cover - optional dependency
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
 try:  # pragma: no cover - optional dependency
-    import requests
-    from requests.exceptions import RequestException, Timeout
+    import requests  # type: ignore[import-untyped]
+    from requests.exceptions import RequestException, Timeout  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover - fallback when requests missing
     logging.getLogger(__name__).warning("requests package not installed; using MagicMock stub")
     from unittest.mock import MagicMock
@@ -46,25 +46,14 @@ except Exception:  # pragma: no cover - fallback when requests missing
         pass
 
     # Timeout depends on requests; ignore redefinition when stubbed
-    class Timeout(RequestException):  # type: ignore[no-redef]
+    class Timeout(RequestException):  # type: ignore[no-redef, no-any-unimported]
         """Fallback Timeout when requests is unavailable."""
 
         pass
 
 
-from typing import TYPE_CHECKING
-
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
-
-if TYPE_CHECKING:
-    from pydantic.v1.fields import ModelField
-else:  # pragma: no cover - runtime import
-    try:  # Support pydantic >= 2 if installed
-        from pydantic.v1.fields import ModelField
-    except Exception:  # pragma: no cover - fallback for pydantic<2
-        from pydantic.fields import ModelField  # type: ignore[attr-defined]
-
 
 from src.shared.decorator_utils import monitor_llm_call
 
@@ -177,7 +166,9 @@ def is_ollama_available() -> bool:
 
     try:
         # Try to connect to Ollama with a small timeout
-        response: requests.Response = requests.get(f"{OLLAMA_API_BASE}", timeout=1)
+        response: requests.Response = requests.get(  # type: ignore[no-any-unimported]
+            f"{OLLAMA_API_BASE}", timeout=1
+        )
         return bool(getattr(response, "status_code", 0) == 200)
     except RequestException as e:
         logger.debug(f"Ollama is not available: {e}")
@@ -532,7 +523,14 @@ def generate_structured_output(
                             base_fields = base_fields()
                         mock_fields = base_fields or {}
                     for field_name, field in mock_fields.items():
-                        if field.is_required():
+                        if (
+                            hasattr(field, "is_required")
+                            and callable(field.is_required)
+                        ):
+                            required = bool(field.is_required())
+                        else:
+                            required = bool(getattr(field, "required", False))
+                        if required:
                             if field.annotation is str:
                                 mocked_fields[field_name] = str(
                                     mock_data.get(field_name, f"Mock {field_name}")
@@ -575,8 +573,10 @@ def generate_structured_output(
 
             def is_required(f: FieldInfo | Any) -> bool:
                 if isinstance(f, FieldInfo):
-                    return bool(f.is_required())
-                return bool(f.required)
+                    if hasattr(f, "is_required") and callable(f.is_required):
+                        return bool(f.is_required())
+                    return bool(getattr(f, "required", False))
+                return bool(getattr(f, "required", False))
 
             for field_name, field in fields:
                 if is_required(field):


### PR DESCRIPTION
## Summary
- patch `_validate_model_after` to support Pydantic v1 and v2
- create compatibility wrappers for `model_validator` and `field_validator`
- ensure tests run with missing Hypothesis dependency installed

## Testing
- `ruff check src/agents/core/agent_state.py`
- `mypy src/agents/core/agent_state.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b52af31b88326856c0cb667e8e716