### PR TITLE
Fix LoggingList debug level

### DIFF
--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -19,16 +19,16 @@ T = TypeVar("T")
 
 class LoggingList(list[T], Generic[T]):
     def clear(self: Self) -> None:
-        logger.info(f"LOGGING_LIST_DEBUG ({id(self)}): clear() called")
+        logger.debug(f"LOGGING_LIST_DEBUG ({id(self)}): clear() called")
         super().clear()
 
     def __delitem__(self: Self, key: SupportsIndex | slice) -> None:
         if isinstance(key, slice) and key.start is None and key.stop is None and key.step is None:
-            logger.info(f"LOGGING_LIST_DEBUG ({id(self)}): __delitem__[:] called (del self[:])")
+            logger.debug(f"LOGGING_LIST_DEBUG ({id(self)}): __delitem__[:] called (del self[:])")
         super().__delitem__(key)
 
     def __init__(self: Self, *args: Any, **kwargs: Any) -> None:
-        logger.info(
+        logger.debug(
             f"LOGGING_LIST_DEBUG: Initializing new LoggingList instance ({id(self)}) from args: {args}"
         )
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary
- reduce LoggingList logging noise by switching info calls to debug

## Testing
- `pre-commit run --files src/sim/knowledge_board.py`
- `pytest -m integration tests/integration/knowledge_board`


------
https://chatgpt.com/codex/tasks/task_e_6858a72c54c0832692f51ebcde3186db