### PR TITLE
Handle async graph timeout

### DIFF
--- a/src/agents/memory/weaviate_vector_store_manager.py
+++ b/src/agents/memory/weaviate_vector_store_manager.py
@@ -3,8 +3,12 @@ import time
 import uuid
 from typing import Any, Callable, Optional, cast
 
-import weaviate
-import weaviate.classes as wvc
+try:  # pragma: no cover - optional dependency
+    import weaviate
+    import weaviate.classes as wvc
+except Exception:  # pragma: no cover - allow absence of weaviate
+    weaviate = None
+    wvc = None
 from typing_extensions import Self
 
 from src.shared.memory_store import MemoryStore

--- a/stubs/weaviate/__init__.py
+++ b/stubs/weaviate/__init__.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+try:
+    from . import classes  # noqa: F401
+except Exception:
+    classes = import_module('stubs.weaviate.classes')

--- a/stubs/weaviate/classes/__init__.py
+++ b/stubs/weaviate/classes/__init__.py
@@ -1,0 +1,5 @@
+class Filter:
+    pass
+
+class MetadataQuery:
+    pass


### PR DESCRIPTION
## Summary
- catch async_select_action_intent timeouts in graph_nodes
- return fallback output on timeout/exception
- enable async agent graph tests
- stub weaviate dependency and patch tests for local graph

## Testing
- `ruff check src/agents/memory/weaviate_vector_store_manager.py tests/integration/graph/test_async_agent_graph.py`
- `PYTHONPATH=stubs pyenv shell 3.11.12 && pytest -m "not unit" tests/integration/graph/test_async_agent_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_6865489ec9d08326970e5921279e17d0