### PR TITLE
Remove nightly CI schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ on:
       - 'scripts/**'
       - '.github/**'
       - 'pyproject.toml'
-  schedule:
-    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       run-redteam:
@@ -162,7 +160,7 @@ jobs:
         run: black --check .
 
   full-suite:
-    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ["self-hosted", "linux"]
     steps:
       - name: Checkout code
@@ -179,14 +177,13 @@ jobs:
           done < .env
 
       - name: Detect non-comment code changes
-        if: github.event_name != 'schedule'
         id: changes
         shell: bash
         run: |
           bash scripts/check_code_changes.sh
 
       - name: Skip workflow if only docs or comments changed
-        if: github.event_name != 'schedule' && steps.changes.outputs.CODE_CHANGES == 'false'
+        if: steps.changes.outputs.CODE_CHANGES == 'false'
         run: |
           echo "No non-comment code changes detected. Skipping remaining steps."
           exit 0
@@ -224,7 +221,6 @@ jobs:
 
   redteam:
     if: |
-      github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run-redteam == 'true') ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-redteam'))
     runs-on: ["self-hosted", "linux"]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -83,7 +83,7 @@ The CI workflow can run this suite by triggering the `run-redteam` input of the 
 ## CI Workflow
 
 - Fast unit tests run on every push/PR
-- Full suite runs nightly and on main branch merges
+ - Full suite runs on main branch merges
 - See `.github/workflows/ci.yml` for details
 - Pushes that only modify Markdown files or documentation paths are ignored by CI
 - A small integration subset runs on Windows to verify ChromaDB paths and Discord bot startup


### PR DESCRIPTION
## Summary
- delete the scheduled cron trigger from CI
- update docs to reflect removal of nightly run

## Testing
- `pre-commit run --files .github/workflows/ci.yml docs/testing.md`
- `pytest tests/test_pytest_sanity.py -q`
- `ruff check .github/workflows/ci.yml docs/testing.md` *(fails: found 1279 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852d9bbd98883269bf7abf57920d187