### PR TITLE
Fix stray text in flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,4 @@ exclude =
     *.egg-info,
     data/
 # Add E203 to ignores if Black handles it and Flake8 complains, but start without.
-# ignore = E203 
+# ignore = E203

--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ exclude =
     data/
 # Add E203 to ignores if Black handles it and Flake8 complains, but start without.
 # ignore = E203
+


### PR DESCRIPTION
## Summary
- clean up `.flake8` by removing leftover shell prompt text

## Testing
- `python scripts/run_tests.py -m unit` *(fails: PackageNotFoundError, database locked)*
- `SKIP=unit-tests pre-commit run --files .flake8`

------
https://chatgpt.com/codex/tasks/task_e_685acef12950832698f8503ac16a2ae2