### PR TITLE
Add multi-token Discord support

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
     - `WEAVIATE_URL` (e.g., http://localhost:8080)
     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
     - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)
+    - `DISCORD_TOKENS_DB_URL` for Postgres storage of additional bot tokens
 
    - See `.env.example` and `docs/testing.md` for details.
 

--- a/docs/configuration_system.md
+++ b/docs/configuration_system.md
@@ -53,8 +53,9 @@ The configuration is organized into the following categories:
 
 ### Discord Bot Settings
 
-- `DISCORD_BOT_TOKEN` - Discord bot token
+- `DISCORD_BOT_TOKEN` - Discord bot token or comma-separated tokens
 - `DISCORD_CHANNEL_ID` - Discord channel ID
+- `DISCORD_TOKENS_DB_URL` - PostgreSQL URL for the `discord_tokens` table
 
 ### Memory Pruning Settings
 

--- a/docs/discord_manual_run.md
+++ b/docs/discord_manual_run.md
@@ -33,3 +33,22 @@ Displays runtime statistics similar to:
 LLM latency: 0 ms; KB size: 0
 ```
 These commands are helpful for manual smoke testing of the Discord interface.
+
+### Using Multiple Bot Tokens
+You can run the simulation with several Discord bot accounts. Store the tokens
+in a PostgreSQL table named `discord_tokens` with columns `agent_id` and `token`.
+Set `DISCORD_TOKENS_DB_URL` to the database connection URL. When present,
+`DISCORD_BOT_TOKEN` can be left blank or contain a comma-separated fallback
+list.
+
+Initialize the table:
+
+```sql
+-- scripts/init_discord_tokens.sql
+CREATE TABLE IF NOT EXISTS discord_tokens (
+    agent_id TEXT PRIMARY KEY,
+    token TEXT NOT NULL
+);
+```
+
+Load the SQL with `psql $DISCORD_TOKENS_DB_URL < scripts/init_discord_tokens.sql`.

--- a/scripts/init_discord_tokens.sql
+++ b/scripts/init_discord_tokens.sql
@@ -1,0 +1,5 @@
+-- Initialize discord_tokens table
+CREATE TABLE IF NOT EXISTS discord_tokens (
+    agent_id TEXT PRIMARY KEY,
+    token TEXT NOT NULL
+);

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -81,6 +81,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "REDIS_DB": 0,
     "DISCORD_BOT_TOKEN": "",
     "DISCORD_CHANNEL_ID": None,
+    "DISCORD_TOKENS_DB_URL": "",
     "OPENAI_API_KEY": "",
     "ANTHROPIC_API_KEY": "",
     "DEFAULT_LOG_LEVEL": "INFO",
@@ -306,6 +307,7 @@ REDIS_PASSWORD = get_config("REDIS_PASSWORD")
 # --- Discord Bot Settings ---
 DISCORD_BOT_TOKEN = get_config("DISCORD_BOT_TOKEN")
 DISCORD_CHANNEL_ID = get_config("DISCORD_CHANNEL_ID")
+DISCORD_TOKENS_DB_URL = get_config("DISCORD_TOKENS_DB_URL")
 
 # --- Memory Pruning Settings ---
 # Whether to enable automatic memory pruning (default to False for safety)

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -15,7 +15,7 @@ from typing import Any, Callable
 from unittest.mock import MagicMock
 
 try:  # pragma: no cover - optional dependency
-    import requests
+    import requests  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover - fallback when requests missing
     requests = MagicMock()
 from typing_extensions import Self

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -31,12 +31,12 @@ except ImportError:  # pragma: no cover - optional dependency
     ollama = MagicMock()
     sys.modules.setdefault("ollama", ollama)
 if TYPE_CHECKING:
-    import requests
-    from requests.exceptions import RequestException, Timeout
+    import requests  # type: ignore[import-untyped]
+    from requests.exceptions import RequestException, Timeout  # type: ignore[import-untyped]
 else:
     try:  # pragma: no cover - optional dependency
-        import requests
-        from requests.exceptions import RequestException, Timeout
+        import requests  # type: ignore[import-untyped]
+        from requests.exceptions import RequestException, Timeout  # type: ignore[import-untyped]
     except ImportError:  # pragma: no cover - fallback when requests missing
         logging.getLogger(__name__).warning("requests package not installed; using MagicMock stub")
         from unittest.mock import MagicMock

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -78,9 +78,9 @@ class Simulation:
         logger.info("Simulation initialized with Knowledge Board.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
         logger.info("Simulation initialized with project tracking system.")
 
         # --- NEW: Initialize Collective Metrics ---
@@ -115,9 +115,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -199,7 +199,10 @@ class Simulation:
         return other_agents_info
 
     async def send_discord_update(
-        self: Self, message: Optional[str] = None, embed: Optional[object] = None
+        self: Self,
+        message: Optional[str] = None,
+        embed: Optional[object] = None,
+        agent_id: Optional[str] = None,
     ) -> None:
         """
         Send an update to Discord if the discord_bot is available.
@@ -211,7 +214,9 @@ class Simulation:
         if self.discord_bot:
             # Use asyncio.create_task to avoid blocking the simulation
             _ = asyncio.create_task(
-                self.discord_bot.send_simulation_update(content=message, embed=embed)
+                self.discord_bot.send_simulation_update(
+                    content=message, embed=embed, agent_id=agent_id
+                )
             )
 
     async def run_step(self: Self, max_turns: int = 1) -> int:
@@ -244,7 +249,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {len(self.messages_to_perceive_this_round)} messages from pending_messages_for_next_round."
@@ -577,7 +584,9 @@ class Simulation:
                 agent_id=creator_agent_id,
                 step=self.current_step,
             )
-            _ = asyncio.create_task(self.discord_bot.send_simulation_update(embed=embed))
+            _ = asyncio.create_task(
+                self.discord_bot.send_simulation_update(embed=embed, agent_id=creator_agent_id)
+            )
 
         return project_id
 
@@ -651,7 +660,9 @@ class Simulation:
                 agent_id=agent_id,
                 step=self.current_step,
             )
-            _ = asyncio.create_task(self.discord_bot.send_simulation_update(embed=embed))
+            _ = asyncio.create_task(
+                self.discord_bot.send_simulation_update(embed=embed, agent_id=agent_id)
+            )
 
         return True
 
@@ -708,7 +719,9 @@ class Simulation:
                 agent_id=agent_id,
                 step=self.current_step,
             )
-            _ = asyncio.create_task(self.discord_bot.send_simulation_update(embed=embed))
+            _ = asyncio.create_task(
+                self.discord_bot.send_simulation_update(embed=embed, agent_id=agent_id)
+            )
 
         return True
 

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -6,6 +6,8 @@ pytest.importorskip("discord")
 from src.interfaces import metrics
 from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
 
+sent_by_token: list[str] = []
+
 
 class DummyDiscordClient:
     """Simple stand-in for discord.Client."""
@@ -14,11 +16,18 @@ class DummyDiscordClient:
         self.event = lambda func: func
         self.user = "dummy"
 
-    def get_channel(self, channel_id: int) -> None:  # pragma: no cover - no channel
-        return None
+    def get_channel(self, channel_id: int) -> object:  # pragma: no cover - minimal
+        token = getattr(self, "token", None)
+
+        class DummyChannel:
+            async def send(self_inner, *args: object, **kwargs: object) -> None:
+                if token is not None:
+                    sent_by_token.append(token)
+
+        return DummyChannel()
 
     async def start(self, token: str) -> None:  # pragma: no cover - not used
-        pass
+        self.token = token
 
     async def close(self) -> None:  # pragma: no cover - not used
         pass
@@ -29,6 +38,30 @@ def simulation_bot() -> SimulationDiscordBot:
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient):
         bot = SimulationDiscordBot("token", 123)
     return bot
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_multi_token_start_and_send() -> None:
+    start_tokens: list[str] = []
+
+    class RecordingClient(DummyDiscordClient):
+        async def start(self, token: str) -> None:
+            start_tokens.append(token)
+
+    tokens = ["tok1", "tok2"]
+
+    def lookup(aid: str) -> str:
+        return tokens[1] if aid == "agent_b" else tokens[0]
+
+    with patch("src.interfaces.discord_bot.discord.Client", RecordingClient):
+        bot = SimulationDiscordBot(tokens, 123, token_lookup=lookup)
+        await bot.run_bot()
+        await bot.send_simulation_update(content="hi", agent_id="agent_b")
+        await bot.stop_bot()
+
+    assert start_tokens == tokens
+    assert sent_by_token == ["tok2"]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- add `DISCORD_TOKENS_DB_URL` config
- support token lookup in `SimulationDiscordBot`
- update documentation for multiple Discord tokens
- create migration script for new `discord_tokens` table
- test multi-token behavior

## Testing
- `bash scripts/lint.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501a2c8ca4832686fd343a8da07557