### PR TITLE
Add ENABLE_OTEL config instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,6 @@ VECTOR_STORE_BACKEND=chroma
 # -- Observability --
 # Endpoint for OpenTelemetry log exporter
 OTEL_EXPORTER_ENDPOINT=http://localhost:4318/v1/logs
+# Set to 1 to activate OpenTelemetry export
+ENABLE_OTEL=1
 

--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
     - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)
     - `DISCORD_TOKENS_DB_URL` for Postgres storage of additional bot tokens
+    - `ENABLE_OTEL=1` to activate OpenTelemetry log export
 
    - See `.env.example` and `docs/testing.md` for details.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,7 +29,7 @@ Once running, access Grafana at [http://localhost:3000](http://localhost:3000) a
 
 Culture.ai can export structured logs via the OpenTelemetry OTLP exporter. The exporter
 sends logs to `localhost:4318/v1/logs` by default. Set `OTEL_EXPORTER_ENDPOINT` to
-override this URL.
+override this URL, and set `ENABLE_OTEL=1` in your `.env` file to activate the exporter.
 
 To receive these logs locally, run an OTLP-compatible collector such as the
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/):


### PR DESCRIPTION
## Summary
- add ENABLE_OTEL variable in `.env.example`
- document using ENABLE_OTEL in observability guide
- mention ENABLE_OTEL in README with other environment variables

## Testing
- `pre-commit run --files README.md docs/observability.md .env.example`

------
https://chatgpt.com/codex/tasks/task_e_6850248640388326b3395a80294113e8