### PR TITLE
Add unit test for http_app main

### DIFF
--- a/tests/unit/interfaces/test_http_app.py
+++ b/tests/unit/interfaces/test_http_app.py
@@ -1,0 +1,24 @@
+import pytest
+
+from src import http_app
+
+
+@pytest.mark.unit
+def test_main_uses_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HTTP_HOST", "127.0.0.1")
+    monkeypatch.setenv("HTTP_PORT", "5678")
+
+    captured: dict[str, object] = {}
+
+    def dummy_run(app: object, host: str, port: int) -> None:
+        captured["app"] = app
+        captured["host"] = host
+        captured["port"] = port
+
+    monkeypatch.setattr(http_app.uvicorn, "run", dummy_run)
+
+    http_app.main()
+
+    assert captured["host"] == "127.0.0.1"
+    assert captured["port"] == 5678
+    assert captured["app"] is http_app.app


### PR DESCRIPTION
## Summary
- test that http_app.main passes HTTP_HOST and HTTP_PORT to `uvicorn.run`

## Testing
- `bash scripts/lint.sh`
- `pytest tests/unit/interfaces/test_http_app.py::test_main_uses_env_vars -q`

------
https://chatgpt.com/codex/tasks/task_e_6855963048588326aab3293622393fb6