### PR TITLE
Add stress test for event kernel and extend ledger tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
         shell: bash
         run: pytest -m "integration" --disable-warnings -q
 
+      - name: Run Stress Tests
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: pytest -m "stress" --disable-warnings -q
+
       - name: Run Windows Path/Discord Integration
         if: matrix.os == 'windows-latest'
         shell: bash

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,6 +36,7 @@ markers =
     longevity: marks tests as longevity tests (can be slow)
     redteam: marks optional jailbreak-scanning tests that require garak
     require_ollama: marks tests that require a running Ollama server
+    stress: marks large-scale stress tests
 
 log_level = DEBUG 
 

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/tests/integration/ledger/test_auction_bidding.py
+++ b/tests/integration/ledger/test_auction_bidding.py
@@ -27,3 +27,25 @@ def test_auction_bidding_and_resolution(tmp_path: Path) -> None:
     assert du_b == pytest.approx(1.0)
     assert ledger.get_staked_du("A") == 0.0
     assert ledger.get_staked_du("B") == 0.0
+
+
+@pytest.mark.integration
+def test_auction_no_bids(tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+
+    auction_id = ledger.open_auction("empty")
+    winner, amount = ledger.resolve_auction(auction_id)
+
+    assert winner is None
+    assert amount == pytest.approx(0.0)
+
+
+@pytest.mark.integration
+def test_insufficient_balance_does_not_go_negative(tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+
+    ledger.log_change("A", 0.0, 5.0, "fund")
+    ledger.log_change("A", 0.0, -10.0, "overspend")
+
+    _, du = ledger.get_balance("A")
+    assert du == pytest.approx(0.0)

--- a/tests/stress/test_event_kernel_stress.py
+++ b/tests/stress/test_event_kernel_stress.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.sim.event_kernel import EventKernel
+from src.sim.version_vector import VersionVector
+
+pytestmark = pytest.mark.stress
+
+
+def _make_cb(order: list[int], n: int):
+    async def _cb() -> None:
+        order.append(n)
+
+    return _cb
+
+
+@pytest.mark.asyncio
+async def test_mass_event_dispatch_deterministic_replay() -> None:
+    event_count = 10_000
+    kernel = EventKernel()
+    order: list[int] = []
+
+    for i in range(event_count):
+        vv = VersionVector({"A": i + 1})
+        kernel.schedule_nowait(_make_cb(order, i), vector=vv)
+
+    executed = await kernel.dispatch(event_count)
+    assert executed == event_count
+    assert kernel.empty()
+    assert order == list(range(event_count))
+    vector_snapshot = kernel.vector.to_dict()
+
+    replay = EventKernel()
+    order_replay: list[int] = []
+    for i in range(event_count):
+        vv = VersionVector({"A": i + 1})
+        replay.schedule_nowait(_make_cb(order_replay, i), vector=vv)
+
+    executed_replay = await replay.dispatch(event_count)
+    assert executed_replay == event_count
+    assert order_replay == order
+    assert replay.vector.to_dict() == vector_snapshot


### PR DESCRIPTION
## Summary
- add stress test verifying deterministic replay of 10k events
- cover auction no-bid and insufficient balance cases
- allow `stress` marker in pytest and run it in CI
- fix missing import in snapshot util

## Testing
- `pre-commit run --files pytest.ini .github/workflows/ci.yml tests/integration/ledger/test_auction_bidding.py tests/stress/test_event_kernel_stress.py src/infra/snapshot.py`
- `pytest tests/stress/test_event_kernel_stress.py -m stress -q -n 0`
- `pytest tests/integration/ledger/test_auction_bidding.py -m integration -q -n 0`

------
https://chatgpt.com/codex/tasks/task_e_685c47291a048326bc67bf01649c74c5