### PR TITLE
Add numpy to dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ To install development dependencies (including linting tools), run:
 ```bash
 pip install -r requirements-dev.txt
 ```
+These development requirements now include `numpy>=2` alongside tools like Ruff,
+Black, and Mypy.
 
 To run the linters and type checker locally, use the helper scripts:
 ```bash
@@ -380,7 +382,7 @@ To customize the simulation:
    pip install -r requirements.txt -r requirements-dev.txt
    ```
    The development requirements include tools such as `pytest-xdist`,
-   `pytest-asyncio`, and `requests` which are required for the full test suite.
+   `pytest-asyncio`, `requests`, and `numpy>=2` which are required for the full test suite.
    You can also run `scripts/setup_test_env.sh` to automate these steps.
    Optional packages like `chromadb`, `weaviate-client`, and `langgraph` are
    included so tests won't be skipped unexpectedly.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,7 +11,7 @@ pip install -r requirements.txt -r requirements-dev.txt
 ```
 You can also run `scripts/setup_test_env.sh` to automatically create a virtual
 environment and install these dependencies.
-The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, and `requests` for HTTP utilities.
+The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, `requests` for HTTP utilities, and `numpy>=2` for compatibility with certain examples.
 
 ## Test Markers and Suite Structure
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ prometheus-client==0.20.0
 hypothesis>=6.0
 pre-commit
 dspy-ai==2.6.27
+numpy>=2


### PR DESCRIPTION
## Summary
- include numpy in development requirements
- document numpy in setup instructions

## Testing
- `ruff check src/ tests/ --exclude src/infra/checkpoint.py`
- `black src/ tests/ --exclude src/infra/checkpoint.py`
- `mypy src/ --exclude src/infra/checkpoint.py` *(fails: Library stubs not installed for "requests" and syntax error in checkpoint.py)*
- `python -m pytest tests/` *(fails: 1 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b7c0fd883269dc97250779ee8ed