### PR TITLE
Handle optional pytest plugins

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,11 @@ Run this script to verify that `requirements.txt` matches
 `requirements.in` whenever dependencies change.
 The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, `requests` for HTTP utilities, and `numpy>=2` for compatibility with certain examples.
 
+If these optional packages are not installed, running `pytest` directly will
+raise warnings because `pytest.ini` specifies `-n auto` and
+`asyncio_mode=strict`. Use `scripts/run_tests.py` instead, which automatically
+detects available plugins and strips those options.
+
 ## Test Markers and Suite Structure
 
 Tests are categorized using pytest markers:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run pytest with optional plugin-based adjustments."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INI_FILE = ROOT / "pytest.ini"
+
+
+def have_module(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def main(argv: list[str]) -> int:
+    has_xdist = have_module("xdist")
+    has_asyncio = have_module("pytest_asyncio")
+
+    cfg = ConfigParser()
+    cfg.read(INI_FILE)
+    modified = False
+
+    if "pytest" in cfg:
+        addopts = cfg["pytest"].get("addopts", "")
+        if not has_xdist and "-n" in addopts:
+            parts = addopts.split()
+            cleaned: list[str] = []
+            skip = False
+            for part in parts:
+                if skip:
+                    skip = False
+                    continue
+                if part == "-n" or part.startswith("-n"):
+                    if part == "-n":
+                        skip = True
+                    modified = True
+                    continue
+                cleaned.append(part)
+            cfg["pytest"]["addopts"] = " ".join(cleaned)
+        if not has_asyncio and cfg["pytest"].get("asyncio_mode"):
+            cfg["pytest"].pop("asyncio_mode")
+            modified = True
+
+    cmd = [sys.executable, "-m", "pytest"]
+
+    if modified:
+        with NamedTemporaryFile("w", delete=False) as tmp:
+            cfg.write(tmp)
+            temp_ini = tmp.name
+        cmd.extend(["-c", temp_ini])
+    else:
+        cmd.extend(["-c", str(INI_FILE)])
+
+    cmd.extend(argv)
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `scripts/run_tests.py` helper to drop `-n` and `asyncio_mode` if required
- document new helper in testing guide

## Testing
- `bash scripts/lint.sh --format`
- `python scripts/run_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfcd53b483269567add13f65ebeb