### PR TITLE
Add test for checkpoint replay using mocked events

### DIFF
--- a/tests/integration/test_log_replay.py
+++ b/tests/integration/test_log_replay.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from src.app import create_simulation
@@ -10,20 +8,28 @@ from tests.utils.mock_llm import MockLLM
 
 @pytest.mark.integration
 def test_replay_from_event_log(monkeypatch, tmp_path):
-    events = []
-    monkeypatch.setattr(event_log, "log_event", lambda e: events.append(e))
+    monkeypatch.setattr(event_log, "log_event", lambda e: None)
     monkeypatch.setattr(event_log, "_get_producer", lambda: None)
 
     with MockLLM():
         sim = create_simulation(num_agents=1, steps=1, scenario="log")
         chk = tmp_path / "sim.pkl"
         save_checkpoint(sim, chk)
-        asyncio.run(sim.async_run(2))
-        expected_ip = sim.agents[0].state.ip
-        expected_step = sim.current_step
+
+    event = {
+        "type": "agent_action",
+        "agent_id": sim.agents[0].agent_id,
+        "step": 3,
+        "ip": 12.34,
+        "du": 56.78,
+    }
+
+    expected_step = event["step"]
+    expected_ip = event["ip"]
+    expected_du = event["du"]
 
     def fake_fetch(after_step=0):
-        return [ev for ev in events if ev.get("step", 0) > after_step]
+        return [e for e in [event] if e.get("step", 0) > after_step]
 
     monkeypatch.setattr(event_log, "fetch_events", fake_fetch)
 
@@ -31,3 +37,4 @@ def test_replay_from_event_log(monkeypatch, tmp_path):
 
     assert loaded.current_step == expected_step
     assert loaded.agents[0].state.ip == expected_ip
+    assert loaded.agents[0].state.du == expected_du


### PR DESCRIPTION
## Summary
- mock event_log.fetch_events to return canned events
- verify that loading a checkpoint with replay=True applies events to update agent state and current_step

## Testing
- `ruff check tests/integration/test_log_replay.py`
- `pytest tests/integration/test_log_replay.py -m integration -vv`

------
https://chatgpt.com/codex/tasks/task_e_6851ce3a33608326b90642f317bfea6c