### PR TITLE
Fix content_summary None handling

### DIFF
--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -98,7 +98,9 @@ class KnowledgeBoard:
 
     def get_recent_entries_for_prompt(self: Self, max_entries: int = 5) -> list[str]:
         """
-        Returns a list of formatted strings for the most recent entries, suitable for an LLM prompt.
+        Returns a list of formatted strings for the most recent entries,
+        suitable for an LLM prompt. ``content_summary`` is cast to ``str`` to
+        gracefully handle ``None`` values before length checks.
 
         Args:
             max_entries (int): The maximum number of recent entries to return.
@@ -121,7 +123,8 @@ class KnowledgeBoard:
             step = entry.get("step", "N/A")
             agent_id = entry.get("agent_id", "Unknown Agent")
             content_summary = entry.get("content_summary", entry.get("content_full", "N/A"))
-            # Convert to string so None or other types won't break length checks
+            # Cast to string so None or other non-string values don't raise
+            # errors when we check the length for truncation
             content_summary = str(content_summary)
             # Truncate content for brevity in prompt if necessary
             max_content_len = 150  # Example max length

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -121,6 +121,7 @@ class KnowledgeBoard:
             step = entry.get("step", "N/A")
             agent_id = entry.get("agent_id", "Unknown Agent")
             content_summary = entry.get("content_summary", entry.get("content_full", "N/A"))
+            # Convert to string so None or other types won't break length checks
             content_summary = str(content_summary)
             # Truncate content for brevity in prompt if necessary
             max_content_len = 150  # Example max length

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -121,6 +121,7 @@ class KnowledgeBoard:
             step = entry.get("step", "N/A")
             agent_id = entry.get("agent_id", "Unknown Agent")
             content_summary = entry.get("content_summary", entry.get("content_full", "N/A"))
+            content_summary = str(content_summary)
             # Truncate content for brevity in prompt if necessary
             max_content_len = 150  # Example max length
             if len(content_summary) > max_content_len:

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -122,7 +122,10 @@ class KnowledgeBoard:
         for entry in recent_raw_entries:
             step = entry.get("step", "N/A")
             agent_id = entry.get("agent_id", "Unknown Agent")
-            content_summary = entry.get("content_summary", entry.get("content_full", "N/A"))
+            content_summary = entry.get("content_summary") or entry.get(
+                "content_full",
+                "N/A",
+            )
             # Cast to string so None or other non-string values don't raise
             # errors when we check the length for truncation
             content_summary = str(content_summary)

--- a/tests/unit/sim/test_knowledge_board.py
+++ b/tests/unit/sim/test_knowledge_board.py
@@ -39,3 +39,11 @@ def test_get_recent_entries_for_prompt_invalid(val: int) -> None:
     kb = _create_board(1)
     with pytest.raises(ValueError):
         kb.get_recent_entries_for_prompt(val)
+
+
+def test_get_recent_entries_with_none_summary() -> None:
+    kb = KnowledgeBoard()
+    kb.add_entry("entry", agent_id="A", step=1)
+    kb.entries[-1]["content_summary"] = None
+    result = kb.get_recent_entries_for_prompt(1)
+    assert result == ["[Step 1, A]: None"]

--- a/tests/unit/sim/test_knowledge_board.py
+++ b/tests/unit/sim/test_knowledge_board.py
@@ -46,4 +46,4 @@ def test_get_recent_entries_with_none_summary() -> None:
     kb.add_entry("entry", agent_id="A", step=1)
     kb.entries[-1]["content_summary"] = None
     result = kb.get_recent_entries_for_prompt(1)
-    assert result == ["[Step 1, A]: None"]
+    assert result == ["[Step 1, A]: entry"]


### PR DESCRIPTION
## Summary
- avoid error when content_summary is None in KnowledgeBoard
- test KnowledgeBoard with None content_summary

## Testing
- `ruff format src/sim/knowledge_board.py tests/unit/sim/test_knowledge_board.py`
- `ruff check src/sim/knowledge_board.py tests/unit/sim/test_knowledge_board.py`
- `mypy src/sim/knowledge_board.py tests/unit/sim/test_knowledge_board.py`
- `pytest -q tests/unit/sim/test_knowledge_board.py`


------
https://chatgpt.com/codex/tasks/task_e_68548e8bdb74832690f31aeff0cd4399