### PR TITLE
Add frontend and utils tests

### DIFF
--- a/culture-ui/src/App.test.tsx
+++ b/culture-ui/src/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 import Home from './pages/Home'
+import App from './App'
 
 vi.mock('./App.css', () => ({}))
 

--- a/culture-ui/src/MissionOverview.test.tsx
+++ b/culture-ui/src/MissionOverview.test.tsx
@@ -1,25 +1,17 @@
-import { vi } from 'vitest'
-
-vi.mock('./lib/api', () => ({
-  fetchMissions: vi.fn(),
-}))
-
-
 import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import MissionOverview, { reorderMissions } from './pages/MissionOverview'
+import * as api from './lib/api'
 
-let missions: any[] = []
-vi.mock('./lib/api', () => ({
-  fetchMissions: vi.fn().mockImplementation(() => Promise.resolve(missions)),
-}))
+vi.mock('./lib/api')
 
 const missions = [
-
   { id: 1, name: 'Gather Intel', status: 'In Progress', progress: 50 },
   { id: 2, name: 'Prepare Brief', status: 'Pending', progress: 0 },
   { id: 3, name: 'Execute Plan', status: 'Complete', progress: 100 },
 ]
+
+;(api.fetchMissions as unknown as vi.Mock).mockResolvedValue(missions)
 
 describe('MissionOverview', () => {
   it('renders missions table', async () => {
@@ -34,6 +26,4 @@ describe('MissionOverview', () => {
     expect(reordered[0].id).toBe(2)
     expect(reordered[1].id).toBe(1)
   })
-
 })
-

--- a/culture-ui/src/components/DockManager.test.tsx
+++ b/culture-ui/src/components/DockManager.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+vi.mock('flexlayout-react/style/light.css', () => ({}))
+vi.mock('flexlayout-react', () => {
+  const Layout = vi.fn((props: any) => {
+    Layout.lastProps = props
+    return null
+  }) as any
+  const Model = {
+    fromJson: vi.fn((json: any) => ({ toJson: () => json }))
+  }
+  return { Layout, Model, TabNode: class {} }
+})
+import DockManager from './DockManager'
+import { widgetRegistry } from '../lib/widgetRegistry'
+import { Layout, Model } from 'flexlayout-react'
+
+
+declare module 'flexlayout-react' {
+  interface Model { toJson(): any }
+}
+
+function TestWidget() {
+  return <div data-testid="widget" />
+}
+
+describe('DockManager', () => {
+  beforeEach(() => {
+    widgetRegistry.register('test', TestWidget)
+    localStorage.clear()
+  })
+
+  it('loads layout from localStorage', () => {
+    localStorage.setItem('dockLayout', JSON.stringify({ saved: true }))
+    render(<DockManager defaultLayout={{}} />)
+    expect(Model.fromJson).toHaveBeenCalledWith({ saved: true })
+  })
+
+  it('persists layout changes', () => {
+    const prevEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    render(<DockManager defaultLayout={{ foo: 1 }} />)
+    const model = Model.fromJson.mock.results[0].value
+    expect(typeof Layout.lastProps.onModelChange).toBe('function')
+    process.env.NODE_ENV = prevEnv
+  })
+})

--- a/culture-ui/src/lib/useEventSource.test.tsx
+++ b/culture-ui/src/lib/useEventSource.test.tsx
@@ -71,6 +71,32 @@ describe('useEventSource', () => {
     expect(screen.getByTestId('value').textContent).toBe(JSON.stringify({ foo: 'bar' }))
   })
 
+  it('falls back to WebSocket when EventSource constructor throws', () => {
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof EventSource
+        WebSocket: typeof MockWebSocket
+      }
+    ).EventSource = class {
+      constructor() {
+        throw new Error('fail')
+      }
+    } as unknown as typeof EventSource
+    ;(
+      globalThis as unknown as {
+        EventSource: typeof EventSource
+        WebSocket: typeof MockWebSocket
+      }
+    ).WebSocket = MockWebSocket
+
+    render(<TestComponent />)
+    const ws = MockWebSocket.instances[0]
+    act(() => {
+      ws.sendMessage('{"b":2}')
+    })
+    expect(screen.getByTestId('value').textContent).toBe(JSON.stringify({ b: 2 }))
+  })
+
   it('falls back to WebSocket on EventSource error', () => {
     ;(
       globalThis as unknown as {

--- a/tests/unit/utils/test_policy.py
+++ b/tests/unit/utils/test_policy.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.infra import config
-from src.utils.policy import evaluate_with_opa
+from src.utils.policy import allow_message, evaluate_with_opa
 
 
 @pytest.mark.unit
@@ -28,3 +28,20 @@ async def test_evaluate_with_opa_allows(monkeypatch: pytest.MonkeyPatch) -> None
     allowed, new_content = await evaluate_with_opa("hello")
     assert allowed is True
     assert new_content == "hello"
+
+
+@pytest.mark.unit
+def test_allow_message_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPA_BLOCKLIST", "foo,bar")
+    assert allow_message("hello world") is True
+
+
+@pytest.mark.unit
+def test_allow_message_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPA_BLOCKLIST", "foo,bar")
+    assert allow_message("bar baz") is False
+
+
+@pytest.mark.unit
+def test_allow_message_none() -> None:
+    assert allow_message(None) is True


### PR DESCRIPTION
## Summary
- test WebSocket fallback when EventSource constructor fails
- cover DockManager layout persistence
- ensure allow_message helper is tested

## Testing
- `pnpm --filter culture-ui test`
- `pytest --cov=src/utils --cov-report=term-missing:skip-covered -q`
- `pre-commit run --files culture-ui/src/App.test.tsx culture-ui/src/MissionOverview.test.tsx culture-ui/src/components/DockManager.test.tsx culture-ui/src/lib/useEventSource.test.tsx tests/unit/utils/test_policy.py`

------
https://chatgpt.com/codex/tasks/task_e_685acf07ac848326b17c56645f8dcaf2