### PR TITLE
Schedule simulation events deterministically

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -130,29 +130,11 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                         logger.debug("Ledger logging failed", exc_info=True)
                 else:
                     logger.warning(
-
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(
-                            state.agent_id,
-                            0.0,
-                            -cost,
-                            "llm_gas",
-                            gas_price_per_call=base_price,
-                            gas_price_per_token=token_price,
-                        )
-                    except Exception as log_err:  # pragma: no cover - optional
-                        logger.warning(
-                            "Failed to log DU deduction for agent %s: %s",
-                            state.agent_id,
-                            log_err,
-                        )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result
@@ -168,8 +150,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse:
-        ...
+    ) -> LLMChatResponse: ...
 
 
 class LLMClientConfig(BaseModel):

--- a/tests/stress/test_event_kernel_stress.py
+++ b/tests/stress/test_event_kernel_stress.py
@@ -24,7 +24,7 @@ async def test_mass_event_dispatch_deterministic_replay() -> None:
         kernel.schedule_nowait(_make_cb(order, i), vector=vv)
 
     executed = await kernel.dispatch(event_count)
-    assert executed == event_count
+    assert len(executed) == event_count
     assert kernel.empty()
     assert order == list(range(event_count))
     vector_snapshot = kernel.vector.to_dict()
@@ -36,6 +36,6 @@ async def test_mass_event_dispatch_deterministic_replay() -> None:
         replay.schedule_nowait(_make_cb(order_replay, i), vector=vv)
 
     executed_replay = await replay.dispatch(event_count)
-    assert executed_replay == event_count
+    assert len(executed_replay) == event_count
     assert order_replay == order
     assert replay.vector.to_dict() == vector_snapshot

--- a/tests/unit/sim/test_world_map.py
+++ b/tests/unit/sim/test_world_map.py
@@ -82,7 +82,7 @@ def test_move_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     agent = ActionAgent({"action": "move", "dx": 1, "dy": 0})
     sim = Simulation([agent])  # type: ignore[arg-type,list-item]
 
-    asyncio.run(sim.run_step())
+    asyncio.run(sim.run_step(max_turns=2))
 
     ip, du = ledger.get_balance(agent.agent_id)
     assert ip == pytest.approx(config.MAP_MOVE_IP_REWARD - config.MAP_MOVE_IP_COST)
@@ -103,7 +103,7 @@ def test_gather_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     sim = Simulation([agent])  # type: ignore[arg-type,list-item]
     sim.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
 
-    asyncio.run(sim.run_step())
+    asyncio.run(sim.run_step(max_turns=2))
 
     ip, du = ledger.get_balance(agent.agent_id)
     assert ip == pytest.approx(config.MAP_GATHER_IP_REWARD - config.MAP_GATHER_IP_COST)
@@ -124,7 +124,7 @@ def test_build_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     sim = Simulation([agent])  # type: ignore[arg-type,list-item]
     sim.world_map.agent_resources[agent.agent_id] = {"wood": 1}
 
-    asyncio.run(sim.run_step())
+    asyncio.run(sim.run_step(max_turns=2))
 
     ip, du = ledger.get_balance(agent.agent_id)
     assert ip == pytest.approx(config.MAP_BUILD_IP_REWARD - config.MAP_BUILD_IP_COST)


### PR DESCRIPTION
## Summary
- fix DU charge helper syntax
- queue map actions and memory tasks through EventKernel
- dispatch scheduled events in async_run
- update world map tests for event queueing
- adjust event kernel stress test expectations

## Testing
- `pytest tests/unit/sim/test_world_map.py::test_move_updates_balance -q`
- `pytest tests/unit/sim/test_world_map.py tests/integration/sim/test_world_map.py -q`
- `pytest tests/unit/sim/test_simulation_role_change.py::test_role_change_grants_extra_turn -q`
- `pytest -m integration tests/integration/sim/test_world_map.py::test_agent_move_updates_map_and_events -q`
- `pytest -m stress tests/stress/test_event_kernel_stress.py::test_mass_event_dispatch_deterministic_replay -q`


------
https://chatgpt.com/codex/tasks/task_e_685da27934f08326b99e03edf535c164