### PR TITLE
Refine debug logging and fix DU calculation

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -117,24 +117,30 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                state.du -= cost
-                try:
-                    ledger.log_change(
-                        state.agent_id,
-                        0.0,
-                        -cost,
-                        "llm_gas",
-                        gas_price_per_call=base_price,
-                        gas_price_per_token=token_price,
-                    )
-                except Exception as log_err:  # pragma: no cover - optional
-
-                    logger.warning(
+                if state.du < cost:
+                    logger.debug(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
+                else:
+                    state.du -= cost
+                    try:
+                        ledger.log_change(
+                            state.agent_id,
+                            0.0,
+                            -cost,
+                            "llm_gas",
+                            gas_price_per_call=base_price,
+                            gas_price_per_token=token_price,
+                        )
+                    except Exception as log_err:  # pragma: no cover - optional
+                        logger.warning(
+                            "Failed to log DU deduction for agent %s: %s",
+                            state.agent_id,
+                            log_err,
+                        )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result
@@ -150,7 +156,8 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse: ...
+    ) -> LLMChatResponse:
+        ...
 
 
 class LLMClientConfig(BaseModel):

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -43,7 +43,7 @@ class EventKernel:
 
     def get_budget(self: Self, agent_id: str) -> int:
         """Return remaining token budget for ``agent_id``."""
-        return self._budgets.get(agent_id, 0)
+        return int(self._budgets.get(agent_id, 0))
 
     async def schedule(
         self: Self,

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -20,24 +20,27 @@ T = TypeVar("T")
 
 
 class LoggingList(list[T], Generic[T]):
-    def clear(self: Self) -> None:
-        logger.debug(f"LOGGING_LIST_DEBUG ({id(self)}): clear() called")
-        super().clear()
+    """List that emits a brief debug message when modified."""
 
-    def __delitem__(self: Self, key: SupportsIndex | slice) -> None:
-        if isinstance(key, slice) and key.start is None and key.stop is None and key.step is None:
-            logger.debug(f"LOGGING_LIST_DEBUG ({id(self)}): __delitem__[:] called (del self[:])")
-        super().__delitem__(key)
+    def _log_change(self: Self) -> None:
+        logger.debug("LoggingList length now %d", len(self))
 
     def __init__(self: Self, *args: Any, **kwargs: Any) -> None:
-        logger.debug(
-            f"LOGGING_LIST_DEBUG: Initializing new LoggingList instance ({id(self)}) from args: {args}"
-        )
         super().__init__(*args, **kwargs)
+        logger.debug("LoggingList initialized with %d entries", len(self))
+
+    def clear(self: Self) -> None:
+        super().clear()
+        self._log_change()
+
+    def __delitem__(self: Self, key: SupportsIndex | slice) -> None:
+        super().__delitem__(key)
+        self._log_change()
 
     # For MyPy, if we override methods that are checked for type hints:
     def append(self: Self, item: T) -> None:
         super().append(item)
+        self._log_change()
 
     # __setitem__ is not overridden to keep superclass type checking intact
 


### PR DESCRIPTION
## Summary
- simplify `LoggingList` debug output
- guard against negative DU balance when charging costs
- fix mypy complaint in `EventKernel`

## Testing
- `bash scripts/lint.sh`
- `python scripts/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_685d85cef4688326bcb45e2d59c41214