### PR TITLE
Fix structured output URL for env override

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -637,8 +637,9 @@ def generate_structured_output(
     try:
         logger.debug(f"Sending structured prompt to Ollama model '{model}':")
         logger.debug(f"---PROMPT START---\n{structured_prompt}\n---PROMPT END---")
+        url = f"{OLLAMA_API_BASE.rstrip('/')}/api/generate"
         response = requests.post(
-            "http://localhost:11434/api/generate",
+            url,
             json={
                 "model": model,
                 "prompt": structured_prompt,

--- a/tests/unit/infra/test_llm_client_url.py
+++ b/tests/unit/infra/test_llm_client_url.py
@@ -1,0 +1,32 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from src.infra import llm_client
+
+
+class DummyModel(BaseModel):
+    foo: str
+
+
+@pytest.mark.unit
+def test_generate_structured_output_uses_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_post(url: str, *args: object, **kwargs: object) -> MagicMock:
+        captured["url"] = url
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"response": json.dumps({"foo": "bar"})}
+        return resp
+
+    monkeypatch.setattr(llm_client, "OLLAMA_API_BASE", "http://override:1234")
+    monkeypatch.setattr(llm_client.requests, "post", fake_post)
+
+    result = llm_client.generate_structured_output("prompt", DummyModel)
+
+    assert isinstance(result, DummyModel)
+    assert result.foo == "bar"
+    assert captured["url"] == "http://override:1234/api/generate"


### PR DESCRIPTION
## Summary
- ensure `generate_structured_output` uses `OLLAMA_API_BASE` when contacting Ollama
- test that URL overrides work via environment changes

## Testing
- `ruff check src/infra/llm_client.py tests/unit/infra/test_llm_client_url.py`
- `black src/infra/llm_client.py tests/unit/infra/test_llm_client_url.py`
- `mypy src/infra/llm_client.py tests/unit/infra/test_llm_client_url.py`
- `pytest -c /dev/null -q tests/unit/infra/test_llm_client_url.py`

------
https://chatgpt.com/codex/tasks/task_e_68536f96b0d88326b69059d6e60ac7b8