### PR TITLE
Add map pathfinding and ledger token tracking

### DIFF
--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -37,6 +37,16 @@ class Ledger:
             )
             """
         )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_tokens (
+                agent_id TEXT,
+                token TEXT,
+                amount INTEGER DEFAULT 0,
+                PRIMARY KEY(agent_id, token)
+            )
+            """
+        )
         self.conn.commit()
 
     def log_change(
@@ -117,6 +127,43 @@ class Ledger:
         if row:
             return float(row[0]), float(row[1])
         return 0.0, 0.0
+
+    def add_tokens(self, agent_id: str, token: str, amount: int) -> None:
+        if amount <= 0:
+            return
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO agent_tokens(agent_id, token, amount)
+            VALUES(?, ?, ?)
+            ON CONFLICT(agent_id, token) DO UPDATE SET
+                amount = amount + excluded.amount
+            """,
+            (agent_id, token, int(amount)),
+        )
+        self.conn.commit()
+
+    def remove_tokens(self, agent_id: str, token: str, amount: int) -> None:
+        if amount <= 0:
+            return
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            UPDATE agent_tokens
+            SET amount = MAX(amount - ?, 0)
+            WHERE agent_id=? AND token=?
+            """,
+            (int(amount), agent_id, token),
+        )
+        self.conn.commit()
+
+    def get_tokens(self, agent_id: str, token: str) -> int:
+        cur = self.conn.execute(
+            "SELECT amount FROM agent_tokens WHERE agent_id=? AND token=?",
+            (agent_id, token),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
 
 
 ledger = Ledger()

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -303,7 +303,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {len(self.messages_to_perceive_this_round)} messages from pending_messages_for_next_round."
@@ -377,9 +379,14 @@ class Simulation:
         if isinstance(map_action, dict):
             action_type = map_action.get("action")
             if action_type == "move":
-                dx = int(map_action.get("dx", 0))
-                dy = int(map_action.get("dy", 0))
-                pos = self.world_map.move(agent_id, dx, dy)
+                if "x" in map_action and "y" in map_action:
+                    tx = int(map_action.get("x", 0))
+                    ty = int(map_action.get("y", 0))
+                    pos = self.world_map.move_to(agent_id, tx, ty)
+                else:
+                    dx = int(map_action.get("dx", 0))
+                    dy = int(map_action.get("dy", 0))
+                    pos = self.world_map.move(agent_id, dx, dy)
                 action_details = {"position": pos}
                 start_ip = current_agent_state.ip
                 start_du = current_agent_state.du

--- a/src/sim/world_map.py
+++ b/src/sim/world_map.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from enum import Enum
+from heapq import heappop, heappush
 from typing import Any
 
 
@@ -26,6 +28,17 @@ class WorldMap:
         self.resources: dict[tuple[int, int], dict[str, int]] = {}
         self.buildings: dict[tuple[int, int], str] = {}
         self.agent_resources: dict[str, dict[str, int]] = {}
+        self.obstacles: set[tuple[int, int]] = set()
+
+    def in_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def passable(self, x: int, y: int) -> bool:
+        return (x, y) not in self.obstacles
+
+    def add_obstacle(self, x: int, y: int) -> None:
+        if self.in_bounds(x, y):
+            self.obstacles.add((x, y))
 
     def add_agent(self, agent_id: str, x: int = 0, y: int = 0) -> None:
         """Place ``agent_id`` on the map and initialize its inventory."""
@@ -45,8 +58,69 @@ class WorldMap:
         x, y = self.agent_positions.get(agent_id, (0, 0))
         new_x = min(max(x + dx, 0), self.width - 1)
         new_y = min(max(y + dy, 0), self.height - 1)
+        if not self.passable(new_x, new_y):
+            return x, y
         self.agent_positions[agent_id] = (new_x, new_y)
         return new_x, new_y
+
+    def move_to(self, agent_id: str, dest_x: int, dest_y: int) -> tuple[int, int]:
+        """Move ``agent_id`` one step toward ``dest_x``, ``dest_y`` using A*."""
+
+        start = self.agent_positions.get(agent_id, (0, 0))
+        path = self.find_path(start, (dest_x, dest_y))
+        if len(path) < 2:
+            return start
+        nxt = path[1]
+        if self.passable(*nxt):
+            self.agent_positions[agent_id] = nxt
+            return nxt
+        return start
+
+    def neighbors(self, pos: tuple[int, int]) -> Iterable[tuple[int, int]]:
+        x, y = pos
+        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+            nx, ny = x + dx, y + dy
+            if self.in_bounds(nx, ny) and self.passable(nx, ny):
+                yield (nx, ny)
+
+    def heuristic(self, a: tuple[int, int], b: tuple[int, int]) -> int:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    def find_path(self, start: tuple[int, int], goal: tuple[int, int]) -> list[tuple[int, int]]:
+        """Return a path from ``start`` to ``goal`` using A* search."""
+
+        if not self.in_bounds(*goal) or not self.passable(*goal):
+            return [start]
+
+        frontier: list[tuple[int, tuple[int, int]]] = []
+        heappush(frontier, (0, start))
+        came_from: dict[tuple[int, int], tuple[int, int] | None] = {start: None}
+        cost_so_far: dict[tuple[int, int], int] = {start: 0}
+
+        while frontier:
+            _, current = heappop(frontier)
+
+            if current == goal:
+                break
+
+            for nxt in self.neighbors(current):
+                new_cost = cost_so_far[current] + 1
+                if nxt not in cost_so_far or new_cost < cost_so_far[nxt]:
+                    cost_so_far[nxt] = new_cost
+                    priority = new_cost + self.heuristic(nxt, goal)
+                    heappush(frontier, (priority, nxt))
+                    came_from[nxt] = current
+
+        if goal not in came_from:
+            return [start]
+
+        path: list[tuple[int, int]] = []
+        curr: tuple[int, int] | None = goal
+        while curr is not None:
+            path.append(curr)
+            curr = came_from.get(curr)
+        path.reverse()
+        return path
 
     def gather(self, agent_id: str, resource: ResourceToken) -> bool:
         """Collect ``resource`` from the agent's current position."""
@@ -63,6 +137,12 @@ class WorldMap:
             del cell[res_key]
         bag = self.agent_resources.setdefault(agent_id, {})
         bag[res_key] = bag.get(res_key, 0) + 1
+        try:
+            from src.infra.ledger import ledger
+
+            ledger.add_tokens(agent_id, res_key, 1)
+        except Exception:  # pragma: no cover - optional
+            pass
         return True
 
     def build(self, agent_id: str, structure: StructureType) -> bool:
@@ -79,6 +159,12 @@ class WorldMap:
         if bag[ResourceToken.WOOD.value] == 0:
             del bag[ResourceToken.WOOD.value]
         self.buildings[pos] = structure.value
+        try:
+            from src.infra.ledger import ledger
+
+            ledger.remove_tokens(agent_id, ResourceToken.WOOD.value, 1)
+        except Exception:  # pragma: no cover - optional
+            pass
         return True
 
     def to_dict(self) -> dict[str, Any]:
@@ -89,4 +175,5 @@ class WorldMap:
             "resources": self.resources,
             "buildings": self.buildings,
             "agent_resources": self.agent_resources,
+            "obstacles": list(self.obstacles),
         }

