### PR TITLE
Add EventConsole widget

### DIFF
--- a/culture-ui/src/main.tsx
+++ b/culture-ui/src/main.tsx
@@ -4,10 +4,11 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { widgetRegistry } from './lib/widgetRegistry'
-import { TimelineWidget, BreakpointList } from './widgets'
+import { TimelineWidget, BreakpointList, EventConsole } from './widgets'
 
 widgetRegistry.register('Timeline', TimelineWidget)
 widgetRegistry.register('Breakpoints', BreakpointList)
+widgetRegistry.register('Events', EventConsole)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/culture-ui/src/widgets/EventConsole.test.tsx
+++ b/culture-ui/src/widgets/EventConsole.test.tsx
@@ -1,0 +1,44 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it } from 'vitest'
+import EventConsole from './EventConsole'
+import { MockEventSource, resetMockSources } from '../lib/testUtils'
+
+afterEach(() => {
+  resetMockSources()
+})
+
+describe('EventConsole', () => {
+  it('renders incoming events', () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+
+    render(<EventConsole />)
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage('{"foo": 1}')
+    })
+
+    expect(screen.getByTestId('events').textContent).toContain('"foo": 1')
+  })
+
+  it('filters events using search input', async () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+
+    render(<EventConsole />)
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage('{"type":"a"}')
+    })
+    act(() => {
+      es.emitMessage('{"type":"b"}')
+    })
+
+    await userEvent.type(screen.getByLabelText('search'), 'b')
+
+    const text = screen.getByTestId('events').textContent || ''
+    expect(text).toMatch(/"type"\s*:\s*"b"/)
+    expect(text).not.toMatch(/"type"\s*:\s*"a"/)
+  })
+})

--- a/culture-ui/src/widgets/EventConsole.tsx
+++ b/culture-ui/src/widgets/EventConsole.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
+
+interface AnyEvent {
+  [key: string]: unknown
+}
+
+export default function EventConsole() {
+  const event = useEventSource<AnyEvent>()
+  const [events, setEvents] = useState<AnyEvent[]>([])
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    if (event) {
+      setEvents((cur) => [...cur, event])
+    }
+  }, [event])
+
+  const filtered = events.filter((ev) =>
+    JSON.stringify(ev).toLowerCase().includes(search.toLowerCase()),
+  )
+
+  return (
+    <div className="p-2" data-testid="event-console">
+      <input
+        aria-label="search"
+        placeholder="Search events"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="mb-2 border p-1"
+      />
+      <div data-testid="events" className="space-y-2 max-h-64 overflow-y-auto">
+        {filtered.map((ev, i) => (
+          <pre key={i} className="bg-muted p-2 text-xs">
+            {JSON.stringify(ev, null, 2)}
+          </pre>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -1,3 +1,4 @@
 export { default as TimelineWidget } from './TimelineWidget'
 export { default as BreakpointList } from './BreakpointList'
+export { default as EventConsole } from './EventConsole'
 


### PR DESCRIPTION
## Summary
- create `EventConsole` component with search/filter and event streaming
- register new widget in `main.tsx`
- export `EventConsole` from widgets index
- test event rendering and filtering

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_6863e606b7b88326a510ded681099244