### PR TITLE
Update log messages with start IP/DU

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -370,8 +370,12 @@ class Simulation:
 
             # Update agent counters and report
             logger.info(f"Agent {agent_id} completed Global Turn {self.current_step}:")
-            logger.info(f"  - IP: {current_agent_state.ip:.1f} (from {current_agent_state.ip})")
-            logger.info(f"  - DU: {current_agent_state.du:.1f} (from {current_agent_state.du})")
+            logger.info(
+                f"  - IP: {current_agent_state.ip:.1f} (from {ip_start})"
+            )
+            logger.info(
+                f"  - DU: {current_agent_state.du:.1f} (from {du_start})"
+            )
 
             # Update the agent state in the simulation's list of agents
             self.agents[agent_to_run_index] = (

--- a/tests/unit/sim/test_simulation_logging.py
+++ b/tests/unit/sim/test_simulation_logging.py
@@ -1,0 +1,67 @@
+import logging
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyAgentState()
+        self.turns = 0
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyAgentState:
+        return self._state
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self._state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        self.turns += 1
+        self._state.ip += 1.0
+        self._state.du += 2.0
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_logs_use_start_values(caplog: pytest.LogCaptureFixture) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    with caplog.at_level(logging.INFO):
+        await sim.run_step(max_turns=1)
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("IP: 1.0 (from 0.0)" in m for m in messages)
+    assert any("DU: 2.0 (from 0.0)" in m for m in messages)


### PR DESCRIPTION
## Summary
- log the starting IP/DU values rather than the ending values
- test that logs include the `ip_start` and `du_start` numbers

## Testing
- `ruff check src/sim/simulation.py tests/unit/sim/test_simulation_logging.py`
- `pytest tests/unit/sim/test_simulation_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68548e8b65fc8326b2e40c2f60233b2f