### PR TITLE
Ensure positive max_entries in KnowledgeBoard

### DIFF
--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -72,6 +72,9 @@ class KnowledgeBoard:
         Returns:
             list[str]: The most recent entries on the board, up to max_entries.
         """
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+
         # Return the display_content for the most recent entries, up to max_entries
         recent_entries = (
             [entry["content_display"] for entry in self.entries[-max_entries:]]
@@ -102,6 +105,9 @@ class KnowledgeBoard:
         Returns:
             list[str]: A list of formatted strings, e.g., "[Step X, Agent Y]: Content..."
         """
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+
         if not self.entries:
             return ["(Knowledge Board is empty)"]
 

--- a/tests/unit/sim/test_knowledge_board.py
+++ b/tests/unit/sim/test_knowledge_board.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.sim.knowledge_board import KnowledgeBoard
+
+pytestmark = pytest.mark.unit
+
+
+def _create_board(num: int) -> KnowledgeBoard:
+    kb = KnowledgeBoard()
+    for i in range(num):
+        kb.add_entry(f"entry{i}", agent_id="A", step=i)
+    return kb
+
+
+def test_get_state_positive() -> None:
+    kb = _create_board(3)
+    result = kb.get_state(2)
+    assert result == [
+        "Step 1 (Agent: A): entry1",
+        "Step 2 (Agent: A): entry2",
+    ]
+
+
+@pytest.mark.parametrize("val", [0, -1])
+def test_get_state_invalid(val: int) -> None:
+    kb = _create_board(1)
+    with pytest.raises(ValueError):
+        kb.get_state(val)
+
+
+def test_get_recent_entries_for_prompt_positive() -> None:
+    kb = _create_board(2)
+    result = kb.get_recent_entries_for_prompt(1)
+    assert result == ["[Step 1, A]: entry1"]
+
+
+@pytest.mark.parametrize("val", [0, -5])
+def test_get_recent_entries_for_prompt_invalid(val: int) -> None:
+    kb = _create_board(1)
+    with pytest.raises(ValueError):
+        kb.get_recent_entries_for_prompt(val)


### PR DESCRIPTION
## Summary
- validate `max_entries` in `get_state` and `get_recent_entries_for_prompt`
- add unit tests for `KnowledgeBoard` argument validation

## Testing
- `ruff check --fix src/sim/knowledge_board.py tests/unit/sim/test_knowledge_board.py`
- `mypy src/sim/knowledge_board.py tests/unit/sim/test_knowledge_board.py`
- `pytest tests/unit/sim/test_knowledge_board.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685377a1ec2c8326bcfc66e2560970c8