### PR TITLE
Extend checkpoint env capture

### DIFF
--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -21,6 +21,21 @@ from src.sim.simulation import Simulation
 
 logger = logging.getLogger(__name__)
 
+# Prefixes for project-specific environment variables that should be captured
+ENV_PREFIXES: tuple[str, ...] = (
+    "CULTURE_",
+    "OLLAMA_",
+    "REDIS_",
+    "WEAVIATE_",
+    "OPENAI_",
+    "ANTHROPIC_",
+    "DISCORD_",
+    "MEMORY_",
+    "ROLE_",
+    "IP_",
+    "DU_",
+)
+
 
 def capture_rng_state() -> tuple[Any, ...]:
     """Return the current ``random`` module state."""
@@ -36,14 +51,18 @@ def capture_environment() -> dict[str, Any]:
     """Capture relevant environment variables and system info."""
     from src.infra.config import DEFAULT_CONFIG
 
-    env = {key: os.environ.get(key) for key in DEFAULT_CONFIG}
+    env: dict[str, Any] = {}
+    prefixes = ENV_PREFIXES
+    for key, value in os.environ.items():
+        if key in DEFAULT_CONFIG or any(key.startswith(p) for p in prefixes):
+            env[key] = value
     env["python_version"] = sys.version
     env["platform"] = platform.platform()
     return env
 
 
 def restore_environment(env: dict[str, Any]) -> None:
-    """Restore environment variables from ``env``."""
+    """Restore environment variables captured by :func:`capture_environment`."""
     from src.infra import config
 
     for key, value in env.items():

--- a/tests/unit/infra/test_checkpoint.py
+++ b/tests/unit/infra/test_checkpoint.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.unit
 
 def test_checkpoint_save_and_load(tmp_path, monkeypatch):
     monkeypatch.setenv("ROLE_DU_GENERATION", '{"A":1, "B":1}')
+    monkeypatch.setenv("CULTURE_CUSTOM_VAR", "xyz")
     random.seed(1234)
     sim = create_simulation(num_agents=1, steps=1, scenario="test")
 
@@ -30,6 +31,7 @@ def test_checkpoint_save_and_load(tmp_path, monkeypatch):
     restore_environment(meta["environment"])
 
     assert os.environ["ROLE_DU_GENERATION"] == '{"A":1, "B":1}'
+    assert os.environ["CULTURE_CUSTOM_VAR"] == "xyz"
     assert random.random() == expected_next
     assert loaded.agents[0].state.current_role == sim.agents[0].state.current_role
 


### PR DESCRIPTION
## Summary
- capture env vars with CULTURE_ or project-specific prefixes
- ensure restore_environment handles these variables
- test that custom env vars are restored

## Testing
- `bash scripts/lint.sh --format`
- `pytest -k checkpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_684c82bf73ac8326b1f8785751cb8aac