### PR TITLE
Implement relationship updater logic and test

### DIFF
--- a/src/agents/dspy_programs/relationship_updater.py
+++ b/src/agents/dspy_programs/relationship_updater.py
@@ -162,13 +162,24 @@ def get_failsafe_output(*args: float, **kwargs: float) -> object:
     )()
 
 
+_RELATIONSHIPS: dict[str, dict[str, dict[str, float]]] = {}
+
+
 def update_relationship(
     agent_id: str, other_agent_id: str, relationship_type: str, strength: float
 ) -> str:
-    # Implementation of the function
-    return "Relationship updated (placeholder)"
+    """Adjust and store the relationship strength between two agents.
 
+    This function maintains a simple in-memory mapping of relationships. The
+    ``strength`` value is treated as a delta and added to the current stored
+    value. The final score is clamped to ``[-1.0, 1.0]``.
+    """
 
-def test_relationship_update() -> None:
-    # Implementation of the function
-    pass
+    agent_rel = _RELATIONSHIPS.setdefault(agent_id, {})
+    other_rel = agent_rel.setdefault(other_agent_id, {})
+    current = float(other_rel.get(relationship_type, 0.0))
+
+    new_strength = max(-1.0, min(1.0, current + float(strength)))
+    other_rel[relationship_type] = new_strength
+
+    return f"{relationship_type} from {agent_id} to {other_agent_id}: {new_strength:.2f}"

--- a/tests/unit/dspy_programs/test_relationship_updater.py
+++ b/tests/unit/dspy_programs/test_relationship_updater.py
@@ -7,6 +7,7 @@ from src.agents.dspy_programs.relationship_updater import (
     FailsafeRelationshipUpdater,
     get_failsafe_output,
     get_relationship_updater,
+    update_relationship,
 )
 
 
@@ -42,3 +43,18 @@ def test_get_relationship_updater_fallback(monkeypatch: MonkeyPatch) -> None:
     assert hasattr(result, "relationship_change_rationale")
     assert result.new_relationship_score == 0.1
     assert "Failsafe" in result.relationship_change_rationale
+
+
+@pytest.mark.unit
+def test_update_relationship_adjusts_strength() -> None:
+    from src.agents.dspy_programs.relationship_updater import _RELATIONSHIPS
+
+    _RELATIONSHIPS.clear()
+
+    msg = update_relationship("a", "b", "friendship", 0.3)
+    assert _RELATIONSHIPS["a"]["b"]["friendship"] == pytest.approx(0.3)
+    assert "a to b" in msg
+
+    msg = update_relationship("a", "b", "friendship", 0.8)
+    # Should clamp to 1.0
+    assert _RELATIONSHIPS["a"]["b"]["friendship"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- implement `update_relationship` to track pairwise strength
- remove unused placeholder test and add a real unit test

## Testing
- `ruff format src/agents/dspy_programs/relationship_updater.py tests/unit/dspy_programs/test_relationship_updater.py --check`
- `ruff check src/agents/dspy_programs/relationship_updater.py tests/unit/dspy_programs/test_relationship_updater.py`
- `mypy src/agents/dspy_programs/relationship_updater.py tests/unit/dspy_programs/test_relationship_updater.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521ed6de5083269b8afb167f48e8b5