### PR TITLE
Implement role change handling

### DIFF
--- a/tests/integration/test_dynamic_role_change.py
+++ b/tests/integration/test_dynamic_role_change.py
@@ -213,7 +213,6 @@ class TestDynamicRoleChange(unittest.IsolatedAsyncioTestCase):
         3. AgentC posts a counter-critique or opposing view to B's post, creating conflict on KB.
         4. AgentA observes the conflict, decides to change role to Facilitator, and attempts to mediate.
         """
-        pytest.xfail("Graph stub does not fully implement role change dynamics")
         logger.info("Starting test_agent_changes_role_to_facilitate...")
 
         # --- Step 1: AgentA (Innovator) proposes an idea ---


### PR DESCRIPTION
## Summary
- process requested role change during message finalization
- enable dynamic role change test

## Testing
- `pre-commit run --files src/agents/graphs/graph_nodes.py tests/integration/test_dynamic_role_change.py`
- `python scripts/run_tests.py -m unit` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685da26a4fc88326826498b7bc4ff376