### PR TITLE
Add LLM call error metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,10 @@ This guide explains how to configure basic monitoring for Culture.ai using Grafa
 
 The imported dashboard includes panels for CPU usage, Knowledge Board size, active agent count, and the LLM query rate (QPS).
 
+Additional Prometheus metrics include:
+
+- `llm_errors_total` – counts failed LLM calls captured by the monitoring decorator.
+
 ## 3. Running Grafana Locally
 
 If you want to run Grafana locally for quick testing, you can use Docker:

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -160,6 +160,7 @@ class LLMClient:
         self.config = config
         self._client = get_ollama_client()
 
+    @monitor_llm_call(model_param="model", context="ollama_chat")
     def chat(
         self,
         model: str,

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -40,6 +40,7 @@ except Exception:  # pragma: no cover - optional dependency
 # Expose metrics for LLM calls and knowledge board state
 LLM_LATENCY_MS = Gauge("llm_latency_ms", "Latency of last LLM call in milliseconds")
 LLM_CALLS_TOTAL = Counter("llm_calls_total", "Total number of LLM calls")
+LLM_ERRORS_TOTAL = Counter("llm_errors_total", "Total number of failed LLM calls")
 KNOWLEDGE_BOARD_SIZE = Gauge(
     "knowledge_board_size", "Number of entries currently on the Knowledge Board"
 )

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -90,6 +90,8 @@ def monitor_llm_call(
                 end_time = time.perf_counter()
                 metrics_data["duration_ms"] = round((end_time - start_time) * 1000, 2)
                 metrics.LLM_CALLS_TOTAL.inc()
+                if not metrics_data.get("success", False):
+                    metrics.LLM_ERRORS_TOTAL.inc()
                 metrics.LLM_LATENCY_MS.set(metrics_data["duration_ms"])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
             return result

--- a/tests/unit/infra/test_llm_client_metrics.py
+++ b/tests/unit/infra/test_llm_client_metrics.py
@@ -1,0 +1,48 @@
+import importlib
+
+import pytest
+
+from src.infra import llm_client as llm_client_mod
+from src.interfaces import metrics
+
+
+@pytest.mark.unit
+def test_llm_client_chat_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(llm_client_mod)
+
+    class DummyClient:
+        def chat(self, model: str, messages: list[dict], options: dict | None = None) -> dict:
+            return {"message": {"content": "ok"}}
+
+    monkeypatch.setattr(module, "get_ollama_client", lambda: DummyClient())
+    client = module.LLMClient(module.LLMClientConfig())
+
+    before_calls = metrics.LLM_CALLS_TOTAL._value.get()
+    before_errors = metrics.LLM_ERRORS_TOTAL._value.get()
+
+    result = client.chat(model="mistral:latest", messages=[{"role": "user", "content": "hi"}])
+    assert result == {"message": {"content": "ok"}}
+
+    assert metrics.LLM_CALLS_TOTAL._value.get() == before_calls + 1
+    assert metrics.LLM_ERRORS_TOTAL._value.get() == before_errors
+
+
+@pytest.mark.unit
+def test_llm_client_chat_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(llm_client_mod)
+
+    class DummyClient:
+        def chat(self, model: str, messages: list[dict], options: dict | None = None) -> dict:
+            raise module.RequestException("boom")
+
+    monkeypatch.setattr(module, "get_ollama_client", lambda: DummyClient())
+    client = module.LLMClient(module.LLMClientConfig())
+
+    before_calls = metrics.LLM_CALLS_TOTAL._value.get()
+    before_errors = metrics.LLM_ERRORS_TOTAL._value.get()
+
+    with pytest.raises(module.RequestException):
+        client.chat(model="m", messages=[{"role": "user", "content": "hi"}])
+
+    assert metrics.LLM_CALLS_TOTAL._value.get() == before_calls + 1
+    assert metrics.LLM_ERRORS_TOTAL._value.get() == before_errors + 1


### PR DESCRIPTION
## Summary
- capture failed LLM call counts via new `LLM_ERRORS_TOTAL` metric
- increment error metric in `monitor_llm_call`
- instrument `LLMClient.chat` with monitoring decorator
- document `llm_errors_total` in observability guide
- test success and error cases for metrics

## Testing
- `python -m pytest -c /tmp/pytest_nox.ini tests/unit/infra/test_llm_client_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0a4a9b3c8326a564493fd7e4b5dc