### PR TITLE
Implement DU cost deduction for LLM calls

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -115,7 +115,7 @@ except Exception:  # pragma: no cover - fallback when llm_client is missing
 
 
 class AgentStateData(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra=Extra.allow)
 
     agent_id: str
     name: str
@@ -430,8 +430,12 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         """Return a dictionary representation of the agent state."""
         base_model = cast(BaseModel, self)
         if _PYDANTIC_V2:
-            return base_model.model_dump(
-                exclude={"llm_client", "mock_llm_client", "memory_store_manager"}
+            return base_model.model_dump(  # type: ignore[attr-defined, no-any-return]
+                exclude={
+                    "llm_client",
+                    "mock_llm_client",
+                    "memory_store_manager",
+                },
             )
         return base_model.dict(
             exclude={"llm_client", "mock_llm_client", "memory_store_manager"}

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -20,7 +20,10 @@ def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
             continue
         content = msg.get("content")
         if isinstance(content, str):
-            sentiment = analyze_sentiment(content)
+            try:
+                sentiment = analyze_sentiment(content, agent_state=state.get("state"))
+            except TypeError:
+                sentiment = analyze_sentiment(content)
             if isinstance(sentiment, str):
                 mapping = {"positive": 1.0, "negative": -1.0, "neutral": 0.0}
                 sentiment = mapping.get(sentiment.lower(), 0.0)
@@ -66,7 +69,12 @@ async def generate_thought_and_message_node(
         result = await agent.async_select_action_intent("", "", "", [])
         if result:
             action_intent = getattr(result, "chosen_action_intent", "idle")
-    structured = generate_structured_output("prompt", AgentActionOutput)
+    try:
+        structured = generate_structured_output(
+            "prompt", AgentActionOutput, agent_state=state.get("state")
+        )
+    except TypeError:
+        structured = generate_structured_output("prompt", AgentActionOutput)
     return {"structured_output": cast(AgentActionOutput | None, structured)}
 
 

--- a/tests/unit/infra/test_llm_du_cost.py
+++ b/tests/unit/infra/test_llm_du_cost.py
@@ -1,0 +1,30 @@
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agents.core.agent_state import AgentState
+from src.infra import llm_client as llm_client_mod
+from src.infra.config import get_config
+
+
+@pytest.mark.unit
+def test_du_decreases_after_llm_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(llm_client_mod)
+    state = AgentState(agent_id="A", name="Agent")
+    start_du = state.du
+
+    fake_client = MagicMock()
+    fake_client.chat.return_value = {"message": {"content": "hi"}}
+    monkeypatch.setattr(module, "get_ollama_client", lambda: fake_client)
+    monkeypatch.setattr(
+        module,
+        "_retry_with_backoff",
+        lambda func, *a, **kw: (func(), None),
+    )
+
+    result = module.generate_text("hi", agent_state=state)
+
+    assert result == "hi"
+    expected = start_du - get_config("DU_COST_PER_ACTION")
+    assert state.du == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- deduct data units from agent state after each LLM call via `charge_du_cost`
- allow `generate_text`, `summarize_memory_context`, `analyze_sentiment`, `generate_structured_output`, and `generate_response` to accept agent state
- pass agent state in graph nodes using these helpers
- fix mypy errors in `AgentState`
- add test ensuring data units decrease after LLM usage
- handle patched LLM helpers in graph node tests

## Testing
- `bash scripts/lint.sh`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_685602ba824c8326bb84f18dc05e8501