### PR TITLE
Fix role change turn order and add test

### DIFF
--- a/scripts/check_no_dspy_import.sh
+++ b/scripts/check_no_dspy_import.sh
@@ -2,7 +2,7 @@
 set -e
 # Fail if any Python file contains a direct import of the deprecated `dspy` package
 pattern='^\s*(from\s+dspy\b|import\s+dspy(\s|$))'
-files=$(git ls-files '*.py' | grep '^src/')
+files=$(git ls-files '*.py' | grep '^src/' | grep -v '^src/dspy_ai/__init__\.py$')
 if grep -nE "$pattern" $files; then
   echo "Direct 'dspy' imports are forbidden. Use 'dspy_ai' instead." >&2
   exit 1

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -379,6 +379,7 @@ class Simulation:
 
             # Determine next agent index based on role change event this turn
             # If agent changed role this turn, retain the same index for immediate extra turn
+            next_agent_index = (agent_to_run_index + 1) % len(self.agents)
             try:
                 # Check for a 'role_change' memory entry at this simulation step
                 has_role_change = any(
@@ -389,13 +390,10 @@ class Simulation:
                     logger.debug(
                         f"Agent {agent_id} changed role at step {self.current_step}, retaining turn for index {agent_to_run_index}"
                     )
-                    self.current_agent_index = agent_to_run_index
-                else:
-                    # Normal rotation to next agent
-                    self.current_agent_index = (agent_to_run_index + 1) % len(self.agents)
+                    next_agent_index = agent_to_run_index
             except Exception:
                 # Fallback to normal rotation on any error
-                self.current_agent_index = (agent_to_run_index + 1) % len(self.agents)
+                next_agent_index = (agent_to_run_index + 1) % len(self.agents)
 
             # --- Log Agent A's relationship to B if they exist (USER REQUEST) ---
             for ag_check in self.agents:
@@ -450,7 +448,7 @@ class Simulation:
                 log_event({"type": "snapshot", **snapshot})
 
             # Advance to the next agent for the next turn
-            self.current_agent_index = (agent_to_run_index + 1) % len(self.agents)
+            self.current_agent_index = next_agent_index
             self.total_turns_executed += 1
             turn_counter_this_run_step += 1
 

--- a/tests/unit/sim/test_simulation_role_change.py
+++ b/tests/unit/sim/test_simulation_role_change.py
@@ -1,0 +1,69 @@
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str, change_on_first_turn: bool = False) -> None:
+        self.agent_id = agent_id
+        self._state = DummyAgentState()
+        self.change_on_first_turn = change_on_first_turn
+        self.turns = 0
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyAgentState:
+        return self._state
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self._state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        self.turns += 1
+        if self.change_on_first_turn:
+            self._state.short_term_memory.append({"type": "role_change", "step": simulation_step})
+            self.change_on_first_turn = False
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_role_change_grants_extra_turn() -> None:
+    import sys
+
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    agent_a = DummyAgent("A", change_on_first_turn=True)
+    agent_b = DummyAgent("B")
+    sim = Simulation([agent_a, agent_b])
+
+    turns = await sim.run_step(max_turns=2)
+
+    assert turns == 2
+    assert agent_a.turns == 2
+    assert agent_b.turns == 0
+    assert sim.current_agent_index == 1


### PR DESCRIPTION
## Summary
- update Simulation.run_step to preserve agent index after role change
- allow dspy_ai wrapper imports in pre-commit script
- add unit test for role change turn behavior

## Testing
- `pre-commit run --files scripts/check_no_dspy_import.sh src/sim/simulation.py tests/unit/sim/test_simulation_role_change.py`
- `pytest tests/unit/sim/test_simulation_role_change.py::test_role_change_grants_extra_turn -q`

------
https://chatgpt.com/codex/tasks/task_e_6853779b75fc83268cd949d166c77fbf