### PR TITLE
Add .editorconfig and update contribution docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Welcome! We're excited that you're interested in contributing to Culture.ai. Thi
 - [Mypy](http://mypy-lang.org/) for static type checking
 - Install dependencies from `requirements-dev.txt` (includes `pytest-xdist`) in addition to `requirements.txt`.
 - Set up your environment and dependencies as described in the README.
+- Enable an [EditorConfig](https://editorconfig.org/) plugin in your editor if available to match the project's formatting settings.
 - If you modify dependencies, run `scripts/check_requirements.sh` to ensure `requirements.txt` is in sync with `requirements.in`.
 
 ## Code Style Guidelines


### PR DESCRIPTION
## Summary
- enforce consistent formatting via `.editorconfig`
- mention EditorConfig plugin in `CONTRIBUTING.md`

## Testing
- `pre-commit run --files .editorconfig CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6855cfbc9d9c832683893b9e795559a3