### PR TITLE
Add vector behavior tests for KnowledgeBoard

### DIFF
--- a/tests/unit/sim/test_knowledge_board.py
+++ b/tests/unit/sim/test_knowledge_board.py
@@ -1,6 +1,9 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from src.sim.knowledge_board import KnowledgeBoard
+from src.sim.version_vector import VersionVector
 
 pytestmark = pytest.mark.unit
 
@@ -47,3 +50,51 @@ def test_get_recent_entries_with_none_summary() -> None:
     kb.entries[-1]["content_summary"] = None
     result = kb.get_recent_entries_for_prompt(1)
     assert result == ["[Step 1, A]: entry"]
+
+
+def test_add_entry_calls_increment_when_no_vector() -> None:
+    kb = KnowledgeBoard()
+    kb.vector.increment = MagicMock()
+    kb.vector.merge = MagicMock()
+
+    kb.add_entry("entry", agent_id="A", step=1)
+
+    kb.vector.increment.assert_called_once_with("A")
+    kb.vector.merge.assert_not_called()
+
+
+def test_add_entry_calls_merge_when_vector_supplied() -> None:
+    kb = KnowledgeBoard()
+    kb.vector.increment = MagicMock()
+    kb.vector.merge = MagicMock()
+
+    vec = {"B": 2}
+    kb.add_entry("entry", agent_id="A", step=1, vector=vec)
+
+    kb.vector.merge.assert_called_once()
+    arg = kb.vector.merge.call_args.args[0]
+    assert isinstance(arg, VersionVector)
+    assert arg.clock == vec
+    kb.vector.increment.assert_not_called()
+
+
+def test_add_law_proposal_increment_and_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    kb = KnowledgeBoard()
+    kb.vector.increment = MagicMock()
+    kb.vector.merge = MagicMock()
+
+    kb.add_law_proposal("test law", agent_id="A", step=2)
+    kb.vector.increment.assert_called_once_with("A")
+    kb.vector.merge.assert_not_called()
+
+    kb.vector.increment.reset_mock()
+    kb.vector.merge.reset_mock()
+
+    vec = {"A": 3}
+    kb.add_law_proposal("another", agent_id="A", step=3, vector=vec)
+
+    kb.vector.merge.assert_called_once()
+    arg = kb.vector.merge.call_args.args[0]
+    assert isinstance(arg, VersionVector)
+    assert arg.clock == vec
+    kb.vector.increment.assert_not_called()


### PR DESCRIPTION
## Summary
- add version vector import to KnowledgeBoard tests
- test that `add_entry` increments or merges board vectors appropriately
- test equivalent behaviour for `add_law_proposal`

## Testing
- `ruff check tests/unit/sim/test_knowledge_board.py`
- `pytest tests/unit/sim/test_knowledge_board.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685c13e68e088326aac4f6ff74335e1d