### PR TITLE
Add governance policy helpers and tests

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -261,3 +261,9 @@ class AgentController:
         state.relationship_history.clear()
         state.mood_history = [(0, 0.0)]
         state.relationship_history = {name: [(0, 0.0)] for name in old_keys}
+
+    async def vote_on_policy(self: Self, proposal: str) -> bool:
+        """Vote on a policy proposal using the governance evaluation helper."""
+        from src.governance import evaluate_policy
+
+        return await evaluate_policy(proposal)

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,5 +1,6 @@
 """Governance utilities for Culture.ai."""
 
+from .policy import evaluate_policy, load_policy
 from .voting import propose_law
 
-__all__ = ["propose_law"]
+__all__ = ["evaluate_policy", "load_policy", "propose_law"]

--- a/src/governance/policy.py
+++ b/src/governance/policy.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import requests
+
+from src.infra import config
+
+logger = logging.getLogger(__name__)
+
+_POLICY_CONTENT: str | None = None
+
+
+def load_policy(path: str) -> str:
+    """Load an OPA policy file into memory."""
+    global _POLICY_CONTENT
+    with open(path, encoding="utf-8") as f:
+        _POLICY_CONTENT = f.read()
+    return _POLICY_CONTENT
+
+
+async def evaluate_policy(action: str) -> bool:
+    """Evaluate an action against the loaded OPA policy via HTTP."""
+    url = config.get_config("OPA_URL")
+    if not url:
+        return True
+    payload: dict[str, Any] = {"input": {"action": action}}
+    if _POLICY_CONTENT is not None:
+        payload["policy"] = _POLICY_CONTENT
+    try:
+        response = await asyncio.to_thread(requests.post, url, json=payload, timeout=2)
+        data = response.json()
+        result = data.get("result", {})
+        return bool(result.get("allow", True))
+    except Exception as exc:  # pragma: no cover - network issues
+        logger.warning("OPA policy evaluation failed: %s", exc)
+        return True

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -196,6 +196,10 @@ class KnowledgeBoard:
             logger.error(f"Failed to add entry to knowledge board: {e}")
             return False
 
+    def add_law_proposal(self: Self, proposal: str, agent_id: str, step: int) -> bool:
+        """Record a law proposal on the board."""
+        return self.add_entry(f"Law proposed: {proposal}", agent_id, step)
+
     def clear_board(self: Self) -> None:
         """Clears all entries from the Knowledge Board."""
         logger.info(

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -100,9 +100,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -139,9 +139,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -303,7 +303,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {len(self.messages_to_perceive_this_round)} messages from pending_messages_for_next_round."
@@ -906,6 +908,9 @@ class Simulation:
         proposer = next((a for a in self.agents if a.agent_id == proposer_id), None)
         if proposer is None:
             return False
+
+        if self.knowledge_board:
+            self.knowledge_board.add_law_proposal(text, proposer_id, self.current_step)
 
         approved = await _propose(proposer, text, self.agents)
         if approved and self.knowledge_board:

--- a/tests/integration/governance/test_policy_enforcement.py
+++ b/tests/integration/governance/test_policy_enforcement.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from src.agents.core.agent_controller import AgentController
+from src.infra import config
+from src.sim.simulation import Simulation
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        pass
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_vote_on_policy_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src import governance
+    from src.governance import policy as gpolicy
+
+    async def deny(_: str) -> bool:
+        return False
+
+    monkeypatch.setattr(gpolicy, "evaluate_policy", deny)
+    monkeypatch.setattr(governance, "evaluate_policy", deny)
+
+    controller = AgentController()
+    allowed = await controller.vote_on_policy("bad law")
+    assert allowed is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_rejected_proposal_not_approved(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def deny(_: str) -> tuple[bool, str]:
+        return False, ""
+
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    monkeypatch.setattr("src.utils.policy.evaluate_with_opa", deny)
+
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+    sim = Simulation(agents=agents)
+
+    approved = await sim.propose_law("a1", "bad law")
+    assert approved is False
+    entries = [e["content_display"] for e in sim.knowledge_board.entries]
+    assert any("Law proposed" in e for e in entries)
+    assert not any("Law approved" in e for e in entries)


### PR DESCRIPTION
## Summary
- add policy loader/evaluator under governance
- update agent controller with vote_on_policy action
- record law proposals on knowledge board and update simulation
- expose new helpers in governance package
- add integration tests for policy enforcement

## Testing
- `ruff check tests/integration/governance/test_policy_enforcement.py src/agents/core/agent_controller.py src/governance/__init__.py src/governance/policy.py src/sim/knowledge_board.py src/sim/simulation.py`
- `black tests/integration/governance/test_policy_enforcement.py src/agents/core/agent_controller.py src/governance/__init__.py src/governance/policy.py src/sim/knowledge_board.py src/sim/simulation.py`
- `mypy src/governance/policy.py src/agents/core/agent_controller.py src/governance/__init__.py src/sim/knowledge_board.py src/sim/simulation.py`
- `pytest -m integration tests/integration/governance/test_policy_enforcement.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b497dce9083268ec26448c6744771