### PR TITLE
Add breakpoint update hook

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -5,3 +5,8 @@ export interface Mission {
   progress: number
 }
 
+export async function fetchMissions(): Promise<Mission[]> {
+  const res = await fetch('/api/missions')
+  return (await res.json()) as Mission[]
+}
+

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -25,6 +25,8 @@ import { CSS } from '@dnd-kit/utilities'
 
 import { reorderMissions } from '../lib/reorderMissions'
 
+export { reorderMissions }
+
 function DraggableRow({ row }: { row: Row<Mission> }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: row.id,

--- a/culture-ui/src/widgets/BreakpointList.test.tsx
+++ b/culture-ui/src/widgets/BreakpointList.test.tsx
@@ -1,0 +1,47 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import BreakpointList from './BreakpointList'
+import { MockEventSource, resetMockSources } from '../lib/testUtils'
+
+afterEach(() => {
+  resetMockSources()
+  vi.restoreAllMocks()
+})
+
+describe('BreakpointList', () => {
+  it('POSTs selected tags to /control', async () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(<BreakpointList />)
+    await userEvent.click(screen.getByLabelText('violence'))
+    await userEvent.click(screen.getByText('Save'))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/control',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'set_breakpoints', tags: ['violence'] }),
+      }),
+    )
+  })
+
+  it('shows toast on breakpoint hit event', () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+
+    render(<BreakpointList />)
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage(
+        '{"event_type":"breakpoint_hit","data":{"tags":["nsfw"],"step":1}}',
+      )
+    })
+
+    expect(screen.getByTestId('toast').textContent).toContain('nsfw')
+  })
+})

--- a/culture-ui/src/widgets/BreakpointList.tsx
+++ b/culture-ui/src/widgets/BreakpointList.tsx
@@ -1,18 +1,66 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
+
+interface BreakpointEvent {
+  event_type?: string
+  data?: { tags?: string[]; step?: number }
+}
 
 const DEFAULT_TAGS = ['violence', 'nsfw', 'sabotage']
 
 export default function BreakpointList() {
   const [tags] = useState<string[]>(DEFAULT_TAGS)
+  const [selected, setSelected] = useState<string[]>([])
+  const [toast, setToast] = useState<string | null>(null)
+  const event = useEventSource<BreakpointEvent>()
+
+  useEffect(() => {
+    if (event?.event_type === 'breakpoint_hit') {
+      const hit = event.data?.tags?.join(', ') ?? ''
+      setToast(`Breakpoint hit: ${hit}`)
+      const t = setTimeout(() => setToast(null), 3000)
+      return () => clearTimeout(t)
+    }
+  }, [event])
+
+  const toggleTag = (tag: string) => {
+    setSelected((cur) =>
+      cur.includes(tag) ? cur.filter((t) => t !== tag) : [...cur, tag],
+    )
+  }
+
+  const sendBreakpoints = async () => {
+    await fetch('/control', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'set_breakpoints', tags: selected }),
+    })
+  }
 
   return (
     <div className="p-2" data-testid="breakpoints">
       <h2 className="font-bold">Breakpoints</h2>
       <ul className="list-disc pl-4">
         {tags.map((tag) => (
-          <li key={tag}>{tag}</li>
+          <li key={tag}>
+            <label>
+              <input
+                type="checkbox"
+                aria-label={tag}
+                checked={selected.includes(tag)}
+                onChange={() => toggleTag(tag)}
+              />{' '}
+              {tag}
+            </label>
+          </li>
         ))}
       </ul>
+      <button onClick={sendBreakpoints}>Save</button>
+      {toast && (
+        <div data-testid="toast" role="alert">
+          {toast}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- post breakpoints to `/control`
- show toast when hitting a breakpoint via SSE
- expose `reorderMissions` and stub `fetchMissions`
- test POST logic and event subscription

## Testing
- `pre-commit run --files culture-ui/src/pages/MissionOverview.tsx culture-ui/src/lib/api.ts culture-ui/src/widgets/BreakpointList.tsx culture-ui/src/widgets/BreakpointList.test.tsx`
- `pnpm --filter culture-ui test`

------
https://chatgpt.com/codex/tasks/task_e_6863352b489083268a4818053521e8e3