### PR TITLE
Handle map action events

### DIFF
--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -218,3 +218,18 @@ async def emit_event(event: SimulationEvent) -> None:
                 },
             )
         )
+
+
+async def emit_map_action_event(
+    agent_id: str,
+    step: int,
+    action: str,
+    **details: Any,
+) -> None:
+    """Convenience helper to enqueue map actions."""
+    await emit_event(
+        SimulationEvent(
+            event_type="map_action",
+            data={"agent_id": agent_id, "step": step, "action": action, **details},
+        )
+    )

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -401,6 +401,47 @@ class SimulationDiscordBot:
         embed.add_field(name="Intent", value=action_intent, inline=True)
         return embed
 
+    def create_map_action_embed(
+        self: Self,
+        agent_id: str,
+        action: str,
+        details: dict[str, Any],
+        step: int,
+    ) -> Any:
+        """Creates an embed describing a world map action."""
+
+        color = discord.Color.blue()
+        if action == "move":
+            pos = details.get("position")
+            desc = f"Agent {agent_id[:8]} moved to {pos}"
+        elif action == "gather":
+            resource = details.get("resource")
+            success = details.get("success")
+            desc = (
+                f"Agent {agent_id[:8]} gathered {resource}"
+                if success
+                else f"Agent {agent_id[:8]} failed to gather {resource}"
+            )
+            color = discord.Color.green() if success else discord.Color.red()
+        elif action == "build":
+            structure = details.get("structure")
+            success = details.get("success")
+            desc = (
+                f"Agent {agent_id[:8]} built {structure}"
+                if success
+                else f"Agent {agent_id[:8]} failed to build {structure}"
+            )
+            color = discord.Color.dark_orange() if success else discord.Color.red()
+        else:
+            desc = f"Agent {agent_id[:8]} performed {action}"
+
+        embed = discord.Embed(
+            title=f"🗺️ Map Action (Step {step})",
+            description=desc,
+            color=color,
+        )
+        return embed
+
     async def run_bot(self: Self) -> None:
         """
         Start the Discord bot and connect to Discord.

--- a/tests/unit/interfaces/test_dashboard_map_action.py
+++ b/tests/unit/interfaces/test_dashboard_map_action.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+class DummyRequest:
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class DummyWS:
+    def __init__(self) -> None:
+        self.accepted = False
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+
+async def _clear_event_queue() -> None:
+    while not db.event_queue.empty():
+        _ = await db.event_queue.get()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_map_action_sse(monkeypatch: pytest.MonkeyPatch) -> None:
+    import src.http_app as http_app
+
+    class CaptureESR:
+        def __init__(self, gen: object) -> None:
+            self.gen = gen
+
+    monkeypatch.setattr(http_app, "EventSourceResponse", CaptureESR)
+    await _clear_event_queue()
+    await db.emit_map_action_event("A", 1, "move", position=(1, 0))
+    await db.event_queue.put(None)
+    resp = await http_app.stream_events(DummyRequest())
+    event = await resp.gen.__anext__()
+    data = json.loads(event["data"])
+    assert data["event_type"] == "map_action"
+    assert data["data"]["agent_id"] == "A"
+    with pytest.raises(StopAsyncIteration):
+        await resp.gen.__anext__()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_map_action_websocket() -> None:
+    ws = DummyWS()
+    await _clear_event_queue()
+    await db.emit_map_action_event("B", 2, "gather", resource="wood", success=True)
+    await db.event_queue.put(None)
+    await db.websocket_events(ws)
+    payload = json.loads(ws.sent[0])
+    assert payload["event_type"] == "map_action"
+    assert payload["data"]["agent_id"] == "B"


### PR DESCRIPTION
## Summary
- send map action updates to dashboards and Discord
- support map action emits in dashboard backend
- fix typing cast usage in snapshot util
- test dashboard map action event handlers

## Testing
- `pre-commit run --files src/interfaces/discord_bot.py src/interfaces/dashboard_backend.py src/sim/simulation.py src/infra/snapshot.py tests/unit/interfaces/test_dashboard_map_action.py`
- `pytest -m unit -q`

------
https://chatgpt.com/codex/tasks/task_e_685c472257fc8326a9c78308cb253954