### PR TITLE
Add event stream hook with SSE fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!/culture-ui/src/lib/
 lib64/
 parts/
 sdist/

--- a/culture-ui/src/lib/useEventSource.test.tsx
+++ b/culture-ui/src/lib/useEventSource.test.tsx
@@ -1,0 +1,150 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useEventSource } from './useEventSource'
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+  url: string
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: (() => void) | null = null
+  closed = false
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+
+  emitMessage(data: string) {
+    this.onmessage?.({ data } as MessageEvent)
+  }
+
+  emitError() {
+    this.onerror?.()
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  closed = false
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  sendMessage(data: string) {
+    this.onmessage?.({ data } as MessageEvent)
+  }
+
+  close() {
+    this.closed = true
+  }
+}
+
+function TestComponent() {
+  const event = useEventSource()
+  return <div data-testid="value">{event ? JSON.stringify(event) : ''}</div>
+}
+
+afterEach(() => {
+  MockEventSource.instances = []
+  MockWebSocket.instances = []
+  ;(
+    globalThis as unknown as {
+      EventSource: unknown
+      WebSocket: unknown
+    }
+  ).EventSource = undefined
+  ;(
+    globalThis as unknown as {
+      EventSource: unknown
+      WebSocket: unknown
+    }
+  ).WebSocket = undefined
+})
+
+describe('useEventSource', () => {
+  it('connects via EventSource and receives messages', () => {
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof MockEventSource
+      }
+    ).EventSource = MockEventSource
+
+    render(<TestComponent />)
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage('{"hello":1}')
+    })
+    expect(screen.getByTestId('value').textContent).toBe(JSON.stringify({ hello: 1 }))
+    act(() => {})
+  })
+
+  it('falls back to WebSocket when EventSource is unavailable', () => {
+    ;(
+      globalThis as unknown as {
+        EventSource: undefined
+        WebSocket: typeof MockWebSocket
+      }
+    ).EventSource = undefined
+    ;(
+      globalThis as unknown as {
+        EventSource: undefined
+        WebSocket: typeof MockWebSocket
+      }
+    ).WebSocket = MockWebSocket
+
+    render(<TestComponent />)
+    const ws = MockWebSocket.instances[0]
+    act(() => {
+      ws.sendMessage('{"foo":"bar"}')
+    })
+    expect(screen.getByTestId('value').textContent).toBe(JSON.stringify({ foo: 'bar' }))
+  })
+
+  it('falls back to WebSocket on EventSource error', () => {
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof MockEventSource
+        WebSocket: typeof MockWebSocket
+      }
+    ).EventSource = MockEventSource
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof MockEventSource
+        WebSocket: typeof MockWebSocket
+      }
+    ).WebSocket = MockWebSocket
+
+    render(<TestComponent />)
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitError()
+    })
+    const ws = MockWebSocket.instances[0]
+    act(() => {
+      ws.sendMessage('{"x":1}')
+    })
+    expect(es.closed).toBe(true)
+    expect(screen.getByTestId('value').textContent).toBe(JSON.stringify({ x: 1 }))
+  })
+
+  it('cleans up connections on unmount', () => {
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof MockEventSource
+      }
+    ).EventSource = MockEventSource
+
+    const { unmount } = render(<TestComponent />)
+    const es = MockEventSource.instances[0]
+    unmount()
+    expect(es.closed).toBe(true)
+  })
+})

--- a/culture-ui/src/lib/useEventSource.ts
+++ b/culture-ui/src/lib/useEventSource.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+
+export interface EventSourceMessage<T = unknown> {
+  data: T
+}
+
+/**
+ * Hook that connects to `/stream/events` via EventSource and
+ * optionally falls back to WebSocket when SSE is unavailable.
+ * Returns the latest parsed event data or `null` if no event has been
+ * received yet.
+ */
+export function useEventSource<T = unknown>() {
+  const [event, setEvent] = useState<T | null>(null)
+
+  useEffect(() => {
+    let es: EventSource | null = null
+    let ws: WebSocket | null = null
+    let active = true
+
+    const handleMessage = (data: string) => {
+      try {
+        setEvent(JSON.parse(data))
+      } catch {
+        // not JSON, return raw string
+        setEvent(data as unknown as T)
+      }
+    }
+
+    const connectWebSocket = () => {
+      if (typeof WebSocket === 'undefined') return
+      try {
+        ws = new WebSocket('/ws/events')
+        ws.onmessage = (ev) => active && handleMessage(ev.data)
+      } catch {
+        // ignore
+      }
+    }
+
+    if (typeof EventSource !== 'undefined') {
+      try {
+        es = new EventSource('/stream/events')
+        es.onmessage = (ev) => active && handleMessage(ev.data)
+        es.onerror = () => {
+          es?.close()
+          connectWebSocket()
+        }
+      } catch {
+        connectWebSocket()
+      }
+    } else {
+      connectWebSocket()
+    }
+
+    return () => {
+      active = false
+      es?.close()
+      ws?.close()
+    }
+  }, [])
+
+  return event
+}

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import clsx from 'clsx'
+import type { ColumnDef, Row } from '@tanstack/react-table'
 import {
-  ColumnDef,
-  Row,
   flexRender,
   getCoreRowModel,
   useReactTable,


### PR DESCRIPTION
## Summary
- create `useEventSource` to listen to `/stream/events`
- fallback to `/ws/events` if SSE unavailable
- expose event data through state
- test connection logic with mocked EventSource and WebSocket
- update type-only imports in `MissionOverview`

## Testing
- `pnpm --filter culture-ui type-check`
- `pnpm --filter culture-ui test`
- `pnpm --filter culture-ui lint`


------
https://chatgpt.com/codex/tasks/task_e_6857a8391d5c8326bfceb8d558aa5955