### PR TITLE
Add DB-backed Discord token lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,14 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
     - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)
    - `DISCORD_TOKENS_DB_URL` for Postgres storage of additional bot tokens
+     (`postgresql://user:pass@localhost/dbname`). Initialize the table with
+     `scripts/init_discord_tokens.sql`:
+     ```sql
+     CREATE TABLE IF NOT EXISTS discord_tokens (
+         agent_id TEXT PRIMARY KEY,
+         token TEXT NOT NULL
+     );
+     ```
    - `ENABLE_OTEL=1` to activate OpenTelemetry log export
    - `ENABLE_REDPANDA=1` to log events to Redpanda
    - `REDPANDA_BROKER` (e.g., localhost:9092) address of the Redpanda broker

--- a/docs/development_notes/vertical_slice_audit_tasks.md
+++ b/docs/development_notes/vertical_slice_audit_tasks.md
@@ -32,7 +32,7 @@ This task list distills the key actions from the May 2025 audit report. Completi
 ## Next Sprint Prep
 
 - [x] Support multiple Discord bot tokens via separate gateway shards.
-- [ ] Map agent IDs to bot tokens in a shared PostgreSQL table.
+- [x] Map agent IDs to bot tokens in a shared PostgreSQL table.
 - [x] Filter outgoing messages through an OPA policy engine.
 
 Completing these tasks will bring the project in line with the audit's recommendations and ready the codebase for stable multi-bot orchestration.

--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -51,6 +51,16 @@ cp .env.example .env
 
 Edit `OLLAMA_API_BASE` in `.env` if your Ollama server uses a different URL.
 
+If you plan to run Discord bots, also set `DISCORD_TOKENS_DB_URL` to your
+PostgreSQL connection string and create the required table:
+
+```sql
+CREATE TABLE IF NOT EXISTS discord_tokens (
+    agent_id TEXT PRIMARY KEY,
+    token TEXT NOT NULL
+);
+```
+
 ## Install Ollama (≥0.1.34)
 
 Culture.ai relies on the WSL build of **Ollama**. Install or upgrade it with:

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -89,7 +89,7 @@ class SimulationDiscordBot:
             db_url = str(config.get_config("DISCORD_TOKENS_DB_URL") or "")
             if db_url:
                 try:
-                    from .token_store import get_token as db_lookup
+                    from .token_store import lookup_token as db_lookup
                 except Exception:
                     logger.exception("Failed to load token store")
                 else:

--- a/tests/unit/interfaces/test_token_store.py
+++ b/tests/unit/interfaces/test_token_store.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.interfaces import token_store
+
+
+class DummyPool:
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+
+    async def fetchrow(self, query: str, agent_id: str) -> dict[str, str] | None:
+        token = self.data.get(agent_id)
+        return {"token": token} if token else None
+
+    async def execute(self, query: str, *args: object) -> None:
+        agent_id, token = args[-2], args[-1]
+        self.data[str(agent_id)] = str(token)
+
+    async def fetch(self, query: str) -> list[dict[str, str]]:
+        return [{"token": t} for t in self.data.values()]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_save_and_get_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    pool = DummyPool()
+
+    async def dummy_get_pool() -> DummyPool:
+        return pool
+
+    monkeypatch.setattr(token_store, "_get_pool", dummy_get_pool)
+    monkeypatch.setattr(token_store, "_pool", pool)
+
+    await token_store.save_token("agent_x", "tok_x")
+    assert await token_store.get_token("agent_x") == "tok_x"
+    assert await token_store.get_token("missing") is None


### PR DESCRIPTION
## Summary
- auto-map Discord tokens per agent in token_store
- default SimulationDiscordBot token lookup to new helper
- document PostgreSQL table for bot tokens
- update Windows setup docs
- mark task complete for PostgreSQL token mapping
- add unit test for token store

## Testing
- `ruff check src/interfaces/token_store.py src/interfaces/discord_bot.py tests/unit/interfaces/test_token_store.py`
- `mypy src/interfaces/token_store.py src/interfaces/discord_bot.py tests/unit/interfaces/test_token_store.py`
- `pytest tests/unit/interfaces/test_token_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c249601083269999de2799322b54