### PR TITLE
Add Windows CI subset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,15 @@ jobs:
         shell: bash
         run: pytest -m "integration" --disable-warnings -q
 
+      - name: Run Windows Path/Discord Integration
+        if: steps.changes.outputs.CODE_CHANGES == 'true' && matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          pytest \
+            tests/integration/test_hierarchical_memory_persistence.py \
+            tests/integration/interfaces/test_discord_bot.py \
+            -m "integration" --disable-warnings -q
+
       - name: Upload coverage artifact
         if: steps.changes.outputs.CODE_CHANGES == 'true'
         uses: actions/upload-artifact@v4

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -86,6 +86,7 @@ The CI workflow can run this suite by triggering the `run-redteam` input of the 
 - Full suite runs nightly and on main branch merges
 - See `.github/workflows/ci.yml` for details
 - Pushes that only modify Markdown files or documentation paths are ignored by CI
+- A small integration subset runs on Windows to verify ChromaDB paths and Discord bot startup
 - After tests complete, the `coverage.xml` file is uploaded as a GitHub Actions artifact. In the workflow run summary, look under **Artifacts** to download it.
 
 ## Adding/Updating Markers


### PR DESCRIPTION
## Summary
- run targeted integration tests on `windows-latest`
- mention Windows subset in testing docs

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/testing.md`
- `pytest -m unit tests/test_pytest_sanity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685226a902748326808d14f0efb5cf6f