### PR TITLE
Fix mypy issue on health endpoint

### DIFF
--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -21,21 +21,30 @@ from src.sim.simulation import Simulation
 
 logger = logging.getLogger(__name__)
 
+# Prefixes for project-specific environment variables that should be captured
+ENV_PREFIXES: tuple[str, ...] = (
+    "CULTURE_",
+    "OLLAMA_",
+    "REDIS_",
+    "WEAVIATE_",
+    "OPENAI_",
+    "ANTHROPIC_",
+    "DISCORD_",
+    "MEMORY_",
+    "ROLE_",
+    "IP_",
+    "DU_",
+)
 
+
+def capture_rng_state() -> dict[str, Any]:
     """Return the current RNG state for ``random`` and ``numpy`` if available."""
-    """Restore RNG state for ``random`` and ``numpy``.
-
-    Accepts states from :func:`capture_rng_state` or the legacy tuple-based
-    format used in older checkpoints.
-    """
-    """Return the current RNG state for ``random`` and ``numpy``."""
     state = {"random": random.getstate()}
     try:  # pragma: no cover - optional dependency
         import numpy as np
 
         state["numpy"] = np.random.get_state()
     except ImportError:
-
         # ``numpy`` is optional; ignore if unavailable
         pass
 
@@ -53,13 +62,11 @@ def restore_rng_state(state: Any) -> None:
         random.setstate(random_state)
 
     if isinstance(state, dict) and "numpy" in state:
-
         try:  # pragma: no cover - optional dependency
             import numpy as np
 
             np.random.set_state(state["numpy"])
         except ImportError:
-
             pass
 
 

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
@@ -45,5 +44,5 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
 
 
 @app.get("/health")
-async def health() -> JSONResponse:  # type: ignore[no-any-unimported]
-    return JSONResponse({"status": "ok"})
+async def health() -> dict[str, str]:
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- remove mypy ignore on health endpoint
- implement missing RNG helpers in `checkpoint.py`
- return a dict from `/health` for type safety

## Testing
- `pre-commit run --files src/interfaces/dashboard_backend.py src/infra/checkpoint.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c8b727cbc832696b8ba3e846bfd6c