### PR TITLE
Fix dspy-ai pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.25.0
 discord.py==2.3.0
 weaviate-client==3.25.0
 chromadb==0.4.24
-dspy-ai==0.2.9
+dspy-ai>=2.6.24,<2.7
 
 pydantic==2.3.0
 pydantic-settings==2.0.3


### PR DESCRIPTION
## Summary
- use a valid dspy-ai release

## Testing
- `ruff check src/ tests/`
- `mypy src/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_684b7364b84883269d68e17633428589