### PR TITLE
Handle human command cost

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ suppress-none-returning = true
 
 [tool.mypy]
 python_version = "3.10"
-mypy_path = "src:stubs"
+mypy_path = "stubs"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -248,7 +248,7 @@ multidict==6.6.0
     #   yarl
 multiprocess==0.70.16
     # via datasets
-numpy==2.3.1
+numpy==2.2.6
     # via
     #   chroma-hnswlib
     #   chromadb

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -31,25 +31,16 @@ ActionIntentLiteral = Literal[
 class MemoryRetriever(Protocol):
     async def aretrieve_relevant_memories(
         self, agent_id: str, query: str, k: int
-    ) -> list[dict[str, Any]]:
-        ...
+    ) -> list[dict[str, Any]]: ...
 
 
 class SummaryAgent(Protocol):
     async def async_generate_l1_summary(
         self, role_prompt: str, memories: str, context: str
-    ) -> Any:
-        ...
+    ) -> Any: ...
 
 
 logger = logging.getLogger(__name__)
-
-
-def generate_structured_output_from_intent(
-    intent: str, prompt: str, schema: type[AgentActionOutput]
-) -> AgentActionOutput:
-    """Compatibility shim for older tests."""
-    return generate_structured_output(prompt, schema)
 
 
 def analyze_perception_sentiment_node(state: AgentTurnState) -> dict[str, Any]:
