### PR TITLE
Add async ledger service

### DIFF
--- a/src/infra/ledger_service.py
+++ b/src/infra/ledger_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+from .ledger import ledger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from pydantic import BaseModel
+else:  # pragma: no cover - optional dependency
+    try:
+        import uvicorn
+        from fastapi import FastAPI
+        from fastapi.responses import JSONResponse
+        from pydantic import BaseModel
+    except Exception:
+        from typing import Callable
+
+        class FastAPI:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def get(
+                self, *args: object, **kwargs: object
+            ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+                def dec(fn: Callable[..., Any]) -> Callable[..., Any]:
+                    return fn
+
+                return dec
+
+            def post(
+                self, *args: object, **kwargs: object
+            ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+                def dec(fn: Callable[..., Any]) -> Callable[..., Any]:
+                    return fn
+
+                return dec
+
+        class JSONResponse:
+            def __init__(self, content: Any, *args: object, **kwargs: object) -> None:
+                self.body = json.dumps(content).encode("utf-8")
+
+        class BaseModel:  # pragma: no cover - minimal stub
+            pass
+
+        uvicorn = None  # type: ignore
+
+
+app = FastAPI()
+
+
+class SpendRequest(BaseModel):
+    agent_id: str
+    ip: float = 0.0
+    du: float = 0.0
+    reason: str = "spend"
+
+
+class RewardRequest(BaseModel):
+    agent_id: str
+    ip: float = 0.0
+    du: float = 0.0
+    reason: str = "reward"
+
+
+@app.get("/balance/{agent_id}")
+async def get_balance(agent_id: str) -> JSONResponse:
+    ip, du = await ledger.get_balance_async(agent_id)
+    return JSONResponse({"ip": ip, "du": du})
+
+
+@app.post("/spend")
+async def spend(req: SpendRequest) -> JSONResponse:
+    ip, du = await ledger.spend(req.agent_id, ip=req.ip, du=req.du, reason=req.reason)
+    return JSONResponse({"ip": ip, "du": du})
+
+
+@app.post("/reward")
+async def reward(req: RewardRequest) -> JSONResponse:
+    ip, du = await ledger.reward(req.agent_id, ip=req.ip, du=req.du, reason=req.reason)
+    return JSONResponse({"ip": ip, "du": du})
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the ledger service.")
+    parser.add_argument("--version", action="store_true", help="Show version and exit")
+    return parser.parse_args(argv or [])
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.version:
+        from src import __version__
+
+        print(__version__)
+        return
+    host = os.getenv("LEDGER_HOST", "0.0.0.0")
+    port = int(os.getenv("LEDGER_PORT", "8001"))
+    if uvicorn is None:  # pragma: no cover - uvicorn missing
+        raise RuntimeError("uvicorn is required to run the service")
+    uvicorn.run(app, host=host, port=port)
+
+
+__all__ = ["app", "get_balance", "reward", "spend"]

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -1,7 +1,11 @@
 """Application configuration settings using pydantic."""
+
 from __future__ import annotations
 
-from pydantic import BaseSettings
+try:
+    from pydantic import BaseSettings  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - fallback for pydantic v2
+    from pydantic_settings import BaseSettings
 
 
 class ConfigSettings(BaseSettings):

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -120,9 +120,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -163,9 +163,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -383,6 +383,7 @@ class Simulation:
                     []
                 )  # Clear pending for the new round accumulation
 
+                debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
                     f"Turn {self.current_step} (Agent {agent_id}, Index 0): Initialized messages_to_perceive_this_round "
                     f"with {debug_len} messages from pending_messages_for_next_round."

--- a/tests/unit/infra/test_ledger_service.py
+++ b/tests/unit/infra/test_ledger_service.py
@@ -1,0 +1,75 @@
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def load_service():
+    if "fastapi" in sys.modules:
+        fastapi_mod = sys.modules["fastapi"]
+    else:
+        fastapi_mod = types.ModuleType("fastapi")
+        sys.modules["fastapi"] = fastapi_mod
+    if not hasattr(fastapi_mod, "FastAPI") or not hasattr(getattr(fastapi_mod, "FastAPI"), "post"):
+
+        class _FastAPI:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def get(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+            def post(self, *args: object, **kwargs: object):
+                def dec(fn):
+                    return fn
+
+                return dec
+
+        fastapi_mod.FastAPI = _FastAPI
+        responses_mod = types.ModuleType("fastapi.responses")
+
+        class _JSONResponse:
+            def __init__(self, content, *a, **k) -> None:
+                self.body = json.dumps(content).encode("utf-8")
+
+        responses_mod.JSONResponse = _JSONResponse
+        sys.modules["fastapi.responses"] = responses_mod
+    if "uvicorn" not in sys.modules:
+        uvicorn_mod = types.ModuleType("uvicorn")
+        uvicorn_mod.run = lambda *a, **k: None
+        sys.modules["uvicorn"] = uvicorn_mod
+    if "src.infra.ledger_service" in sys.modules:
+        del sys.modules["src.infra.ledger_service"]
+    return importlib.import_module("src.infra.ledger_service")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reward_and_spend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    svc = load_service()
+    from src.infra.ledger import Ledger
+
+    test_ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr(svc, "ledger", test_ledger)
+
+    req = svc.RewardRequest(agent_id="a", ip=2.0, du=3.0)
+    resp = await svc.reward(req)
+    data = json.loads(resp.body)
+    assert data["ip"] == pytest.approx(2.0)
+    assert data["du"] == pytest.approx(3.0)
+
+    spend_req = svc.SpendRequest(agent_id="a", du=1.0)
+    resp = await svc.spend(spend_req)
+    data = json.loads(resp.body)
+    assert data["du"] == pytest.approx(2.0)
+
+    bal_resp = await svc.get_balance("a")
+    data = json.loads(bal_resp.body)
+    assert data["ip"] == pytest.approx(2.0)
+    assert data["du"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- make ledger async-friendly and add reward/spend helpers
- expose simple FastAPI service for ledger testing
- patch settings to work with pydantic 2
- add unit tests for the service
- fix minor debug log variable

## Testing
- `ruff check src/infra/ledger.py src/infra/ledger_service.py tests/unit/infra/test_ledger_service.py src/infra/settings.py src/sim/simulation.py && black --check src/infra/ledger.py src/infra/ledger_service.py tests/unit/infra/test_ledger_service.py src/infra/settings.py src/sim/simulation.py`
- `pytest tests/unit/infra/test_ledger_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2e99958c8326a780875f3747081d