--- a/tests/unit/sim/test_world_map.py
+++ b/tests/unit/sim/test_world_map.py
@@ -130,3 +130,28 @@ def test_build_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert ip == pytest.approx(config.MAP_BUILD_IP_REWARD - config.MAP_BUILD_IP_COST)
     assert du == pytest.approx(config.MAP_BUILD_DU_REWARD - config.MAP_BUILD_DU_COST)
     assert sim.world_map.buildings[(0, 0)] == StructureType.HUT.value
+
+
+def test_pathfinding_large_map() -> None:
+    m = WorldMap(width=20, height=20)
+    m.add_agent("A")
+    # create a wall of obstacles except for a gap
+    for y in range(10):
+        if y != 5:
+            m.add_obstacle(5, y)
+    # move towards the other side of the wall
+    for _ in range(20):
+        m.move_to("A", 10, 0)
+    x, y = m.agent_positions["A"]
+    assert (x, y) == (10, 0)
+
+
+def test_gather_after_pathfinding() -> None:
+    m = WorldMap(width=15, height=15)
+    m.add_agent("A")
+    m.add_resource(10, 10, ResourceToken.WOOD, 1)
+    for _ in range(20):
+        m.move_to("A", 10, 10)
+    assert m.agent_positions["A"] == (10, 10)
+    assert m.gather("A", ResourceToken.WOOD)
+    assert m.agent_resources["A"].get("wood", 0) == 1


### PR DESCRIPTION
## Summary
- extend `WorldMap` with obstacles and A* pathfinding
- track resource token transactions in the ledger
- support destination-based moves in `Simulation`
- cover new movement and gather behavior on large maps

## Testing
- `black --check src/sim/world_map.py src/infra/ledger.py src/sim/simulation.py tests/unit/sim/test_world_map.py`
- `isort --check-only src/sim/world_map.py src/infra/ledger.py src/sim/simulation.py tests/unit/sim/test_world_map.py`
- `ruff check src/sim/world_map.py src/infra/ledger.py src/sim/simulation.py tests/unit/sim/test_world_map.py`
- `mypy src/sim/world_map.py src/infra/ledger.py src/sim/simulation.py tests/unit/sim/test_world_map.py`
- `python scripts/run_tests.py tests/unit/sim/test_world_map.py`

------
https://chatgpt.com/codex/tasks/task_e_685b496d28888326b687024a195683e1