### PR TITLE
Fix KB metric after pruning

### DIFF
--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -156,7 +156,6 @@ class KnowledgeBoard:
                 "content_display": formatted_content,  # Store formatted entry for display
             }
             self.entries.append(new_entry_dict)  # Append first
-            metrics.KNOWLEDGE_BOARD_SIZE.set(len(self.entries))
 
             # Enforce maximum board size
             max_entries = int(config.MAX_KB_ENTRIES)
@@ -168,6 +167,8 @@ class KnowledgeBoard:
                     excess,
                     max_entries,
                 )
+
+            metrics.KNOWLEDGE_BOARD_SIZE.set(len(self.entries))
 
             logger.info(  # Log after append
                 f"KnowledgeBoard: Added entry ID {entry_id} by {agent_id} at step {step}: '{entry}'. "

--- a/tests/unit/interfaces/test_metrics.py
+++ b/tests/unit/interfaces/test_metrics.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 
+from src.infra import config
 from src.interfaces import metrics
 from src.shared.decorator_utils import monitor_llm_call
 from src.sim.knowledge_board import KnowledgeBoard
@@ -27,3 +28,22 @@ def test_kb_size_metric() -> None:
     start = metrics.KNOWLEDGE_BOARD_SIZE._value.get()
     kb.add_entry("entry", "agent", 1)
     assert metrics.KNOWLEDGE_BOARD_SIZE._value.get() == start + 1
+
+
+@pytest.mark.unit
+def test_kb_size_metric_pruning(monkeypatch: pytest.MonkeyPatch) -> None:
+    kb = KnowledgeBoard()
+
+    # Add several entries with the default max limit (100)
+    kb.add_entry("e1", "A", 1)
+    kb.add_entry("e2", "A", 2)
+    kb.add_entry("e3", "A", 3)
+    before = metrics.KNOWLEDGE_BOARD_SIZE._value.get()
+
+    # Now lower the max size and add another entry to trigger pruning
+    monkeypatch.setattr(config, "MAX_KB_ENTRIES", 2)
+    kb.add_entry("e4", "A", 4)
+
+    after = metrics.KNOWLEDGE_BOARD_SIZE._value.get()
+    assert after == before - 1
+    assert len(kb.entries) == 2


### PR DESCRIPTION
## Summary
- update metric after entries pruned
- test that pruning decreases metric

## Testing
- `pre-commit run --files src/sim/knowledge_board.py tests/unit/interfaces/test_metrics.py`
- `pytest -q tests/unit/interfaces/test_metrics.py::test_kb_size_metric_pruning tests/unit/interfaces/test_metrics.py::test_kb_size_metric`

------
https://chatgpt.com/codex/tasks/task_e_68548e8d67fc83269b38277390e35d61