### PR TITLE
Remove noqa comment from weaviate stub

### DIFF
--- a/stubs/weaviate/__init__.py
+++ b/stubs/weaviate/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
 try:
-    from . import classes  # noqa: F401
+    from . import classes
 except Exception:
     classes = import_module('stubs.weaviate.classes')


### PR DESCRIPTION
## Summary
- clean up weaviate stub by removing a redundant `noqa` comment

## Testing
- `ruff check stubs/weaviate/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68685d1f4c2c8326ba3404f6e35f5e0b