### PR TITLE
Remove placeholder tests and add unit tests for role thought generator

### DIFF
--- a/src/agents/dspy_programs/role_thought_generator.py
+++ b/src/agents/dspy_programs/role_thought_generator.py
@@ -114,23 +114,3 @@ def generate_role_prefixed_thought(agent_role: str, current_situation: str) -> s
 def get_failsafe_output(*args: object, **kwargs: object) -> str:
     role_name = args[0] if args else kwargs.get("role_name", "unknown")
     return f"Failsafe: Unable to generate thought for role {role_name}."
-
-
-def test_role_prefixed_thought() -> None:
-    # Implementation of test_role_prefixed_thought method
-    pass
-
-
-def test_signature_fields() -> None:
-    # Implementation of test_signature_fields method
-    pass
-
-
-def test_signature_output() -> None:
-    # Implementation of test_signature_output method
-    pass
-
-
-def test_signature_input_fields() -> None:
-    # Implementation of test_signature_input_fields method
-    pass

--- a/tests/unit/dspy_programs/test_role_thought_generator.py
+++ b/tests/unit/dspy_programs/test_role_thought_generator.py
@@ -1,0 +1,27 @@
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from src.agents.dspy_programs import role_thought_generator as rtg
+
+
+def test_get_failsafe_output_positional() -> None:
+    assert rtg.get_failsafe_output("Analyst") == (
+        "Failsafe: Unable to generate thought for role Analyst."
+    )
+
+
+def test_failsafe_role_thought_generator() -> None:
+    generator = rtg.FailsafeRoleThoughtGenerator()
+    result = generator("Facilitator", "context")
+    assert getattr(result, "thought") == (
+        "Failsafe: Unable to generate thought for role Facilitator."
+    )
+
+
+def test_generate_role_prefixed_thought_failsafe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        rtg, "get_role_thought_generator", lambda: rtg.FailsafeRoleThoughtGenerator()
+    )
+    thought = rtg.generate_role_prefixed_thought("Researcher", "test situation")
+    assert thought == "Failsafe: Unable to generate thought for role Researcher."


### PR DESCRIPTION
## Summary
- remove unused placeholder tests in `role_thought_generator.py`
- add real unit tests for role thought generator fallback logic

## Testing
- `ruff format src/agents/dspy_programs/role_thought_generator.py tests/unit/dspy_programs/test_role_thought_generator.py`
- `ruff check src/agents/dspy_programs/role_thought_generator.py tests/unit/dspy_programs/test_role_thought_generator.py`
- `mypy src/agents/dspy_programs/role_thought_generator.py tests/unit/dspy_programs/test_role_thought_generator.py`
- `pytest tests/unit/dspy_programs/test_role_thought_generator.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68521ed8511083269a6050a116f4c454