### PR TITLE
Add UI type check step

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run type check
+        run: pnpm --filter culture-ui type-check
+
       - name: Run lint
         run: pnpm --filter culture-ui lint
 

--- a/culture-ui/README.md
+++ b/culture-ui/README.md
@@ -38,6 +38,14 @@ Check the UI source with ESLint:
 pnpm --filter culture-ui lint
 ```
 
+## Type check
+
+Verify the codebase with the TypeScript compiler:
+
+```bash
+pnpm --filter culture-ui type-check
+```
+
 ## Workspace integration
 
 `culture-ui` is defined in `pnpm-workspace.yaml`. Running `pnpm install` at the root installs both backend and UI dependencies. Use `--filter culture-ui` to run scripts only for the UI when needed.

--- a/culture-ui/package.json
+++ b/culture-ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "type-check": "tsc -b"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- add a `type-check` script to `culture-ui`
- run that type check in the UI workflow
- document how to run the type checker

## Testing
- `pre-commit run --files culture-ui/package.json culture-ui/README.md .github/workflows/ui.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c2494b2c8326ba6ec8d49a4ac837