### PR TITLE
Fix embedding utils import error

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
 import time
 from typing import Any, cast
@@ -13,17 +12,9 @@ from src.agents.core.mood_utils import get_descriptive_mood
 from src.agents.dspy_programs.intent_selector import IntentSelectorProgram
 from src.infra.config import get_config
 
+from .embedding_utils import compute_embedding
+
 logger = logging.getLogger(__name__)
-
-
-def _compute_embedding(text: str, dim: int = 8) -> list[float]:
-    """Return a deterministic embedding vector for ``text``."""
-    digest = hashlib.sha256(text.encode()).hexdigest()
-    segment_len = len(digest) // dim
-    return [
-        int(digest[i * segment_len : (i + 1) * segment_len], 16) / (16**segment_len)
-        for i in range(dim)
-    ]
 
 
 class AgentController:
@@ -244,7 +235,7 @@ class AgentController:
 
             sender_emb = msg.get("sender_embedding")
             if sender_emb is None and msg.get("sender_role"):
-                sender_emb = _compute_embedding(str(msg.get("sender_role")))
+                sender_emb = compute_embedding(str(msg.get("sender_role")))
             if sender_emb is not None:
                 self.gossip_update(sender_emb, float(sentiment_value))
 

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -5,7 +5,6 @@ Defines the base class for all agents in the Culture simulation.
 
 import asyncio
 import copy
-import hashlib
 import logging
 import uuid
 from collections.abc import Awaitable
@@ -28,6 +27,8 @@ from src.infra import config
 from src.infra.async_dspy_manager import AsyncDSPyManager
 from src.infra.config import get_config
 from src.infra.llm_client import get_ollama_client
+
+from .embedding_utils import compute_embedding
 
 if TYPE_CHECKING:
     from src.interfaces.dashboard_backend import AgentMessage as DashboardAgentMessage
@@ -81,16 +82,6 @@ from src.agents.dspy_programs.role_thought_generator import get_role_thought_gen
 AgentMessage = DashboardAgentMessage
 
 logger = logging.getLogger(__name__)
-
-
-def compute_embedding(text: str, dim: int = 8) -> list[float]:
-    """Return a deterministic embedding vector for ``text``."""
-    digest = hashlib.sha256(text.encode()).hexdigest()
-    segment_len = len(digest) // dim
-    return [
-        int(digest[i * segment_len : (i + 1) * segment_len], 16) / (16**segment_len)
-        for i in range(dim)
-    ]
 
 
 class Agent:

--- a/src/agents/core/embedding_utils.py
+++ b/src/agents/core/embedding_utils.py
@@ -1,0 +1,15 @@
+"""Utility functions for embeddings used across agents."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def compute_embedding(text: str, dim: int = 8) -> list[float]:
+    """Return a deterministic embedding vector for ``text``."""
+    digest = hashlib.sha256(text.encode()).hexdigest()
+    segment_len = len(digest) // dim
+    return [
+        int(digest[i * segment_len : (i + 1) * segment_len], 16) / (16**segment_len)
+        for i in range(dim)
+    ]

--- a/src/agents/core/role_embeddings.py
+++ b/src/agents/core/role_embeddings.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
-import hashlib
+# Skip self argument annotation warnings for simple methods
+# ruff: noqa: ANN101
 import math
 
+from .embedding_utils import compute_embedding
 from .roles import INITIAL_ROLES
-
-
-def _compute_embedding(text: str, dim: int = 8) -> list[float]:
-    """Return a deterministic embedding vector for ``text``."""
-    digest = hashlib.sha256(text.encode()).hexdigest()
-    segment_len = len(digest) // dim
-    return [
-        int(digest[i * segment_len : (i + 1) * segment_len], 16) / (16**segment_len)
-        for i in range(dim)
-    ]
 
 
 class RoleEmbeddingManager:
@@ -21,7 +13,7 @@ class RoleEmbeddingManager:
 
     def __init__(self) -> None:
         self.role_vectors: dict[str, list[float]] = {
-            role: _compute_embedding(role) for role in INITIAL_ROLES
+            role: compute_embedding(role) for role in INITIAL_ROLES
         }
         self.reputation: dict[str, float] = {role: 0.0 for role in INITIAL_ROLES}
 
@@ -33,7 +25,7 @@ class RoleEmbeddingManager:
         return dot / (norm1 * norm2) if norm1 and norm2 else 0.0
 
     def best_role(self, query: str, threshold: float = 0.7) -> tuple[str | None, float]:
-        q_emb = _compute_embedding(query)
+        q_emb = compute_embedding(query)
         best_role = None
         best_sim = -1.0
         for role, vec in self.role_vectors.items():

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:


### PR DESCRIPTION
## Summary
- centralize `compute_embedding` helper for reuse across agents
- import `compute_embedding` from new module
- add missing `cast` import to snapshot utilities

## Testing
- `pre-commit run --files src/infra/snapshot.py src/agents/core/base_agent.py src/agents/core/agent_controller.py src/agents/core/role_embeddings.py src/agents/core/embedding_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685c47045db08326b3abcd5dad557443