### PR TITLE
Optimize CI workflow triggers and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,21 @@ name: CI
 
 on:
   push:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/**'
+      - 'pyproject.toml'
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
+    branches: [main, develop]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/**'
+      - 'pyproject.toml'
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -21,6 +29,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   build:
@@ -151,7 +163,7 @@ jobs:
 
   full-suite:
     if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "linux"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -215,7 +227,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run-redteam == 'true') ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-redteam'))
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "linux"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines 
 
 For advanced testing, parallelization, and CI details, see [docs/testing.md](docs/testing.md).
 CI workflows are skipped when a commit only modifies documentation (`*.md` files or files under `docs/`).
+Outdated runs on the same branch are automatically canceled, and heavy test suites run on a self-hosted Linux runner.
 See [docs/ci_status.md](docs/ci_status.md) for tips on checking CI status with the GitHub interface or the `gh` CLI. Because this repository has no remote configured by default, you'll need to add your GitHub remote before checking statuses.
 
 ## Code Quality and Type Safety

--- a/docs/ci_status.md
+++ b/docs/ci_status.md
@@ -2,6 +2,8 @@
 
 Culture.ai uses GitHub Actions to run tests and linters on each branch. This repository does not include a remote by default, so you must add your GitHub remote to view CI results.
 
+Long-running jobs execute on a self-hosted Linux runner. Each workflow also cancels previous runs on the same branch to save time.
+
 ## Adding the Remote
 
 Use the `git remote add` command to connect your local clone to the GitHub repository:


### PR DESCRIPTION
## Summary
- scope CI to code directories only
- cancel old workflow runs and restrict token permissions
- run long suites on a self-hosted runner
- document CI concurrency and self-hosted runner

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md docs/ci_status.md`

------
https://chatgpt.com/codex/tasks/task_e_6852d0735f10832690558ec385ccc17b