### PR TITLE
Fix simulation role change flow

### DIFF
--- a/tests/unit/graphs/test_agent_graph_builder.py
+++ b/tests/unit/graphs/test_agent_graph_builder.py
@@ -1,5 +1,7 @@
 import pytest
 
+# ruff: noqa: E402
+
 # - allow runtime dependency checks before imports
 
 pytest.importorskip("langgraph")
@@ -33,7 +35,7 @@ def test_build_graph_structure() -> None:
         ("analyze_perception_sentiment", "prepare_relationship_prompt"),
         ("prepare_relationship_prompt", "retrieve_and_summarize_memories"),
         ("retrieve_and_summarize_memories", "generate_thought_and_message"),
-        ("generate_thought_and_message", "handle_idle"),
+        ("generate_thought_and_message", "route_action_intent"),
         ("handle_idle", "finalize_message_agent"),
         ("finalize_message_agent", END),
     }


### PR DESCRIPTION
## Summary
- handle agents lacking `is_alive`/`age` fields gracefully in `_run_agent_turn`
- detect role change events by inspecting `short_term_memory`
- ensure debug logging and role change branch run outside map_action block
- add missing default for `next_agent_index`
- update graph builder test for new routing logic

## Testing
- `pre-commit run --files src/sim/simulation.py tests/unit/graphs/test_agent_graph_builder.py`
- `pytest tests/unit/interfaces/test_dashboard_backend_missions.py::test_get_missions_returns_data tests/unit/graphs/test_agent_graph_builder.py::test_build_graph_structure -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f60f8c54832681d61a949e71d914