### PR TITLE
Add pip-tools requirement check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,13 @@ jobs:
             ~/.cache/pip
             ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+      - name: Check locked requirements
+        if: steps.changes.outputs.CODE_CHANGES == 'true'
+        shell: bash
+        run: bash scripts/check_requirements.sh
 
       - name: Install dependencies
         if: steps.changes.outputs.CODE_CHANGES == 'true'
@@ -179,6 +184,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Check locked requirements
+        shell: bash
+        run: bash scripts/check_requirements.sh
+
       - name: Install dependencies
         shell: bash
         run: |
@@ -215,6 +224,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+      - name: Check locked requirements
+        shell: bash
+        run: bash scripts/check_requirements.sh
 
       - name: Install dependencies
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Welcome! We're excited that you're interested in contributing to Culture.ai. Thi
 - [Mypy](http://mypy-lang.org/) for static type checking
 - Install dependencies from `requirements-dev.txt` (includes `pytest-xdist`) in addition to `requirements.txt`.
 - Set up your environment and dependencies as described in the README.
+- If you modify dependencies, run `scripts/check_requirements.sh` to ensure `requirements.txt` is in sync with `requirements.in`.
 
 ## Code Style Guidelines
 - **Follow [PEP 8](https://peps.python.org/pep-0008/)** for Python code style.
@@ -39,6 +40,7 @@ Welcome! We're excited that you're interested in contributing to Culture.ai. Thi
   ```bash
   python -m pytest --cov=src --cov-report=term-missing tests/
   ```
+- **Dependency lock check:** `scripts/check_requirements.sh` verifies that `requirements.txt` matches the output of `pip-compile`. The CI workflow runs this step automatically.
 - See [docs/testing.md](docs/testing.md) for advanced test strategies, markers, and troubleshooting.
 
 ## Reporting Bugs & Requesting Features

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,3 +16,4 @@ hypothesis>=6.0
 pre-commit
 dspy-ai==2.6.27
 numpy>=2
+pip-tools

--- a/scripts/check_requirements.sh
+++ b/scripts/check_requirements.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure pip-tools is installed
+command -v pip-compile >/dev/null 2>&1 || { echo "pip-compile not found" >&2; exit 1; }
+
+# Generate requirements to a temp file without writing to disk
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+pip-compile --dry-run --no-header --no-annotate --output-file - requirements.in \
+  2>&1 | grep -v '^WARNING:' | grep -v 'Dry-run' > "$TMP_FILE"
+
+if ! diff -q requirements.txt "$TMP_FILE" >/dev/null; then
+  echo "requirements.txt is out of date. Run 'pip-compile requirements.in' to update." >&2
+  diff -u requirements.txt "$TMP_FILE" >&2 || true
+  exit 1
+fi
+
+echo "requirements.txt is up to date."


### PR DESCRIPTION
## Summary
- add `pip-tools` to development requirements
- verify locked dependencies via `scripts/check_requirements.sh`
- run the requirements check in CI before installing dependencies
- document dependency workflow in CONTRIBUTING
- fix script to use `pip-compile --dry-run`

## Testing
- `python -m pytest -k test_pytest_sanity -q`
- `ruff check src/ tests/ --no-fix` *(fails: Import block is un-sorted)*
- `mypy src/`

------
https://chatgpt.com/codex/tasks/task_e_684cb48718f88326ada7cd83063a74bc