### PR TITLE
Add Redpanda setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,10 +542,12 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
     - `WEAVIATE_URL` (e.g., http://localhost:8080)
     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
     - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)
-    - `DISCORD_TOKENS_DB_URL` for Postgres storage of additional bot tokens
-    - `ENABLE_OTEL=1` to activate OpenTelemetry log export
+   - `DISCORD_TOKENS_DB_URL` for Postgres storage of additional bot tokens
+   - `ENABLE_OTEL=1` to activate OpenTelemetry log export
+   - `ENABLE_REDPANDA=1` to log events to Redpanda
+   - `REDPANDA_BROKER` (e.g., localhost:9092) address of the Redpanda broker
 
-   - See `.env.example` and `docs/testing.md` for details.
+   - See `.env.example`, `docs/testing.md`, and `docs/redpanda_setup.md` for details.
 
 ### Windows / WSL2 Notes
 

--- a/docs/redpanda_setup.md
+++ b/docs/redpanda_setup.md
@@ -1,0 +1,51 @@
+# Redpanda Setup
+
+This guide explains how to install and run Redpanda for event logging and deterministic replay in Culture.ai.
+
+## Install Redpanda
+
+The easiest way to install Redpanda on Linux is via the official install script:
+
+```bash
+curl -1s https://raw.githubusercontent.com/redpanda-data/redpanda/master/install.sh | bash
+```
+
+This script adds the package repository and installs the latest stable Redpanda release.
+
+## Docker Compose Example
+
+You can also run Redpanda using Docker Compose. Save the following as `docker-compose.redpanda.yml`:
+
+```yaml
+version: '3.8'
+services:
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:latest
+    command: >
+      redpanda start --overprovisioned --smp 1 \
+      --memory 1G --reserve-memory 0M --node-id 0
+    ports:
+      - "9092:9092"
+      - "9644:9644"
+    volumes:
+      - redpanda_data:/var/lib/redpanda/data
+volumes:
+  redpanda_data:
+```
+
+Start the service:
+
+```bash
+docker compose -f docker-compose.redpanda.yml up -d
+```
+
+## Environment Variables
+
+Set the following variables in your `.env` file so Culture.ai can connect:
+
+```env
+ENABLE_REDPANDA=1
+REDPANDA_BROKER=localhost:9092
+```
+
+`ENABLE_REDPANDA` enables event logging and replay. `REDPANDA_BROKER` should point to the broker address used by your Docker Compose setup.

--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -118,3 +118,5 @@ python -m src.app --steps 5 --discord
 
 The `--steps` flag sets how many iterations to perform before exiting. Use `--discord` to enable interaction with your configured Discord bot.
 
+To enable deterministic replay of simulations, follow [docs/redpanda_setup.md](redpanda_setup.md) to install Redpanda and set the `ENABLE_REDPANDA` and `REDPANDA_BROKER` environment variables.
+


### PR DESCRIPTION
## Summary
- document installing Redpanda and include a docker-compose example
- reference the Redpanda guide from the Windows setup guide
- mention Redpanda environment variables in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851a52b9b948326bead01d6423400b2