### PR TITLE
Implement missions API and tests

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -1,0 +1,14 @@
+export interface Mission {
+  id: number
+  name: string
+  status: string
+  progress: number
+}
+
+export async function fetchMissions(): Promise<Mission[]> {
+  const response = await fetch('/api/missions')
+  if (!response.ok) {
+    throw new Error('Failed to fetch missions')
+  }
+  return response.json()
+}

--- a/culture-ui/src/pages/MissionOverview.test.tsx
+++ b/culture-ui/src/pages/MissionOverview.test.tsx
@@ -1,0 +1,21 @@
+import { vi } from 'vitest'
+
+vi.mock('../lib/api', () => ({
+  fetchMissions: vi.fn(),
+}))
+
+import { render, screen } from '@testing-library/react'
+import MissionOverview from './MissionOverview'
+import { fetchMissions } from '../lib/api'
+
+const missions = [
+  { id: 1, name: 'Test Mission', status: 'Pending', progress: 0 },
+]
+
+describe('MissionOverview', () => {
+  it('renders missions returned by fetchMissions', async () => {
+    ;(fetchMissions as unknown as vi.Mock).mockResolvedValue(missions)
+    render(<MissionOverview />)
+    expect(await screen.findByText('Test Mission')).toBeInTheDocument()
+  })
+})

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import clsx from 'clsx'
 import {
   ColumnDef,
@@ -7,7 +7,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import missionsData from '../mock/missions.json'
+import { fetchMissions, type Mission } from '../lib/api'
 import {
   DndContext,
   KeyboardSensor,
@@ -23,13 +23,6 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-
-interface Mission {
-  id: number
-  name: string
-  status: string
-  progress: number
-}
 
 function DraggableRow({ row }: { row: Row<Mission> }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -59,7 +52,16 @@ function DraggableRow({ row }: { row: Row<Mission> }) {
 }
 
 export default function MissionOverview() {
-  const [data, setData] = useState<Mission[]>(missionsData as Mission[])
+  const [data, setData] = useState<Mission[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    fetchMissions()
+      .then(setData)
+      .catch((err) => setError(err as Error))
+      .finally(() => setLoading(false))
+  }, [])
 
   const columns: ColumnDef<Mission>[] = [
     {
@@ -94,6 +96,14 @@ export default function MissionOverview() {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   )
+
+  if (loading) {
+    return <div className="p-4">Loading missions...</div>
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-500">Error loading missions</div>
+  }
 
   return (
     <div className="p-4">


### PR DESCRIPTION
## Summary
- add `fetchMissions` utility
- load missions via API in `MissionOverview`
- show loading and error states
- test table population with `fetchMissions`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a83a4f3c8326b32b40c98b3407bb