### PR TITLE
Add vLLM backend instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,8 @@ REDPANDA_BROKER=localhost:9092  # required
 # -- Snapshot Settings --
 # Set to 1 to compress snapshots with zstandard
 SNAPSHOT_COMPRESS=0
+
+# -- vLLM Server (optional) --
+# Model and port when using the vLLM backend
+VLLM_MODEL=mistralai/Mistral-7B-Instruct-v0.2
+VLLM_PORT=8001

--- a/README.md
+++ b/README.md
@@ -604,7 +604,11 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    `--swap-space` option to avoid out-of-memory errors when running more than
    ten agents:
    ```bash
-   scripts/start_vllm.sh  # defaults to port 8001 (override with VLLM_PORT)
+   # Optionally override the model or port used by vLLM (defaults to port 8001)
+   VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 \
+   scripts/start_vllm.sh
+   # Point the application to the vLLM server
+   export OLLAMA_API_BASE="http://localhost:$VLLM_PORT"
    ```
 5. **Run Weaviate (for vector store, optional):**
    ```bash
@@ -613,8 +617,10 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    ```
 6. **Configure environment variables:**
    - Copy `.env.example` to `.env` and edit as needed:
-    - `OLLAMA_API_BASE` (e.g., http://localhost:11434)
+    - `OLLAMA_API_BASE` (e.g., http://localhost:11434, or http://localhost:$VLLM_PORT for vLLM)
     - `OLLAMA_REQUEST_TIMEOUT` (request timeout in seconds)
+    - `VLLM_MODEL` (e.g., mistralai/Mistral-7B-Instruct-v0.2) for the vLLM backend
+    - `VLLM_PORT` (e.g., 8001) for the vLLM backend
     - `WEAVIATE_URL` (e.g., http://localhost:8080)
     - `VECTOR_STORE_BACKEND` ("chroma" or "weaviate")
     - `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` (for Discord integration)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -15,7 +15,11 @@ This runbook outlines routine operations for working with Culture.ai.
    Alternatively, start a vLLM server with swap space enabled to avoid
    out-of-memory errors when running many agents:
    ```bash
-   scripts/start_vllm.sh  # defaults to port 8001 (override with VLLM_PORT)
+   # Optionally override the model or port used by vLLM (defaults to port 8001)
+   VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 \
+   scripts/start_vllm.sh
+   # Point the application to the vLLM server
+   export OLLAMA_API_BASE="http://localhost:$VLLM_PORT"
    ```
 4. (Optional) Start the vector store:
    ```bash


### PR DESCRIPTION
## Summary
- update README with instructions to run the vLLM backend
- mention VLLM_PORT and VLLM_MODEL variables in setup docs
- document vLLM example config in `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68649924001483268f9ceeb843037139