### PR TITLE
Add RoleProfile helpers and fix DU logic

### DIFF
--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -9,6 +9,7 @@ from typing_extensions import Self
 
 from src.agents.core.agent_state import AgentState
 from src.agents.core.mood_utils import get_descriptive_mood
+from src.agents.core.roles import create_role_profile
 from src.agents.dspy_programs.intent_selector import IntentSelectorProgram
 from src.infra.config import get_config
 
@@ -98,7 +99,7 @@ class AgentController:
             logger.info(
                 "AGENT_STATE (%s): Role changed from %s to %s. IP cost: %.2f. New IP: %.2f",
                 state.agent_id,
-                state.current_role,
+                state.current_role.name,
                 new_role,
                 state._role_change_ip_cost,
                 state.ip,
@@ -114,7 +115,7 @@ class AgentController:
                 )
             except Exception:  # pragma: no cover - ledger optional
                 logger.debug("Ledger logging failed", exc_info=True)
-            state.current_role = new_role
+            state.current_role = create_role_profile(new_role)
             state.steps_in_current_role = 0
             state.role_history.append((current_step, new_role))
             return True
@@ -122,7 +123,7 @@ class AgentController:
 
     def can_change_role(self: Self, new_role: str, current_step: int) -> bool:
         state = self._require_state()
