### PR TITLE
Implement role embeddings and gossip updates

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -57,8 +57,12 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     if semantic_manager:
         semantic = semantic_manager.get_recent_summaries(state["agent_id"], limit=2)
         memories_content.extend(semantic)
+    agent_state = state.get("state")
+    role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(  # type: ignore[attr-defined]
-        state.get("current_role", ""), "\n".join(memories_content), ""
+        role_prompt,
+        "\n".join(memories_content),
+        "",
     )
     summary = getattr(summary_result, "summary", "")
     return {"rag_summary": summary, "memory_history_list": memories}

--- a/tests/unit/core/test_role_embedding.py
+++ b/tests/unit/core/test_role_embedding.py
@@ -1,0 +1,32 @@
+import pytest
+
+from src.agents.core.agent_controller import AgentController
+from src.agents.core.agent_state import AgentState
+
+
+@pytest.mark.unit
+def test_role_embedding_initialized() -> None:
+    s1 = AgentState(agent_id="a1", name="A")
+    s2 = AgentState(agent_id="a2", name="B")
+    assert len(s1.role_embedding) == 8
+    assert len(s2.role_embedding) == 8
+    assert s1.role_embedding != s2.role_embedding
+
+
+@pytest.mark.unit
+def test_gossip_update_changes_embedding() -> None:
+    state = AgentState(agent_id="a", name="A")
+    controller = AgentController(state)
+    original = list(state.role_embedding)
+    other = [v + 0.5 for v in original]
+    controller.gossip_update(other, 1.0)
+    assert state.role_embedding != original
+
+
+@pytest.mark.unit
+def test_role_prompt_contains_embedding() -> None:
+    state = AgentState(agent_id="a", name="A")
+    state.reputation["b"] = 0.5
+    prompt = state.role_prompt
+    assert isinstance(prompt, str)
+    assert f"{state.role_embedding[0]:.2f}" in prompt


### PR DESCRIPTION
## Summary
- initialize `AgentState.role_embedding` with a random vector
- derive a `role_prompt` from the embedding and reputation
- update `AgentController` with a gossip-based embedding update
- rely on `role_prompt` in DSPy helpers and memory summarization
- test random embedding initialization and gossip updates

## Testing
- `ruff format src/agents/core/agent_state.py src/agents/core/agent_controller.py src/agents/core/base_agent.py src/agents/graphs/graph_nodes.py`
- `ruff check src/agents/core/agent_state.py src/agents/core/agent_controller.py src/agents/core/base_agent.py src/agents/graphs/graph_nodes.py`
- `isort src/agents/core/agent_state.py src/agents/core/agent_controller.py src/agents/core/base_agent.py src/agents/graphs/graph_nodes.py`
- `black src/agents/core/agent_state.py src/agents/core/agent_controller.py src/agents/core/base_agent.py src/agents/graphs/graph_nodes.py`
- `mypy src/agents/core/agent_state.py src/agents/core/agent_controller.py src/agents/core/base_agent.py src/agents/graphs/graph_nodes.py`
- `python scripts/run_tests.py tests/unit/core/test_role_embedding.py`

------
https://chatgpt.com/codex/tasks/task_e_685aa67343e4832686f0dc929dd8c2cc