### PR TITLE
Add role embedding reputation tracking

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -33,6 +33,7 @@ from src.agents.core.roles import (
     create_role_profile,
     ensure_profile,
 )
+from .embedding_utils import compute_embedding
 from src.infra.config import get_config  # Import get_config function
 from src.infra.llm_client import LLMClient, LLMClientConfig
 
@@ -42,14 +43,18 @@ logger = logging.getLogger(__name__)
 def field_validator(*args: Any, **kwargs: Any) -> Any:
     """Compatibility wrapper for Pydantic field validators."""
     if not _PYDANTIC_V2:
-        kwargs.pop("mode", None)
+        mode = kwargs.pop("mode", None)
+        if mode == "before":
+            kwargs["pre"] = True
     return _field_validator(*args, **kwargs)
 
 
 def model_validator(*args: Any, **kwargs: Any) -> Any:
     """Compatibility wrapper for Pydantic model validators."""
     if not _PYDANTIC_V2:
-        kwargs.pop("mode", None)
+        mode = kwargs.pop("mode", None)
+        if mode == "before":
+            kwargs["pre"] = True
     return _model_validator(*args, **kwargs)
 
 
@@ -195,6 +200,8 @@ class AgentStateData(BaseModel):
     conversation_history: deque[str] = Field(
         default_factory=deque
     )  # Added for process_perceived_messages
