### PR TITLE
Fix get_config_value_with_override default

### DIFF
--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -541,7 +541,7 @@ logger.info("Configuration loaded successfully")
 
 
 def get_config_value_with_override(
-    key: str, default: Any = None, module_name: str = "src.infra.config_default"
+    key: str, default: Any = None, module_name: str = "src.infra.config"
 ) -> Any:
     """Fetches a config value, trying overrides first, then primary, then default."""
     # Dynamically import the configuration module

--- a/tests/unit/infra/test_config_utils.py
+++ b/tests/unit/infra/test_config_utils.py
@@ -29,3 +29,9 @@ def test_get_config_value_with_missing_module() -> None:
         )
         == "def"
     )
+
+
+@pytest.mark.unit
+def test_get_config_value_with_default_args() -> None:
+    """Ensure default arguments return the provided default value."""
+    assert config.get_config_value_with_override("MISSING_KEY", default="def") == "def"


### PR DESCRIPTION
## Summary
- fix `get_config_value_with_override` to use `src.infra.config` by default
- test that default arguments return the specified default

## Testing
- `bash scripts/lint.sh`
- `pytest tests/unit/infra/test_config_utils.py::test_get_config_value_with_default_args -q`

------
https://chatgpt.com/codex/tasks/task_e_68536f9593d88326bd818f82162ff151