### PR TITLE
Implement Discord message handling

### DIFF
--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -1,7 +1,12 @@
 """Application configuration settings using pydantic."""
 from __future__ import annotations
 
-from pydantic import BaseSettings
+try:  # pragma: no cover - prefer pydantic-settings if available
+    from pydantic_settings import BaseSettings as _BaseSettings
+except Exception:  # pragma: no cover - fallback for older pydantic
+    from pydantic import BaseSettings as _BaseSettings  # type: ignore[no-redef]
+
+BaseSettings = _BaseSettings  # type: ignore[misc]
 
 
 class ConfigSettings(BaseSettings):

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,6 +7,19 @@ pytest.importorskip("discord")
 from src.interfaces import metrics
 from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
 
+
+class SimulationEvent:
+    def __init__(self, event_type: str, data: dict[str, object] | None = None) -> None:
+        self.event_type = event_type
+        self.data = data
+
+
+class AgentMessage:
+    def __init__(self, agent_id: str, content: str, step: int) -> None:
+        self.agent_id = agent_id
+        self.content = content
+        self.step = step
+
 sent_by_token: list[str] = []
 
 
@@ -13,18 +27,30 @@ class DummyDiscordClient:
     """Simple stand-in for discord.Client."""
 
     def __init__(self, *args: object, **kwargs: object) -> None:
-        self.event = lambda func: func
+        self._events: dict[str, object] = {}
+
+        def _event(func: object) -> object:
+            if hasattr(func, "__name__"):
+                self._events[func.__name__] = func
+            return func
+
+        self.event = _event
         self.user = "dummy"
 
     def get_channel(self, channel_id: int) -> object:  # pragma: no cover - minimal
         token = getattr(self, "token", None)
 
         class DummyChannel:
+            def __init__(self) -> None:
+                self.sent: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
             async def send(self_inner, *args: object, **kwargs: object) -> None:
+                self_inner.sent.append((args, kwargs))
                 if token is not None:
                     sent_by_token.append(token)
 
-        return DummyChannel()
+        self.channel = DummyChannel()
+        return self.channel
 
     async def start(self, token: str) -> None:  # pragma: no cover - not used
         self.token = token
@@ -83,3 +109,38 @@ async def test_stats_command(simulation_bot: SimulationDiscordBot) -> None:
     metrics.KNOWLEDGE_BOARD_SIZE.set(7)
     await stats.callback(ctx)
     ctx.send.assert_awaited_once_with("LLM latency: 42.0 ms; KB size: 7")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    q_events: asyncio.Queue[SimulationEvent] = asyncio.Queue()
+    q_msgs: asyncio.Queue[AgentMessage] = asyncio.Queue()
+
+    class Client(DummyDiscordClient):
+        pass
+
+    with patch("src.interfaces.discord_bot.discord.Client", Client), patch(
+        "src.interfaces.discord_bot.event_queue",
+        q_events,
+    ), patch("src.interfaces.discord_bot.message_sse_queue", q_msgs), patch(
+        "src.interfaces.dashboard_backend.EventSourceResponse", object
+    ):
+        bot = SimulationDiscordBot("token", 123)
+        assert "on_message" in bot.client._events
+        await bot.run_bot()
+
+        on_msg = bot.client._events["on_message"]
+        msg = MagicMock()
+        msg.content = "hello"
+        msg.author = "user1"
+        await on_msg(msg)
+        stored = await q_events.get()
+        assert stored.event_type == "broadcast"
+        assert (stored.data or {})["content"] == "hello"
+
+        await q_msgs.put(AgentMessage(agent_id="agent1", content="hi", step=0))
+        await asyncio.sleep(0)
+        assert bot.client.channel.sent
+
+        await bot.stop_bot()


### PR DESCRIPTION
## Summary
- extend SimulationDiscordBot with message handler
- ensure dashboard settings import works with pydantic 2
- add integration test for broadcast handling

## Testing
- `ruff check src/interfaces/discord_bot.py src/infra/settings.py tests/integration/interfaces/test_discord_bot.py`
- `mypy --config-file pyproject.toml src/interfaces/discord_bot.py tests/integration/interfaces/test_discord_bot.py --disable-error-code attr-defined --disable-error-code valid-type --disable-error-code no-redef --disable-error-code redundant-cast`
- `pytest tests/integration/interfaces/test_discord_bot.py::test_on_message_broadcast -m integration -n0 -vv`

------
https://chatgpt.com/codex/tasks/task_e_685f2e97a45c8326b830ce01f2ebfa0c