### PR TITLE
Add Redpanda event replay and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,11 @@ REDIS_PASSWORD=
 WEAVIATE_URL=http://localhost:8080
 # Backend for the vector store ("chroma" or "weaviate")
 VECTOR_STORE_BACKEND=chroma
+
+# -- Redpanda Logging --
+# Enable Redpanda event logging (set to 1 to enable)
+ENABLE_REDPANDA=0
+# Broker address for the Redpanda/Kafka cluster
+REDPANDA_BROKER=localhost:9092
+# Topic used for event logging
+REDPANDA_TOPIC=culture.events

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -33,6 +33,9 @@ This runbook outlines routine operations for working with Culture.ai.
    ```bash
    python -m src.app --steps 5 --checkpoint my_sim.pkl --replay
    ```
+   When `--replay` is provided and `ENABLE_REDPANDA=1`, the simulation will
+   restore RNG/environment state and replay agent actions from the Redpanda
+   event log.
 
 ## Running Tests
 Run the full suite with coverage:

--- a/src/app.py
+++ b/src/app.py
@@ -141,7 +141,7 @@ def main() -> None:
     meta: dict[str, object] | None = None
     if args.checkpoint and Path(args.checkpoint).exists():
         logging.info("Loading simulation from checkpoint %s", args.checkpoint)
-        sim, meta = load_checkpoint(args.checkpoint)
+        sim, meta = load_checkpoint(args.checkpoint, replay=args.replay)
         sim.steps_to_run = args.steps
     else:
         sim = create_simulation(

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -7,15 +7,22 @@ import os
 from typing import Any
 
 try:  # pragma: no cover - optional dependency
+    from confluent_kafka import Consumer as KafkaConsumer
     from confluent_kafka import Producer as KafkaProducer
 except Exception:  # pragma: no cover - fallback
-    KafkaProducer = Any
+    KafkaConsumer = KafkaProducer = Any
 
 
 _broker = os.getenv("REDPANDA_BROKER", "localhost:9092")
 _topic = os.getenv("REDPANDA_TOPIC", "culture.events")
 
 _producer: Any | None = None
+
+_consumer_conf = {
+    "bootstrap.servers": _broker,
+    "group.id": os.getenv("REPLAY_GROUP", "culture-replay"),
+    "auto.offset.reset": "earliest",
+}
 
 
 def _get_producer() -> Any:
@@ -38,3 +45,35 @@ def log_event(event: dict[str, Any]) -> None:
         import logging
 
         logging.getLogger(__name__).debug("Failed to log event: %s", exc)
+
+
+def fetch_events(after_step: int = 0) -> list[dict[str, Any]]:
+    """Retrieve events from Redpanda after ``after_step``."""
+    if os.getenv("ENABLE_REDPANDA", "0") != "1":
+        return []
+    events: list[dict[str, Any]] = []
+    try:
+        consumer = KafkaConsumer(_consumer_conf)
+        consumer.subscribe([_topic])
+        while True:
+            msg = consumer.poll(0.1)
+            if msg is None:
+                break
+            if msg.error():
+                break
+            try:
+                event = json.loads(msg.value().decode("utf-8"))
+            except Exception:
+                continue
+            if event.get("step", 0) > after_step:
+                events.append(event)
+    except Exception as exc:  # pragma: no cover - best effort
+        import logging
+
+        logging.getLogger(__name__).debug("Failed to fetch events: %s", exc)
+    finally:
+        try:
+            consumer.close()
+        except Exception:  # pragma: no cover - ignore
+            pass
+    return events

--- a/tests/integration/test_log_replay.py
+++ b/tests/integration/test_log_replay.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+from src.app import create_simulation
+from src.infra import event_log
+from src.infra.checkpoint import load_checkpoint, save_checkpoint
+from tests.utils.mock_llm import MockLLM
+
+
+@pytest.mark.integration
+def test_replay_from_event_log(monkeypatch, tmp_path):
+    events = []
+    monkeypatch.setattr(event_log, "log_event", lambda e: events.append(e))
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+
+    with MockLLM():
+        sim = create_simulation(num_agents=1, steps=1, scenario="log")
+        chk = tmp_path / "sim.pkl"
+        save_checkpoint(sim, chk)
+        asyncio.run(sim.async_run(2))
+        expected_ip = sim.agents[0].state.ip
+        expected_step = sim.current_step
+
+    def fake_fetch(after_step=0):
+        return [ev for ev in events if ev.get("step", 0) > after_step]
+
+    monkeypatch.setattr(event_log, "fetch_events", fake_fetch)
+
+    loaded, _ = load_checkpoint(chk, replay=True)
+
+    assert loaded.current_step == expected_step
+    assert loaded.agents[0].state.ip == expected_ip


### PR DESCRIPTION
## Summary
- log events with Kafka consumer/producer
- replay logged events when loading checkpoints
- capture environment changes in event log
- document usage in runbook and env example
- add integration test for log-based replay

## Testing
- `ruff check src/app.py src/infra/checkpoint.py src/infra/event_log/__init__.py src/sim/simulation.py tests/integration/test_log_replay.py`
- `pytest -m "unit and not dspy" -q`

------
https://chatgpt.com/codex/tasks/task_e_68501a13dad083268de83e0e21b87a79