@@ -147,13 +138,13 @@ async def generate_thought_and_message_node(
     # The arguments are placeholders as the mock doesn't use them.
     result = await cast(Agent, agent).async_select_action_intent("", "", "", [])
 
+    # If the mocked result is already the full output, just return it.
+    if isinstance(result, AgentActionOutput):
+        return {"structured_output": result}
 
-        # If the mocked result is already the full output, just return it.
-        if isinstance(result, AgentActionOutput):
-            return {"structured_output": result}
-
-        if result:
-            action_intent = getattr(result, "chosen_action_intent", "idle")
+    action_intent = "idle"
+    if result:
+        action_intent = getattr(result, "chosen_action_intent", "idle")
 
     try:
         structured = cast(
@@ -166,7 +157,6 @@ async def generate_thought_and_message_node(
         structured = cast(
             AgentActionOutput | None,
             generate_structured_output("prompt", AgentActionOutput),
-
         )
 
     if structured:

--- a/src/infra/dspy_ollama_integration.py
+++ b/src/infra/dspy_ollama_integration.py
@@ -221,7 +221,7 @@ class OllamaLM(BaseLM):
         start_time = time.time()
 
         # Merge default kwargs with provided kwargs
-        request_kwargs: ollama_types.Options = {
+        request_kwargs: dict[str, Any] = {
             "temperature": self.temperature,
             "num_predict": self.max_tokens,
         }

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -86,9 +86,10 @@ def get_event_queue() -> asyncio.Queue["SimulationEvent | None"]:
     except RuntimeError:  # pragma: no cover - no running loop
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-    if _event_queue is None or _event_queue._loop is not loop:
+    if _event_queue is None or getattr(_event_queue, "_loop", None) is not loop:  # type: ignore[attr-defined]
         _event_queue = asyncio.Queue()
     return _event_queue
+
 
 # Simulation control state
 SIM_STATE: dict[str, Any] = {"paused": False, "speed": 1.0, "semantic_manager": None}

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -252,6 +252,21 @@ class Simulation:
             return
 
         target = self.agents[self.current_agent_index]
+        state = target.state
+        ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE"))
+        du_cost = float(config.get_config("DU_COST_PER_ACTION"))
+
+        if state.ip < ip_cost or state.du < du_cost:
+            logger.info("Rejecting human command for %s: insufficient resources", target.agent_id)
+            return
+
+        state.ip -= ip_cost
+        state.du -= du_cost
+        try:
+            await ledger.spend(target.agent_id, ip=ip_cost, du=du_cost, reason="human_dm")
+        except Exception:  # pragma: no cover - optional
+            logger.debug("Ledger spend failed", exc_info=True)
+
         msg = {
             "step": self.current_step,
             "sender_id": "human",
@@ -266,9 +281,10 @@ class Simulation:
 
     async def _forward_external_events(self: Self) -> None:
         """Background task that forwards events from ``event_queue``."""
+        queue = get_event_queue()
         try:
             while True:
-                evt: SimulationEvent | None = await event_queue.get()
+                evt: SimulationEvent | None = await queue.get()
                 if evt is None:
                     break
                 if evt.event_type == "broadcast" and evt.data:

--- a/stubs/langgraph/__init__.py
+++ b/stubs/langgraph/__init__.py
@@ -1,3 +1,3 @@
 """Stub package for langgraph tests."""
 
-__all__ = []
+__all__: list[str] = []

--- a/stubs/langgraph/graph/__init__.py
+++ b/stubs/langgraph/graph/__init__.py
@@ -1,3 +1,3 @@
-from .graph import END, START
+from .graph import END, START, StateGraph
 
-__all__ = ["END", "START"]
+__all__ = ["END", "START", "StateGraph"]

--- a/stubs/langgraph/graph/graph.py
+++ b/stubs/langgraph/graph/graph.py
@@ -3,4 +3,21 @@
 END = "__end__"
 START = "__start__"
 
-__all__ = ["END", "START"]
+
+class StateGraph:
+    """Placeholder StateGraph for type checking."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+    def add_node(self, *args: object, **kwargs: object) -> None: ...
+
+    def set_entry_point(self, *args: object, **kwargs: object) -> None: ...
+
+    def add_edge(self, *args: object, **kwargs: object) -> None: ...
+
+    def add_conditional_edges(self, *args: object, **kwargs: object) -> None: ...
+
+    def compile(self) -> object: ...
+
+
+__all__ = ["END", "START", "StateGraph"]

--- a/tests/unit/sim/test_human_command.py
+++ b/tests/unit/sim/test_human_command.py
@@ -1,0 +1,102 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyState:
+    def __init__(self, ip: float = 2.0, du: float = 2.0) -> None:
+        self.ip = ip
+        self.du = du
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str, ip: float = 2.0, du: float = 2.0) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState(ip, du)
+        from src.infra.ledger import ledger as _ledger
+
+        _ledger.log_change(agent_id, ip, du, "init")
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:
+        return self._state
+
+    def update_state(self, state: DummyState) -> None:
+        self._state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_human_command_deducts_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    await sim._handle_human_command("hello")
+
+    assert agent.state.ip == pytest.approx(1.0)
+    assert agent.state.du == pytest.approx(1.0)
+    ip, du = ledger.get_balance(agent.agent_id)
+    assert ip == pytest.approx(1.0)
+    assert du == pytest.approx(1.0)
+    async with sim._msg_lock:
+        assert sim.pending_messages_for_next_round[-1]["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_human_command_rejected_without_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    agent = DummyAgent("A", ip=0.5, du=0.5)
+    sim = Simulation([agent])
+
+    await sim._handle_human_command("hello")
+
+    assert agent.state.ip == pytest.approx(0.5)
+    assert agent.state.du == pytest.approx(0.5)
+    ip, du = ledger.get_balance(agent.agent_id)
+    assert ip == pytest.approx(0.5)
+    assert du == pytest.approx(0.5)
+    async with sim._msg_lock:
+        assert sim.pending_messages_for_next_round == []


### PR DESCRIPTION
## Summary
- reject human commands if the target agent lacks DU or IP
- deduct DU/IP cost from agent and ledger when command accepted
- fix `generate_thought_and_message_node` indentation
- test human command deduction and rejection
- fix mypy duplicate-module errors and stub definitions
- **pin numpy to 2.2.6 for Python 3.10 compatibility**
- **patch `dspy_ollama_integration` typing issue and update tests**

## Testing
- `ruff check src/infra/dspy_ollama_integration.py tests/unit/sim/test_human_command.py src/sim/simulation.py src/agents/graphs/graph_nodes.py src/interfaces/dashboard_backend.py stubs/langgraph/__init__.py stubs/langgraph/graph/__init__.py stubs/langgraph/graph/graph.py`
- `black --check src/infra/dspy_ollama_integration.py tests/unit/sim/test_human_command.py src/sim/simulation.py src/agents/graphs/graph_nodes.py src/interfaces/dashboard_backend.py stubs/langgraph/__init__.py stubs/langgraph/graph/__init__.py stubs/langgraph/graph/graph.py`
- `mypy src/`
- `python scripts/run_tests.py tests/unit/sim/test_human_command.py`


------
https://chatgpt.com/codex/tasks/task_e_686548a07fd4832680d65931ab0acb14