### PR TITLE
Fix docs referencing archived benchmarks

### DIFF
--- a/docs/advanced_memory_pruning_design_proposal.md
+++ b/docs/advanced_memory_pruning_design_proposal.md
@@ -342,7 +342,7 @@ Phase 2 will build on these usage statistics to implement the actual pruning mec
 - **Thresholds:**
   - L1 MUS: 0.2
   - L2 MUS: 0.3
-  - Configuration: l1_low_l2_medium (see benchmarks/mus_threshold_tuning_report.md)
+  - Configuration: l1_low_l2_medium (see archives/benchmarks/mus_threshold_tuning_report.md [archived])
 
 ### Rationale
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,7 +232,7 @@ Pruning is performed using both age-based and MUS-based strategies:
 
 - **L1 MUS Threshold:** 0.2
 - **L2 MUS Threshold:** 0.3
-- **Configuration:** l1_low_l2_medium (see benchmarks/mus_threshold_tuning_report.md)
+  - **Configuration:** l1_low_l2_medium (see archives/benchmarks/mus_threshold_tuning_report.md [archived])
 
 These values were selected based on the MUS threshold tuning experiments (see report for details), balancing memory efficiency and RAG performance. Asymmetric thresholds (lower for L1, higher for L2) provide optimal tradeoff between aggressive pruning of less critical L1s and preservation of high-value L2s.
 
@@ -513,11 +513,9 @@ Various tools in the `tools/` directory:
 
 #### Benchmarking
 
-Benchmarking tools in the `benchmarks/` directory:
-- Evaluate memory system performance
-- Test memory utility scoring (MUS)
-- Compare different pruning strategies
-- Assess RAG retrieval effectiveness
+Benchmarking tools were archived with the former `benchmarks/` directory.
+These scripts evaluated memory system performance, MUS scoring, different
+pruning strategies, and overall RAG retrieval effectiveness.
 
 ## 10. Configuration Management
 
@@ -630,7 +628,7 @@ Located in `tests/integration/`, these verify:
 
 ### Benchmarks
 
-Located in `benchmarks/`, these evaluate:
+The original benchmarking suite has been archived. These tools evaluated:
 - Performance characteristics
 - Resource utilization
 - Effectiveness of algorithms (e.g., MUS pruning)

--- a/docs/development_notes/CLEANUP_SUMMARY.md
+++ b/docs/development_notes/CLEANUP_SUMMARY.md
@@ -46,6 +46,7 @@ A multi-phase approach was used to clean the codebase:
 ## Key Directories After Cleanup:
 
 *   `archives`: Contains zipped versions of `benchmarks`, `experiments`, and `tests`.
+*   Benchmarking tools referenced in documentation were removed from the repository and archived under `archives`.
 *   `src`: Main application source code (113 files).
 *   `tests`: Minimal structure with `__init__.py` files (4 files).
 *   Other essential project files and directories (`docs`, `scripts`, `config`, etc.) with minimal file counts.


### PR DESCRIPTION
## Summary
- fix link to MUS tuning report in `advanced_memory_pruning_design_proposal.md`
- clarify that benchmarking tools were archived in `architecture.md`
- document that benchmarks were archived in `CLEANUP_SUMMARY.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685593837910832692fa101aa52e7061