### PR TITLE
Move pnpm config to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+pnpm.only-built-dependencies[]=@parcel/watcher
+pnpm.only-built-dependencies[]=@tailwindcss/oxide

--- a/culture-ui/package.json
+++ b/culture-ui/package.json
@@ -42,11 +42,5 @@
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
     "vitest": "^3.2.4"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@tailwindcss/oxide"
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- move pnpm.onlyBuiltDependencies setting into a root `.npmrc`
- remove unused root `package.json`
- regenerate lockfile without a root importer

## Testing
- `pnpm install`
- `pnpm -r lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578c704bb883268637fdeda1cf4a12