### PR TITLE
Integrate OPA policy checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ REDIS_PASSWORD=
 WEAVIATE_URL=http://localhost:8080
 # Backend for the vector store ("chroma" or "weaviate")
 VECTOR_STORE_BACKEND=chroma
+
+# -- Policy Engine (OPA) --
+# Endpoint for Open Policy Agent decisions
+OPA_URL=http://localhost:8181/v1/data/discord/allow

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -49,3 +49,15 @@ export DEBUG_SQLITE=1
 
 This sets the database to WAL mode and increases the busy timeout to help diagnose locking issues.
 
+## 6. Policy Engine (OPA)
+
+Culture.ai can optionally send outgoing messages through an [Open Policy Agent](https://www.openpolicyagent.org/) service for additional filtering. Set the `OPA_URL` environment variable to point at your OPA policy endpoint (for example `http://localhost:8181/v1/data/discord/allow`). The endpoint should return JSON in the form:
+
+```json
+{
+  "result": {"allow": true, "content": "optional modified text"}
+}
+```
+
+If `allow` is `false`, the message will be blocked. If `content` is returned, it will replace the original text before sending.
+

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -36,6 +36,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "VECTOR_STORE_BACKEND": "chroma",  # chroma or weaviate
     "WEAVIATE_URL": "http://localhost:8080",
     "OLLAMA_REQUEST_TIMEOUT": 10,
+    "OPA_URL": "",
     "TARGETED_MESSAGE_MULTIPLIER": 3.0,
     "POSITIVE_RELATIONSHIP_LEARNING_RATE": 0.3,
     "NEGATIVE_RELATIONSHIP_LEARNING_RATE": 0.4,
@@ -306,6 +307,7 @@ REDIS_PASSWORD = get_config("REDIS_PASSWORD")
 # --- Discord Bot Settings ---
 DISCORD_BOT_TOKEN = get_config("DISCORD_BOT_TOKEN")
 DISCORD_CHANNEL_ID = get_config("DISCORD_CHANNEL_ID")
+OPA_URL = get_config("OPA_URL")
 
 # --- Memory Pruning Settings ---
 # Whether to enable automatic memory pruning (default to False for safety)

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -10,11 +10,8 @@ import logging
 import typing
 from typing import TYPE_CHECKING, Any, Optional
 
-import requests
-
-from src.infra import config
 from src.interfaces import metrics
-from src.utils.policy import allow_message
+from src.utils.policy import allow_message, evaluate_with_opa
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     import discord
@@ -31,25 +28,6 @@ else:  # pragma: no cover - runtime import with fallback
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
-
-
-async def _evaluate_with_opa(content: str) -> tuple[bool, str]:
-    """Check message content against OPA policy."""
-    url = typing.cast(str, config.get_config("OPA_URL"))
-    if not url:
-        return True, content
-    try:
-        response = await asyncio.to_thread(
-            requests.post, url, json={"input": {"message": content}}, timeout=2
-        )
-        data = response.json()
-        result = typing.cast(dict[str, typing.Any], data.get("result", {}))
-        allow = typing.cast(bool, result.get("allow", True))
-        new_content = typing.cast(str, result.get("content", content))
-        return allow, new_content
-    except Exception as e:  # pragma: no cover - network failures
-        logger.warning(f"OPA evaluation failed: {e}")
-        return True, content
 
 
 class SimulationDiscordBot:
@@ -135,7 +113,7 @@ class SimulationDiscordBot:
             logger.debug("Message blocked by policy")
             return False
         if content is not None:
-            allowed, content = await _evaluate_with_opa(content)
+            allowed, content = await evaluate_with_opa(content)
             if not allowed:
                 logger.debug("Message blocked by OPA policy")
                 return False

--- a/src/utils/policy.py
+++ b/src/utils/policy.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+import typing
+
+import requests
+
+from src.infra import config
 
 
 def allow_message(content: str | None) -> bool:
@@ -12,3 +19,22 @@ def allow_message(content: str | None) -> bool:
     blocked_words = os.getenv("OPA_BLOCKLIST", "").split(",")
     content_lower = content.lower()
     return not any(word.strip().lower() in content_lower for word in blocked_words if word.strip())
+
+
+async def evaluate_with_opa(content: str) -> tuple[bool, str]:
+    """Check message content against OPA policy."""
+    url = typing.cast(str, config.get_config("OPA_URL"))
+    if not url:
+        return True, content
+    try:
+        response = await asyncio.to_thread(
+            requests.post, url, json={"input": {"message": content}}, timeout=2
+        )
+        data = response.json()
+        result = typing.cast(dict[str, typing.Any], data.get("result", {}))
+        allow = typing.cast(bool, result.get("allow", True))
+        new_content = typing.cast(str, result.get("content", content))
+        return allow, new_content
+    except Exception as e:  # pragma: no cover - network failures
+        logging.getLogger(__name__).warning("OPA evaluation failed: %s", e)
+        return True, content

--- a/tests/unit/interfaces/test_discord_policy.py
+++ b/tests/unit/interfaces/test_discord_policy.py
@@ -1,0 +1,66 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.infra import config
+from src.interfaces.discord_bot import SimulationDiscordBot
+
+
+class DummyChannel:
+    def __init__(self) -> None:
+        self.send = AsyncMock()
+
+
+class DummyDiscordClient:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.event = lambda fn: fn
+        self.user = "dummy"
+
+    def get_channel(self, channel_id: int) -> DummyChannel:
+        return DummyChannel()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"result": {"allow": False}}
+    monkeypatch.setattr(
+        "src.interfaces.discord_bot.requests.post", MagicMock(return_value=mock_resp)
+    )
+    with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient), patch(
+        "src.interfaces.discord_bot.discord.TextChannel", DummyChannel
+    ), patch("src.interfaces.discord_bot.discord.Thread", DummyChannel), patch(
+        "src.interfaces.discord_bot.discord.DiscordException", Exception
+    ):
+        bot = SimulationDiscordBot("token", 1)
+        bot.is_ready = True
+        channel = DummyChannel()
+        bot.client.get_channel = MagicMock(return_value=channel)
+        result = await bot.send_simulation_update(content="hi")
+        assert result is False
+        channel.send.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_opa_modifies_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"result": {"allow": True, "content": "bar"}}
+    monkeypatch.setattr(
+        "src.interfaces.discord_bot.requests.post", MagicMock(return_value=mock_resp)
+    )
+    with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient), patch(
+        "src.interfaces.discord_bot.discord.TextChannel", DummyChannel
+    ), patch("src.interfaces.discord_bot.discord.Thread", DummyChannel), patch(
+        "src.interfaces.discord_bot.discord.DiscordException", Exception
+    ):
+        bot = SimulationDiscordBot("token", 1)
+        bot.is_ready = True
+        channel = DummyChannel()
+        bot.client.get_channel = MagicMock(return_value=channel)
+        result = await bot.send_simulation_update(content="foo")
+        assert result is True
+        channel.send.assert_awaited_once_with("bar")

