### PR TITLE
Fix ChromaDB import logging

### DIFF
--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -62,7 +62,8 @@ ChromaMetaList = list[ChromaMeta]
 T = TypeVar("T")
 
 # Ensure chromadb version compatibility (optional, for debugging)
-logger.info(f"Using ChromaDB version: {chromadb.__version__}")
+if chromadb is not None:
+    logger.info(f"Using ChromaDB version: {chromadb.__version__}")
 
 
 def first_list_element(lst: list[list[T]] | object) -> list[T]:

--- a/tests/unit/memory/test_vector_store_import_no_chromadb.py
+++ b/tests/unit/memory/test_vector_store_import_no_chromadb.py
@@ -1,0 +1,31 @@
+import builtins
+import importlib
+import sys
+from collections.abc import Sequence
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.vector_store
+def test_vector_store_import_without_chromadb(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing vector_store should succeed when chromadb is missing."""
+
+    original_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict | None = None,
+        locals: dict | None = None,
+        fromlist: Sequence[str] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "chromadb" or name.startswith("chromadb."):
+            raise ImportError("No module named 'chromadb'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("src.agents.memory.vector_store", None)
+
+    module = importlib.import_module("src.agents.memory.vector_store")
+    assert module.chromadb is None


### PR DESCRIPTION
## Summary
- avoid accessing ChromaDB when it isn't installed
- add test ensuring vector store import works without ChromaDB

## Testing
- `ruff check src/agents/memory/vector_store.py tests/unit/memory/test_vector_store_import_no_chromadb.py`
- `black src/agents/memory/vector_store.py tests/unit/memory/test_vector_store_import_no_chromadb.py`
- `mypy src/agents/memory/vector_store.py tests/unit/memory/test_vector_store_import_no_chromadb.py`
- `pytest tests/unit/memory/test_vector_store_import_no_chromadb.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b851e07e88326b0ebae11c7944dc0