### PR TITLE
Add Windows vLLM start script

### DIFF
--- a/docs/windows_setup.md
+++ b/docs/windows_setup.md
@@ -83,6 +83,16 @@ ollama pull mistral:latest
 ollama serve &
 ```
 
+Alternatively you can run the model with **vLLM**. Start the server from WSL or any
+shell where Python is available:
+
+```cmd
+scripts\start_vllm.bat
+```
+
+This script mirrors `scripts/start_vllm.sh` and honors the `VLLM_MODEL`,
+`VLLM_PORT`, and `VLLM_SWAP_SPACE` environment variables.
+
 ## Run the Example Vertical Slice
 
 1. Install the CUDA-enabled PyTorch build and the remaining project requirements:

--- a/scripts/start_vllm.bat
+++ b/scripts/start_vllm.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Start the vLLM OpenAI-compatible API server with recommended defaults.
+
+if not defined VLLM_MODEL set VLLM_MODEL=mistralai/Mistral-7B-Instruct-v0.2
+if not defined VLLM_PORT set VLLM_PORT=8001
+if not defined VLLM_SWAP_SPACE set VLLM_SWAP_SPACE=16
+
+python -m vllm.entrypoints.openai.api_server ^
+  --model "%VLLM_MODEL%" ^
+  --port "%VLLM_PORT%" ^
+  --swap-space "%VLLM_SWAP_SPACE%"


### PR DESCRIPTION
## Summary
- add `start_vllm.bat` with defaults mirroring `start_vllm.sh`
- document new script in Windows setup guide

## Testing
- `bash scripts/lint.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685591f3a0e883268ada171cb4654602