### PR TITLE
Add vertical slice convenience script for Windows

### DIFF
--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -67,6 +67,10 @@ ollama serve &
    ```bash
    python -m examples.walking_vertical_slice
    ```
+   On Windows you can instead run the convenience script:
+   ```cmd
+   scripts\vertical_slice.bat
+   ```
 
 The script launches three agents for a few steps and stores their memories in
 ChromaDB. See `docs/walking_vertical_slice.md` for details.

--- a/scripts/vertical_slice.bat
+++ b/scripts/vertical_slice.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Run the walking vertical slice demo. Activates venv if present.
+if exist venv\Scripts\activate.bat (
+    call venv\Scripts\activate.bat
+)
+python -m examples.walking_vertical_slice
+


### PR DESCRIPTION
## Summary
- add a batch script to run the walking vertical slice demo
- document the script in the Windows setup guide

## Testing
- `ruff check .`
- `ruff format --check .`
- `black --check .`
- `.venv/bin/mypy src/ --strict` *(fails: Class cannot subclass `Signature`)*
- `.venv/bin/python -m pytest -q` *(fails: test_graph_nodes.py)*

------
https://chatgpt.com/codex/tasks/task_e_684f2575b3908326b846e838135cc089