### PR TITLE
Add HeaderBar component with controls

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Sidebar from './components/Sidebar'
+import HeaderBar from './components/HeaderBar'
 import Home from './pages/Home'
 import MissionOverview from './pages/MissionOverview'
 import AgentDataOverview from './pages/AgentDataOverview'
@@ -13,6 +14,7 @@ export default function App() {
     <div className="flex h-screen">
       <Sidebar />
       <main className="flex-1 overflow-y-auto">
+        <HeaderBar />
         <DockManager defaultLayout={defaultLayout}>
           <Routes>
             <Route path="/" element={<Home />} />

--- a/culture-ui/src/components/HeaderBar.test.tsx
+++ b/culture-ui/src/components/HeaderBar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import HeaderBar from './HeaderBar'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('HeaderBar', () => {
+  it('toggles pause and resume', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response))
+    global.fetch = fetchMock as unknown as typeof fetch
+    render(<HeaderBar />)
+    const button = screen.getByRole('button', { name: /pause/i })
+    await userEvent.click(button)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/control',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: 'pause' }),
+      }),
+    )
+    await userEvent.click(button)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/control',
+      expect.objectContaining({
+        body: JSON.stringify({ command: 'resume' }),
+      }),
+    )
+  })
+
+  it('sends speed updates', () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true } as Response))
+    global.fetch = fetchMock as unknown as typeof fetch
+    render(<HeaderBar />)
+    const slider = screen.getByRole('slider') as HTMLInputElement
+    fireEvent.change(slider, { target: { value: '2' } })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/control',
+      expect.objectContaining({
+        body: JSON.stringify({ command: 'set_speed', speed: 2 }),
+      }),
+    )
+  })
+})

--- a/culture-ui/src/components/HeaderBar.tsx
+++ b/culture-ui/src/components/HeaderBar.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+
+export default function HeaderBar() {
+  const [time, setTime] = useState(() => new Date())
+  const [paused, setPaused] = useState(false)
+  const [speed, setSpeed] = useState(1)
+  const scenarios = ['Demo', 'Test']
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const sendCommand = async (cmd: Record<string, unknown>) => {
+    await fetch('/control', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(cmd),
+    })
+  }
+
+  const togglePause = async () => {
+    const command = paused ? 'resume' : 'pause'
+    await sendCommand({ command })
+    setPaused(!paused)
+  }
+
+  const handleSpeedChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = Number(e.target.value)
+    setSpeed(value)
+    await sendCommand({ command: 'set_speed', speed: value })
+  }
+
+  return (
+    <header className="flex items-center justify-between p-2 bg-gray-200">
+      <div>{time.toLocaleTimeString()}</div>
+      <div className="flex items-center space-x-2">
+        <label className="flex items-center space-x-1">
+          <span>Speed</span>
+          <input
+            aria-label="speed"
+            type="range"
+            min="0.1"
+            max="5"
+            step="0.1"
+            value={speed}
+            onChange={handleSpeedChange}
+          />
+        </label>
+        <button onClick={togglePause}>{paused ? 'Resume' : 'Pause'}</button>
+        <select aria-label="scenario">
+          {scenarios.map((s) => (
+            <option key={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add `HeaderBar` component with clock, speed slider, pause/resume button and scenario dropdown
- integrate `HeaderBar` into `App`
- test button interactions with Vitest

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`

------
https://chatgpt.com/codex/tasks/task_e_6863e604f7dc8326ad34cbeb7d77f5f1