### PR TITLE
Update vLLM default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    `--swap-space` option to avoid out-of-memory errors when running more than
    ten agents:
    ```bash
-   scripts/start_vllm.sh
+   scripts/start_vllm.sh  # defaults to port 8001 (override with VLLM_PORT)
    ```
 5. **Run Weaviate (for vector store, optional):**
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -15,7 +15,7 @@ This runbook outlines routine operations for working with Culture.ai.
    Alternatively, start a vLLM server with swap space enabled to avoid
    out-of-memory errors when running many agents:
    ```bash
-   scripts/start_vllm.sh
+   scripts/start_vllm.sh  # defaults to port 8001 (override with VLLM_PORT)
    ```
 4. (Optional) Start the vector store:
    ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,7 +44,8 @@ bash scripts/setup_test_env.sh
 
 Launches the vLLM OpenAI-compatible API server with sane defaults. The script
 exposes the `VLLM_MODEL`, `VLLM_PORT`, and `VLLM_SWAP_SPACE` environment
-variables to customize the model, port, and swap space size.
+variables to customize the model, port, and swap space size. By default, the
+server listens on port `8001`.
 
 Usage:
 ```bash

--- a/scripts/start_vllm.sh
+++ b/scripts/start_vllm.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 MODEL=${VLLM_MODEL:-"mistralai/Mistral-7B-Instruct-v0.2"}
-PORT=${VLLM_PORT:-8000}
+PORT=${VLLM_PORT:-8001}
 SWAP=${VLLM_SWAP_SPACE:-16}
 
 python -m vllm.entrypoints.openai.api_server \

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -3,8 +3,7 @@ import logging
 import random
 from collections import deque
 from enum import Enum
-from typing import Any, Optional
-
+from typing import Any, Optional, cast
 
 from pydantic import (
     BaseModel,
@@ -353,15 +352,16 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         mock_llm_client = model.mock_llm_client
         if llm_client_config and not llm_client:
             if mock_llm_client:
-
                 model.llm_client = mock_llm_client
             else:
-                model.llm_client = get_default_llm_client()
-
-                model.llm_client = LLMClient(config=LLMClientConfig(**config_data))
+                config_data = llm_client_config
+                if hasattr(config_data, "model_dump"):
+                    config_data = cast(dict[str, Any], config_data.model_dump())
+                elif not isinstance(config_data, dict):
+                    raise ValueError("llm_client_config must be a Pydantic model or a dict")
 
                 if isinstance(llm_client_config, BaseModel):
-                    model.llm_client = LLMClient(config=cast(LLMClientConfig, llm_client_config))
+                    model.llm_client = LLMClient(config=llm_client_config)  # type: ignore[arg-type]
                 else:
                     model.llm_client = LLMClient(config=LLMClientConfig(**config_data))
 

--- a/src/agents/dspy_programs/rag_context_synthesizer.py
+++ b/src/agents/dspy_programs/rag_context_synthesizer.py
@@ -31,8 +31,8 @@ except ImportError as e:
     raise
 
 
-# dspy lacks type hints, so Signature resolves to Any
-class RAGSynthesis(dspy.Signature):  # type: ignore[no-any-unimported]
+# dspy lacks type hints, so Signature resolves to ``Any``.
+class RAGSynthesis(dspy.Signature):  # type: ignore[misc,no-any-unimported]
     """
     Given a query and a list of retrieved context passages, synthesize a concise and relevant
     answer or insight that addresses the query based strictly on the provided contexts.

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -63,7 +63,7 @@ else:  # pragma: no cover - runtime import
     try:  # Support pydantic >= 2 if installed
         from pydantic.v1.fields import ModelField
     except Exception:  # pragma: no cover - fallback for pydantic<2
-        from pydantic.fields import ModelField  # type: ignore[attr-defined]
+        from pydantic.fields import ModelField  # type: ignore[attr-defined]  # noqa: F401
 
 
 from src.shared.decorator_utils import monitor_llm_call


### PR DESCRIPTION
## Summary
- set default port to 8001 in `start_vllm.sh`
- reference new default port in docs
- fix undefined `config_data` and related issues in `AgentState`
- adjust `type: ignore` directives for DSPy classes so mypy passes

## Testing
- `ruff check --no-fix src tests`
- `mypy scripts --strict`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `bash scripts/start_vllm.sh --help` *(fails: ModuleNotFoundError: No module named 'vllm')*

------
https://chatgpt.com/codex/tasks/task_e_684b52b5011c83268671e255df2b07bb