+    role_embedding: list[float] = Field(default_factory=list)
+    reputation_score: float = 0.0
 
     # Configuration parameters (will be initialized from global config)
     _max_short_term_memory: int = PrivateAttr(
@@ -330,21 +337,13 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         return "Contribute to the simulation as effectively as possible."
 
     # ------------------------------------------------------------------
-    # Role embedding compatibility layer
+    # Role embedding utilities
     # ------------------------------------------------------------------
-    @property
-    def role_embedding(self) -> list[float]:
-        return self.current_role.embedding
-
-    @role_embedding.setter
-    def role_embedding(self, value: list[float]) -> None:
-        self.current_role.embedding = value
-
     @property
     def role_prompt(self) -> str:
         """Return a prompt snippet derived from the embedding and reputation."""
         avg_rep = sum(self.reputation.values()) / len(self.reputation) if self.reputation else 0.0
-        role_rep = self.current_role.reputation
+        role_rep = self.reputation_score
         emb_str = " ".join(f"{v:.2f}" for v in self.role_embedding)
         return f"Embedding: {emb_str}; reputation: {avg_rep:.2f}; role_rep: {role_rep:.2f}"
 
@@ -358,6 +357,8 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
     @role.setter
     def role(self, value: str) -> None:
         self.current_role = create_role_profile(value)
+        self.role_embedding = list(self.current_role.embedding)
+        self.reputation_score = self.current_role.reputation
 
     @property
     def ip_cost_per_message(self) -> float:
@@ -421,16 +422,20 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         if not self.current_role.embedding or not other_embedding:
             return
         lr = 0.1
-        self.current_role.embedding = [
-            a + lr * interaction_score * (b - a) for a, b in zip(self.current_role.embedding, other_embedding)
+        self.role_embedding = [
+            a + lr * interaction_score * (b - a)
+            for a, b in zip(self.role_embedding, other_embedding)
         ]
+        self.current_role.embedding = list(self.role_embedding)
         role_name, sim = ROLE_EMBEDDINGS.nearest_role_from_embedding(other_embedding)
         if role_name:
             cur = self.role_reputation.get(role_name, 0.0)
             self.role_reputation[role_name] = (cur + sim * interaction_score) / 2
             self.learned_roles[role_name] = other_embedding
             if role_name == self.current_role.name:
-                self.current_role.reputation = self.role_reputation[role_name]
+                self.reputation_score = self.role_reputation[role_name]
+            ROLE_EMBEDDINGS.update_role_vector(role_name, other_embedding)
+            ROLE_EMBEDDINGS.update_reputation(role_name, sim * interaction_score)
 
     @field_validator("current_role", mode="before")
     @classmethod
@@ -494,6 +499,18 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                 model["role_reputation"] = {}
             if not model.get("learned_roles"):
                 model["learned_roles"] = {}
+            if not model.get("role_embedding"):
+                cur = model.get("current_role")
+                if isinstance(cur, RoleProfile):
+                    model["role_embedding"] = list(cur.embedding)
+                else:
+                    model["role_embedding"] = compute_embedding(str(cur))
+            if not model.get("reputation_score"):
+                cur_role = model.get("current_role")
+                if isinstance(cur_role, RoleProfile):
+                    model["reputation_score"] = cur_role.reputation
+                else:
+                    model["reputation_score"] = 0.0
             return model
         else:
             if not model.role_history:
@@ -505,6 +522,10 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                 model.role_reputation = {}
             if not model.learned_roles:
                 model.learned_roles = {}
+            if not model.role_embedding:
+                model.role_embedding = list(model.current_role.embedding)
+            if not model.reputation_score:
+                model.reputation_score = model.current_role.reputation
             return model
 
     def get_llm_client(self) -> Any:
@@ -554,4 +575,8 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             obj.role_reputation = {}
         if not obj.learned_roles:
             obj.learned_roles = {}
+        if not obj.role_embedding:
+            obj.role_embedding = list(obj.current_role.embedding)
+        if not obj.reputation_score:
+            obj.reputation_score = obj.current_role.reputation
         return obj

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -211,6 +211,8 @@ class Agent:
         agent_state_kwargs["current_role"] = ensure_profile(role_value)
         if role_embedding is not None:
             agent_state_kwargs["current_role"].embedding = role_embedding
+        agent_state_kwargs["role_embedding"] = list(agent_state_kwargs["current_role"].embedding)
+        agent_state_kwargs["reputation_score"] = agent_state_kwargs["current_role"].reputation
         agent_state_kwargs["steps_in_current_role"] = steps_in_role  # derived above
         agent_state_kwargs["mood"] = mood  # derived above
         agent_state_kwargs["agent_goal"] = agent_goal  # derived above

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, cast
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_graph_types import AgentTurnState
 from src.agents.core.agent_state import AgentState
+from src.agents.core.embedding_utils import compute_embedding
 from src.agents.core.mood_utils import get_descriptive_mood
 from src.agents.core.role_embeddings import ROLE_EMBEDDINGS
 from src.agents.core.roles import ensure_profile
@@ -177,9 +178,12 @@ def _embedding_similarity(vec1: list[float], vec2: list[float]) -> float:
 
 
 def process_role_change(agent_state: AgentState, requested_role: str) -> bool:
-    resolved_role, _ = ROLE_EMBEDDINGS.best_role(requested_role)
+    req_emb = compute_embedding(requested_role)
+    resolved_role, _ = ROLE_EMBEDDINGS.nearest_role_from_embedding(req_emb)
     if resolved_role is None:
-        logger.warning(f"Agent {agent_state.agent_id} requested invalid role: {requested_role}")
+        logger.warning(
+            f"Agent {agent_state.agent_id} requested invalid role: {requested_role}"
+        )
         return False
     requested_role = resolved_role
     current_role = _get_current_role(agent_state)

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -130,29 +130,11 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                         logger.debug("Ledger logging failed", exc_info=True)
                 else:
                     logger.warning(
-
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(
-                            state.agent_id,
-                            0.0,
-                            -cost,
-                            "llm_gas",
-                            gas_price_per_call=base_price,
-                            gas_price_per_token=token_price,
-                        )
-                    except Exception as log_err:  # pragma: no cover - optional
-                        logger.warning(
-                            "Failed to log DU deduction for agent %s: %s",
-                            state.agent_id,
-                            log_err,
-                        )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result


### PR DESCRIPTION
## Summary
- manage role vectors and reputation updates in `RoleEmbeddingManager`
- store `role_embedding` and `reputation_score` in `AgentState`
- adjust agent initialization and role change logic to use nearest-neighbor matching
- fix DU cost accounting logic
- test gossip updates and global manager changes

## Testing
- `ruff check src/agents/core src/agents/graphs/basic_agent_graph.py src/infra/llm_client.py tests/unit/core/test_role_embedding.py`
- `pytest tests/unit/core/test_role_embedding.py -n0 -q`


------
https://chatgpt.com/codex/tasks/task_e_685da27e440c8326b7493d4f0c90f311