### PR TITLE
Refactor event queue creation

### DIFF
--- a/tests/unit/interfaces/test_event_queue_creation.py
+++ b/tests/unit/interfaces/test_event_queue_creation.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+async def _clear_event_queue() -> None:
+    queue = db.get_event_queue()
+    while not queue.empty():
+        _ = await queue.get()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_event_queue_running_loop() -> None:
+    await _clear_event_queue()
+    q1 = db.get_event_queue()
+    await q1.put(db.SimulationEvent(event_type="a", data={}))
+    q2 = db.get_event_queue()
+    assert q1 is q2
+    _ = await q1.get()
+
+
+@pytest.mark.unit
+def test_get_event_queue_no_running_loop() -> None:
+    q1 = db.get_event_queue()
+
+    async def call_in_loop() -> asyncio.Queue[db.SimulationEvent | None]:
+        return db.get_event_queue()
+
+    loop = asyncio.new_event_loop()
+    try:
+        q2 = loop.run_until_complete(call_in_loop())
+    finally:
+        loop.close()
+
+    assert q1 is not q2


### PR DESCRIPTION
## Summary
- update dashboard backend to make a local event loop instead of using `set_event_loop`
- add test for `get_event_queue` creation behaviour
- track which loop owns the event queue
- skip widget registration when FastAPI stub lacks decorators
- define `register_widget` function even if the app has no decorators

## Testing
- `ruff check src/interfaces/dashboard_backend.py tests/unit/interfaces/test_event_queue_creation.py`
- `mypy src/interfaces/dashboard_backend.py tests/unit/interfaces/test_event_queue_creation.py`
- `pytest tests/unit/interfaces/test_event_queue_creation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6866a18ee79483268cb843015cf7d019