### PR TITLE
Implement optional settings dependency

### DIFF
--- a/src/agents/memory/weaviate_vector_store_manager.py
+++ b/src/agents/memory/weaviate_vector_store_manager.py
@@ -7,8 +7,8 @@ try:  # pragma: no cover - optional dependency
     import weaviate
     import weaviate.classes as wvc
 except Exception:  # pragma: no cover - allow absence of weaviate
-    weaviate = None
-    wvc = None
+    weaviate = None  # type: ignore[assignment]
+    wvc = None  # type: ignore[assignment]
 from typing_extensions import Self
 
 from src.shared.memory_store import MemoryStore
@@ -97,7 +97,7 @@ class WeaviateVectorStoreManager(MemoryStore):
         else:
             host = "localhost"
             port = 8080
-        return weaviate.connect_to_custom(
+        return cast(Any, weaviate).connect_to_custom(
             http_host=host,
             http_port=port,
             http_secure=url.startswith("https"),

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+try:
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+except Exception:  # pragma: no cover - optional dependency
+    from pydantic import BaseModel
+
+    class BaseSettings(BaseModel):
+        """Fallback settings base class."""
+
+    SettingsConfigDict = dict  # type: ignore[misc]
 
 
 class ConfigSettings(BaseSettings):


### PR DESCRIPTION
## Summary
- make pydantic settings optional for test environments
- install missing packages and run integration test for queue overflow

## Testing
- `ruff check src/infra/settings.py src/interfaces/dashboard_backend.py src/agents/core/base_agent.py src/agents/memory/weaviate_vector_store_manager.py tests/integration/interfaces/test_dashboard_backend_api.py`
- `mypy src/infra/settings.py src/interfaces/dashboard_backend.py src/agents/core/base_agent.py src/agents/memory/weaviate_vector_store_manager.py`
- `pytest -n1 -m integration tests/integration/interfaces/test_dashboard_backend_api.py::test_message_queue_overflow -vv`

------
https://chatgpt.com/codex/tasks/task_e_6865d9545b548326a59f1ab3ad835bf1