### PR TITLE
Fix deprecated asyncio_mode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -62,5 +62,5 @@ python_classes = Test*
 python_functions = test_*
 
 # Asyncio settings for pytest-asyncio
-# Options for asyncio_mode: auto, strict, legacy
-asyncio_mode = auto
+# Options for asyncio_mode: strict, legacy
+asyncio_mode = strict


### PR DESCRIPTION
## Summary
- update pytest.ini to use strict asyncio_mode

## Testing
- `python -m pytest tests/test_pytest_sanity.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_684c8b7b58d883269e8915bfd829b3cf