### PR TITLE
Add OTEL exporter endpoint configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ REDIS_PASSWORD=
 WEAVIATE_URL=http://localhost:8080
 # Backend for the vector store ("chroma" or "weaviate")
 VECTOR_STORE_BACKEND=chroma
+
+# -- Observability --
+# Endpoint for OpenTelemetry log exporter
+OTEL_EXPORTER_ENDPOINT=http://localhost:4318/v1/logs

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,8 +27,9 @@ Once running, access Grafana at [http://localhost:3000](http://localhost:3000) a
 
 ## 4. OpenTelemetry Logs
 
-Culture.ai can export structured logs via the OpenTelemetry OTLP exporter. The exporter is
-enabled by default and sends logs to `localhost:4318`.
+Culture.ai can export structured logs via the OpenTelemetry OTLP exporter. The exporter
+sends logs to `localhost:4318/v1/logs` by default. Set `OTEL_EXPORTER_ENDPOINT` to
+override this URL.
 
 To receive these logs locally, run an OTLP-compatible collector such as the
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/):

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -84,6 +84,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "OPENAI_API_KEY": "",
     "ANTHROPIC_API_KEY": "",
     "DEFAULT_LOG_LEVEL": "INFO",
+    # Endpoint for sending logs via OpenTelemetry
     "OTEL_EXPORTER_ENDPOINT": "http://localhost:4318/v1/logs",
     "MEMORY_PRUNING_ENABLED": False,
     "MEMORY_PRUNING_L2_ENABLED": True,

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -84,6 +84,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "OPENAI_API_KEY": "",
     "ANTHROPIC_API_KEY": "",
     "DEFAULT_LOG_LEVEL": "INFO",
+    "OTEL_EXPORTER_ENDPOINT": "http://localhost:4318/v1/logs",
     "MEMORY_PRUNING_ENABLED": False,
     "MEMORY_PRUNING_L2_ENABLED": True,
     "MEMORY_PRUNING_L1_MUS_ENABLED": False,
@@ -287,6 +288,7 @@ WEAVIATE_URL = get_config("WEAVIATE_URL")
 
 # --- Basic Configuration ---
 DEFAULT_LOG_LEVEL = get_config("DEFAULT_LOG_LEVEL")
+OTEL_EXPORTER_ENDPOINT = get_config("OTEL_EXPORTER_ENDPOINT")
 
 # --- API Keys ---
 OPENAI_API_KEY = get_config("OPENAI_API_KEY")

--- a/src/infra/logging_config.py
+++ b/src/infra/logging_config.py
@@ -56,7 +56,10 @@ def setup_logging(log_dir: str = "logs") -> tuple[logging.Logger, logging.Logger
         try:  # pragma: no cover - best effort
             resource = Resource.create({"service.name": "culture"})
             provider = LoggerProvider(resource=resource)
-            exporter = OTLPLogExporter(endpoint="http://localhost:4318/v1/logs")
+            from .config import get_config
+
+            endpoint = get_config("OTEL_EXPORTER_ENDPOINT")
+            exporter = OTLPLogExporter(endpoint=endpoint)
             provider.add_log_processor(BatchLogProcessor(exporter))
             otel_handler = LoggingHandler(level=logging.INFO, logger_provider=provider)
             root_logger.addHandler(otel_handler)

--- a/tests/unit/infra/test_logging_config.py
+++ b/tests/unit/infra/test_logging_config.py
@@ -11,7 +11,6 @@ def test_custom_otel_endpoint(monkeypatch, tmp_path):
     monkeypatch.setenv("ENABLE_OTEL", "1")
     monkeypatch.setenv("OTEL_EXPORTER_ENDPOINT", "http://example.com:4318/v1/logs")
 
-    # Reload configuration to pick up the new environment variable
     config.load_config()
 
     endpoints: list[str] = []

--- a/tests/unit/infra/test_logging_config.py
+++ b/tests/unit/infra/test_logging_config.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+
+from src.infra import config, logging_config
+
+
+@pytest.mark.unit
+def test_custom_otel_endpoint(monkeypatch, tmp_path):
+    """setup_logging should read OTEL_EXPORTER_ENDPOINT env var."""
+    monkeypatch.setenv("ENABLE_OTEL", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_ENDPOINT", "http://example.com:4318/v1/logs")
+
+    # Reload configuration to pick up the new environment variable
+    config.load_config()
+
+    endpoints: list[str] = []
+
+    class DummyExporter:
+        def __init__(self, *, endpoint: str) -> None:
+            endpoints.append(endpoint)
+
+    class DummyResource:
+        @staticmethod
+        def create(_: dict[str, str]):
+            return object()
+
+    class DummyProvider:
+        def __init__(self, resource: object):
+            self.resource = resource
+
+        def add_log_processor(self, processor: object) -> None:
+            self.processor = processor
+
+    class DummyProcessor:
+        def __init__(self, exporter: object):
+            self.exporter = exporter
+
+    class DummyHandler(logging.Handler):
+        def __init__(self, level: int, logger_provider: object) -> None:
+            super().__init__(level)
+            self.provider = logger_provider
+
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple stub
+            pass
+
+    monkeypatch.setattr(logging_config, "OTEL_AVAILABLE", True)
+    monkeypatch.setattr(logging_config, "OTLPLogExporter", DummyExporter, raising=False)
+    monkeypatch.setattr(logging_config, "BatchLogProcessor", DummyProcessor, raising=False)
+    monkeypatch.setattr(logging_config, "LoggerProvider", DummyProvider, raising=False)
+    monkeypatch.setattr(logging_config, "LoggingHandler", DummyHandler, raising=False)
+    monkeypatch.setattr(logging_config, "Resource", DummyResource, raising=False)
+
+    logging_config.setup_logging(log_dir=str(tmp_path))
+
+    assert endpoints == ["http://example.com:4318/v1/logs"]


### PR DESCRIPTION
## Summary
- make OTEL exporter endpoint configurable via new `OTEL_EXPORTER_ENDPOINT`
- use the config value in `setup_logging`
- document the variable in `.env.example` and observability docs
- test custom endpoint handling

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest tests/unit/infra/test_logging_config.py -q`
- `python -m pytest -m "unit and not dspy" -n auto`

------
https://chatgpt.com/codex/tasks/task_e_68501a121ee083268eb807344ea9468b