### PR TITLE
Fix Ollama integration typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ suppress-none-returning = true
 
 [tool.mypy]
 python_version = "3.10"
+mypy_path = "src"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -11,13 +11,16 @@ import sys
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 from unittest.mock import MagicMock
 
-try:  # pragma: no cover - optional dependency
+if TYPE_CHECKING:
     import requests
-except Exception:  # pragma: no cover - fallback when requests missing
-    requests = MagicMock()
+else:
+    try:  # pragma: no cover - optional dependency
+        import requests
+    except Exception:  # pragma: no cover - fallback when requests missing
+        requests = MagicMock()
 from typing_extensions import Self
 
 # Import DSPy and Ollama, providing fallbacks when unavailable
@@ -122,13 +125,17 @@ else:
     sys.modules.setdefault("dspy", dspy)
     DSPY_AVAILABLE = False
 
-try:
+if TYPE_CHECKING:
     import ollama
     from ollama import _types as ollama_types
-except Exception:  # pragma: no cover - optional dependency
-    logging.getLogger(__name__).warning("ollama package not installed; using MagicMock stub")
-    ollama = MagicMock()
-    ollama_types = SimpleNamespace(Options=dict)  # type: ignore[assignment]
+else:
+    try:
+        import ollama
+        from ollama import _types as ollama_types
+    except Exception:  # pragma: no cover - optional dependency
+        logging.getLogger(__name__).warning("ollama package not installed; using MagicMock stub")
+        ollama = MagicMock()
+        ollama_types: Any = SimpleNamespace(Options=dict)
 
 
 # Configure logging

--- a/src/ollama/__init__.pyi
+++ b/src/ollama/__init__.pyi
@@ -1,0 +1,9 @@
+from typing import Any
+
+from . import _types
+
+class Client:
+    def __init__(self, host: str = ...) -> None: ...
+    def generate(self, *, model: str, prompt: str, options: _types.Options) -> dict[str, Any]: ...
+
+__all__ = ["Client", "_types"]

--- a/src/ollama/_types.pyi
+++ b/src/ollama/_types.pyi
@@ -1,0 +1,6 @@
+from typing import TypedDict
+
+class Options(TypedDict, total=False):
+    temperature: float
+    num_predict: int
+    # additional fields omitted


### PR DESCRIPTION
## Summary
- clean up unnecessary type ignore in dspy_ollama_integration
- add local stubs for `ollama` to provide `Options` type
- configure mypy to use local stubs

## Testing
- `ruff format pyproject.toml src/infra/dspy_ollama_integration.py src/ollama/__init__.pyi src/ollama/_types.pyi`
- `ruff check pyproject.toml src/infra/dspy_ollama_integration.py src/ollama/__init__.pyi src/ollama/_types.pyi`
- `mypy src/infra/dspy_ollama_integration.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519e311f10832693f8fc6786077bfe