### PR TITLE
Implement semantic memory grouping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ langgraph==0.2.0
 requests==2.32.3
 sqlite-web
 
+numpy>=2
+
 sqlalchemy==2.0.41
 asyncpg==0.30.0
 

--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -15,6 +15,7 @@ from .graph_nodes import (
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
+    retrieve_semantic_context_node,
 )
 from .interaction_handlers import (
     handle_ask_clarification_node,
@@ -40,6 +41,7 @@ def build_graph() -> Any:
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)
     graph_builder.add_node("retrieve_and_summarize_memories", retrieve_and_summarize_memories_node)
+    graph_builder.add_node("retrieve_semantic_context", retrieve_semantic_context_node)
     graph_builder.add_node("generate_thought_and_message", generate_thought_and_message_node)
 
     graph_builder.add_node("route_action_intent", route_action_intent)
@@ -59,7 +61,8 @@ def build_graph() -> Any:
     graph_builder.set_entry_point("analyze_perception_sentiment")
     graph_builder.add_edge("analyze_perception_sentiment", "prepare_relationship_prompt")
     graph_builder.add_edge("prepare_relationship_prompt", "retrieve_and_summarize_memories")
-    graph_builder.add_edge("retrieve_and_summarize_memories", "generate_thought_and_message")
+    graph_builder.add_edge("retrieve_and_summarize_memories", "retrieve_semantic_context")
+    graph_builder.add_edge("retrieve_semantic_context", "generate_thought_and_message")
     graph_builder.add_edge("generate_thought_and_message", "route_action_intent")
 
     graph_builder.add_conditional_edges(

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -68,6 +68,24 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     return {"rag_summary": summary, "memory_history_list": memories}
 
 
+async def retrieve_semantic_context_node(state: AgentTurnState) -> dict[str, Any]:
+    """Retrieve semantically grouped context for the agent."""
+    semantic_manager: SemanticMemoryManager | None = state.get("semantic_manager")
+    if not semantic_manager:
+        return {"semantic_context": ""}
+    query = state.get("rag_summary", "")
+    import asyncio
+
+    memories = await asyncio.to_thread(
+        semantic_manager.retrieve_context,
+        state["agent_id"],
+        query,
+        5,
+    )
+    context = "\n".join(m.get("content", "") for m in memories)
+    return {"semantic_context": context}
+
+
 async def generate_thought_and_message_node(
     state: AgentTurnState,
 ) -> dict[str, AgentActionOutput | None]:

--- a/tests/integration/memory/test_semantic_group_retrieval.py
+++ b/tests/integration/memory/test_semantic_group_retrieval.py
@@ -1,0 +1,55 @@
+import unittest
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+
+@pytest.mark.integration
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+class TestSemanticGroupingRetrieval(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject(self, request, chroma_test_dir):
+        self.request = request
+        self.chroma_test_dir = chroma_test_dir
+
+    def setUp(self):
+        self.vector_store = ChromaVectorStoreManager(persist_directory=self.chroma_test_dir)
+        self.manager = SemanticMemoryManager(self.vector_store, driver=None)
+        self.agent_id = "semantic_agent"
+        for i in range(5):
+            self.vector_store.add_memory(
+                agent_id=self.agent_id,
+                step=i,
+                event_type="thought",
+                content=f"Cat likes napping {i}",
+                memory_type="raw",
+            )
+        for i in range(5):
+            self.vector_store.add_memory(
+                agent_id=self.agent_id,
+                step=10 + i,
+                event_type="thought",
+                content=f"Dog enjoys walking {i}",
+                memory_type="raw",
+            )
+        self.manager.group_memories_by_topic(self.agent_id, num_topics=2)
+
+    def tearDown(self):
+        client = getattr(self.vector_store, "client", None)
+        if client and hasattr(client, "close"):
+            client.close()
+
+    def test_hit_rate(self):
+        cat_res = self.manager.retrieve_context(self.agent_id, "sleepy cat", k=5)
+        dog_res = self.manager.retrieve_context(self.agent_id, "walk with dog", k=5)
+        cat_hits = sum(1 for m in cat_res if "cat" in m["content"].lower())
+        dog_hits = sum(1 for m in dog_res if "dog" in m["content"].lower())
+        total_hits = cat_hits + dog_hits
+        total = len(cat_res) + len(dog_res)
+        hit_rate = total_hits / total if total else 0
+        assert hit_rate > 0.7


### PR DESCRIPTION
## Summary
- implement a semantic memory grouping method that clusters memories by cosine similarity
- add a retrieval node that queries semantic groups
- wire the node into the basic agent graph
- add integration test stub for semantic grouping retrieval
- fix semantic memory grouping and add numpy dependency

## Testing
- `ruff format src/agents/memory/semantic_memory_manager.py > /tmp/ruff_format.log && tail -n 20 /tmp/ruff_format.log`
- `ruff check src/agents/memory/semantic_memory_manager.py`
- `pytest -m "integration and memory" tests/integration/memory/test_semantic_group_retrieval.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_685b54642f1c8326a6d040aa96278acc