### PR TITLE
Fix bool parsing in dynamic config

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -157,7 +157,19 @@ class AgentController:
         if hasattr(state, private_attr_name):
             current_val = getattr(state, private_attr_name)
             try:
-                casted = type(current_val)(value)
+                if isinstance(current_val, bool):
+                    if isinstance(value, str):
+                        lowered = value.strip().lower()
+                        if lowered == "true":
+                            casted = True
+                        elif lowered == "false":
+                            casted = False
+                        else:
+                            casted = bool(value)
+                    else:
+                        casted = bool(value)
+                else:
+                    casted = type(current_val)(value)
                 setattr(state, private_attr_name, casted)
             except (ValueError, TypeError):
                 logger.error(


### PR DESCRIPTION
## Summary
- properly parse `true`/`false` strings in `update_dynamic_config`

## Testing
- `bash scripts/lint.sh --format`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854b93a75788326a2ca2816932bcbf3