### PR TITLE
Add async board lock and update config

### DIFF
--- a/src/agents/dspy_programs/l2_summary_generator.py
+++ b/src/agents/dspy_programs/l2_summary_generator.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from src.infra import llm_client  # noqa: F401
 from src.infra.dspy_ollama_integration import configure_dspy_with_ollama, dspy
 
 # Configure logging

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -273,6 +273,7 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
                 [
                     str(mem.get("content", ""))
                     for mem in list(agent_state_obj.short_term_memory)[-10:]
+                    if hasattr(mem, "get")
                 ]
             )
             # Use public property with hasattr

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -105,7 +105,7 @@ def restore_environment(env: dict[str, Any]) -> None:
             os.environ.pop(key, None)
         else:
             os.environ[key] = str(value)
-    config.load_config()
+    config.load_config(validate_required=False)
     log_event({"type": "environment_change", "env": env})
 
 

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -119,6 +119,11 @@ DEFAULT_CONFIG: dict[str, object] = {
     "SNAPSHOT_INTERVAL_STEPS": 100,
     "MAX_AGENT_AGE": 10,
     "AGENT_TOKEN_BUDGET": 10000,
+    "ROLE_DU_GENERATION": {
+        "Facilitator": {"base": 1.0},
+        "Innovator": {"base": 1.0},
+        "Analyzer": {"base": 1.0},
+    },
     "GENE_MUTATION_RATE": 0.1,
 }
 

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pydantic_settings import BaseSettings
 
 
-
 class ConfigSettings(BaseSettings):
     """Configuration loaded from environment variables and ``.env`` file."""
 
@@ -111,6 +110,11 @@ class ConfigSettings(BaseSettings):
     SNAPSHOT_INTERVAL_STEPS: int = 100
     MAX_AGENT_AGE: int = 10
     AGENT_TOKEN_BUDGET: int = 10000
+    ROLE_DU_GENERATION: dict[str, object] = {
+        "Facilitator": {"base": 1.0},
+        "Innovator": {"base": 1.0},
+        "Analyzer": {"base": 1.0},
+    }
     GENE_MUTATION_RATE: float = 0.1
 
     class Config:

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -2,6 +2,7 @@
 Defines the Knowledge Board class for maintaining shared knowledge among agents.
 """
 
+import asyncio
 import logging
 import uuid
 from typing import Any, Generic, SupportsIndex, TypeVar
@@ -63,6 +64,8 @@ class KnowledgeBoard:
         else:
             self.entries = LoggingList()
         self.vector = VersionVector()
+        # Lock to synchronize concurrent access to ``entries``
+        self.lock = asyncio.Lock()
         logger.info(
             f"KnowledgeBoard initialized. Instance ID: {id(self)}. Entries list ID: {id(self.entries)} type: {type(self.entries)}"
         )

--- a/tests/integration/knowledge_board/test_concurrent_writes.py
+++ b/tests/integration/knowledge_board/test_concurrent_writes.py
@@ -1,0 +1,19 @@
+import asyncio
+
+import pytest
+
+from src.sim.knowledge_board import KnowledgeBoard
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_writes() -> None:
+    board = KnowledgeBoard()
+
+    async def writer(i: int) -> None:
+        async with board.lock:
+            board.add_entry(f"entry-{i}", "agent", i)
+
+    await asyncio.gather(*(writer(i) for i in range(20)))
+
+    assert len(board.get_full_entries()) == 20

--- a/tests/integration/sim/test_agent_lifecycle.py
+++ b/tests/integration/sim/test_agent_lifecycle.py
@@ -64,7 +64,9 @@ def test_agent_retirement_and_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
     assert agent.state.inheritance == 15.0
 
     child = DummyAgent("a2")
-    sim.spawn_agent(child, inheritance=agent.state.inheritance)
+    asyncio.get_event_loop().run_until_complete(
+        sim.spawn_agent(child, inheritance=agent.state.inheritance)
+    )
     assert child.state.ip == 25.0  # inherited 15 + default 10
     assert len(sim.agents) == 2
 
@@ -85,7 +87,9 @@ def test_gene_inheritance_no_mutation(monkeypatch: pytest.MonkeyPatch, tmp_path:
     asyncio.get_event_loop().run_until_complete(sim.run_step())
 
     child = DummyAgent("c")
-    sim.spawn_agent(child, inheritance=parent.state.inheritance, parent=parent)
+    asyncio.get_event_loop().run_until_complete(
+        sim.spawn_agent(child, inheritance=parent.state.inheritance, parent=parent)
+    )
 
     assert child.state.genes == parent.state.genes
     assert child.state.parent_id == "p"
@@ -110,7 +114,9 @@ def test_gene_inheritance_with_mutation(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     monkeypatch.setattr(random, "uniform", lambda a, b: 0.1)
     child = DummyAgent("c")
-    sim.spawn_agent(child, inheritance=parent.state.inheritance, parent=parent)
+    asyncio.get_event_loop().run_until_complete(
+        sim.spawn_agent(child, inheritance=parent.state.inheritance, parent=parent)
+    )
 
     assert child.state.genes["g1"] == pytest.approx(0.6)
     rows = ledger.conn.execute("SELECT parent_id, child_id FROM genealogy").fetchall()

--- a/tests/unit/infra/test_checkpoint.py
+++ b/tests/unit/infra/test_checkpoint.py
@@ -103,7 +103,7 @@ def test_checkpoint_loads_graph_board(tmp_path, monkeypatch):
     from tests.integration.knowledge_board.test_graph_backend import DummyDriver
 
     monkeypatch.setattr(neo4j.GraphDatabase, "driver", lambda *a, **k: DummyDriver())
-    config.load_config()
+    config.load_config(validate_required=False)
     sim = create_simulation(num_agents=1, steps=1, scenario="test")
     sim.knowledge_board.add_entry("hello", sim.agents[0].agent_id, step=0)
 

--- a/tests/unit/interfaces/test_discord_policy.py
+++ b/tests/unit/interfaces/test_discord_policy.py
@@ -23,7 +23,8 @@ class DummyDiscordClient:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    config.load_config(validate_required=False)
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"result": {"allow": False}}
     monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))
@@ -45,7 +46,8 @@ async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_opa_modifies_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    config.load_config(validate_required=False)
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"result": {"allow": True, "content": "bar"}}
     monkeypatch.setattr("src.utils.policy.requests.post", MagicMock(return_value=mock_resp))


### PR DESCRIPTION
## Summary
- guard knowledge board writes with `asyncio.Lock`
- acquire config without requiring env vars when running tests
- protect message buffers with a lock in `Simulation`
- relax config validation in checkpoint restore
- update default DU generation config
- fix OPA policy tests

## Testing
- `ruff check --fix src/infra/settings.py src/infra/config.py src/infra/checkpoint.py src/sim/simulation.py src/agents/graphs/basic_agent_graph.py src/agents/dspy_programs/l2_summary_generator.py tests/unit/infra/test_checkpoint.py tests/unit/interfaces/test_discord_policy.py`
- `pytest -m "unit"`

------
https://chatgpt.com/codex/tasks/task_e_685f2e9dfcc08326b3a67336270ccc49