### PR TITLE
Fix reset_state logic

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -202,6 +202,7 @@ class AgentController:
                 self.update_relationship(sender, 0.0, is_targeted=True)
 
     def reset_state(self: Self) -> None:
+        """Reset mood and relationship histories while preserving known agents."""
         state = self._require_state()
         old_keys = list(state.relationship_history.keys())
         state.relationship_history.clear()

--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -203,8 +203,7 @@ class AgentController:
 
     def reset_state(self: Self) -> None:
         state = self._require_state()
+        old_keys = list(state.relationship_history.keys())
         state.relationship_history.clear()
         state.mood_history = [(0, 0.0)]
-        state.relationship_history = {
-            name: [(0, 0.0)] for name in state.relationship_history.keys()
-        }
+        state.relationship_history = {name: [(0, 0.0)] for name in old_keys}


### PR DESCRIPTION
## Summary
- fix resetting relationship_history to preserve existing keys

## Testing
- `pre-commit run --files src/agents/core/agent_controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b9393a308326a225a57ee60171a9