### PR TITLE
Remove unused helper in mock LLM utils

### DIFF
--- a/tests/utils/mock_llm.py
+++ b/tests/utils/mock_llm.py
@@ -103,8 +103,3 @@ def MockLLM(
         except ImportError:
             # If DSPy isn't available, proceed without patching it
             yield
-
-
-def get_mock_llm_response(prompt: str) -> dict[str, str]:
-    # ... existing code ...
-    return {"response": "mock"}


### PR DESCRIPTION
## Summary
- clean up mock LLM helper

## Testing
- `bash scripts/lint.sh`
- `pytest tests/test_pytest_sanity.py::test_pytest_sanity -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfced3748326aea7086c1a4b7fe2