### PR TITLE
Implement widget registry with metadata

### DIFF
--- a/culture-ui/src/lib/widgetRegistry.ts
+++ b/culture-ui/src/lib/widgetRegistry.ts
@@ -1,5 +1,13 @@
+export interface WidgetMeta {
+  scriptUrl?: string
+}
+
+export interface WidgetInfo extends WidgetMeta {
+  name: string
+}
+
 export interface WidgetRegistry {
-  register(name: string, component: React.ComponentType): void
+  register(name: string, component: React.ComponentType, meta?: WidgetMeta): void
   get(name: string): React.ComponentType | undefined
   list(): string[]
 }
@@ -7,13 +15,13 @@ export interface WidgetRegistry {
 class Registry implements WidgetRegistry {
   private widgets = new Map<string, React.ComponentType>()
 
-  register(name: string, component: React.ComponentType) {
+  register(name: string, component: React.ComponentType, meta?: WidgetMeta) {
     this.widgets.set(name, component)
     try {
-      void fetch('/api/register_widget', {
+      void fetch('/api/widgets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, ...(meta ?? {}) }),
       }).catch(() => {})
     } catch {
       // ignore registration errors
@@ -33,5 +41,21 @@ export const widgetRegistry = new Registry()
 export const registerWidget = widgetRegistry.register.bind(widgetRegistry)
 export const getWidget = widgetRegistry.get.bind(widgetRegistry)
 export const listWidgets = widgetRegistry.list.bind(widgetRegistry)
+
+export async function loadRemoteWidgets() {
+  try {
+    const res = await fetch('/api/widgets')
+    const data = (await res.json()) as { widgets: WidgetInfo[] }
+    await Promise.all(
+      data.widgets.map(async (w) => {
+        if (w.scriptUrl) {
+          await import(/* @vite-ignore */ w.scriptUrl)
+        }
+      }),
+    )
+  } catch {
+    // ignore failures
+  }
+}
 
 

--- a/culture-ui/src/main.tsx
+++ b/culture-ui/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
-import { widgetRegistry } from './lib/widgetRegistry'
+import { widgetRegistry, loadRemoteWidgets } from './lib/widgetRegistry'
 import {
   TimelineWidget,
   BreakpointList,
@@ -19,6 +19,8 @@ widgetRegistry.register('WorldMap', WorldMap)
 widgetRegistry.register('KpiCard', KpiCard)
 widgetRegistry.register('Breakpoints', BreakpointList)
 widgetRegistry.register('Events', EventConsole)
+
+void loadRemoteWidgets();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/interfaces/widget_registry.py
+++ b/src/interfaces/widget_registry.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class WidgetRegistry:
+    """Simple registry for dashboard widgets."""
+
+    def __init__(self) -> None:
+        self._widgets: dict[str, dict[str, Any]] = {}
+
+    def register(self, name: str, metadata: dict[str, Any] | None = None) -> None:
+        self._widgets[name] = metadata or {}
+
+    def get(self, name: str) -> dict[str, Any] | None:
+        return self._widgets.get(name)
+
+    def list(self) -> list[dict[str, Any]]:
+        return [{"name": n, **meta} for n, meta in sorted(self._widgets.items())]
+
+
+__all__ = ["WidgetRegistry"]

--- a/tests/unit/interfaces/test_dashboard_backend_register_widget.py
+++ b/tests/unit/interfaces/test_dashboard_backend_register_widget.py
@@ -8,8 +8,8 @@ from src.interfaces import dashboard_backend as db
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_register_widget_adds_name() -> None:
-    db.REGISTERED_WIDGETS.clear()
-    resp = await db.register_widget({"name": "extra"})
+    db.WIDGET_REGISTRY._widgets.clear()
+    resp = await db.register_widget({"name": "extra", "script_url": "s.js"})
     data = json.loads(resp.body)
-    assert "extra" in db.REGISTERED_WIDGETS
-    assert "extra" in data["widgets"]
+    assert db.WIDGET_REGISTRY.get("extra") == {"script_url": "s.js"}
+    assert any(w["name"] == "extra" for w in data["widgets"])


### PR DESCRIPTION
## Summary
- add a reusable `WidgetRegistry` for keeping widget metadata
- expose `/api/widgets` endpoints and use registry in `dashboard_backend`
- support remote widget loading in the React UI
- register widgets from the server at startup
- adjust tests for new behavior

## Testing
- `ruff format src/interfaces/widget_registry.py src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_register_widget.py`
- `ruff check src/interfaces/widget_registry.py src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_register_widget.py`
- `black src/interfaces/widget_registry.py src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_register_widget.py`
- `mypy src/interfaces/widget_registry.py src/interfaces/dashboard_backend.py`
- `pytest tests/unit/interfaces/test_dashboard_backend_register_widget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686868f3b0bc832681f6b36901d695d9