### PR TITLE
Improve code-change detection for docstrings

### DIFF
--- a/tests/unit/scripts/test_check_code_changes.py
+++ b/tests/unit/scripts/test_check_code_changes.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_docstring_only_changes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+
+    file_path = repo / "foo.py"
+    file_path.write_text('def func():\n    """Original docstring."""\n    pass\n')
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True)
+
+    file_path.write_text('def func():\n    """Updated docstring."""\n    pass\n')
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "doc change"], cwd=repo, check=True)
+
+    output_file = repo / "out.txt"
+    env = os.environ.copy()
+    env["GITHUB_OUTPUT"] = str(output_file)
+    script = Path(__file__).resolve().parents[3] / "scripts" / "check_code_changes.sh"
+    subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
+
+    assert "CODE_CHANGES=false" in output_file.read_text()


### PR DESCRIPTION
## Summary
- enhance `check_code_changes.sh` script to ignore lines inside triple-quoted blocks
- add a unit test verifying that modifying docstrings does not trigger CODE_CHANGES

## Testing
- `pre-commit run --files scripts/check_code_changes.sh tests/unit/scripts/test_check_code_changes.py`
- `python -m pytest tests/unit/scripts/test_check_code_changes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b83998df083269b070dcc83bf4c6e