### PR TITLE
Implement DSPy loader with tests

### DIFF
--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -9,6 +9,7 @@ import json
 import logging
 import sys
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
 from unittest.mock import MagicMock
@@ -359,9 +360,35 @@ class OllamaLM(BaseLM):  # type: ignore[misc, valid-type]
             return self.__call__(prompt=prompt)
 
     def _try_load_compiled_program(self: Self, program_path: str) -> bool:
-        # Implementation of _try_load_compiled_program method
-        # This method should return a boolean indicating whether the program was loaded successfully
-        return False  # Placeholder return, actual implementation needed
+        """Attempt to load a compiled DSPy program from ``program_path``.
+
+        This helper is primarily used in tests to verify that a compiled
+        program JSON can be read successfully. It simply ensures the file
+        exists and contains valid JSON.
+
+        Args:
+            program_path: Path to the compiled DSPy program JSON file.
+
+        Returns:
+            ``True`` if the program file exists and can be parsed, ``False`` otherwise.
+        """
+
+        path = Path(program_path)
+        if not path.exists():
+            logger.error("Compiled DSPy program not found at %s", program_path)
+            return False
+
+        try:
+            with path.open() as f:
+                json.load(f)
+            return True
+        except Exception as e:
+            logger.error(
+                "Failed to load compiled DSPy program from %s: %s",
+                program_path,
+                e,
+            )
+            return False
 
 
 def configure_dspy_with_ollama(

--- a/tests/unit/infra/test_dspy_loader.py
+++ b/tests/unit/infra/test_dspy_loader.py
@@ -1,0 +1,27 @@
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.infra.dspy_ollama_integration import OllamaLM
+
+
+@pytest.mark.unit
+def test_try_load_compiled_program_success(tmp_path: Path) -> None:
+    file_path = tmp_path / "prog.json"
+    file_path.write_text("{}")
+    with patch("src.infra.dspy_ollama_integration.ollama.Client", MagicMock()):
+        lm = OllamaLM()
+        assert lm._try_load_compiled_program(str(file_path)) is True
+
+
+@pytest.mark.unit
+def test_try_load_compiled_program_failure(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    missing_path = tmp_path / "missing.json"
+    with patch("src.infra.dspy_ollama_integration.ollama.Client", MagicMock()):
+        lm = OllamaLM()
+        with caplog.at_level(logging.ERROR):
+            result = lm._try_load_compiled_program(str(missing_path))
+    assert result is False
+    assert "Compiled DSPy program not found" in caplog.text


### PR DESCRIPTION
## Summary
- load a compiled DSPy program in `OllamaLM`
- test loading success and failure cases

## Testing
- `ruff check src/infra/dspy_ollama_integration.py tests/unit/infra/test_dspy_loader.py`
- `mypy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb48687088326b1d55e0f3153e6e0