### PR TITLE
Add Discord token DB lookup

### DIFF
--- a/src/interfaces/token_store.py
+++ b/src/interfaces/token_store.py
@@ -1,0 +1,41 @@
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+from src.infra import config
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import asyncpg
+else:  # pragma: no cover - optional dependency
+    asyncpg = None
+
+logger = logging.getLogger(__name__)
+
+_pool: Any | None = None
+
+
+async def _get_pool() -> Any:
+    global asyncpg
+    if asyncpg is None:
+        try:
+            import asyncpg as _asyncpg
+        except Exception as exc:
+            raise RuntimeError("asyncpg is required for Discord token store") from exc
+        asyncpg = _asyncpg
+
+    global _pool
+    if _pool is None:
+        db_url = str(config.get_config("DISCORD_TOKENS_DB_URL") or "")
+        if not db_url:
+            raise RuntimeError("DISCORD_TOKENS_DB_URL is not set")
+        _pool = await asyncpg.create_pool(db_url)
+    return _pool
+
+
+async def get_token(agent_id: str) -> Optional[str]:
+    """Return the Discord token for the given agent ID if present."""
+    pool = await _get_pool()
+    row = await pool.fetchrow(
+        "SELECT token FROM discord_tokens WHERE agent_id=$1",
+        agent_id,
+    )
+    return row["token"] if row else None

--- a/tests/integration/interfaces/test_token_store.py
+++ b/tests/integration/interfaces/test_token_store.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("asyncpg")
+import shutil
+
+import asyncpg
+import testing.postgresql
+
+from src.infra import config
+from src.interfaces import token_store
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    if shutil.which("initdb") is None:
+        pytest.skip("PostgreSQL binaries not available")
+    sql_path = Path("scripts/init_discord_tokens.sql")
+    sql = sql_path.read_text()
+
+    with testing.postgresql.Postgresql() as pg:
+        conn = await asyncpg.connect(pg.url())
+        await conn.execute(sql)
+        await conn.execute(
+            "INSERT INTO discord_tokens(agent_id, token) VALUES($1, $2)",
+            "agent_a",
+            "tok_a",
+        )
+        await conn.close()
+
+        monkeypatch.setitem(config.CONFIG_OVERRIDES, "DISCORD_TOKENS_DB_URL", pg.url())
+        # Reset pool in case previous tests populated it
+        token_store._pool = None  # type: ignore[attr-defined]
+
+        assert await token_store.get_token("agent_a") == "tok_a"
+        assert await token_store.get_token("missing") is None


### PR DESCRIPTION
## Summary
- add PostgreSQL token store using asyncpg
- load token lookup from `DISCORD_TOKENS_DB_URL` in SimulationDiscordBot
- test token retrieval with a temporary PostgreSQL instance

## Testing
- `ruff check src/interfaces/token_store.py src/interfaces/discord_bot.py tests/integration/interfaces -q`
- `mypy src/interfaces/token_store.py src/interfaces/discord_bot.py`
- `pytest tests/integration/interfaces/test_token_store.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6851953a2bf883269718f24a13ffdb45