### PR TITLE
Add policy evaluation unit tests

### DIFF
--- a/tests/unit/infra/test_snapshot.py
+++ b/tests/unit/infra/test_snapshot.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 import zstandard as zstd
@@ -6,9 +7,6 @@ import zstandard as zstd
 from src.infra.snapshot import save_snapshot
 
 pytestmark = pytest.mark.unit
-
-
-from pathlib import Path
 
 
 def test_save_snapshot_compressed(tmp_path: Path) -> None:

--- a/tests/unit/utils/test_policy.py
+++ b/tests/unit/utils/test_policy.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.infra import config
+from src.utils.policy import evaluate_with_opa
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_evaluate_with_opa_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"result": {"allow": False, "content": "filtered"}}
+    monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))
+    allowed, new_content = await evaluate_with_opa("test")
+    assert allowed is False
+    assert new_content == "filtered"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_evaluate_with_opa_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"result": {"allow": True}}
+    monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))
+    allowed, new_content = await evaluate_with_opa("hello")
+    assert allowed is True
+    assert new_content == "hello"


### PR DESCRIPTION
## Summary
- add tests for evaluating messages with OPA policy
- fix flake issues in snapshot test

## Testing
- `ruff check .`
- `mypy src` *(fails: Source file found twice)*
- `pytest tests/unit/utils/test_policy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ce3abb1c83269a455bab0e51bd7f