### PR TITLE
Implement quadratic voting with influence weights

### DIFF
--- a/src/governance/voting.py
+++ b/src/governance/voting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Iterable
 
 from src.agents.core.base_agent import Agent
@@ -16,14 +17,16 @@ async def _vote(agent: Agent, proposal: str) -> bool:
 
 
 async def propose_law(proposer: Agent, text: str, agents: Iterable[Agent]) -> bool:
-    """Propose a law and collect votes from all agents."""
+    """Propose a law and collect weighted votes from all agents."""
     allowed, _ = await evaluate_with_opa(text)
     if not allowed:
         return False
 
     votes = await asyncio.gather(*[_vote(a, text) for a in agents])
-    yes_votes = sum(1 for v in votes if v)
-    approved = yes_votes > len(votes) / 2
+    weights = [math.sqrt(getattr(a.state, "ip", 0.0)) for a in agents]
+    yes_weight = sum(w for w, v in zip(weights, votes) if v)
+    no_weight = sum(w for w, v in zip(weights, votes) if not v)
+    approved = yes_weight > no_weight
     if approved:
         law_board.add_law(text)
     return approved

--- a/tests/integration/governance/test_law_board_integration.py
+++ b/tests/integration/governance/test_law_board_integration.py
@@ -43,7 +43,7 @@ from src.sim.simulation import Simulation
 
 
 class DummyState(SimpleNamespace):
-    ip: float = 0.0
+    ip: float = 1.0
     du: float = 0.0
     age: int = 0
     is_alive: bool = True


### PR DESCRIPTION
## Summary
- extend governance voting to compute weighted approval using quadratic influence points
- allow DummyAgent in tests to specify influence
- cover quadratic voting scenarios in integration tests

## Testing
- `ruff check src/governance/voting.py tests/integration/governance/test_voting_scenarios.py tests/integration/governance/test_law_board_integration.py`
- `pytest -m "integration" tests/integration/governance/test_voting_scenarios.py::test_quadratic_yes_overrides_majority -q`
- `pytest -m "integration" tests/integration/governance/test_voting_scenarios.py::test_quadratic_no_overrides_majority -q`


------
https://chatgpt.com/codex/tasks/task_e_6864992011648326a4926a76000d0a7c