### PR TITLE
Add Agent Data page link

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -2,32 +2,47 @@ import { NavLink, Route, Routes } from 'react-router-dom'
 import clsx from 'clsx'
 import Home from './pages/Home'
 import MissionOverview from './pages/MissionOverview'
+import AgentDataOverview from './pages/AgentDataOverview'
 
 export default function App() {
   return (
     <div className="flex min-h-screen">
       <aside className="w-48 border-r p-4">
-        <nav className="space-y-2">
-          <NavLink
-            to="/"
-            end
-            className={({ isActive }) => clsx(isActive && 'font-bold text-brand')}
-          >
-            Home
-          </NavLink>
-          <br />
-          <NavLink
-            to="/missions"
-            className={({ isActive }) => clsx(isActive && 'font-bold text-brand')}
-          >
-            Mission Overview
-          </NavLink>
+        <nav>
+          <ul className="space-y-2">
+            <li>
+              <NavLink
+                to="/"
+                end
+                className={({ isActive }) => clsx(isActive && 'font-bold text-brand')}
+              >
+                Home
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/missions"
+                className={({ isActive }) => clsx(isActive && 'font-bold text-brand')}
+              >
+                Mission Overview
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/agent-data"
+                className={({ isActive }) => clsx(isActive && 'font-bold text-brand')}
+              >
+                Agent Data
+              </NavLink>
+            </li>
+          </ul>
         </nav>
       </aside>
       <main className="flex-1 p-4">
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/missions" element={<MissionOverview />} />
+          <Route path="/agent-data" element={<AgentDataOverview />} />
         </Routes>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add Agent Data link in the UI sidebar
- create route to render `AgentDataOverview` page
- refactor sidebar HTML structure with `<ul>` list

## Testing
- `pnpm lint`
- `pnpm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6857a83bc4b88326beee16f7ee94f1f2