### PR TITLE
Store Discord tokens in Postgres

### DIFF
--- a/src/interfaces/token_store.py
+++ b/src/interfaces/token_store.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Optional
 
 from src.infra import config
@@ -24,7 +25,9 @@ async def _get_pool() -> Any:
 
     global _pool
     if _pool is None:
-        db_url = str(config.get_config("DISCORD_TOKENS_DB_URL") or "")
+        db_url = os.environ.get("DISCORD_TOKENS_DB_URL") or str(
+            config.get_config("DISCORD_TOKENS_DB_URL") or ""
+        )
         if not db_url:
             raise RuntimeError("DISCORD_TOKENS_DB_URL is not set")
         _pool = await asyncpg.create_pool(db_url)
@@ -39,3 +42,21 @@ async def get_token(agent_id: str) -> Optional[str]:
         agent_id,
     )
     return row["token"] if row else None
+
+
+async def save_token(agent_id: str, token: str) -> None:
+    """Insert or update a Discord token for the given agent ID."""
+    pool = await _get_pool()
+    await pool.execute(
+        "INSERT INTO discord_tokens(agent_id, token) VALUES($1, $2)\n"
+        "ON CONFLICT(agent_id) DO UPDATE SET token = EXCLUDED.token",
+        agent_id,
+        token,
+    )
+
+
+async def list_tokens() -> list[str]:
+    """Return all stored Discord tokens."""
+    pool = await _get_pool()
+    rows = await pool.fetch("SELECT token FROM discord_tokens")
+    return [row["token"] for row in rows]

--- a/tests/integration/interfaces/test_token_store_save.py
+++ b/tests/integration/interfaces/test_token_store_save.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("asyncpg")
+import shutil
+
+import asyncpg
+import testing.postgresql
+
+from src.infra import config
+from src.interfaces import token_store
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    if shutil.which("initdb") is None:
+        pytest.skip("PostgreSQL binaries not available")
+    sql_path = Path("scripts/init_discord_tokens.sql")
+    sql = sql_path.read_text()
+
+    with testing.postgresql.Postgresql() as pg:
+        conn = await asyncpg.connect(pg.url())
+        await conn.execute(sql)
+        await conn.close()
+
+        monkeypatch.setitem(config.CONFIG_OVERRIDES, "DISCORD_TOKENS_DB_URL", pg.url())
+        token_store._pool = None  # type: ignore[attr-defined]
+
+        await token_store.save_token("agent_z", "tok_z")
+        assert await token_store.get_token("agent_z") == "tok_z"


### PR DESCRIPTION
## Summary
- keep token store DB connection in `DISCORD_TOKENS_DB_URL`
- add `save_token` and `list_tokens` helpers
- load Discord tokens from database when not provided
- test saving and loading tokens

## Testing
- `ruff check src/interfaces/discord_bot.py src/interfaces/token_store.py tests/integration/interfaces/test_token_store_save.py`
- `black src/interfaces/discord_bot.py src/interfaces/token_store.py tests/integration/interfaces/test_token_store_save.py`
- `mypy src/interfaces/discord_bot.py src/interfaces/token_store.py`
- `pytest -m integration tests/integration/interfaces/test_token_store.py tests/integration/interfaces/test_token_store_save.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68519e2af9588326bb57200b9e6b960f