### PR TITLE
Implement L2 summary LLM fallback

### DIFF
--- a/src/agents/dspy_programs/l2_summary_generator.py
+++ b/src/agents/dspy_programs/l2_summary_generator.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from src.infra import llm_client
 from src.infra.dspy_ollama_integration import configure_dspy_with_ollama, dspy
 
 # Configure logging
@@ -142,11 +143,18 @@ class L2SummaryGenerator:
         """
         try:
             if not self.l2_predictor or not dspy:
-                # Fallback if DSPy is not available - this would need a direct LLM implementation
                 logger.warning(
-                    "DSPy not available for L2 summary generation - fallback not implemented"
+                    "DSPy not available for L2 summary generation - using direct LLM fallback"
                 )
-                return ""
+                prompt = (
+                    "Summarize the following L1 summaries into a concise L2 overview.\n"
+                    f"Agent Role: {agent_role}\n"
+                    f"Agent Goals: {agent_goals or 'N/A'}\n"
+                    f"Mood Trend: {overall_mood_trend or 'N/A'}\n"
+                    f"L1 SUMMARIES:\n{l1_summaries_context}\n\nL2 SUMMARY:"
+                )
+                llm_result = llm_client.generate_text(prompt, temperature=0.3)
+                return llm_result or ""
 
             logger.debug(f"Generating L2 summary for agent in role: {agent_role}")
             logger.debug(f"L1 summaries context: {l1_summaries_context[:200]}...")

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -130,29 +130,11 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                         logger.debug("Ledger logging failed", exc_info=True)
                 else:
                     logger.warning(
-
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(
-                            state.agent_id,
-                            0.0,
-                            -cost,
-                            "llm_gas",
-                            gas_price_per_call=base_price,
-                            gas_price_per_token=token_price,
-                        )
-                    except Exception as log_err:  # pragma: no cover - optional
-                        logger.warning(
-                            "Failed to log DU deduction for agent %s: %s",
-                            state.agent_id,
-                            log_err,
-                        )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result
@@ -168,8 +150,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse:
-        ...
+    ) -> LLMChatResponse: ...
 
 
 class LLMClientConfig(BaseModel):


### PR DESCRIPTION
## Summary
- call `generate_text` when DSPy is unavailable in L2 summary generator
- fix syntax in `llm_client` so mypy/tests run
- test the new fallback path

## Testing
- `ruff check src/agents/dspy_programs/l2_summary_generator.py tests/unit/test_dspy_summary_generators.py src/infra/llm_client.py`
- `mypy src/agents/dspy_programs/l2_summary_generator.py src/infra/llm_client.py`
- `pytest tests/unit/test_dspy_summary_generators.py::TestL2SummaryGeneratorFallback::test_direct_llm_fallback_used_when_dspy_missing -m "" -q`

------
https://chatgpt.com/codex/tasks/task_e_685da28acae483269bbf91d75544f7b5