### PR TITLE
Add Simulation event queue hooks

### DIFF
--- a/tests/integration/sim/test_async_batch.py
+++ b/tests/integration/sim/test_async_batch.py
@@ -1,9 +1,20 @@
 import asyncio
+import sys
 import time
 from types import SimpleNamespace
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import pytest
+
+from src.interfaces.dashboard_backend import SimulationEvent, event_queue
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+sys.modules.setdefault("neo4j", DummyNeo4j())
 
 from src.sim.simulation import Simulation
 
@@ -11,10 +22,10 @@ from src.sim.simulation import Simulation
 class DummyState(SimpleNamespace):
     ip: float = 0.0
     du: float = 0.0
-    short_term_memory: ClassVar[list] = []
+    short_term_memory: ClassVar[list[Any]] = []
     messages_sent_count: int = 0
     last_message_step: int = 0
-    relationships: ClassVar[dict] = {}
+    relationships: ClassVar[dict[str, Any]] = {}
     role: str = "dummy"
     steps_in_current_role: int = 0
 
@@ -36,10 +47,10 @@ class DummyAgent:
     async def run_turn(
         self,
         simulation_step: int,
-        environment_perception: dict | None = None,
+        environment_perception: dict[str, Any] | None = None,
         vector_store_manager: object | None = None,
         knowledge_board: object | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         await asyncio.sleep(0.1)
         return {"step": simulation_step}
 
@@ -48,7 +59,7 @@ class DummyAgent:
 @pytest.mark.integration
 async def test_concurrent_agent_turns() -> None:
     agents = [DummyAgent(str(i)) for i in range(5)]
-    sim = Simulation(agents=agents)
+    sim = Simulation(agents=agents)  # type: ignore[arg-type]
 
     start = time.perf_counter()
     results = await sim.run_turns_concurrent(agents)
@@ -57,3 +68,26 @@ async def test_concurrent_agent_turns() -> None:
     assert len(results) == 5
     assert elapsed < 0.5
     assert sim.current_step == 5
+
+
+async def _clear_event_queue() -> None:
+    while not event_queue.empty():
+        _ = await event_queue.get()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_events_enqueued_during_run_step() -> None:
+    await _clear_event_queue()
+    agent = DummyAgent("agent1")
+    sim = Simulation(agents=[agent])  # type: ignore[list-item]
+
+    await sim.run_step()
+
+    evt = await asyncio.wait_for(event_queue.get(), 0.1)
+    assert isinstance(evt, SimulationEvent)
+    assert evt.event_type == "agent_action"
+    assert evt.data is not None
+    assert evt.data["agent_id"] == "agent1"
+    assert evt.data["step"] == 1
+    await _clear_event_queue()


### PR DESCRIPTION
## Summary
- emit `SimulationEvent` objects when agents act and when snapshots are saved
- push `None` to the event queue on `Simulation.close`
- test that running a step enqueues an event

## Testing
- `ruff check tests/integration/sim/test_async_batch.py src/sim/simulation.py`
- `mypy --config-file=pyproject.toml src/sim/simulation.py tests/integration/sim/test_async_batch.py`
- `pytest -m "integration" tests/integration/sim/test_async_batch.py::test_events_enqueued_during_run_step -vv`


------
https://chatgpt.com/codex/tasks/task_e_68581337b788832692d13125aacf4407