### PR TITLE
Enable Mypy strict mode

### DIFF
--- a/docs/coding_standards.md
+++ b/docs/coding_standards.md
@@ -117,6 +117,7 @@ def retrieve_relevant_memories(
 ### 5.1. Usage
 - Use type hints for all function signatures.
 - Use type hints for complex variables where the type is not obvious.
+- Mypy strict mode is enforced globally via `strict = true` in `pyproject.toml`.
 - Import types from the `typing` module: `List`, `Dict`, `Optional`, etc.
 
 ### 5.2. Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ exclude = [
 files = ["src"]
 # Temporarily disable the Pydantic mypy plugin due to compatibility issues
 # plugins = ["pydantic.mypy"]
-# strict = true  # Uncomment if your mypy version supports this global flag
+strict = true  # Global strict typing
 
 #[tool.ruff.lint.per-file-ignores] # This line and the following are removed as they are now under [tool.ruff.per-file-ignores]
 #"src/agents/dspy_programs/*_examples.py" = ["E501"]


### PR DESCRIPTION
## Summary
- enable `strict=true` in `pyproject.toml`
- document strict typing in coding standards

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68501a12dc748326b19be52c713137eb