### PR TITLE
Implement context manager for GraphKnowledgeBoard and expand tests

### DIFF
--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -40,6 +40,18 @@ class GraphKnowledgeBoard:
             )
         metrics.KNOWLEDGE_BOARD_SIZE.set(self._count_entries())
 
+    # Enable use as a context manager
+    def __enter__(self: Self) -> Self:  # pragma: no cover - convenience
+        return self
+
+    def __exit__(
+        self: Self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any | None,
+    ) -> None:  # pragma: no cover - convenience
+        self.close()
+
     # --- Internal helpers -------------------------------------------------
     def _run(self: Self, query: str, **params: Any) -> list[Any]:
         with self.driver.session() as session:

--- a/tests/integration/knowledge_board/test_graph_backend.py
+++ b/tests/integration/knowledge_board/test_graph_backend.py
@@ -83,6 +83,24 @@ def test_graph_board_add_and_retrieve(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.integration
+def test_graph_board_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KNOWLEDGE_BOARD_BACKEND", "graph")
+    config.load_config()
+    dummy_driver = DummyDriver()
+    monkeypatch.setattr("neo4j.GraphDatabase.driver", lambda *a, **k: dummy_driver)
+    board = GraphKnowledgeBoard()
+    board.clear_board()
+    board.add_entry("first", "A", 1)
+    board.add_entry("second", "B", 2)
+    entries = board.get_full_entries()
+    assert [e["content_full"] for e in entries] == ["first", "second"]
+    board_dict = board.to_dict()
+    assert len(board_dict["entries"]) == 2
+    assert board_dict["entries"][0]["step"] == 1
+    assert board_dict["entries"][1]["step"] == 2
+
+
+@pytest.mark.integration
 def test_simulation_closes_graph_board(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KNOWLEDGE_BOARD_BACKEND", "graph")
     config.load_config()


### PR DESCRIPTION
## Summary
- add context manager hooks to `GraphKnowledgeBoard`
- extend integration tests for graph knowledge board to verify full roundtrip behaviour

## Testing
- `ruff check src tests --fix`
- `pytest tests/integration/knowledge_board/test_graph_backend.py::test_graph_board_roundtrip -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa66c5b648326b0500a322fdb1d2c