### PR TITLE
Add semantic memory consolidation module

### DIFF
--- a/src/agents/memory/__init__.py
+++ b/src/agents/memory/__init__.py
@@ -6,12 +6,13 @@ including persistence, retrieval, and memory utility operations.
 """
 
 from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 
 try:  # pragma: no cover - optional dependency
     from src.agents.memory.vector_store import ChromaVectorStoreManager
 except Exception:  # pragma: no cover - fallback when chromadb missing
     ChromaVectorStoreManager = None  # type: ignore[misc, assignment]
 
-__all__ = ["MemoryTrackingManager"]
+__all__ = ["MemoryTrackingManager", "SemanticMemoryManager"]
 if ChromaVectorStoreManager is not None:
     __all__.insert(0, "ChromaVectorStoreManager")

--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from neo4j import Driver
+from typing_extensions import Self
+
+from .vector_store import ChromaVectorStoreManager
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticMemoryManager:
+    """Manage consolidation of episodic memories into semantic memories."""
+
+    def __init__(self: Self, vector_store: ChromaVectorStoreManager, driver: Driver) -> None:
+        self.vector_store = vector_store
+        self.driver = driver
+
+    def consolidate_memories(self: Self, agent_id: str) -> str:
+        """Consolidate an agent's episodic memories into a semantic summary."""
+        memories = self.vector_store.retrieve_filtered_memories(
+            agent_id, filters={"memory_type": "raw"}, limit=None
+        )
+        if not memories:
+            return ""
+        summary = "\n".join(mem["content"] for mem in memories)
+        now = datetime.utcnow().isoformat()
+        with self.driver.session() as session:
+            session.run(
+                """
+                MERGE (a:Agent {id: $agent_id})
+                CREATE (s:SemanticMemory {summary: $summary, created_at: $now})
+                CREATE (a)-[:HAS_SEMANTIC]->(s)
+                """,
+                agent_id=agent_id,
+                summary=summary,
+                now=now,
+            )
+        return summary
+
+    def get_recent_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
+        """Return recent semantic summaries for an agent."""
+        with self.driver.session() as session:
+            records = session.run(
+                """
+                MATCH (a:Agent {id: $agent_id})-[:HAS_SEMANTIC]->(s:SemanticMemory)
+                RETURN s.summary AS summary
+                ORDER BY s.created_at DESC
+                LIMIT $limit
+                """,
+                agent_id=agent_id,
+                limit=limit,
+            )
+            return [record["summary"] for record in records]
+
+    async def run_nightly_job(self: Self, agent_id: str) -> None:
+        """Asynchronously consolidate memories, intended to run nightly."""
+        import asyncio
+
+        await asyncio.to_thread(self.consolidate_memories, agent_id)

--- a/tests/unit/memory/test_semantic_memory_manager.py
+++ b/tests/unit/memory/test_semantic_memory_manager.py
@@ -1,0 +1,65 @@
+import pytest
+
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from tests.utils.dummy_chromadb import setup_dummy_chromadb
+
+
+class DummySession:
+    def __init__(self, store: list[dict[str, str]]) -> None:
+        self.store = store
+
+    def run(self, query: str, **params: object):
+        if query.strip().startswith("MERGE"):
+            self.store.append(
+                {
+                    "agent": params["agent_id"],
+                    "summary": params["summary"],
+                    "created_at": params["now"],
+                }
+            )
+            return []
+        if query.strip().startswith("MATCH"):
+            limit = params.get("limit", 3)
+            items = list(reversed(self.store))[: int(limit)]
+            return [{"summary": item["summary"]} for item in items]
+        return []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummyDriver:
+    def __init__(self) -> None:
+        self.store: list[dict[str, str]] = []
+
+    def session(self) -> DummySession:
+        return DummySession(self.store)
+
+
+@pytest.fixture(autouse=True)
+def _dummy_chroma() -> None:
+    setup_dummy_chromadb()
+
+
+@pytest.mark.unit
+def test_consolidation_and_retrieval(tmp_path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path),
+        embedding_function=lambda texts: [[0.0] for _ in texts],
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+
+    vector.add_memory("agent", 1, "thought", "first")
+    vector.add_memory("agent", 2, "thought", "second")
+
+    summary = manager.consolidate_memories("agent")
+    assert "first" in summary and "second" in summary
+    assert driver.store[0]["agent"] == "agent"
+
+    recent = manager.get_recent_summaries("agent", limit=1)
+    assert recent == [summary]


### PR DESCRIPTION
## Summary
- implement `SemanticMemoryManager` for episodic-to-semantic consolidation
- expose new manager from memory package
- integrate semantic summaries in retrieval node
- test semantic consolidation functionality

## Testing
- `ruff check src/agents/graphs/graph_nodes.py src/agents/memory/__init__.py src/agents/memory/semantic_memory_manager.py tests/unit/memory/test_semantic_memory_manager.py`
- `ruff format src/agents/graphs/graph_nodes.py src/agents/memory/__init__.py src/agents/memory/semantic_memory_manager.py tests/unit/memory/test_semantic_memory_manager.py`
- `black src/agents/graphs/graph_nodes.py src/agents/memory/__init__.py src/agents/memory/semantic_memory_manager.py tests/unit/memory/test_semantic_memory_manager.py`
- `mypy src/agents/graphs/graph_nodes.py src/agents/memory/__init__.py src/agents/memory/semantic_memory_manager.py`
- `pytest tests/unit/memory/test_semantic_memory_manager.py -v`

------
https://chatgpt.com/codex/tasks/task_e_6858a7401928832695db80d6ecc7a148