### PR TITLE
Fix mission reorder helper

### DIFF
--- a/culture-ui/src/MissionOverview.test.tsx
+++ b/culture-ui/src/MissionOverview.test.tsx
@@ -1,15 +1,26 @@
 import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
+import { vi } from 'vitest'
 import MissionOverview, { reorderMissions } from './pages/MissionOverview'
+import { fetchMissions } from './lib/api'
+import missions from './mock/missions.json'
+
+vi.mock('./lib/api', () => ({
+  fetchMissions: vi.fn(),
+}))
+
+beforeEach(() => {
+  ;(fetchMissions as unknown as vi.Mock).mockResolvedValue(missions)
+})
 
 describe('MissionOverview', () => {
-  it('renders missions table', () => {
+  it('renders missions table', async () => {
     render(
       <BrowserRouter>
         <MissionOverview />
       </BrowserRouter>,
     )
-    expect(screen.getByRole('heading', { name: /mission overview/i })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /mission overview/i })).toBeInTheDocument()
     expect(screen.getByRole('table')).toBeInTheDocument()
     const table = screen.getByRole('table')
     const rows = table.querySelectorAll('tbody tr')
@@ -18,27 +29,18 @@ describe('MissionOverview', () => {
     expect(rows[1]).toHaveTextContent('Prepare Brief')
   })
 
-  it('reorders rows via drag and drop', () => {
+  it('reorders rows via drag and drop', async () => {
     render(
       <BrowserRouter>
         <MissionOverview />
       </BrowserRouter>,
     )
-    const table = screen.getByRole('table')
+    const table = await screen.findByRole('table')
     const rowsBefore = table.querySelectorAll('tbody tr')
     expect(rowsBefore[0]).toHaveTextContent('Gather Intel')
 
-    // simulate drag end
-    const newData = reorderMissions(
-      Array.from(rowsBefore).map((r) => ({
-        id: Number(r.firstChild?.textContent),
-        name: '',
-        status: '',
-        progress: 0,
-      })),
-      1,
-      2,
-    )
+    // simulate drag end using the helper
+    const newData = reorderMissions(missions, 0, 1)
 
     // update DOM with reordered data for test verification
     newData.forEach((mission, idx) => {

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -23,6 +23,14 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 
+export function reorderMissions(
+  missions: Mission[],
+  from: number,
+  to: number,
+) {
+  return arrayMove(missions, from, to)
+}
+
 function DraggableRow({ row }: { row: Row<Mission> }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: row.id,
@@ -111,7 +119,14 @@ export default function MissionOverview() {
         sensors={sensors}
         onDragEnd={({ active, over }) => {
           if (over && active.id !== over.id) {
-            setData((items) => reorderMissions(items, Number(active.id), Number(over.id)))
+            setData((items) => {
+              const from = items.findIndex((m) => m.id === Number(active.id))
+              const to = items.findIndex((m) => m.id === Number(over.id))
+              if (from === -1 || to === -1) {
+                return items
+              }
+              return reorderMissions(items, from, to)
+            })
           }
         }}
       >


### PR DESCRIPTION
## Summary
- update `reorderMissions` to move by index
- convert `onDragEnd` logic to translate ids to indexes
- simplify reorder test to use helper with mission data

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_685813388908832686e0e3d76223bd5f