### PR TITLE
Remove outdated test counts from docs

### DIFF
--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -44,7 +44,7 @@ Culture.ai implements robust error handling and resilience mechanisms across all
 - Logs include module, function, error type, and context variables (if safe).
 
 ## Testing and Verification
-- All error handling is verified by running the full test suite (22 tests).
+- All error handling is verified by running the full test suite.
 - Manual fault injection is used to verify logging and fallback behavior.
 
 ## References

--- a/docs/pydantic_v2_migration_plan.md
+++ b/docs/pydantic_v2_migration_plan.md
@@ -237,7 +237,7 @@ age: Annotated[int, Field(ge=0, le=120)]
 
 ### Final Verification
 - **Command:** `python -m pytest tests/ -v -W default::DeprecationWarning --tb=short`
-- **Result:** All 35 tests passed, no v1 warnings from our codebase.
+ - **Result:** All tests passed, no v1 warnings from our codebase.
 
 ---
 

--- a/src/agents/dspy_programs/intent_selector.py
+++ b/src/agents/dspy_programs/intent_selector.py
@@ -8,7 +8,6 @@ from typing_extensions import Self
 import dspy_ai as dspy  # type: ignore
 
 
-
 class _StubLM(dspy.LM):
     """Deterministic LM returning a fixed intent for tests."""
 


### PR DESCRIPTION
## Summary
- update `docs/error_handling.md` to remove the hardcoded count of tests
- adjust `docs/pydantic_v2_migration_plan.md` to avoid specifying a test count
- run ruff formatting on `intent_selector.py`

## Testing
- `pytest --collect-only -q`
- `ruff check .`
- `mypy src`

------
https://chatgpt.com/codex/tasks/task_e_6855938353e48326994777388390837a