### PR TITLE
Fix redundant locks in Simulation

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -125,9 +125,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -167,14 +167,12 @@ class Simulation:
         # --- End NEW ---
 
         # Lock to synchronize access to message buffers
-        self._msg_lock = asyncio.Lock()
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
-        self._msg_lock = asyncio.Lock()
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -455,9 +453,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(


### PR DESCRIPTION
## Summary
- remove duplicate `_msg_lock` assignments in `Simulation.__init__`
- handle missing agents in `generate_thought_and_message_node`
- run `ruff format`

## Testing
- `pip install hypothesis pytest-xdist pytest-asyncio starlette pydantic-settings -q`
- `pytest -q tests/unit/graphs/test_graph_nodes.py::test_generate_thought_and_message_node -vv`

------
https://chatgpt.com/codex/tasks/task_e_6865d95359848326a4be48484d323ab0