### PR TITLE
Fix duplicate step increment in simulation

### DIFF
--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -103,9 +103,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -143,9 +143,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -312,9 +312,6 @@ class Simulation:
             self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
             self.pending_messages_for_next_round = []
 
-            # Increment current_step for this agent's turn. current_step becomes 1-indexed.
-            self.current_step += 1
-
             agent_to_run_index = self.current_agent_index
             agent = self.agents[agent_to_run_index]
             agent_id = agent.agent_id
@@ -328,9 +325,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {len(self.messages_to_perceive_this_round)} messages from pending_messages_for_next_round."

--- a/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
+++ b/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
@@ -883,21 +883,13 @@ class TestConflictResolution(unittest.IsolatedAsyncioTestCase):
 
             # Assertion 5: Agent A's message to Agent C should be in pending_messages
             # (or messages_to_perceive_this_round if sim has advanced to next round perception phase already)
-            # For now, check pending_messages_for_next_round as current_step was just completed for Agent A
-            # The current_step would have been incremented by run_step to 4.
-            # Messages sent in step 3 (Agent A's turn) will be recorded with step=3.
-
-            # Correct step for Agent A's second message is self.simulation.current_step -1 (because current_step was already incremented)
-            # However, the mock is for its turn, so the message in pending should reflect the step it was *generated* in.
-            # When agent A (index 0) runs, simulation current_step is 3.
-            # After its turn, simulation.current_step becomes 4.
-            # Messages are logged with the step they occurred in.
-            # Agent A's turn was step 3 of the simulation (0-indexed overall steps).
+            # For now we inspect ``pending_messages_for_next_round`` since Agent A
+            # just completed its turn. ``run_step`` increments ``current_step`` to
+            # ``4`` at the start of this turn, so messages generated now should be
+            # recorded with step ``4``.
 
             agent_a_message_to_c_found = False
-            for (
-                msg
-            ) in (
+            for msg in (
                 self.simulation.pending_messages_for_next_round
             ):  # Check messages generated THIS turn
                 if (


### PR DESCRIPTION
## Summary
- fix `_run_agent_turn` double incrementing `current_step`
- update comment in conflict resolution scenario test to match new logic
- import `cast` in snapshot utilities

## Testing
- `ruff format src/infra/snapshot.py src/sim/simulation.py tests/integration/conflict_resolution/test_conflict_resolution_scenario.py`
- `ruff check src/infra/snapshot.py src/sim/simulation.py tests/integration/conflict_resolution/test_conflict_resolution_scenario.py tests/integration/test_dynamic_role_change.py`
- `mypy --config-file pyproject.toml src/infra/snapshot.py src/sim/simulation.py`
- `python scripts/run_tests.py -m unit tests/unit/core/test_agent_controller_updates.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685c46f34d6c8326b7af9b7b1aa2de7d