-        if new_role == state.current_role:
+        if new_role == state.current_role.name:
             logger.debug(
                 "AGENT_STATE (%s): Role change to %s denied (already current role).",
                 state.agent_id,

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -16,6 +16,7 @@ from src.agents.core.agent_graph_types import AgentTurnState
 from src.agents.core.agent_state import AgentState
 from src.agents.core.mood_utils import get_descriptive_mood
 from src.agents.core.role_embeddings import ROLE_EMBEDDINGS
+from src.agents.core.roles import ensure_profile
 
 # Import L1SummaryGenerator for DSPy-based L1 summary generation
 from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
@@ -151,13 +152,16 @@ DU_COST_REQUEST_DETAILED_CLARIFICATION = config.DU_COST_REQUEST_DETAILED_CLARIFI
 
 def _get_current_role(agent_state: AgentState) -> str:
     if hasattr(agent_state, "current_role"):
-        return cast(str, getattr(agent_state, "current_role"))
+        cur = getattr(agent_state, "current_role")
+        if hasattr(cur, "name"):
+            return cast(str, cur.name)
+        return cast(str, cur)
     return cast(str, getattr(agent_state, "role"))
 
 
 def _set_current_role(agent_state: AgentState, role: str) -> None:
     if hasattr(agent_state, "current_role"):
-        agent_state.current_role = role
+        agent_state.current_role = ensure_profile(role)
     else:
         setattr(agent_state, "role", role)
 

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -117,18 +117,20 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                state.du -= cost
-                try:
-                    ledger.log_change(
-                        state.agent_id,
-                        0.0,
-                        -cost,
-                        "llm_gas",
-                        gas_price_per_call=base_price,
-                        gas_price_per_token=token_price,
-                    )
-                except Exception as log_err:  # pragma: no cover - optional
-
+                if state.du >= cost:
+                    state.du -= cost
+                    try:
+                        ledger.log_change(
+                            state.agent_id,
+                            0.0,
+                            -cost,
+                            "llm_gas",
+                            gas_price_per_call=base_price,
+                            gas_price_per_token=token_price,
+                        )
+                    except Exception:  # pragma: no cover - optional
+                        logger.debug("Ledger logging failed", exc_info=True)
+                else:
                     logger.warning(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,

--- a/tests/unit/core/test_agent_controller_updates.py
+++ b/tests/unit/core/test_agent_controller_updates.py
@@ -3,6 +3,7 @@ import pytest
 try:
     from src.agents.core.agent_controller import AgentController
     from src.agents.core.agent_state import AgentState
+    from src.agents.core.roles import create_role_profile
 except IndentationError:
     pytest.skip("agent_state module is unparsable", allow_module_level=True)
 
@@ -47,11 +48,11 @@ def test_update_relationship_learning_rates_and_history() -> None:
 
 @pytest.mark.unit
 def test_change_role_cost_and_cooldown() -> None:
-    state = AgentState(agent_id="a1", name="A", current_role="Facilitator", ip=10.0)
+    state = AgentState(agent_id="a1", name="A", current_role=create_role_profile("Facilitator"), ip=10.0)
     controller = AgentController(state)
 
     assert controller.change_role("Innovator", current_step=1)
-    assert state.current_role == "Innovator"
+    assert state.current_role.name == "Innovator"
     assert state.ip == pytest.approx(5.0)
 
     assert not controller.change_role("Analyzer", current_step=2)

--- a/tests/unit/core/test_role_embedding.py
+++ b/tests/unit/core/test_role_embedding.py
@@ -2,12 +2,13 @@ import pytest
 
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentState
+from src.agents.core.roles import create_default_role_profiles
 
 
 @pytest.mark.unit
 def test_role_embedding_initialized() -> None:
-    s1 = AgentState(agent_id="a1", name="A")
-    s2 = AgentState(agent_id="a2", name="B")
+    s1 = AgentState(agent_id="a1", name="A", current_role="Facilitator")
+    s2 = AgentState(agent_id="a2", name="B", current_role="Analyzer")
     assert len(s1.role_embedding) == 8
     assert len(s2.role_embedding) == 8
     assert s1.role_embedding != s2.role_embedding
@@ -30,3 +31,22 @@ def test_role_prompt_contains_embedding() -> None:
     prompt = state.role_prompt
     assert isinstance(prompt, str)
     assert f"{state.role_embedding[0]:.2f}" in prompt
+
+
+@pytest.mark.unit
+def test_create_default_profiles() -> None:
+    profiles = create_default_role_profiles()
+    assert set(profiles.keys())
+    for name, prof in profiles.items():
+        assert prof.name == name
+        assert len(prof.embedding) == 8
+        assert prof.reputation == 0.0
+
+
+@pytest.mark.unit
+def test_gossip_updates_reputation() -> None:
+    state = AgentState(agent_id="a", name="A")
+    controller = AgentController(state)
+    other = [v + 0.5 for v in state.role_embedding]
+    controller.gossip_update(other, 1.0)
+    assert state.current_role.reputation != 0.0

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from src.agents.core import roles
 from src.agents.core.role_embeddings import ROLE_EMBEDDINGS
+from src.agents.core.roles import create_role_profile
 from src.agents.graphs import basic_agent_graph as bag
 from src.infra import ledger as ledger_mod
 
@@ -21,7 +22,7 @@ class DummyController:
 def make_agent_state() -> SimpleNamespace:
     return SimpleNamespace(
         agent_id="a",
-        current_role="Innovator",
+        current_role=create_role_profile("Innovator"),
         steps_in_current_role=5,
         role_change_cooldown=3,
         ip=10.0,
@@ -45,7 +46,7 @@ def test_process_role_change_success(monkeypatch: pytest.MonkeyPatch) -> None:
     state = make_agent_state()
     monkeypatch.setattr(ledger_mod, "ledger", DummyLedger())
     assert bag.process_role_change(state, "Analyzer") is True
-    assert state.current_role == "Analyzer"
+    assert state.current_role.name == "Analyzer"
     assert state.ip == 8.0
 
 
@@ -63,7 +64,7 @@ def test_process_role_change_invalid_role() -> None:
         assert not bag.process_role_change(state, "UnknownRole")
     finally:
         ROLE_EMBEDDINGS.best_role = original
-    assert state.current_role == "Innovator"
+    assert state.current_role.name == "Innovator"
 
 
 @pytest.mark.unit
@@ -97,7 +98,7 @@ def test_update_state_node_role_change(monkeypatch: pytest.MonkeyPatch) -> None:
         }
     )
 
-    assert state.current_role == "Analyzer"
+    assert state.current_role.name == "Analyzer"
     assert controller.added[0][0].startswith("Changed role")
     assert output["data_units"] == int(state.du)
 

--- a/tests/unit/infra/test_checkpoint.py
+++ b/tests/unit/infra/test_checkpoint.py
@@ -36,7 +36,7 @@ def test_checkpoint_save_and_load(tmp_path, monkeypatch):
     assert "random" in meta["rng_state"]
 
     assert random.random() == expected_next
-    assert loaded.agents[0].state.current_role == sim.agents[0].state.current_role
+    assert loaded.agents[0].state.current_role.name == sim.agents[0].state.current_role.name
 
 
 def test_deterministic_replay_multiple_runs(tmp_path, monkeypatch):
@@ -75,7 +75,7 @@ def test_numpy_rng_restore(tmp_path, monkeypatch):
 
     assert "numpy" in meta["rng_state"]
     assert np.random.random() == expected_next
-    assert loaded.agents[0].state.current_role == sim.agents[0].state.current_role
+    assert loaded.agents[0].state.current_role.name == sim.agents[0].state.current_role.name
 
 
 def test_checkpoint_preserves_board_and_collective_metrics(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- provide compatibility layer for `AgentState.role`
- ensure role profiles are parsed from dicts
- guard DU deductions against negatives
- adapt tests for deterministic role embeddings

## Testing
- `ruff check .`
- `pytest -m "unit and not dspy" -q`

------
https://chatgpt.com/codex/tasks/task_e_685d85e0b0688326800354d9a74671c0