### PR TITLE
Add ruff formatting check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
         shell: bash
         run: ruff check . --output-format=full
 
+      - name: Run Ruff Format (Formatter)
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
+        shell: bash
+        run: ruff format --check .
+
       - name: Run Mypy (Type Check)
         if: steps.changes.outputs.CODE_CHANGES == 'true'
         shell: bash


### PR DESCRIPTION
## Summary
- run `ruff format --check .` in CI before running tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `ruff check .` *(fails: SyntaxError in src/infra/checkpoint.py)*
- `mypy src/` *(fails: unexpected indent)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests')*

------
https://chatgpt.com/codex/tasks/task_e_684c8b71c01c83268716ed8aa21f7265