### PR TITLE
Pin DSPy version

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
    ```bash
    pip install -r requirements.txt
    ```
+   The project currently supports **DSPy 2.6.27**; `requirements.txt` pins `dspy-ai==2.6.27`.
 
 4. Install Ollama following the [official instructions](https://ollama.ai/download)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ pydantic-settings
 prometheus-client==0.20.0
 hypothesis>=6.0
 pre-commit
+dspy-ai==2.6.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.25.0
 discord.py==2.3.0
 weaviate-client==3.25.0
 chromadb==0.4.24
-dspy-ai>=2.6.24,<2.7
+dspy-ai==2.6.27
 
 pydantic==2.3.0
 pydantic-settings==2.0.3

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -60,7 +60,6 @@ def _serialize_simulation(sim: Simulation) -> dict[str, Any]:
     """Convert a ``Simulation`` instance into a serializable dictionary."""
     return {
         "agents": [cast(Agent, agent).state.to_dict(exclude_none=True) for agent in sim.agents],
-
         "current_step": sim.current_step,
         "current_agent_index": sim.current_agent_index,
         "scenario": sim.scenario,

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -31,12 +31,12 @@ except ImportError:  # pragma: no cover - optional dependency
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
 if TYPE_CHECKING:
-    import requests  # type: ignore[import-untyped]
-    from requests.exceptions import RequestException, Timeout  # type: ignore[import-untyped]
+    import requests
+    from requests.exceptions import RequestException, Timeout
 else:
     try:  # pragma: no cover - optional dependency
-        import requests  # type: ignore[import-untyped]
-        from requests.exceptions import RequestException, Timeout  # type: ignore[import-untyped]
+        import requests
+        from requests.exceptions import RequestException, Timeout
     except ImportError:  # pragma: no cover - fallback when requests missing
         logging.getLogger(__name__).warning("requests package not installed; using MagicMock stub")
         from unittest.mock import MagicMock

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -58,7 +58,6 @@ class SimulationDiscordBot:
 
         # Set up event handlers
         @self.client.event
-
         async def on_ready() -> None:
             """Event handler that fires when the bot connects to Discord."""
             self.is_ready = True

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -65,9 +65,9 @@ def monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data[
-                            "error_message"
-                        ] = "Function returned None, indicating an error"
+                        metrics_data["error_message"] = (
+                            "Function returned None, indicating an error"
+                        )
                 else:
                     metrics_data["success"] = True
                     if result is not None and hasattr(result, "usage"):

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -76,9 +76,9 @@ class Simulation:
         logger.info("Simulation initialized with Knowledge Board.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
         logger.info("Simulation initialized with project tracking system.")
 
         # --- NEW: Initialize Collective Metrics ---
@@ -113,9 +113,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -359,9 +359,9 @@ class Simulation:
             logger.info(f"  - DU: {current_agent_state.du:.1f} (from {current_agent_state.du})")
 
             # Update the agent state in the simulation's list of agents
-            self.agents[
-                agent_to_run_index
-            ] = agent  # Ensure the agent object itself is updated if it was replaced
+            self.agents[agent_to_run_index] = (
+                agent  # Ensure the agent object itself is updated if it was replaced
+            )
             self.agents[agent_to_run_index].update_state(current_agent_state)
 
             # Determine next agent index based on role change event this turn

--- a/tests/manual/test_relationship_cases.py
+++ b/tests/manual/test_relationship_cases.py
@@ -403,7 +403,9 @@ async def test_case_4_broadcast_vs_targeted(use_discord: bool = False) -> None:
             f"OBSERVED MULTIPLIER: {observed_multiplier:.2f}x (Expected: {targeted_multiplier:.2f}x)"
         )
         if abs(observed_multiplier - targeted_multiplier) < 0.1:
-            logging.info("✅ VERIFICATION PASSED: Targeted message multiplier is working correctly")
+            logging.info(
+                "✅ VERIFICATION PASSED: Targeted message multiplier is working correctly"
+            )
         else:
             logging.info(
                 "❌ VERIFICATION FAILED: Targeted message multiplier not applying correctly"

--- a/tests/unit/dspy/test_dspy_role_adherence.py
+++ b/tests/unit/dspy/test_dspy_role_adherence.py
@@ -160,7 +160,9 @@ def test_role_prefix_adherence() -> None:
     logger.info(f"Success rate: {success_rate:.1f}% ({success_count}/{total_tests} successful)")
 
     if success_count == total_tests:
-        logger.info("✅ All tests passed! DSPy role adherence implementation is working correctly.")
+        logger.info(
+            "✅ All tests passed! DSPy role adherence implementation is working correctly."
+        )
     else:
         logger.warning(
             f"⚠️ {total_tests - success_count} tests failed. DSPy role adherence needs improvement."


### PR DESCRIPTION
## Summary
- pin DSPy to version 2.6.27
- document pinned DSPy in installation instructions
- remove unused type ignores and format code

## Testing
- `ruff check src/ tests/`
- `black --check src/ tests/`
- `mypy src/`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_684b83949e6083268627ecc8158c4c47