### PR TITLE
Add dspy version range check

### DIFF
--- a/tests/env/test_dspy_version.py
+++ b/tests/env/test_dspy_version.py
@@ -1,7 +1,11 @@
 import importlib.metadata as im
 
+import pytest
+from packaging.version import Version
 
-def test_dspy_version():
-    v = im.version("dspy-ai")
-    major, minor, *_ = map(int, v.split(".")[:2])
-    assert major == 2 and 24 <= minor < 7, f"Unsupported DSPy version: {v}"
+
+@pytest.mark.unit
+def test_dspy_version() -> None:
+    """Ensure the installed DSPy version is within the supported 2.6 range."""
+    v = Version(im.version("dspy-ai"))
+    assert Version("2.6.24") <= v < Version("2.7.0"), f"Unsupported DSPy version: {v}"


### PR DESCRIPTION
## Summary
- ensure DSPy version is within the supported `2.6` range

## Testing
- `pre-commit run --files tests/env/test_dspy_version.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9d35ec4c832682a995f90c35dbd1