### PR TITLE
Update Windows setup run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
      * Role change parameters
    * See `docs/configuration_system.md` for detailed configuration documentation
 
+Once Ollama is running you can launch a basic simulation:
+```bash
+python -m src.app --steps 5 --discord
+```
+See [docs/windows_setup.md#run-the-simulation](docs/windows_setup.md#run-the-simulation) for a step-by-step guide on Windows.
+
+
 ## Code Linting and Formatting
 
 This project uses **Ruff** and **Black** for linting and formatting. Ruff handles

--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -68,3 +68,14 @@ ollama serve &
 
 The script launches three agents for a few steps and stores their memories in
 ChromaDB. See `docs/walking_vertical_slice.md` for details.
+
+## Run the Simulation
+
+Once Ollama is running and your `.env` is configured, launch the main application:
+
+```bash
+python -m src.app --steps 5 --discord
+```
+
+The `--steps` flag sets how many iterations to perform before exiting. Use `--discord` to enable interaction with your configured Discord bot.
+


### PR DESCRIPTION
## Summary
- document how to run the main app with `--steps` and `--discord` in `docs/windows_setup.md`
- cross-link the Windows instructions from the README after the installation steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c82bee1048326b3985ecdae19a91b