### PR TITLE
Add ledger hooks for all actions and token config

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -716,12 +716,20 @@ class Agent:
 
     def __str__(self: Self) -> str:
         """Returns a string representation of the agent."""
-        role = self._state.current_role.name if hasattr(self._state.current_role, "name") else self._state.current_role
+        role = (
+            self._state.current_role.name
+            if hasattr(self._state.current_role, "name")
+            else self._state.current_role
+        )
         return f"Agent(id={self.agent_id}, role={role})"
 
     def __repr__(self: Self) -> str:
         """Returns a detailed string representation for debugging."""
-        role = self._state.current_role.name if hasattr(self._state.current_role, "name") else self._state.current_role
+        role = (
+            self._state.current_role.name
+            if hasattr(self._state.current_role, "name")
+            else self._state.current_role
+        )
         return (
             f"Agent(agent_id='{self.agent_id}', role='{role}', "
             f"ip={self._state.ip}, du={self._state.du})"
@@ -1055,21 +1063,21 @@ class Agent:
         state.ip = max(0, state.ip)
         state.du = max(0, state.du)
 
-        # Record final deltas to ledger
+        # Record final deltas to ledger. Log even when no economic change
+        # occurred so the action itself is traceable in the ledger.
         final_ip_change = state.ip - start_ip
         final_du_change = state.du - start_du
-        if final_ip_change or final_du_change:
-            try:
-                from src.infra.ledger import ledger
+        try:
+            from src.infra.ledger import ledger
 
-                ledger.log_change(
-                    self.agent_id,
-                    final_ip_change,
-                    final_du_change,
-                    f"action:{action_intent}",
-                )
-            except Exception:  # pragma: no cover - ledger errors should not block
-                logger.debug("Ledger logging failed", exc_info=True)
+            ledger.log_change(
+                self.agent_id,
+                final_ip_change,
+                final_du_change,
+                f"action:{action_intent}",
+            )
+        except Exception:  # pragma: no cover - ledger errors should not block
+            logger.debug("Ledger logging failed", exc_info=True)
 
     def perceive_messages(self: Self, messages: list[SimulationMessage]) -> None:
         """Allows the agent to perceive messages from other agents or the environment."""

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -132,6 +132,22 @@ DEFAULT_CONFIG: dict[str, object] = {
     "MAX_AGENT_AGE": 10,
     "AGENT_TOKEN_BUDGET": 10000,
     "GENE_MUTATION_RATE": 0.1,
+    # Token economics per action intent
+    "ACTION_TOKEN_EFFECTS": {
+        "idle": {"cost": 0, "reward": 0},
+        "continue_collaboration": {"cost": 0, "reward": 0},
+        "propose_idea": {"cost": 1, "reward": 0},
+        "ask_clarification": {"cost": 1, "reward": 0},
+        "perform_deep_analysis": {"cost": 2, "reward": 0},
+        "create_project": {"cost": 2, "reward": 1},
+        "join_project": {"cost": 1, "reward": 0},
+        "leave_project": {"cost": 0, "reward": 0},
+        "request_role_change": {"cost": 1, "reward": 0},
+        "send_direct_message": {"cost": 0, "reward": 0},
+        "move": {"cost": 1, "reward": 0},
+        "gather": {"cost": 0, "reward": 0},
+        "build": {"cost": 2, "reward": 1},
+    },
 }
 
 # Global config dictionary
@@ -578,6 +594,9 @@ SNAPSHOT_COMPRESS = bool(get_config("SNAPSHOT_COMPRESS"))
 S3_BUCKET = get_config("S3_BUCKET")
 S3_PREFIX = get_config("S3_PREFIX")
 SNAPSHOT_INTERVAL_STEPS = get_config("SNAPSHOT_INTERVAL_STEPS")
+
+# Token costs and rewards per action intent
+ACTION_TOKEN_EFFECTS = get_config("ACTION_TOKEN_EFFECTS")
 
 
 # --- Helper Functions ---


### PR DESCRIPTION
## Summary
- define `ACTION_TOKEN_EFFECTS` config for intent token economics
- log agent actions to the ledger even when no DU/IP change occurs
- unit test verifying ledger hooks run on log_change

## Testing
- `ruff check src/agents/core/base_agent.py src/infra/config.py tests/unit/infra/test_ledger.py`
- `python scripts/run_tests.py -k test_log_change_triggers_hooks -m unit`


------
https://chatgpt.com/codex/tasks/task_e_685dd0febf908326b4a0848c3f1a5de1