### PR TITLE
Add Discord bot tests for event processing and error logging

### DIFF
--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -145,3 +145,34 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         assert bot.client.channel.sent
 
         await bot.stop_bot()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    q_events: asyncio.Queue[SimulationEvent] = asyncio.Queue()
+    q_msgs: asyncio.Queue[AgentMessage] = asyncio.Queue()
+
+    class Client(DummyDiscordClient):
+        pass
+
+    with patch("src.interfaces.discord_bot.discord.Client", Client), patch(
+        "src.interfaces.discord_bot.event_queue",
+        q_events,
+    ), patch(
+        "src.interfaces.discord_bot.message_sse_queue",
+        q_msgs,
+    ):
+        bot = SimulationDiscordBot("token", 456)
+        await bot.run_bot()
+        on_msg = bot.client._events["on_message"]
+        msg = MagicMock()
+        msg.content = "hello world"
+        msg.author = "userA"
+        await on_msg(msg)
+        event = await q_events.get()
+        agent_state = {"messages": []}
+        agent_state["messages"].append(event.data["content"])
+        assert agent_state["messages"] == ["hello world"]
+        await bot.stop_bot()
+

--- a/tests/unit/interfaces/test_discord_errors.py
+++ b/tests/unit/interfaces/test_discord_errors.py
@@ -1,0 +1,45 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from src.interfaces.discord_bot import SimulationDiscordBot
+
+
+class DummyChannel:
+    async def send(self, *args: object, **kwargs: object) -> None:
+        raise DummyException("fail")
+
+
+class DummyClient:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.event = lambda fn: fn
+        self.user = "dummy"
+
+    def get_channel(self, channel_id: int) -> DummyChannel:
+        return DummyChannel()
+
+
+class DummyException(Exception):
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_simulation_update_logs_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    with patch("src.interfaces.discord_bot.discord.Client", DummyClient), patch(
+        "src.interfaces.discord_bot.discord.DiscordException",
+        DummyException,
+    ):
+        bot = SimulationDiscordBot("token", 999)
+        bot.is_ready = True
+        error_called = asyncio.Event()
+
+        def fake_error(msg: str, exc_info: bool = False) -> None:
+            error_called.set()
+
+        monkeypatch.setattr("src.interfaces.discord_bot.logger.error", fake_error)
+        result = await bot.send_simulation_update(content="hi")
+        assert result is False
+        assert error_called.is_set()
+


### PR DESCRIPTION
## Summary
- test that user messages propagate to a simulation event that can modify state
- verify graceful error logging when the Discord API fails

## Testing
- `ruff check tests/integration/interfaces/test_discord_bot.py tests/unit/interfaces/test_discord_errors.py`
- `pytest tests/integration/interfaces/test_discord_bot.py::test_on_message_updates_agent_state tests/unit/interfaces/test_discord_errors.py::test_send_simulation_update_logs_error -q`

------
https://chatgpt.com/codex/tasks/task_e_6864992678c08326a0ae2c5d416133bf