### PR TITLE
Remove redundant logger

### DIFF
--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -19,7 +19,7 @@ except ImportError:
 except Exception as e:
     logging.warning(f"Failed to load environment variables from .env file: {e}")
 
-# Configure logger
+# Initialize module logger for configuration messages
 logger = logging.getLogger(__name__)
 
 # Allow runtime overrides of configuration values. Used in testing.
@@ -489,9 +489,7 @@ def get_redis_config() -> dict[str, object]:
     return {"host": REDIS_HOST, "port": REDIS_PORT, "db": REDIS_DB, "password": REDIS_PASSWORD}
 
 
-logger = logging.getLogger(__name__)
-
-# Log loaded configuration for verification (optional, be careful with sensitive data)
+# Log loaded configuration for verification. Avoid including sensitive data.
 logger.info("Configuration loaded successfully")
 
 


### PR DESCRIPTION
## Summary
- clean up infra config logger
- clarify logger comments

## Testing
- `ruff check .`
- `mypy src/infra/config.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis' and AttributeError in AgentState)*

------
https://chatgpt.com/codex/tasks/task_e_684b839d53b48326b8acaeca95d12055