### PR TITLE
Update compile_agent_graph test

### DIFF
--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -81,11 +81,11 @@ class SemanticMemoryManager:
             self.topic_centroids[agent_id] = np.zeros((len(groups), 1))
             return groups
 
-        groups: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        topic_groups: dict[int, list[dict[str, Any]]] = defaultdict(list)
         centroids: list[np.ndarray] = []
         for mem, emb in zip(memories, embeddings):
             if not centroids:
-                groups[0].append(mem)
+                topic_groups[0].append(mem)
                 centroids.append(emb)
                 continue
             sims = (
@@ -93,18 +93,18 @@ class SemanticMemoryManager:
             )
             idx = int(np.argmax(sims))
             if sims[idx] < threshold and len(centroids) < num_topics:
-                groups[len(centroids)].append(mem)
+                topic_groups[len(centroids)].append(mem)
                 centroids.append(emb)
             else:
-                groups[idx].append(mem)
+                topic_groups[idx].append(mem)
                 c = centroids[idx]
-                centroids[idx] = (c * (len(groups[idx]) - 1) + emb) / len(groups[idx])
+                centroids[idx] = (c * (len(topic_groups[idx]) - 1) + emb) / len(topic_groups[idx])
 
-        self.topic_groups[agent_id] = groups
+        self.topic_groups[agent_id] = topic_groups
         self.topic_centroids[agent_id] = (
             np.stack(centroids) if centroids else np.empty((0, embeddings.shape[1]))
         )
-        return groups
+        return topic_groups
 
     def retrieve_context(
         self: Self, agent_id: str, query: str, k: int = 5

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -97,10 +97,10 @@ def load_snapshot(
             )
         with file_path.open("rb") as f:
             payload = zstd.ZstdDecompressor().decompress(f.read()).decode("utf-8")
-        data = json.loads(payload)
+        data = cast(dict[str, Any], json.loads(payload))
     else:
         with file_path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
+            data = cast(dict[str, Any], json.load(f))
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/tests/unit/graphs/test_agent_graph_builder.py
+++ b/tests/unit/graphs/test_agent_graph_builder.py
@@ -21,6 +21,7 @@ def test_build_graph_structure() -> None:
         "analyze_perception_sentiment",
         "prepare_relationship_prompt",
         "retrieve_and_summarize_memories",
+        "retrieve_semantic_context",
         "generate_thought_and_message",
         "route_action_intent",
         "handle_propose_idea",
@@ -36,9 +37,9 @@ def test_build_graph_structure() -> None:
         (START, "analyze_perception_sentiment"),
         ("analyze_perception_sentiment", "prepare_relationship_prompt"),
         ("prepare_relationship_prompt", "retrieve_and_summarize_memories"),
-        ("retrieve_and_summarize_memories", "generate_thought_and_message"),
+        ("retrieve_and_summarize_memories", "retrieve_semantic_context"),
+        ("retrieve_semantic_context", "generate_thought_and_message"),
         ("generate_thought_and_message", "route_action_intent"),
-
         ("handle_idle", "finalize_message_agent"),
         ("finalize_message_agent", END),
     }

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -128,20 +128,6 @@ def test_route_helpers() -> None:
 
 @pytest.mark.unit
 def test_compile_agent_graph(monkeypatch: pytest.MonkeyPatch) -> None:
-    import sys
-    import types
-
-    if "langgraph" not in sys.modules:
-        langgraph_mod = types.ModuleType("langgraph")
-        graph_mod = types.ModuleType("langgraph.graph")
-        graph_mod.StateGraph = object
-        graph_mod.END = "END"
-        sys.modules["langgraph"] = langgraph_mod
-        sys.modules["langgraph.graph"] = graph_mod
-
-    class DummyGraph:
-        def compile(self) -> str:
-            return "compiled"
-
-    monkeypatch.setattr("src.agents.graphs.agent_graph_builder.build_graph", lambda: DummyGraph())
-    assert bag.compile_agent_graph() == "compiled"
+    compiled = "compiled"
+    monkeypatch.setattr(bag, "build_graph", lambda: compiled)
+    assert bag.compile_agent_graph() == compiled


### PR DESCRIPTION
## Summary
- update test_compile_agent_graph to expect compiled output
- align graph builder test with current graph structure
- remove unused import in snapshot util
- fix mypy errors in snapshot loading and semantic memory manager

## Testing
- `ruff check --fix tests/unit/graphs/test_agent_graph_builder.py tests/unit/graphs/test_basic_agent_graph_utils.py src/infra/snapshot.py src/agents/memory/semantic_memory_manager.py`
- `black --check tests/unit/graphs/test_agent_graph_builder.py tests/unit/graphs/test_basic_agent_graph_utils.py src/infra/snapshot.py src/agents/memory/semantic_memory_manager.py`
- `mypy src/`
- `python scripts/run_tests.py -m unit`


------
https://chatgpt.com/codex/tasks/task_e_685c1094c70c8326af4c89703fd920af