### PR TITLE
Implement semantic summary consolidation

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -130,29 +130,11 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                         logger.debug("Ledger logging failed", exc_info=True)
                 else:
                     logger.warning(
-
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(
-                            state.agent_id,
-                            0.0,
-                            -cost,
-                            "llm_gas",
-                            gas_price_per_call=base_price,
-                            gas_price_per_token=token_price,
-                        )
-                    except Exception as log_err:  # pragma: no cover - optional
-                        logger.warning(
-                            "Failed to log DU deduction for agent %s: %s",
-                            state.agent_id,
-                            log_err,
-                        )
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 from src.agents.core import ResourceManager
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentActionIntent
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaDBException
 from src.infra import config  # Import to access MAX_PROJECT_MEMBERS
 from src.infra.event_log import log_event
@@ -34,6 +35,7 @@ from src.sim.world_map import ResourceToken, StructureType, WorldMap
 # Use TYPE_CHECKING to avoid circular import issues if Agent needs Simulation later
 if TYPE_CHECKING:
     from src.agents.core.base_agent import Agent
+    from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
     from src.agents.memory.vector_store import ChromaVectorStoreManager
     from src.interfaces.discord_bot import SimulationDiscordBot
 
@@ -53,6 +55,7 @@ class Simulation:
         self: Self,
         agents: list["Agent"],
         vector_store_manager: Optional["ChromaVectorStoreManager"] = None,
+        semantic_manager: Optional["SemanticMemoryManager"] = None,
         scenario: str = "",
         discord_bot: Optional["SimulationDiscordBot"] = None,
     ) -> None:
@@ -108,9 +111,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -128,6 +131,9 @@ class Simulation:
                 "Simulation initialized without vector store manager. "
                 "Memory will not be persisted."
             )
+
+        self.semantic_manager = semantic_manager
+        self._last_semantic_job_step = 0
         self._last_memory_prune_step = 0
         self._last_consolidation_step = 0
         self._last_trace_hash = ""
@@ -148,9 +154,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -654,6 +660,24 @@ class Simulation:
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.error("Failed nightly consolidation: %s", exc)
         self._last_consolidation_step = self.current_step
+
+        semantic_interval = int(
+            config.get_config_value_with_override(
+                "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS",
+                config.SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS,
+            )
+        )
+        if (
+            self.semantic_manager
+            and semantic_interval > 0
+            and self.current_step - self._last_semantic_job_step >= semantic_interval
+        ):
+            for ag in self.agents:
+                try:
+                    await self.semantic_manager.run_nightly_job(ag.agent_id)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.error("Failed semantic nightly job: %s", exc)
+            self._last_semantic_job_step = self.current_step
 
         self.vector.increment(self.agents[next_agent_index].get_id())
         await self.event_kernel.schedule_at(

--- a/tests/integration/memory/test_semantic_recent_summaries.py
+++ b/tests/integration/memory/test_semantic_recent_summaries.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("chromadb")
+
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+async def test_nightly_job_and_retrieval(chroma_test_dir: str) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir,
+        embedding_function=lambda texts: [[0.0] for _ in texts],
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+
+    vector.add_memory("agent", 1, "thought", "first")
+    vector.add_memory("agent", 2, "thought", "second")
+
+    await manager.run_nightly_job("agent")
+
+    assert driver.store[0]["agent"] == "agent"
+    recent = manager.get_recent_summaries("agent", limit=1)
+    assert recent == ["first\nsecond"]

--- a/tests/integration/memory/test_simulation_semantic_job.py
+++ b/tests/integration/memory/test_simulation_semantic_job.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.infra import config
+from src.sim.simulation import Simulation
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = SimpleNamespace(ip=0.0, du=0.0, mood_level=0.0)
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, new_state: SimpleNamespace) -> None:
+        self.state = new_state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+
+def setup_semantic_manager(tmp_path):
+    vector = ChromaVectorStoreManager(
+        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+    return manager, vector, driver
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_simulation_schedules_semantic_job(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setitem(config.CONFIG_OVERRIDES, "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 1)
+    manager, vector, driver = setup_semantic_manager(tmp_path)
+    agent = DummyAgent("a1")
+    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+
+    vector.add_memory("a1", 0, "thought", "hello")
+
+    await sim.run_step()
+    assert driver.store  # summary written

--- a/tests/unit/memory/test_semantic_memory_manager.py
+++ b/tests/unit/memory/test_semantic_memory_manager.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
@@ -59,6 +61,8 @@ def test_consolidation_and_retrieval(tmp_path) -> None:
 
     summary = manager.consolidate_memories("agent")
     assert "first" in summary and "second" in summary
+
+    asyncio.get_event_loop().run_until_complete(manager.run_nightly_job("agent"))
     assert driver.store[0]["agent"] == "agent"
 
     recent = manager.get_recent_summaries("agent", limit=1)


### PR DESCRIPTION
## Summary
- refactor `SemanticMemoryManager` to persist summaries during nightly job
- expose recent summaries via dashboard API
- run nightly semantic job from `Simulation`
- provide new integration tests for semantic summaries
- fix semantic job scheduling

## Testing
- `bash scripts/lint.sh`
- `pytest -m integration tests/integration/memory/test_semantic_recent_summaries.py::test_nightly_job_and_retrieval -q`
- `pytest -m integration tests/integration/memory/test_simulation_semantic_job.py::test_simulation_schedules_semantic_job -q`


------
https://chatgpt.com/codex/tasks/task_e_685da27cf5fc83268922a0db7c7296ce