### PR TITLE
Enable optional vLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ Metrics include `llm_latency_ms`, `llm_calls_total`, `knowledge_board_size`, and
 check the latest values with the `!stats` Discord command.
 
 For routine operations and troubleshooting, see [docs/runbook.md](docs/runbook.md).
+When running against a local vLLM server, set `VLLM_API_BASE` to its base URL.
 
 ### Walking Vertical Slice
 To verify your local setup with actual LLM calls, run the minimal demo script:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -19,7 +19,8 @@ This runbook outlines routine operations for working with Culture.ai.
    VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 \
    scripts/start_vllm.sh
    # Point the application to the vLLM server
-   export OLLAMA_API_BASE="http://localhost:$VLLM_PORT"
+   export VLLM_API_BASE="http://localhost:$VLLM_PORT"
+   # When set, the application uses the vLLM OpenAI-compatible endpoint
    ```
 4. (Optional) Start the vector store:
    ```bash

--- a/tests/unit/infra/test_llm_client_vllm.py
+++ b/tests/unit/infra/test_llm_client_vllm.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.infra import llm_client
+
+
+@pytest.mark.unit
+@pytest.mark.disable_global_llm_mock
+def test_generate_text_vllm(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_post(url: str, *args: object, **kwargs: object) -> MagicMock:
+        captured["url"] = url
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+        return resp
+
+    monkeypatch.setattr(llm_client, "VLLM_API_BASE", "http://vllm:8001")
+    monkeypatch.setattr(llm_client, "USE_VLLM", True)
+    monkeypatch.setattr(llm_client, "client", llm_client._create_vllm_client())
+    monkeypatch.setattr(llm_client.requests, "post", fake_post)
+
+    result = llm_client.generate_text("hello")
+
+    assert result == "hi"
+    assert captured["url"] == "http://vllm:8001/v1/chat/completions"


### PR DESCRIPTION
## Summary
- support vLLM OpenAI-compatible API by checking `VLLM_API_BASE`
- document vLLM usage in the runbook and README
- test vLLM client behaviour

## Testing
- `ruff check src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `black --check src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `pytest -q tests/unit/infra/test_llm_client_vllm.py tests/unit/infra/test_llm_client_url.py tests/unit/infra/test_llm_client_success.py tests/unit/infra/test_llm_client_failure.py tests/unit/infra/test_llm_client_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_6865d96f1a048326948809934a04bbbd