--- a/tests/unit/interfaces/test_discord_policy.py
+++ b/tests/unit/interfaces/test_discord_policy.py
@@ -26,9 +26,7 @@ async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"result": {"allow": False}}
-    monkeypatch.setattr(
-        "src.interfaces.discord_bot.requests.post", MagicMock(return_value=mock_resp)
-    )
+    monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient), patch(
         "src.interfaces.discord_bot.discord.TextChannel", DummyChannel
     ), patch("src.interfaces.discord_bot.discord.Thread", DummyChannel), patch(
@@ -49,9 +47,7 @@ async def test_opa_modifies_message(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"result": {"allow": True, "content": "bar"}}
-    monkeypatch.setattr(
-        "src.interfaces.discord_bot.requests.post", MagicMock(return_value=mock_resp)
-    )
+    monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient), patch(
         "src.interfaces.discord_bot.discord.TextChannel", DummyChannel
     ), patch("src.interfaces.discord_bot.discord.Thread", DummyChannel), patch(


### PR DESCRIPTION
## Summary
- add OPA_URL config setting and expose via config module
- query OPA in `SimulationDiscordBot` before sending messages
- document policy engine usage
- update environment example with OPA_URL
- test Discord bot behaviour when OPA blocks or modifies messages

## Testing
- `pre-commit run --files src/interfaces/discord_bot.py src/infra/config.py tests/unit/interfaces/test_discord_policy.py`
- `pytest tests/unit/interfaces/test_discord_policy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68501a2d469c8326b98103c4d539d383