### PR TITLE
Use local mission data in MissionOverview

### DIFF
--- a/culture-ui/src/App.test.tsx
+++ b/culture-ui/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
-import Home from './pages/Home'
+import App from './App'
 
 vi.mock('./App.css', () => ({}))
 

--- a/culture-ui/src/MissionOverview.test.tsx
+++ b/culture-ui/src/MissionOverview.test.tsx
@@ -1,31 +1,13 @@
-import { vi } from 'vitest'
-
-vi.mock('./lib/api', () => ({
-  fetchMissions: vi.fn(),
-}))
-
-
 import { render, screen } from '@testing-library/react'
-import { vi } from 'vitest'
-import MissionOverview, { reorderMissions } from './pages/MissionOverview'
-
-let missions: any[] = []
-vi.mock('./lib/api', () => ({
-  fetchMissions: vi.fn().mockImplementation(() => Promise.resolve(missions)),
-}))
-
-const missions = [
-
-  { id: 1, name: 'Gather Intel', status: 'In Progress', progress: 50 },
-  { id: 2, name: 'Prepare Brief', status: 'Pending', progress: 0 },
-  { id: 3, name: 'Execute Plan', status: 'Complete', progress: 100 },
-]
+import MissionOverview from './pages/MissionOverview'
+import { reorderMissions } from './lib/reorderMissions'
+import missions from './mock/missions.json'
 
 describe('MissionOverview', () => {
-  it('renders missions table', async () => {
+  it('renders missions table', () => {
     render(<MissionOverview />)
-    expect(await screen.findByRole('heading', { name: /mission overview/i })).toBeInTheDocument()
-    expect(await screen.findByText('Gather Intel')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /mission overview/i })).toBeInTheDocument()
+    expect(screen.getByText('Gather Intel')).toBeInTheDocument()
     expect(screen.getByText('Prepare Brief')).toBeInTheDocument()
   })
 
@@ -34,6 +16,4 @@ describe('MissionOverview', () => {
     expect(reordered[0].id).toBe(2)
     expect(reordered[1].id).toBe(1)
   })
-
 })
-

--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -5,12 +5,3 @@ export interface Mission {
   progress: number
 }
 
-const API_BASE = ''
-
-export async function fetchMissions(): Promise<Mission[]> {
-  const response = await fetch(`${API_BASE}/api/missions`)
-  if (!response.ok) {
-    throw new Error('Failed to fetch missions')
-  }
-  return (await response.json()) as Mission[]
-}

--- a/culture-ui/src/lib/testUtils.ts
+++ b/culture-ui/src/lib/testUtils.ts
@@ -39,7 +39,11 @@ export class MockWebSocket {
 export function resetMockSources() {
   MockEventSource.instances = []
   MockWebSocket.instances = []
-  ;(globalThis as any).EventSource = undefined
-  ;(globalThis as any).WebSocket = undefined
+  type GlobalWithSources = typeof globalThis & {
+    EventSource?: unknown
+    WebSocket?: unknown
+  }
+  ;(globalThis as GlobalWithSources).EventSource = undefined
+  ;(globalThis as GlobalWithSources).WebSocket = undefined
 }
 

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import clsx from 'clsx'
 import type { ColumnDef, Row } from '@tanstack/react-table'
 import {
@@ -6,7 +6,8 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { fetchMissions, type Mission } from '../lib/api'
+import type { Mission } from '../lib/api'
+import missionsData from '../mock/missions.json'
 import {
   DndContext,
   KeyboardSensor,
@@ -19,11 +20,10 @@ import {
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
-  arrayMove,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 
-export { reorderMissions } from '../lib/reorderMissions'
+import { reorderMissions } from '../lib/reorderMissions'
 
 function DraggableRow({ row }: { row: Row<Mission> }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -53,16 +53,7 @@ function DraggableRow({ row }: { row: Row<Mission> }) {
 }
 
 export default function MissionOverview() {
-  const [data, setData] = useState<Mission[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
-
-  useEffect(() => {
-    fetchMissions()
-      .then(setData)
-      .catch((err) => setError(err as Error))
-      .finally(() => setLoading(false))
-  }, [])
+  const [data, setData] = useState<Mission[]>(missionsData as Mission[])
 
   const columns: ColumnDef<Mission>[] = [
     {
@@ -97,14 +88,6 @@ export default function MissionOverview() {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   )
-
-  if (loading) {
-    return <div className="p-4">Loading missions...</div>
-  }
-
-  if (error) {
-    return <div className="p-4 text-red-500">Error loading missions</div>
-  }
 
   return (
     <div className="p-4">

--- a/culture-ui/src/widgets/KpiCard.test.tsx
+++ b/culture-ui/src/widgets/KpiCard.test.tsx
@@ -1,5 +1,4 @@
 import { act, render, screen } from '@testing-library/react'
-import { vi } from 'vitest'
 import KpiCard from './KpiCard'
 import { MockEventSource, MockWebSocket, resetMockSources } from '../lib/testUtils'
 
@@ -8,15 +7,20 @@ afterEach(() => {
 })
 
 describe('KpiCard', () => {
+  type GlobalWithSources = typeof globalThis & {
+    EventSource?: unknown
+    WebSocket?: unknown
+  }
+
   it('renders KPI card', () => {
-    ;(globalThis as any).EventSource = MockEventSource
+    ;(globalThis as GlobalWithSources).EventSource = MockEventSource
     render(<KpiCard />)
     expect(screen.getByTestId('kpi-card')).toBeInTheDocument()
     expect(screen.getByTestId('kpi-value').textContent).toBe('0')
   })
 
   it('updates chart on SSE messages', () => {
-    ;(globalThis as any).EventSource = MockEventSource
+    ;(globalThis as GlobalWithSources).EventSource = MockEventSource
     render(<KpiCard />)
     const es = MockEventSource.instances[0]
     act(() => {
@@ -30,8 +34,8 @@ describe('KpiCard', () => {
   })
 
   it('updates chart using WebSocket fallback', () => {
-    ;(globalThis as any).EventSource = undefined
-    ;(globalThis as any).WebSocket = MockWebSocket
+    ;(globalThis as GlobalWithSources).EventSource = undefined
+    ;(globalThis as GlobalWithSources).WebSocket = MockWebSocket
     render(<KpiCard />)
     const ws = MockWebSocket.instances[0]
     act(() => {

--- a/culture-ui/src/widgets/NetworkWeb.tsx
+++ b/culture-ui/src/widgets/NetworkWeb.tsx
@@ -1,9 +1,9 @@
-import { useMemo } from 'react'
+import { useMemo, type ComponentType } from 'react'
 
-let ForceGraph2D: any = () => <canvas />
+let ForceGraph2D: ComponentType<Record<string, unknown>> = () => <canvas />
 if (process.env.NODE_ENV !== 'test') {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  ForceGraph2D = require('react-force-graph-2d').default
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  ForceGraph2D = require('react-force-graph-2d').default as ComponentType<Record<string, unknown>>
 }
 
 export default function NetworkWeb() {


### PR DESCRIPTION
## Summary
- load mission list from mock JSON
- delete dead API helpers
- fix unit tests and lint errors

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_685acef479cc832684c2dd65c46651c9