### PR TITLE
Add dockable widgets

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -3,6 +3,10 @@ import Sidebar from './components/Sidebar'
 import Home from './pages/Home'
 import MissionOverview from './pages/MissionOverview'
 import AgentDataOverview from './pages/AgentDataOverview'
+import NetworkWebPage from './pages/NetworkWeb'
+import WorldMapPage from './pages/WorldMap'
+import TimelineWidgetPage from './pages/TimelineWidget'
+import KpiCardPage from './pages/KpiCard'
 import DockManager from './components/DockManager'
 import { createDefaultLayout } from './lib/defaultLayout'
 
@@ -18,6 +22,10 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/missions" element={<MissionOverview />} />
             <Route path="/agent-data" element={<AgentDataOverview />} />
+            <Route path="/network-web" element={<NetworkWebPage />} />
+            <Route path="/world-map" element={<WorldMapPage />} />
+            <Route path="/timeline" element={<TimelineWidgetPage />} />
+            <Route path="/kpi-card" element={<KpiCardPage />} />
           </Routes>
         </DockManager>
       </main>

--- a/culture-ui/src/components/Sidebar.tsx
+++ b/culture-ui/src/components/Sidebar.tsx
@@ -22,6 +22,26 @@ export default function Sidebar() {
             Agent Data
           </NavLink>
         </li>
+        <li>
+          <NavLink to="/network-web" className={linkClass}>
+            Network Web
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/world-map" className={linkClass}>
+            World Map
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/timeline" className={linkClass}>
+            Timeline Widget
+          </NavLink>
+        </li>
+        <li>
+          <NavLink to="/kpi-card" className={linkClass}>
+            KPI Card
+          </NavLink>
+        </li>
       </ul>
     </nav>
   )

--- a/culture-ui/src/lib/defaultLayout.ts
+++ b/culture-ui/src/lib/defaultLayout.ts
@@ -2,6 +2,13 @@ import type { IJsonModel } from 'flexlayout-react'
 import { listWidgets } from './widgetRegistry'
 
 export function createDefaultLayout(): IJsonModel {
+  const widgets = listWidgets()
+  const order = ['NetworkWeb', 'WorldMap', 'TimelineWidget', 'KpiCard']
+  const sorted = [
+    ...order.filter((n) => widgets.includes(n)),
+    ...widgets.filter((n) => !order.includes(n)),
+  ]
+
   return {
     global: {},
     layout: {
@@ -9,7 +16,7 @@ export function createDefaultLayout(): IJsonModel {
       children: [
         {
           type: 'tabset',
-          children: listWidgets().map((name) => ({
+          children: sorted.map((name) => ({
             type: 'tab',
             name,
             component: name,

--- a/culture-ui/src/main.tsx
+++ b/culture-ui/src/main.tsx
@@ -4,9 +4,18 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { widgetRegistry } from './lib/widgetRegistry'
-import { TimelineWidget, BreakpointList } from './widgets'
+import {
+  TimelineWidget,
+  BreakpointList,
+  NetworkWeb,
+  WorldMap,
+  KpiCard,
+} from './widgets'
 
-widgetRegistry.register('Timeline', TimelineWidget)
+widgetRegistry.register('TimelineWidget', TimelineWidget)
+widgetRegistry.register('NetworkWeb', NetworkWeb)
+widgetRegistry.register('WorldMap', WorldMap)
+widgetRegistry.register('KpiCard', KpiCard)
 widgetRegistry.register('Breakpoints', BreakpointList)
 
 createRoot(document.getElementById('root')!).render(

--- a/culture-ui/src/pages/KpiCard.tsx
+++ b/culture-ui/src/pages/KpiCard.tsx
@@ -1,0 +1,14 @@
+import KpiCard from '../widgets/KpiCard'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function KpiCardPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">KPI Card</h1>
+      <KpiCard />
+    </div>
+  )
+}
+
+registerWidget('KpiCard', KpiCardPage)
+

--- a/culture-ui/src/pages/NetworkWeb.tsx
+++ b/culture-ui/src/pages/NetworkWeb.tsx
@@ -1,0 +1,14 @@
+import NetworkWeb from '../widgets/NetworkWeb'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function NetworkWebPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Network Web</h1>
+      <NetworkWeb />
+    </div>
+  )
+}
+
+registerWidget('NetworkWeb', NetworkWebPage)
+

--- a/culture-ui/src/pages/TimelineWidget.tsx
+++ b/culture-ui/src/pages/TimelineWidget.tsx
@@ -1,0 +1,14 @@
+import TimelineWidget from '../widgets/TimelineWidget'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function TimelineWidgetPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Timeline Widget</h1>
+      <TimelineWidget />
+    </div>
+  )
+}
+
+registerWidget('TimelineWidget', TimelineWidgetPage)
+

--- a/culture-ui/src/pages/WorldMap.tsx
+++ b/culture-ui/src/pages/WorldMap.tsx
@@ -1,0 +1,14 @@
+import WorldMap from '../widgets/WorldMap'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function WorldMapPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">World Map</h1>
+      <WorldMap />
+    </div>
+  )
+}
+
+registerWidget('WorldMap', WorldMapPage)
+

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -1,3 +1,6 @@
 export { default as TimelineWidget } from './TimelineWidget'
 export { default as BreakpointList } from './BreakpointList'
+export { default as NetworkWeb } from './NetworkWeb'
+export { default as WorldMap } from './WorldMap'
+export { default as KpiCard } from './KpiCard'
 


### PR DESCRIPTION
## Summary
- register NetworkWeb, WorldMap, TimelineWidget and KpiCard
- include these widgets in the default layout
- add pages and sidebar links for new widgets

## Testing
- `pnpm lint`
- `pnpm test`
- `pre-commit run --files culture-ui/src/main.tsx culture-ui/src/pages/NetworkWeb.tsx culture-ui/src/pages/WorldMap.tsx culture-ui/src/pages/TimelineWidget.tsx culture-ui/src/pages/KpiCard.tsx culture-ui/src/components/Sidebar.tsx culture-ui/src/lib/defaultLayout.ts culture-ui/src/App.tsx culture-ui/src/widgets/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_6863e605b3708326b1bdec289ab7f819