### PR TITLE
Add Windows test environment script

### DIFF
--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -33,6 +33,13 @@ python3.10 -m venv venv
 source venv/bin/activate
 ```
 
+Alternatively, run the helper script to automatically create `.venv` and
+install all test requirements:
+
+```cmd
+scripts\setup_test_env.bat
+```
+
 Copy the example environment file and customize it if needed:
 
 ```bash

--- a/scripts/setup_test_env.bat
+++ b/scripts/setup_test_env.bat
@@ -1,0 +1,21 @@
+@echo off
+REM Set up a Python virtual environment and install dependencies for Culture.ai tests
+
+set VENV_DIR=.venv
+
+if not exist %VENV_DIR% (
+    python -m venv %VENV_DIR%
+)
+
+call %VENV_DIR%\Scripts\activate.bat
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt -r requirements-dev.txt
+
+python - <<PY
+import importlib.util, subprocess, sys
+if importlib.util.find_spec("xdist") is None:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "pytest-xdist"])
+PY
+
+echo Environment ready. Run pytest with %VENV_DIR%\Scripts\python -m pytest

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -48,7 +48,8 @@ def test_prepare_relationship_prompt_node() -> None:
 async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
     state = {"agent_id": "a"}
     out = await retrieve_and_summarize_memories_node(state)
-    assert out == {"rag_summary": "(No memory retrieval)"}
+    assert out["rag_summary"] == "(No memory retrieval)"
+    assert out["memory_history_list"] == []
 
 
 class DummyManager:
@@ -75,7 +76,8 @@ async def test_retrieve_and_summarize_memories_node_with_manager() -> None:
         "current_role": "r",
     }
     out = await retrieve_and_summarize_memories_node(state)
-    assert out == {"rag_summary": "SUM"}
+    assert out["rag_summary"] == "SUM"
+    assert out["memory_history_list"] == [{"content": "m1"}, {"content": "m2"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a Windows batch script to mirror setup_test_env.sh
- document the batch file in the Windows setup guide
- fix failing graph node tests

## Testing
- `pre-commit run --files tests/unit/graphs/test_graph_nodes.py`
- `PYTHONPATH=. pytest tests/unit/graphs/test_graph_nodes.py::test_retrieve_and_summarize_memories_node_with_manager tests/unit/graphs/test_graph_nodes.py::test_retrieve_and_summarize_memories_node_no_manager -q`

------
https://chatgpt.com/codex/tasks/task_e_684f37ba47d88326bbc21af6ea03d322