### PR TITLE
Enable redteam job on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,10 @@ jobs:
         run: pytest -m "slow or dspy or integration" --disable-warnings -q
 
   redteam:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.run-redteam == 'true'
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run-redteam == 'true') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-redteam'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -177,6 +180,8 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
+        env:
+          PIP_DEFAULT_TIMEOUT: '120'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
@@ -184,4 +189,15 @@ jobs:
           pip install garak
 
       - name: Run Red Team Suite
-        run: pytest tests/redteam -m redteam --disable-warnings -q
+        shell: bash
+        run: |
+          set -o pipefail
+          pytest tests/redteam -m redteam --disable-warnings -q | tee redteam.log
+
+      - name: Fail on prompt leaks
+        shell: bash
+        run: |
+          if grep -i "leak" redteam.log; then
+            echo "Prompt leak detected" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- run redteam tests in CI when the `run-redteam` label is on a PR
- install garak with a longer pip timeout
- fail the job if any prompt leak output appears in the redteam log

## Testing
- `ruff check .` *(fails: SyntaxError in src/agents/core/agent_state.py)*
- `mypy src` *(fails: invalid syntax in src/agents/core/agent_state.py)*
- `pytest` *(fails: unrecognized argument -n)*

------
https://chatgpt.com/codex/tasks/task_e_684b610c148083269a96e8bd93c910c0