### PR TITLE
Add Codex environment script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guidelines for Codex
+
+- Run tests and linters for every code change.
+- You may skip running tests and linters if the changes only modify documentation or code comments.

--- a/scripts/codex_environment.sh
+++ b/scripts/codex_environment.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Script to install essential dependencies for the Culture.ai "AI Genesis Engine" project.
+# Designed for a headless, time-limited environment (e.g., ChatGPT Code Interpreter).
+# It installs core libraries for DSPy, LangGraph, Ollama support, Discord bot, and ChromaDB.
+# The script favors pre-built binary wheels and CPU-only packages to avoid long build times.
+
+set -e  # Exit immediately on any error to avoid partial installs
+
+# (Optional) Upgrade pip to latest version for better dependency resolution (especially on fresh envs)
+python -m pip install --upgrade pip --no-cache-dir
+
+# Install core dependencies:
+# - pydantic v2 (data validation, required by LiteLLM)
+# - openai (OpenAI API client, needed for OpenAI and proxy usage)
+# - litellm (LiteLLM for unified local/remote LLM API, ensures OpenAI>=1.0.0)
+# - dspy (DSPy for prompt/program optimization)
+# - langgraph (LangChain's LangGraph for agent orchestration)
+# - discord.py (Discord bot API wrapper)
+# - chromadb (Chroma vector DB for memory storage)
+# - python-dotenv (to load configuration from .env files)
+echo "Installing core Python packages..."
+pip install -U --no-cache-dir --prefer-binary \
+    "pydantic>=2.0" \
+    openai \
+    litellm \
+    dspy \
+    langgraph \
+    discord.py \
+    chromadb \
+    python-dotenv
+
+# Install sentence-transformers for embeddings.
+# This is used for computing text embeddings (e.g., memory vectors) via local models.
+# Note: This will pull in Hugging Face Transformers and PyTorch (if not already present).
+# It may be slow to install. If running in a very constrained environment, you can skip this
+# or install a lighter embedding method. However, it's essential for full simulation functionality.
+echo "Installing sentence-transformers (for text embeddings)..."
+pip install -U --no-cache-dir --prefer-binary sentence-transformers
+
+# All done. If we reached here, all essential packages are installed.
+echo "✅ Setup Complete"
+# User-provided custom instructions


### PR DESCRIPTION
## Summary
- add guidance for Codex usage
- add script to install dependencies in a lightweight environment

## Testing
- `pre-commit run --files scripts/codex_environment.sh`
- `python scripts/run_tests.py -m "not integration and not ollama"` *(fails: Could not find a version that satisfies the requirement numpy==2.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68630f8b7c008326b812e80d1fada932