### PR TITLE
Fix role-specific memory retrieval fallback

### DIFF
--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -730,7 +730,6 @@ class ChromaVectorStoreManager(MemoryStore):
                 logger.warning(
                     "Neither role nor query provided for role-specific memory retrieval"
                 )
-                return []
             return self.retrieve_relevant_memories(
                 agent_id, query, k, include_usage_stats=include_usage_stats
             )


### PR DESCRIPTION
## Summary
- ensure `retrieve_relevant_memories` runs when no role is provided

## Testing
- `ruff check src/agents/memory/vector_store.py --no-fix`
- `black --check src/agents/memory/vector_store.py`
- `mypy src/agents/memory/vector_store.py`
- `pytest tests/unit/memory/test_role_history.py::test_retrieve_role_specific_memories_without_query tests/unit/memory/test_role_history.py::test_retrieve_role_specific_memories_with_query_no_role -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b935000083268230dc2212600e9c