### PR TITLE
Update Discord docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
 * **Collective Metrics:** The simulation tracks collective IP and DU, and agents perceive these global metrics.
 * **Dynamic Roles & Basic Goals:** Agents can be assigned roles (Innovator, Analyzer, Facilitator) that influence their behavior and can dynamically request role changes.
 * **Basic Group/Project Affiliation:** Agents can propose, create, join, and leave projects.
-* **Initial Discord Output:** A read-only Discord bot interface provides real-time visibility into simulation events.
+* **Initial Discord Output:** A Discord bot interface provides real-time visibility into simulation events and routes any user messages through the shared event queue (see `Simulation._handle_human_command`).
 * **DSPy Integration:** Advanced prompt optimization using DSPy with local Ollama models.
 * **LLM Performance Monitoring:** Comprehensive monitoring of LLM call performance metrics.
 * **Memory Pruning System:** Sophisticated pruning to maintain optimal performance while preserving critical information.

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -39,9 +39,11 @@ class SimulationDiscordBot:
     """
     A Discord bot that provides real-time updates about the Culture simulation.
 
-    This bot connects to a specified Discord channel and sends read-only updates
-    about simulation events, including Knowledge Board updates, agent messages,
-    role changes, and other significant state changes.
+    This bot connects to a specified Discord channel and sends updates about
+    simulation events, including Knowledge Board updates, agent messages, role
+    changes, and other significant state changes. Incoming Discord messages are
+    placed on the shared event queue and ultimately handled by
+    ``Simulation._handle_human_command``.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
- update Discord docstring to mention event queue and message handling
- remove read-only wording and explain message routing in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866a18d671c8326ac9ad3e1aa42b975