### PR TITLE
Pin CUDA-enabled torch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu121
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
@@ -177,6 +178,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu121
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
@@ -214,6 +216,7 @@ jobs:
           PIP_DEFAULT_TIMEOUT: '120'
         run: |
           python -m pip install --upgrade pip
+          pip install --extra-index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu121
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install garak

--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -57,10 +57,12 @@ ollama serve &
 
 ## Run the Example Vertical Slice
 
-1. Install project requirements from the repository root:
+1. Install the CUDA-enabled PyTorch build and the remaining project requirements:
    ```bash
+   pip install --extra-index-url https://download.pytorch.org/whl/cu121 torch==2.3.0+cu121
    pip install -r requirements.txt -r requirements-dev.txt
    ```
+   The requirements file pins this PyTorch version, so ensure your system has CUDA 12.1 drivers installed.
 2. Execute the demo using your running Ollama instance:
    ```bash
    python -m examples.walking_vertical_slice

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.3.0+cu121
 fastapi==0.105.0
 uvicorn==0.25.0
 discord.py==2.3.0


### PR DESCRIPTION
## Summary
- pin a CUDA-enabled torch version in requirements
- install CUDA-enabled torch in CI
- document torch version and CUDA requirement

## Testing
- `pre-commit run --files requirements.txt docs/windows_setup.md .github/workflows/ci.yml`
- `ruff check . --output-format=full`
- `mypy src/ --strict` *(fails: Class cannot subclass "Signature")*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_684c82bdc56883269f0b422d3d5332ef