### PR TITLE
Update control API to use value parameter

### DIFF
--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -40,3 +40,20 @@ Widgets are rendered based on the registry contents, enabling third‑party exte
 The dashboard includes a **Timeline** widget that visualizes simulation steps. Users can scrub through completed steps using a slider control.
 
 Events may carry tags such as `violence`, `nsfw`, or `sabotage`. When a tag matches one of the configured breakpoints the simulation automatically pauses.
+
+## Control API
+
+The UI sends JSON commands to `/control` to manage the simulation. The current payloads are:
+
+```json
+{ "command": "pause" }
+{ "command": "resume" }
+{ "command": "set_speed", "value": 1.5 }
+{ "command": "set_breakpoints", "tags": ["nsfw"] }
+```
+
+Each request returns the updated simulation state:
+
+```json
+{ "paused": false, "speed": 1.5, "breakpoints": ["nsfw"] }
+```

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -171,7 +171,7 @@ async def handle_control_command(cmd: dict[str, Any]) -> dict[str, Any]:
         SIM_STATE["paused"] = False
     elif action == "set_speed":
         try:
-            SIM_STATE["speed"] = float(cmd.get("speed", 1))
+            SIM_STATE["speed"] = float(cmd.get("value", 1))
         except (TypeError, ValueError):
             pass
     elif action == "set_breakpoints":

--- a/tests/unit/interfaces/test_dashboard_backend_control.py
+++ b/tests/unit/interfaces/test_dashboard_backend_control.py
@@ -62,7 +62,7 @@ async def test_control_pause_resume() -> None:
     data = json.loads(resp.body)
     assert data["paused"] is True
 
-    resp = await db.control({"command": "set_speed", "speed": 2})
+    resp = await db.control({"command": "set_speed", "value": 2})
     data = json.loads(resp.body)
     assert data["speed"] == 2
 
@@ -97,3 +97,13 @@ async def test_ws_control() -> None:
     await db.ws_control(ws)
     assert ws.accepted is True
     assert json.loads(ws.sent[0])["paused"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_speed_invalid_value() -> None:
+    db = load_dashboard_backend()
+    await db.control({"command": "set_speed", "value": 2})
+    resp = await db.control({"command": "set_speed", "value": "bad"})
+    data = json.loads(resp.body)
+    assert data["speed"] == 2


### PR DESCRIPTION
## Summary
- use `value` field for setting sim speed in dashboard backend
- document control API JSON format
- update dashboard backend control tests
- add regression test for invalid speed input

## Testing
- `ruff check src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_control.py`
- `black src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_control.py`
- `mypy src/interfaces/dashboard_backend.py`
- `pytest tests/unit/interfaces/test_dashboard_backend_control.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e5e5862c8326a49472076a51e64f