### PR TITLE
Update docs for Redpanda and roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,12 @@ default. Adjust the log level or path as needed by customizing this function.
 For deterministic event logging and replay, install Redpanda as described in
 [docs/redpanda_setup.md](docs/redpanda_setup.md). Set `ENABLE_REDPANDA` and
 `REDPANDA_BROKER` in your `.env` to activate this feature.
+You can install Redpanda quickly with:
+```bash
+curl -1s https://raw.githubusercontent.com/redpanda-data/redpanda/master/install.sh | bash
+docker compose -f docker-compose.redpanda.yml up -d
+```
+Events are written to the `culture-events` topic and can be consumed using the `rpk` CLI.
 
 ### Prometheus Metrics
 The simulation exposes Prometheus metrics on port 8000 when `src.interfaces.metrics` is imported.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,12 @@ The `Roles` system (`src/agents/core/roles.py`) defines:
 - Each agent stores an embedding vector derived from its current role
 - Reputation gossip influences role similarity calculations
 
+Culture.ai also supports a **free-form role** mechanism. In addition to the
+predefined roles above, agents may be assigned any descriptive role string at
+runtime. These ad-hoc roles are persisted in `role_history` and converted into
+embeddings for similarity checks. Free-form roles enable emergent personas and
+dynamic roleplay beyond the initial Innovator/Analyzer/Facilitator triad.
+
 ### Interactions
 
 The Agent Core components interact with:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -66,3 +66,26 @@ Culture.ai can optionally send outgoing messages through an [Open Policy Agent](
 
 If `allow` is `false`, the message will be blocked. If `content` is returned, it will replace the original text before sending.
 
+## 7. Redpanda Event Log
+
+Culture.ai can stream all simulation events to a Redpanda broker for later replay and analysis.
+Follow [docs/redpanda_setup.md](redpanda_setup.md) to install Redpanda locally and start it with Docker Compose.
+Set the following variables in your `.env`:
+
+```env
+ENABLE_REDPANDA=1
+REDPANDA_BROKER=localhost:9092
+```
+
+Events will be written to the `culture-events` topic. You can inspect them with the `rpk` CLI or any Kafka-compatible consumer.
+
+## 8. Metrics Reference
+
+Prometheus metrics exported by the simulation include:
+
+- `active_agent_count` – number of agents currently active
+- `llm_calls_total` – total LLM invocations
+- `llm_latency_ms` – latency of the last LLM call
+- `llm_errors_total` – failed LLM calls
+- `knowledge_board_size` – total Knowledge Board entries
+


### PR DESCRIPTION
## Summary
- add quick Redpanda setup instructions to README
- document Redpanda logging and Prometheus metrics
- describe the free-form role mechanism in the architecture docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4982ed3c83269284a7f03ef73bb2