### PR TITLE
Validate required env vars on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # Example Environment Variables for Culture Project
+#
+# The following variables are required for startup:
+# OLLAMA_API_BASE, MODEL_NAME and REDPANDA_BROKER.
 
 # -- Ollama Configuration --
 # Base URL for your Ollama instance (e.g., http://localhost:11434)
-OLLAMA_API_BASE=http://localhost:11434
+OLLAMA_API_BASE=http://localhost:11434  # required
 # Timeout in seconds for Ollama API requests
 OLLAMA_REQUEST_TIMEOUT=10
 
@@ -26,7 +29,7 @@ WEAVIATE_URL=http://localhost:8080
 VECTOR_STORE_BACKEND=chroma
 
 # -- Model Configuration --
-MODEL_NAME=mistral:latest
+MODEL_NAME=mistral:latest  # required
 
 # -- Policy Agent Service --
 OPA_URL=http://opa
@@ -47,7 +50,7 @@ DISCORD_CHANNEL_ID=
 # Set to 1 to enable event logging and deterministic replay
 ENABLE_REDPANDA=0
 # Address of the Redpanda broker
-REDPANDA_BROKER=localhost:9092
+REDPANDA_BROKER=localhost:9092  # required
 
 # -- Snapshot Settings --
 # Set to 1 to compress snapshots with zstandard

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -1,13 +1,15 @@
 """Application configuration settings using pydantic."""
+
 from __future__ import annotations
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class ConfigSettings(BaseSettings):
     """Configuration loaded from environment variables and ``.env`` file."""
 
-    OLLAMA_API_BASE: str = "http://localhost:11434"
+    OLLAMA_API_BASE: str = ""
+    MODEL_NAME: str = ""
     DEFAULT_LLM_MODEL: str = "mistral:latest"
     DEFAULT_TEMPERATURE: float = 0.7
     MEMORY_THRESHOLD_L1: float = 0.2

--- a/tests/unit/infra/test_config_required_keys.py
+++ b/tests/unit/infra/test_config_required_keys.py
@@ -5,12 +5,14 @@ from src.infra import config
 
 @pytest.mark.unit
 def test_load_config_missing_required_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
     monkeypatch.delenv("REDPANDA_BROKER", raising=False)
     monkeypatch.delenv("OPA_URL", raising=False)
     monkeypatch.delenv("MODEL_NAME", raising=False)
     with pytest.raises(RuntimeError) as exc:
         config.load_config(validate_required=True)
     msg = str(exc.value)
+    assert "OLLAMA_API_BASE" in msg
     assert "REDPANDA_BROKER" in msg
     assert "OPA_URL" in msg
     assert "MODEL_NAME" in msg
@@ -18,6 +20,7 @@ def test_load_config_missing_required_keys(monkeypatch: pytest.MonkeyPatch) -> N
 
 @pytest.mark.unit
 def test_load_config_with_required_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_API_BASE", "http://localhost:11434")
     monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
     monkeypatch.setenv("OPA_URL", "http://opa")
     monkeypatch.setenv("MODEL_NAME", "test-model")
@@ -25,3 +28,4 @@ def test_load_config_with_required_keys(monkeypatch: pytest.MonkeyPatch) -> None
     assert cfg["REDPANDA_BROKER"] == "localhost:9092"
     assert cfg["OPA_URL"] == "http://opa"
     assert cfg["MODEL_NAME"] == "test-model"
+    assert cfg["OLLAMA_API_BASE"] == "http://localhost:11434"

--- a/tests/unit/infra/test_config_validation.py
+++ b/tests/unit/infra/test_config_validation.py
@@ -14,6 +14,17 @@ def test_missing_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_missing_ollama_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    monkeypatch.setenv("MODEL_NAME", "model")
+    monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        config.load_config(validate_required=True)
+    assert "OLLAMA_API_BASE" in str(exc.value)
+
+
+@pytest.mark.unit
 def test_empty_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
     monkeypatch.setenv("OPA_URL", "http://opa")
@@ -21,3 +32,14 @@ def test_empty_model_name(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(RuntimeError) as exc:
         config.load_config(validate_required=True)
     assert "MODEL_NAME" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_empty_ollama_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    monkeypatch.setenv("MODEL_NAME", "model")
+    monkeypatch.setenv("OLLAMA_API_BASE", "")
+    with pytest.raises(RuntimeError) as exc:
+        config.load_config(validate_required=True)
+    assert "OLLAMA_API_BASE" in str(exc.value)


### PR DESCRIPTION
## Summary
- ensure OLLAMA_API_BASE, REDPANDA_BROKER and MODEL_NAME are required
- update example environment file with required keys
- add MODEL_NAME and validation logic in config
- test failure when required keys missing

## Testing
- `ruff check src/infra/settings.py src/infra/config.py tests/unit/infra/test_config_required_keys.py tests/unit/infra/test_config_validation.py`
- `mypy src/infra/config.py src/infra/settings.py tests/unit/infra/test_config_required_keys.py tests/unit/infra/test_config_validation.py`
- `python scripts/run_tests.py tests/unit/infra/test_config_required_keys.py tests/unit/infra/test_config_validation.py -m unit -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2ea0a9f88326b2eb9f4688396aec