### PR TITLE
Add dashboard event streaming

### DIFF
--- a/docs/static/knowledge_board.html
+++ b/docs/static/knowledge_board.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Knowledge Board Activity</title>
+    <script>
+    window.addEventListener('DOMContentLoaded', () => {
+        const es = new EventSource('/stream/events');
+        es.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            const list = document.getElementById('events');
+            const li = document.createElement('li');
+            li.textContent = JSON.stringify(data);
+            list.appendChild(li);
+        };
+    });
+    </script>
+</head>
+<body>
+    <h1>Knowledge Board Activity</h1>
+    <ul id="events"></ul>
+</body>
+</html>

--- a/docs/static/relationship_graph.html
+++ b/docs/static/relationship_graph.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Relationship Graph</title>
+    <script>
+    window.addEventListener('DOMContentLoaded', () => {
+        const ws = new WebSocket('/ws/events');
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            const log = document.getElementById('log');
+            log.textContent += JSON.stringify(data) + '\n';
+        };
+    });
+    </script>
+</head>
+<body>
+    <h1>Relationship Graph</h1>
+    <pre id="log"></pre>
+</body>
+</html>

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -3,13 +3,15 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 # Global queue for agent messages
 message_sse_queue: asyncio.Queue["AgentMessage"] = asyncio.Queue()
+# Queue for general simulation events streamed via SSE/WebSocket
+event_queue: asyncio.Queue["SimulationEvent | None"] = asyncio.Queue()
 
 
 class AgentMessage(BaseModel):
@@ -20,6 +22,13 @@ class AgentMessage(BaseModel):
     action_intent: str | None = None
     timestamp: float | None = None
     extra: dict[str, Any] | None = None
+
+
+class SimulationEvent(BaseModel):
+    """Generic simulation event structure for dashboards."""
+
+    event_type: str
+    data: dict[str, Any] | None = None
 
 
 app = FastAPI()
@@ -47,3 +56,30 @@ async def stream_messages(request: Request) -> EventSourceResponse:  # type: ign
 @app.get("/health")
 async def health() -> Response:
     return JSONResponse({"status": "ok"})
+
+
+@app.get("/stream/events")
+async def stream_events(request: Request) -> EventSourceResponse:  # type: ignore[no-any-unimported]
+    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
+        while True:
+            if await request.is_disconnected():
+                break
+            event: SimulationEvent | None = await event_queue.get()
+            if event is None:
+                break
+            yield {"event": "simulation_event", "data": event.json()}
+
+    return EventSourceResponse(event_generator())
+
+
+@app.websocket("/ws/events")
+async def websocket_events(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            event: SimulationEvent | None = await event_queue.get()
+            if event is None:
+                break
+            await websocket.send_text(event.json())
+    except WebSocketDisconnect:
+        pass

--- a/tests/integration/interfaces/test_dashboard_backend_api.py
+++ b/tests/integration/interfaces/test_dashboard_backend_api.py
@@ -1,0 +1,132 @@
+import json
+
+import pytest
+
+
+class DummyRequest:
+    async def is_disconnected(self) -> bool:  # pragma: no cover - simple stub
+        return False
+
+
+class DummyWebSocket:
+    def __init__(self) -> None:
+        self.accepted = False
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_events_sse(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sys
+    import types
+
+    if "fastapi" in sys.modules:
+        fastapi_mod = sys.modules["fastapi"]
+    else:
+        fastapi_mod = types.ModuleType("fastapi")
+        sys.modules["fastapi"] = fastapi_mod
+    if not hasattr(fastapi_mod, "WebSocket"):
+
+        class _WS:
+            async def accept(self) -> None:
+                pass
+
+            async def send_text(self, text: str) -> None:
+                pass
+
+        class _FastAPI:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def get(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+            def websocket(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+        fastapi_mod.FastAPI = _FastAPI
+        fastapi_mod.Request = DummyRequest
+        fastapi_mod.Response = object
+        fastapi_mod.WebSocket = _WS
+        fastapi_mod.WebSocketDisconnect = Exception
+    from src.interfaces import dashboard_backend as db
+
+    captured: list[dict[str, str]] = []
+
+    class CaptureESR:
+        def __init__(self, gen: object) -> None:
+            self.gen = gen
+
+    monkeypatch.setattr(db, "EventSourceResponse", CaptureESR)
+
+    await db.event_queue.put(db.SimulationEvent(event_type="tick", data={"step": 1}))
+    await db.event_queue.put(None)
+    resp = await db.stream_events(DummyRequest())
+    event = await resp.gen.__anext__()
+    captured.append(event)
+    assert json.loads(captured[0]["data"])["data"]["step"] == 1
+    with pytest.raises(StopAsyncIteration):
+        await resp.gen.__anext__()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_websocket_events() -> None:
+    import sys
+    import types
+
+    if "fastapi" in sys.modules:
+        fastapi_mod = sys.modules["fastapi"]
+    else:
+        fastapi_mod = types.ModuleType("fastapi")
+        sys.modules["fastapi"] = fastapi_mod
+    if not hasattr(fastapi_mod, "WebSocket"):
+
+        class _WS:
+            async def accept(self) -> None:
+                pass
+
+            async def send_text(self, text: str) -> None:
+                pass
+
+        class _FastAPI:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def get(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+            def websocket(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+        fastapi_mod.FastAPI = _FastAPI
+        fastapi_mod.Request = DummyRequest
+        fastapi_mod.Response = object
+        fastapi_mod.WebSocket = _WS
+        fastapi_mod.WebSocketDisconnect = Exception
+    from src.interfaces import dashboard_backend as db
+
+    ws = DummyWebSocket()
+    await db.event_queue.put(db.SimulationEvent(event_type="start", data={"step": 2}))
+    await db.event_queue.put(None)
+    await db.websocket_events(ws)
+    payload = json.loads(ws.sent[0])
+    assert payload["data"]["step"] == 2


### PR DESCRIPTION
## Summary
- extend `dashboard_backend` with `SimulationEvent` streaming via WebSocket and SSE
- add simple dashboard pages for relationship graphs and knowledge board activity
- add tests for event streaming API

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest -c /dev/null --rootdir=. -p pytest_asyncio tests/integration/interfaces/test_dashboard_backend_api.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685226a41b1c8326964d0966441d4d8f