### PR TITLE
Fix mock JSON warning

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -562,7 +562,8 @@ def generate_structured_output(
                         mock_dict = json.loads(str(mock_data))
                         return response_model(**mock_dict)
                     except json.JSONDecodeError:
-                        pass
+                        logger.warning("Invalid mock structured output: %s", mock_data)
+                        # Fall back to field defaults when mock data is malformed
             # Only define field_defaults if not already defined
             field_defaults: JSONDict = {}
             if hasattr(response_model, "model_fields"):


### PR DESCRIPTION
## Summary
- warn when invalid structured output is used in the mock path of `generate_structured_output`
- fallback to defaults when mock data is malformed

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest -q tests/test_pytest_sanity.py`

------
https://chatgpt.com/codex/tasks/task_e_6854b93ff8808326aead97feb24653f7