### PR TITLE
Add role embedding management

### DIFF
--- a/src/agents/core/__init__.py
+++ b/src/agents/core/__init__.py
@@ -1,3 +1,4 @@
 from .resource_manager import ResourceManager
+from .role_embeddings import ROLE_EMBEDDINGS, RoleEmbeddingManager
 
-__all__ = ["ResourceManager"]
+__all__ = ["ROLE_EMBEDDINGS", "ResourceManager", "RoleEmbeddingManager"]

--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -97,13 +97,7 @@ class AgentController:
     def gossip_update(self: Self, other_embedding: list[float], interaction_score: float) -> None:
         """Adjust role embedding based on interaction gossip."""
         state = self._require_state()
-        if not state.role_embedding or not other_embedding:
-            return
-        lr = 0.1
-        new_embed: list[float] = []
-        for a, b in zip(state.role_embedding, other_embedding):
-            new_embed.append(a + lr * interaction_score * (b - a))
-        state.role_embedding = new_embed
+        state.apply_gossip(other_embedding, interaction_score)
 
     def change_role(self: Self, new_role: str, current_step: int) -> bool:
         state = self._require_state()

--- a/src/agents/core/role_embeddings.py
+++ b/src/agents/core/role_embeddings.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import hashlib
+import math
+
+from .roles import INITIAL_ROLES
+
+
+def _compute_embedding(text: str, dim: int = 8) -> list[float]:
+    """Return a deterministic embedding vector for ``text``."""
+    digest = hashlib.sha256(text.encode()).hexdigest()
+    segment_len = len(digest) // dim
+    return [
+        int(digest[i * segment_len : (i + 1) * segment_len], 16) / (16 ** segment_len)
+        for i in range(dim)
+    ]
+
+
+class RoleEmbeddingManager:
+    """Manage role embeddings and reputation scores."""
+
+    def __init__(self) -> None:
+        self.role_vectors: dict[str, list[float]] = {
+            role: _compute_embedding(role) for role in INITIAL_ROLES
+        }
+        self.reputation: dict[str, float] = {role: 0.0 for role in INITIAL_ROLES}
+
+    @staticmethod
+    def similarity(v1: list[float], v2: list[float]) -> float:
+        dot = sum(a * b for a, b in zip(v1, v2))
+        norm1 = math.sqrt(sum(a * a for a in v1))
+        norm2 = math.sqrt(sum(b * b for b in v2))
+        return dot / (norm1 * norm2) if norm1 and norm2 else 0.0
+
+    def best_role(self, query: str, threshold: float = 0.7) -> tuple[str | None, float]:
+        q_emb = _compute_embedding(query)
+        best_role = None
+        best_sim = -1.0
+        for role, vec in self.role_vectors.items():
+            sim = self.similarity(q_emb, vec)
+            if sim > best_sim:
+                best_role = role
+                best_sim = sim
+        if best_sim < threshold:
+            return None, best_sim
+        return best_role, best_sim
+
+    def nearest_role_from_embedding(
+        self, embedding: list[float], threshold: float = 0.7
+    ) -> tuple[str | None, float]:
+        best_role = None
+        best_sim = -1.0
+        for role, vec in self.role_vectors.items():
+            sim = self.similarity(embedding, vec)
+            if sim > best_sim:
+                best_role = role
+                best_sim = sim
+        if best_sim < threshold:
+            return None, best_sim
+        return best_role, best_sim
+
+    def update_role_vector(self, role: str, other_vector: list[float], lr: float = 0.1) -> None:
+        current = self.role_vectors.get(role)
+        if current is None:
+            self.role_vectors[role] = list(other_vector)
+        else:
+            self.role_vectors[role] = [
+                a + lr * (b - a) for a, b in zip(current, other_vector)
+            ]
+
+    def update_reputation(self, role: str, value: float) -> None:
+        cur = self.reputation.get(role, 0.0)
+        self.reputation[role] = (cur + value) / 2
+
+
+ROLE_EMBEDDINGS = RoleEmbeddingManager()

