### PR TITLE
Add missions API endpoint

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -5,10 +5,12 @@ export interface Mission {
   progress: number
 }
 
+const API_BASE = ''
+
 export async function fetchMissions(): Promise<Mission[]> {
-  const response = await fetch('/api/missions')
+  const response = await fetch(`${API_BASE}/api/missions`)
   if (!response.ok) {
     throw new Error('Failed to fetch missions')
   }
-  return response.json()
+  return (await response.json()) as Mission[]
 }

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -4,6 +4,7 @@ import asyncio
 # ruff: noqa: ANN101
 import json
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
@@ -67,6 +68,11 @@ message_sse_queue: asyncio.Queue["AgentMessage"] = asyncio.Queue()
 # Queue for general simulation events streamed via SSE/WebSocket
 event_queue: asyncio.Queue["SimulationEvent | None"] = asyncio.Queue()
 
+# Path to the initial missions data bundled with the front-end
+MISSIONS_PATH = (
+    Path(__file__).resolve().parents[2] / "culture-ui" / "src" / "mock" / "missions.json"
+)
+
 
 class AgentMessage(BaseModel):
     agent_id: str
@@ -110,6 +116,14 @@ async def stream_messages(request: Request) -> EventSourceResponse:
 @app.get("/health")
 async def health() -> Response:
     return JSONResponse({"status": "ok"})
+
+
+@app.get("/api/missions")
+async def get_missions() -> Response:
+    """Return the list of missions from the bundled JSON file."""
+    with open(MISSIONS_PATH, encoding="utf-8") as f:
+        missions = json.load(f)
+    return JSONResponse(missions)
 
 
 @app.get("/stream/events")

--- a/tests/unit/interfaces/test_dashboard_backend_missions.py
+++ b/tests/unit/interfaces/test_dashboard_backend_missions.py
@@ -1,0 +1,17 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_missions_returns_data(tmp_path, monkeypatch):
+    missions = [{"id": 1, "name": "Test", "status": "Pending", "progress": 0}]
+    path = tmp_path / "missions.json"
+    path.write_text(json.dumps(missions))
+    monkeypatch.setattr(db, "MISSIONS_PATH", path)
+
+    response = await db.get_missions()
+    assert json.loads(response.body) == missions


### PR DESCRIPTION
## Summary
- expose missions data through `GET /api/missions` in dashboard backend
- fetch missions via `/api/missions` in the UI API helper
- test the new backend endpoint
- mock mission fetching in UI tests so pnpm test succeeds

## Testing
- `pre-commit run --files culture-ui/src/MissionOverview.test.tsx`
- `pytest -m unit tests/unit/interfaces/test_dashboard_backend_missions.py`
- `pnpm --filter culture-ui test`

------
https://chatgpt.com/codex/tasks/task_e_68581337ffbc832690f88929c48c87f4