### PR TITLE
Add version flag to apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,12 @@ Run a basic simulation (default parameters):
 python -m src.app --steps 5
 ```
 
+Display the installed version:
+```bash
+python -m src.app --version
+python -m src.http_app --version
+```
+
 Start the HTTP dashboard backend (optional):
 ```bash
 python -m src.http_app

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,4 @@
+"""Culture package initialization."""
+
+# Semantic version of the Culture project
+__version__ = "0.1.0"

--- a/src/app.py
+++ b/src/app.py
@@ -88,6 +88,11 @@ def create_simulation(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Culture.ai simulation.")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Show the Culture.ai version and exit.",
+    )
     parser.add_argument("--agents", type=int, default=3, help="Number of agents.")
     parser.add_argument("--steps", type=int, default=10, help="Number of steps to run.")
     parser.add_argument(
@@ -131,6 +136,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     setup_logging()
     args = parse_args()
+
+    if args.version:
+        from src import __version__
+
+        print(__version__)
+        return
 
     configure_warning_filters(
         apply_filters=not args.no_warning_filters,

--- a/src/http_app.py
+++ b/src/http_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import os
 
 import uvicorn
@@ -7,8 +8,26 @@ import uvicorn
 from src.interfaces.dashboard_backend import app
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the FastAPI dashboard backend.")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Show the Culture.ai version and exit.",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
     """Run the FastAPI application for the dashboard backend."""
+    args = parse_args()
+
+    if args.version:
+        from src import __version__
+
+        print(__version__)
+        return
+
     host = os.getenv("HTTP_HOST", "0.0.0.0")
     port_str = os.getenv("HTTP_PORT", "8000")
     try:


### PR DESCRIPTION
## Summary
- expose project `__version__`
- add `--version` CLI flag to `src.app` and `src.http_app`
- document version usage in README

## Testing
- `bash scripts/lint.sh --format`
- `pytest tests/ -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*

------
https://chatgpt.com/codex/tasks/task_e_6855cfbddf048326830950aa512332ae