### PR TITLE
Implement robustness improvements

### DIFF
--- a/src/infra/async_dspy_manager.py
+++ b/src/infra/async_dspy_manager.py
@@ -46,6 +46,12 @@ class AsyncDSPyManager:
     ) -> None:
         self.shutdown()
 
+    def __del__(self: Self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.shutdown()
+        except Exception:
+            logger.debug("AsyncDSPyManager shutdown failed during __del__", exc_info=True)
+
     async def submit(
         self: Self,
         dspy_callable: Callable[..., object],

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -6,7 +6,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-import zstandard as zstd
+try:
+    import zstandard as zstd
+except ImportError:  # pragma: no cover - optional dependency
+    zstd = None
 
 from .config import SNAPSHOT_COMPRESS
 
@@ -34,6 +37,10 @@ def save_snapshot(
     path.mkdir(parents=True, exist_ok=True)
 
     if compress:
+        if zstd is None:
+            raise RuntimeError(
+                "Compression requires the optional 'zstandard' package. Install via 'pip install zstandard'."
+            )
         file_path = path / f"snapshot_{step}.json.zst"
         compressed = zstd.ZstdCompressor().compress(json.dumps(data, indent=2).encode("utf-8"))
         with file_path.open("wb") as f:

--- a/tests/unit/infra/test_snapshot.py
+++ b/tests/unit/infra/test_snapshot.py
@@ -17,3 +17,15 @@ def test_save_snapshot_compressed(tmp_path: Path) -> None:
     with fname.open("rb") as f:
         decompressed = zstd.ZstdDecompressor().decompress(f.read())
     assert json.loads(decompressed.decode("utf-8")) == data
+
+
+def test_save_snapshot_compress_without_zstd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data = {"a": 1}
+    from src import infra
+
+    monkeypatch.setattr(infra.snapshot, "zstd", None)
+
+    with pytest.raises(RuntimeError):
+        save_snapshot(1, data, directory=tmp_path, compress=True)


### PR DESCRIPTION
## Summary
- handle optional zstandard dependency in snapshot utilities
- narrow exception handling in SimulationDiscordBot
- add a destructor to AsyncDSPyManager for cleanup
- test compressed snapshot when zstandard is missing

## Testing
- `ruff check src/infra/async_dspy_manager.py src/infra/snapshot.py src/interfaces/discord_bot.py tests/unit/infra/test_snapshot.py`
- `ruff format src/infra/async_dspy_manager.py src/infra/snapshot.py src/interfaces/discord_bot.py tests/unit/infra/test_snapshot.py`
- `mypy src/infra/async_dspy_manager.py src/infra/snapshot.py src/interfaces/discord_bot.py tests/unit/infra/test_snapshot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536e661b0083268a337ec7aec49121