### PR TITLE
Add integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,30 @@ jobs:
             echo "Prompt leak detected" >&2
             exit 1
           fi
+
+  integration:
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.10"
+
+      - name: Run Integration Suite
+        shell: bash
+        run: |
+          pytest -m "integration" --disable-warnings -q | tee integration.log
+
+      - name: Upload integration logs
+        if: failure()
+        permissions:
+          actions: write
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration.log
+          path: integration.log


### PR DESCRIPTION
## Summary
- run `pytest -m "integration"` in a dedicated CI job
- upload integration logs as artifacts when the job fails

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_685acf0070788326b4194479fcf3d36d