### PR TITLE
Add ledger with SQLite and log resource changes

### DIFF
--- a/docs/ledger_service.md
+++ b/docs/ledger_service.md
@@ -1,0 +1,21 @@
+# Ledger Service
+
+The ledger provides a persistent record of IP and DU adjustments for each agent.
+It uses a small SQLite database in WAL mode located at `ledger.sqlite3` by
+default.
+
+## Usage
+
+```python
+from src.infra.ledger import ledger
+
+# record changes
+ledger.log_change("agent-1", delta_ip=1.5, delta_du=-2, reason="message")
+
+# query balances
+ip, du = ledger.get_balance("agent-1")
+```
+
+Transactions are stored in the `transactions` table while current balances are
+kept in `agent_balances`. The ledger is lightweight and requires no setup other
+than importing the module.

--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -23,8 +23,20 @@ logger = logging.getLogger(__name__)
 
 def handle_propose_idea_node(state: AgentTurnState) -> dict[str, Any]:
     agent_state = state["state"]
+    start_ip = agent_state.ip
     agent_state.ip -= IP_COST_TO_POST_IDEA
     agent_state.ip += IP_AWARD_FOR_PROPOSAL
+    try:
+        from src.infra.ledger import ledger
+
+        ledger.log_change(
+            agent_state.agent_id,
+            agent_state.ip - start_ip,
+            0.0,
+            "propose_idea",
+        )
+    except Exception:  # pragma: no cover - optional
+        logger.debug("Ledger logging failed", exc_info=True)
     return dict(state)
 
 
@@ -38,7 +50,19 @@ def handle_idle_node(state: AgentTurnState) -> dict[str, Any]:
 
 def handle_deep_analysis_node(state: AgentTurnState) -> dict[str, Any]:
     agent_state = state["state"]
+    start_du = agent_state.du
     agent_state.du -= DU_COST_DEEP_ANALYSIS
+    try:
+        from src.infra.ledger import ledger
+
+        ledger.log_change(
+            agent_state.agent_id,
+            0.0,
+            agent_state.du - start_du,
+            "deep_analysis",
+        )
+    except Exception:  # pragma: no cover - optional
+        logger.debug("Ledger logging failed", exc_info=True)
     return dict(state)
 
 
@@ -80,8 +104,21 @@ def handle_propose_idea(
     metas = [metadata]
     knowledge_board.add_documents(docs, metas)
     memory_store.add_documents(docs, metas)
+    start_ip = agent.ip
+    start_du = agent.du
     agent.ip -= IP_COST_TO_POST_IDEA
     agent.du += config.DU_AWARD_FOR_PROPOSAL
+    try:
+        from src.infra.ledger import ledger
+
+        ledger.log_change(
+            agent.id,
+            agent.ip - start_ip,
+            agent.du - start_du,
+            "propose_idea",
+        )
+    except Exception:  # pragma: no cover - optional
+        logger.debug("Ledger logging failed", exc_info=True)
 
 
 def handle_retrieve_and_update(agent: AgentAttributes, memory_store: MemoryStore) -> None:

--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class Ledger:
+    """Simple SQLite-backed ledger tracking agent resources."""
+
+    def __init__(self, db_path: str | Path = "ledger.sqlite3") -> None:
+        path = Path(db_path)
+        self.conn = sqlite3.connect(path.as_posix())
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA foreign_keys=ON")
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_balances (
+                agent_id TEXT PRIMARY KEY,
+                ip REAL DEFAULT 0,
+                du REAL DEFAULT 0
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS transactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT,
+                delta_ip REAL,
+                delta_du REAL,
+                reason TEXT,
+                ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+    def log_change(
+        self, agent_id: str, delta_ip: float = 0.0, delta_du: float = 0.0, reason: str = ""
+    ) -> None:
+        """Record a transaction and update balances."""
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO transactions(agent_id, delta_ip, delta_du, reason) VALUES (?,?,?,?)",
+            (agent_id, float(delta_ip), float(delta_du), reason),
+        )
+        cur.execute(
+            """
+            INSERT INTO agent_balances(agent_id, ip, du)
+            VALUES(?, ?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                ip = ip + excluded.ip,
+                du = du + excluded.du
+            """,
+            (agent_id, float(delta_ip), float(delta_du)),
+        )
+        self.conn.commit()
+
+    def get_balance(self, agent_id: str) -> tuple[float, float]:
+        """Return the current balance for ``agent_id``."""
+        cur = self.conn.execute("SELECT ip, du FROM agent_balances WHERE agent_id=?", (agent_id,))
+        row = cur.fetchone()
+        if row:
+            return float(row[0]), float(row[1])
+        return 0.0, 0.0
+
+
+ledger = Ledger()
+
+__all__ = ["Ledger", "ledger"]

--- a/tests/unit/infra/test_ledger.py
+++ b/tests/unit/infra/test_ledger.py
@@ -1,0 +1,28 @@
+import sqlite3
+
+import pytest
+
+from src.infra.ledger import Ledger
+
+pytestmark = pytest.mark.unit
+
+
+def test_transaction_record_and_balance(tmp_path):
+    db = tmp_path / "ledger.sqlite"
+    ledger = Ledger(db)
+    ledger.log_change("a1", 5.0, 2.0, "init")
+    ledger.log_change("a1", -1.0, 0.0, "spend")
+
+    ip, du = ledger.get_balance("a1")
+    assert ip == pytest.approx(4.0)
+    assert du == pytest.approx(2.0)
+
+    conn = sqlite3.connect(db)
+    row = conn.execute("SELECT COUNT(*) FROM transactions WHERE agent_id='a1'").fetchone()
+    assert row[0] == 2
+    conn.close()
+
+
+def test_unknown_agent_balance(tmp_path):
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    assert ledger.get_balance("nope") == (0.0, 0.0)


### PR DESCRIPTION
## Summary
- implement `Ledger` backed by SQLite WAL
- record IP/DU resource changes to the ledger from agents and graph handlers
- add tests verifying ledger balances and transaction records
- document ledger usage

## Testing
- `ruff check src/infra/ledger.py tests/unit/infra/test_ledger.py src/agents/core/base_agent.py src/agents/core/agent_controller.py src/agents/graphs/basic_agent_graph.py src/agents/graphs/interaction_handlers.py`
- `black src/infra/ledger.py tests/unit/infra/test_ledger.py src/agents/core/base_agent.py src/agents/core/agent_controller.py src/agents/graphs/basic_agent_graph.py src/agents/graphs/interaction_handlers.py`
- `mypy src/infra/ledger.py`
- `python scripts/run_tests.py tests/unit/infra/test_ledger.py`

------
https://chatgpt.com/codex/tasks/task_e_685602bad3d483269dfcaa103583e58f