### PR TITLE
Add theme toggle with persistence

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Sidebar from './components/Sidebar'
+import Header from './components/Header'
 import Home from './pages/Home'
 import MissionOverview from './pages/MissionOverview'
 import AgentDataOverview from './pages/AgentDataOverview'
@@ -12,15 +13,18 @@ export default function App() {
   return (
     <div className="flex h-screen">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto">
-        <DockManager defaultLayout={defaultLayout}>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/missions" element={<MissionOverview />} />
-            <Route path="/agent-data" element={<AgentDataOverview />} />
-          </Routes>
-        </DockManager>
-      </main>
+      <div className="flex-1 flex flex-col overflow-y-auto">
+        <Header />
+        <main className="flex-1 overflow-y-auto">
+          <DockManager defaultLayout={defaultLayout}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/missions" element={<MissionOverview />} />
+              <Route path="/agent-data" element={<AgentDataOverview />} />
+            </Routes>
+          </DockManager>
+        </main>
+      </div>
     </div>
   )
 }

--- a/culture-ui/src/components/Header.test.tsx
+++ b/culture-ui/src/components/Header.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Header from './Header'
+
+describe('Header theme toggle', () => {
+  beforeEach(() => {
+    document.body.className = ''
+    localStorage.clear()
+  })
+
+  it('toggles dark class on body', async () => {
+    const user = userEvent.setup()
+    render(<Header />)
+    const button = screen.getByRole('button', { name: /toggle theme/i })
+
+    expect(document.body.classList.contains('dark')).toBe(false)
+
+    await user.click(button)
+    expect(document.body.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('theme')).toBe('dark')
+
+    await user.click(button)
+    expect(document.body.classList.contains('dark')).toBe(false)
+    expect(localStorage.getItem('theme')).toBe('light')
+  })
+})

--- a/culture-ui/src/components/Header.tsx
+++ b/culture-ui/src/components/Header.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'theme'
+
+export default function Header() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    return (localStorage.getItem(STORAGE_KEY) as 'light' | 'dark') || 'light'
+  })
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+  }
+
+  return (
+    <header className="p-4 border-b flex justify-end">
+      <button onClick={toggleTheme}>Toggle Theme</button>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add `Header` component with theme toggle storing preference in `localStorage`
- wire up `Header` in `App`
- test theme toggle logic

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_6863e5feffe08326ae0019ae97944ad0