### PR TITLE
Enhance EventKernel with trace hashes and token limits

### DIFF
--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -664,9 +664,9 @@ class Simulation:
                 vector=self.vector,
             )
 
-        executed = await self.event_kernel.dispatch(max_turns)
+        events = await self.event_kernel.dispatch(max_turns)
         self.vector = self.event_kernel.vector
-        return executed
+        return len(events)
 
     async def async_run(self: Self, num_steps: int) -> None:
         """

--- a/tests/unit/sim/test_event_kernel.py
+++ b/tests/unit/sim/test_event_kernel.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.sim.event_kernel import EventKernel
+from src.sim.version_vector import VersionVector
 
 pytestmark = pytest.mark.unit
 
@@ -21,9 +22,9 @@ async def test_schedule_order_fifo() -> None:
     await kernel.schedule(_make_cb(order, 2))
     await kernel.schedule(_make_cb(order, 3))
 
-    executed = await kernel.dispatch(10)
+    events = await kernel.dispatch(10)
 
-    assert executed == 3
+    assert len(events) == 3
     assert order == [1, 2, 3]
     assert kernel.empty()
 
@@ -36,12 +37,47 @@ async def test_dispatch_limit() -> None:
     for i in range(3):
         kernel.schedule_nowait(_make_cb(order, i))
 
-    executed = await kernel.dispatch(2)
-    assert executed == 2
+    events = await kernel.dispatch(2)
+    assert len(events) == 2
     assert order == [0, 1]
     assert not kernel.empty()
 
-    executed += await kernel.dispatch(2)
-    assert executed == 3
+    events += await kernel.dispatch(2)
+    assert len(events) == 3
     assert order == [0, 1, 2]
     assert kernel.empty()
+
+
+@pytest.mark.asyncio
+async def test_token_budget_enforced() -> None:
+    kernel = EventKernel()
+    kernel.set_budget("A", 2)
+    order: list[int] = []
+
+    kernel.schedule_nowait(_make_cb(order, 1), agent_id="A")
+    kernel.schedule_nowait(_make_cb(order, 2), agent_id="A")
+    with pytest.raises(ValueError):
+        kernel.schedule_nowait(_make_cb(order, 3), agent_id="A")
+
+    events = await kernel.dispatch(10)
+    assert len(events) == 2
+    assert order == [1, 2]
+    assert kernel.get_budget("A") == 0
+
+
+@pytest.mark.asyncio
+async def test_vector_merging() -> None:
+    kernel = EventKernel()
+    order: list[int] = []
+
+    vv1 = VersionVector({"A": 1})
+    vv2 = VersionVector({"B": 2})
+
+    kernel.schedule_nowait(_make_cb(order, 1), vector=vv1)
+    kernel.schedule_nowait(_make_cb(order, 2), vector=vv2)
+
+    events = await kernel.dispatch(10)
+
+    assert len(events) == 2
+    assert kernel.vector.to_dict() == {"A": 1, "B": 2}
+    assert all(e.trace_hash for e in events)


### PR DESCRIPTION
## Summary
- add trace hash to events and enforce token budgets
- use new dispatch API returning events
- track remaining budget via `get_budget`
- update Simulation.run_step accordingly
- test budget handling and version vector merging

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q tests/unit/sim/test_event_kernel.py`
- `pytest -q tests/unit/sim/test_simulation_role_change.py tests/unit/sim/test_simulation_logging.py`
- `pytest -q tests/unit/sim`

------
https://chatgpt.com/codex/tasks/task_e_685c47a689ac83268252975392165ef8