### PR TITLE
Fix redundant exception handling

### DIFF
--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -488,17 +488,11 @@ class ChromaVectorStoreManager(MemoryStore):
             return formatted_results
 
         except (ChromaDBException, OSError, ValidationError, json.JSONDecodeError) as e:
-            logger.error(
-                f"ChromaDB retrieve_relevant_memories failed: "
-                f"agent_id={agent_id}, query={query}, error={e}",
-                exc_info=True,
-            )
-            return []
-        except (ChromaDBException, ValidationError, OSError) as e:
-            logger.error(
-                f"Unexpected error in retrieve_relevant_memories: "
-                f"agent_id={agent_id}, query={query}, error={e}",
-                exc_info=True,
+            logger.exception(
+                "ChromaDB retrieve_relevant_memories failed: agent_id=%s, query=%s, error=%s",
+                agent_id,
+                query,
+                e,
             )
             return []
 


### PR DESCRIPTION
## Summary
- streamline error handling in `retrieve_relevant_memories`
- log retrieval errors with `logger.exception`

## Testing
- `ruff format src/agents/memory/vector_store.py`
- `black src/agents/memory/vector_store.py -q`
- `mypy src/agents/memory/vector_store.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b935403c83268caa52b563e76e39