### PR TITLE
Add config validation for required env vars

### DIFF
--- a/tests/unit/infra/test_config_required_keys.py
+++ b/tests/unit/infra/test_config_required_keys.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.infra import config
+
+
+@pytest.mark.unit
+def test_load_config_missing_required_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REDPANDA_BROKER", raising=False)
+    monkeypatch.delenv("OPA_URL", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        config.load_config(validate_required=True)
+    msg = str(exc.value)
+    assert "REDPANDA_BROKER" in msg
+    assert "OPA_URL" in msg
+
+
+@pytest.mark.unit
+def test_load_config_with_required_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    cfg = config.load_config(validate_required=True)
+    assert cfg["REDPANDA_BROKER"] == "localhost:9092"
+    assert cfg["OPA_URL"] == "http://opa"

--- a/tests/unit/infra/test_logging_config.py
+++ b/tests/unit/infra/test_logging_config.py
@@ -11,7 +11,7 @@ def test_custom_otel_endpoint(monkeypatch, tmp_path):
     monkeypatch.setenv("ENABLE_OTEL", "1")
     monkeypatch.setenv("OTEL_EXPORTER_ENDPOINT", "http://example.com:4318/v1/logs")
 
-    config.load_config()
+    config.load_config(validate_required=False)
 
     endpoints: list[str] = []
 


### PR DESCRIPTION
## Summary
- validate mandatory config keys like `REDPANDA_BROKER` and `OPA_URL`
- allow skipping validation when loading defaults
- adjust logging config test
- add tests covering validation errors

## Testing
- `ruff check .`
- `black --check src/infra/config.py tests/unit/infra/test_logging_config.py tests/unit/infra/test_config_required_keys.py`
- `mypy src/infra/config.py`
- `pytest -m unit tests/unit/infra/test_logging_config.py tests/unit/infra/test_config_required_keys.py -n 0`


------
https://chatgpt.com/codex/tasks/task_e_685b49535ec083269d4b3b00f3c70c78