### PR TITLE
Add S3 snapshot integration tests

### DIFF
--- a/tests/integration/snapshot/test_s3_snapshot.py
+++ b/tests/integration/snapshot/test_s3_snapshot.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("zstandard")
+mock_s3 = pytest.importorskip("tests.utils.mock_s3")
+
+from src.infra.snapshot import load_snapshot, save_snapshot
+
+setup_mock_s3 = mock_s3.setup_mock_s3
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def s3_client(tmp_path: Path):
+    client = setup_mock_s3()
+    # store objects under tmp_path for easy cleanup
+    client.base_dir = tmp_path
+    return client
+
+
+def test_upload_and_download_snapshot(tmp_path: Path, s3_client) -> None:
+    data = {"msg": "hello"}
+    save_snapshot(1, data, directory=tmp_path, compress=True)
+    src = tmp_path / "snapshot_1.json.zst"
+    assert src.exists()
+
+    s3_client.upload_file(str(src), "bucket", "snap.zst")
+
+    src.unlink()
+    assert not src.exists()
+
+    s3_client.download_file("bucket", "snap.zst", src)
+
+    loaded = load_snapshot(src)
+    assert loaded == data
+
+
+def test_put_and_get_snapshot(tmp_path: Path, s3_client) -> None:
+    data = {"val": 42}
+    save_snapshot(2, data, directory=tmp_path, compress=True)
+    src = tmp_path / "snapshot_2.json.zst"
+
+    with src.open("rb") as f:
+        s3_client.put_object(Bucket="bucket", Key="obj.zst", Body=f.read())
+
+    src.unlink()
+
+    body = s3_client.get_object(Bucket="bucket", Key="obj.zst")["Body"]
+    out = tmp_path / "downloaded.zst"
+    with out.open("wb") as f:
+        f.write(body.read())
+
+    loaded = load_snapshot(out)
+    assert loaded == data

--- a/tests/utils/mock_s3.py
+++ b/tests/utils/mock_s3.py
@@ -1,0 +1,53 @@
+import shutil
+import sys
+import tempfile
+import types
+from pathlib import Path
+from typing import Any
+
+
+class DummyS3Client:
+    """A minimal in-memory S3 client for tests."""
+
+    def __init__(self, base_dir: str | None = None) -> None:
+        self.base_dir = Path(base_dir or tempfile.mkdtemp())
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, bucket: str, key: str) -> Path:
+        path = self.base_dir / bucket / key
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def upload_file(self, Filename: str | Path, Bucket: str, Key: str) -> None:
+        shutil.copyfile(Filename, self._path(Bucket, Key))
+
+    def download_file(self, Bucket: str, Key: str, Filename: str | Path) -> None:
+        shutil.copyfile(self._path(Bucket, Key), Filename)
+
+    def put_object(self, Bucket: str, Key: str, Body: bytes) -> None:
+        with self._path(Bucket, Key).open("wb") as f:
+            f.write(Body)
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        return {"Body": self._path(Bucket, Key).open("rb")}
+
+
+def setup_mock_s3() -> DummyS3Client:
+    """Install a lightweight ``boto3`` stub returning :class:`DummyS3Client`."""
+
+    client = DummyS3Client()
+
+    if "boto3" in sys.modules:
+        boto3 = sys.modules["boto3"]
+    else:
+        boto3 = types.ModuleType("boto3")
+        sys.modules["boto3"] = boto3
+
+    def client_factory(service_name: str, *args: Any, **kwargs: Any) -> Any:
+        if service_name == "s3":
+            return client
+        raise NotImplementedError(f"Unsupported service {service_name}")
+
+    boto3.client = client_factory  # type: ignore[attr-defined]
+
+    return client


### PR DESCRIPTION
## Summary
- implement `load_snapshot` helper
- add optional `DummyS3Client` and `setup_mock_s3`
- test uploading and retrieving compressed snapshots via mock S3

## Testing
- `ruff check src/infra/snapshot.py tests/integration/snapshot/test_s3_snapshot.py tests/utils/mock_s3.py`
- `black src/infra/snapshot.py tests/integration/snapshot/test_s3_snapshot.py tests/utils/mock_s3.py --check`
- `mypy src/infra/snapshot.py`
- `pytest tests/integration/snapshot/test_s3_snapshot.py tests/unit/infra/test_snapshot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b547114c88326a0a4175c65326bb7