### PR TITLE
Remove unused mypy ignore

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -45,5 +45,5 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
 
 
 @app.get("/health")
-async def health() -> JSONResponse:  # type: ignore[no-any-unimported]
+async def health() -> JSONResponse:
     return JSONResponse({"status": "ok"})


### PR DESCRIPTION
## Summary
- remove unnecessary mypy suppression on `health`

## Testing
- `mypy src/interfaces/dashboard_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_684c8b7cf7b883269d7e56205359acc6