### PR TITLE
Add dynamic widget registration API

### DIFF
--- a/culture-ui/src/lib/widgetRegistry.ts
+++ b/culture-ui/src/lib/widgetRegistry.ts
@@ -9,6 +9,15 @@ class Registry implements WidgetRegistry {
 
   register(name: string, component: React.ComponentType) {
     this.widgets.set(name, component)
+    try {
+      void fetch('/api/register_widget', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      }).catch(() => {})
+    } catch {
+      // ignore registration errors
+    }
   }
 
   get(name: string) {

--- a/culture-ui/src/main.tsx
+++ b/culture-ui/src/main.tsx
@@ -10,6 +10,7 @@ import {
   NetworkWeb,
   WorldMap,
   KpiCard,
+  EventConsole,
 } from './widgets'
 
 widgetRegistry.register('TimelineWidget', TimelineWidget)

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -3,5 +3,6 @@ export { default as BreakpointList } from './BreakpointList'
 export { default as NetworkWeb } from './NetworkWeb'
 export { default as WorldMap } from './WorldMap'
 export { default as KpiCard } from './KpiCard'
+export { default as EventConsole } from './EventConsole'
 
 

--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -57,3 +57,18 @@ Each request returns the updated simulation state:
 ```json
 { "paused": false, "speed": 1.5, "breakpoints": ["nsfw"] }
 ```
+
+## Widget Registration API
+
+Plugins can inform the backend about available UI widgets by calling:
+
+```http
+POST /api/register_widget
+{ "name": "MyWidget" }
+```
+
+The response returns the complete set of registered widget names:
+
+```json
+{ "widgets": ["MyWidget"] }
+```

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -94,6 +94,8 @@ def get_event_queue() -> asyncio.Queue["SimulationEvent | None"]:
 # Simulation control state
 SIM_STATE: dict[str, Any] = {"paused": False, "speed": 1.0, "semantic_manager": None}
 BREAKPOINT_TAGS: set[str] = {"violence", "nsfw"}
+# Names of widgets registered by the UI or plugins
+REGISTERED_WIDGETS: set[str] = set()
 
 # Path to the initial missions data bundled with the front-end
 MISSIONS_PATH = (
@@ -164,6 +166,15 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
         except Exception:  # pragma: no cover - defensive
             summaries = []
     return JSONResponse({"summaries": summaries})
+
+
+@app.post("/api/register_widget")
+async def register_widget(widget: dict[str, Any]) -> Response:
+    """Register a widget name provided by the UI or a plugin."""
+    name = widget.get("name")
+    if isinstance(name, str):
+        REGISTERED_WIDGETS.add(name)
+    return JSONResponse({"widgets": sorted(REGISTERED_WIDGETS)})
 
 
 @app.websocket("/ws/events")
@@ -267,6 +278,7 @@ async def emit_map_action_event(
 
 
 __all__ = [
+    "REGISTERED_WIDGETS",
     "EventSourceResponse",
     "SimulationEvent",
     "app",
@@ -274,4 +286,5 @@ __all__ = [
     "emit_map_action_event",
     "get_event_queue",
     "message_sse_queue",
+    "register_widget",
 ]

--- a/tests/unit/interfaces/test_dashboard_backend_register_widget.py
+++ b/tests/unit/interfaces/test_dashboard_backend_register_widget.py
@@ -1,0 +1,15 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_widget_adds_name() -> None:
+    db.REGISTERED_WIDGETS.clear()
+    resp = await db.register_widget({"name": "extra"})
+    data = json.loads(resp.body)
+    assert "extra" in db.REGISTERED_WIDGETS
+    assert "extra" in data["widgets"]


### PR DESCRIPTION
## Summary
- allow dashboard backend to store widget names via `/api/register_widget`
- track registered widgets in the FastAPI app
- notify backend whenever a widget is registered in the UI
- export `EventConsole` widget and update imports
- document the widget registration endpoint
- test widget registration logic

## Testing
- `ruff check src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_register_widget.py`
- `mypy src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_register_widget.py`
- `pytest tests/unit/interfaces/test_dashboard_backend_register_widget.py -q`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui type-check`
- `pnpm --filter culture-ui test`

------
https://chatgpt.com/codex/tasks/task_e_6865d960827c8326841deecec359cdba