### PR TITLE
Handle insufficient DU in LLM cost

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -118,15 +118,23 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                state.du -= cost
-                try:
-                    ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
-                except Exception as log_err:  # pragma: no cover - optional
+                if state.du - cost >= 0:
+                    state.du -= cost
+                    try:
+                        ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
+                    except Exception as log_err:  # pragma: no cover - optional
+                        logger.warning(
+                            "Ledger logging failed for %s (delta_du=%s)",
+                            state.agent_id,
+                            -cost,
+                            exc_info=log_err,
+                        )
+                else:
                     logger.warning(
-                        "Ledger logging failed for %s (delta_du=%s)",
+                        "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
-                        -cost,
-                        exc_info=log_err,
+                        cost,
+                        state.du,
                     )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")


### PR DESCRIPTION
## Summary
- avoid overdrawing Data Units when charging LLM costs
- test that DU never drops below zero

## Testing
- `ruff check src/infra/llm_client.py tests/unit/infra/test_llm_du_cost.py`
- `ruff format src/infra/llm_client.py tests/unit/infra/test_llm_du_cost.py`
- `mypy src/infra/llm_client.py tests/unit/infra/test_llm_du_cost.py`
- `pytest -c /dev/null tests/unit/infra/test_llm_du_cost.py::test_du_never_negative -q`

------
https://chatgpt.com/codex/tasks/task_e_685c46f58cac832698e16df1133add55