### PR TITLE
Run ruff format on dashboard backend

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
-
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
@@ -47,6 +46,4 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
 
 @app.get("/health")
 async def health() -> Response:
-
     return JSONResponse({"status": "ok"})
-


### PR DESCRIPTION
## Summary
- apply `ruff format` on `dashboard_backend.py`

## Testing
- `pre-commit run --files src/interfaces/dashboard_backend.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68519e2c49588326838989690705d387