--- a/tests/integration/agents/test_role_vector_adaptation.py
+++ b/tests/integration/agents/test_role_vector_adaptation.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from src.agents.core import roles
+from src.agents.core.role_embeddings import ROLE_EMBEDDINGS
 from src.agents.graphs import basic_agent_graph as bag
 
 
@@ -19,7 +20,7 @@ def test_role_change_allowed_by_similarity() -> None:
         last_action_step=0,
         short_term_memory=[],
         du=0.0,
-        role_embedding=roles.ROLE_EMBEDDINGS[roles.ROLE_INNOVATOR],
+        role_embedding=ROLE_EMBEDDINGS.role_vectors[roles.ROLE_INNOVATOR],
         role_reputation={},
     )
     assert bag.process_role_change(state, roles.ROLE_ANALYZER)

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 import pytest
 
 from src.agents.core import roles
+from src.agents.core.role_embeddings import ROLE_EMBEDDINGS
 from src.agents.graphs import basic_agent_graph as bag
+from src.infra import ledger as ledger_mod
 
 
 class DummyController:
@@ -28,23 +30,59 @@ def make_agent_state() -> SimpleNamespace:
         last_action_step=0,
         short_term_memory=[],
         du=0.0,
-        role_embedding=roles.ROLE_EMBEDDINGS[roles.ROLE_INNOVATOR],
+        role_embedding=ROLE_EMBEDDINGS.role_vectors[roles.ROLE_INNOVATOR],
         role_reputation={},
     )
+
+
+class DummyLedger:
+    def log_change(self, *args: object, **kwargs: object) -> None:
+        pass
 
 
 @pytest.mark.unit
 def test_process_role_change_success(monkeypatch: pytest.MonkeyPatch) -> None:
     state = make_agent_state()
+    monkeypatch.setattr(ledger_mod, "ledger", DummyLedger())
     assert bag.process_role_change(state, "Analyzer") is True
     assert state.current_role == "Analyzer"
     assert state.ip == 8.0
 
 
 @pytest.mark.unit
+def test_process_role_change_invalid_role() -> None:
+    state = make_agent_state()
+    ledger_mod.ledger = DummyLedger()
+    original = ROLE_EMBEDDINGS.best_role
+
+    def fake_best_role(role: str, threshold: float = 0.7) -> tuple[str | None, float]:
+        return None, 0.0
+
+    ROLE_EMBEDDINGS.best_role = fake_best_role
+    try:
+        assert not bag.process_role_change(state, "UnknownRole")
+    finally:
+        ROLE_EMBEDDINGS.best_role = original
+    assert state.current_role == "Innovator"
+
+
+@pytest.mark.unit
+def test_process_role_change_similarity_threshold() -> None:
+    state = make_agent_state()
+    ledger_mod.ledger = DummyLedger()
+    state.role_embedding = [0.0] * 8
+    assert not bag.process_role_change(state, "Analyzer")
+    state.role_embedding = ROLE_EMBEDDINGS.role_vectors[roles.ROLE_ANALYZER]
+    state.steps_in_current_role = 5
+    state.ip = 10.0
+    assert bag.process_role_change(state, "Analyzer")
+
+
+@pytest.mark.unit
 def test_update_state_node_role_change(monkeypatch: pytest.MonkeyPatch) -> None:
     state = make_agent_state()
     controller = DummyController(state)
+    monkeypatch.setattr(ledger_mod, "ledger", DummyLedger())
     monkeypatch.setattr(bag, "AgentController", lambda s: controller)
     monkeypatch.setattr(random, "random", lambda: 0.9)
 


### PR DESCRIPTION
## Summary
- manage latent role vectors via new `role_embeddings` module
- update `basic_agent_graph` role change logic to use embeddings
- let `AgentState` track learned roles from gossip
- adjust unit tests for new embedding behavior

## Testing
- `ruff check .`
- `pytest -q tests/unit/graphs/test_basic_agent_graph_utils.py::test_process_role_change_success tests/unit/graphs/test_basic_agent_graph_utils.py::test_process_role_change_invalid_role tests/unit/graphs/test_basic_agent_graph_utils.py::test_process_role_change_similarity_threshold -s`

------
https://chatgpt.com/codex/tasks/task_e_685b545cb63483268b92873a16c9268c