### PR TITLE
Add ledger gas price tracking and staking tests

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -1,4 +1,3 @@
-# ruff: noqa: ANN401, ANN101, ANN102
 """Provides a client for interacting with the Ollama LLM service."""
 
 from __future__ import annotations
@@ -120,7 +119,14 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                 cost = base_price + token_price * tokens
                 state.du -= cost
                 try:
-                    ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
+                    ledger.log_change(
+                        state.agent_id,
+                        0.0,
+                        -cost,
+                        "llm_gas",
+                        gas_price_per_call=base_price,
+                        gas_price_per_token=token_price,
+                    )
                 except Exception as log_err:  # pragma: no cover - optional
                     logger.warning(
                         "Ledger logging failed for %s (delta_du=%s)",

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import typing
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 try:
     import zstandard as zstd
@@ -102,7 +101,6 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/tests/integration/ledger/test_action_staking_refund.py
+++ b/tests/integration/ledger/test_action_staking_refund.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+
+from src.infra.ledger import Ledger
+
+
+@pytest.mark.integration
+def test_action_staking_and_refund(tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+
+    ledger.log_change("A", 0.0, 5.0, "fund")
+
+    ledger.stake_du_for_action("A", "act1", 3.0)
+
+    assert ledger.get_staked_du("A") == pytest.approx(3.0)
+    _, du = ledger.get_balance("A")
+    assert du == pytest.approx(2.0)
+
+    ledger.claim_action_refund("A", "act1")
+
+    assert ledger.get_staked_du("A") == pytest.approx(0.0)
+    _, du_after = ledger.get_balance("A")
+    assert du_after == pytest.approx(5.0)

--- a/tests/integration/ledger/test_gas_price_tracking.py
+++ b/tests/integration/ledger/test_gas_price_tracking.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.core.agent_state import AgentState
+from src.infra import config, llm_client
+from src.infra.ledger import Ledger
+
+
+@pytest.mark.integration
+@pytest.mark.require_ollama
+def test_gas_price_logging(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("GAS_PRICE_PER_CALL", "1.0")
+    monkeypatch.setenv("GAS_PRICE_PER_TOKEN", "0.0")
+    config.load_config(validate_required=False)
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr(llm_client, "ledger", ledger)
+
+    def fake_chat(*args: object, **kwargs: object) -> dict[str, object]:
+        return {
+            "message": {"content": "ok"},
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+
+    monkeypatch.setattr(llm_client, "client", SimpleNamespace(chat=fake_chat))
+
+    state = AgentState(agent_id="A", name="Agent", ip=0.0, du=5.0)
+    ledger.log_change(state.agent_id, 0.0, 5.0, "fund")
+
+    llm_client.generate_text("hi", agent_state=state)
+
+    row = ledger.conn.execute(
+        "SELECT gas_price_per_call, gas_price_per_token FROM transactions WHERE reason='llm_gas' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row == (1.0, 0.0)
+
+    monkeypatch.setenv("GAS_PRICE_PER_CALL", "2.0")
+    monkeypatch.setenv("GAS_PRICE_PER_TOKEN", "0.5")
+    config.load_config(validate_required=False)
+
+    llm_client.generate_text("bye", agent_state=state)
+
+    row = ledger.conn.execute(
+        "SELECT gas_price_per_call, gas_price_per_token FROM transactions WHERE reason='llm_gas' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row == (2.0, 0.5)


### PR DESCRIPTION
## Summary
- track gas price per call and per token in ledger transactions
- allow agents to stake DU on actions and claim refunds
- log gas price details when charging DU
- verify staking refunds and gas price updates
- run linters

## Testing
- `pipx run ruff check src/infra/ledger.py src/infra/llm_client.py`
- `pipx run ruff format src/infra/ledger.py src/infra/llm_client.py`
- `pipx run mypy src/infra/ledger.py src/infra/llm_client.py`
- `pytest -m integration tests/integration/ledger/test_action_staking_refund.py tests/integration/ledger/test_gas_price_tracking.py -vv`
- `pytest tests/unit/infra/test_snapshot.py::test_load_snapshot_roundtrip tests/unit/infra/test_snapshot.py::test_load_snapshot_hash_mismatch -vv`

------
https://chatgpt.com/codex/tasks/task_e_685c471bfc00832684f13b9e85496534