### PR TITLE
Add tests for semantic summaries and SSE

### DIFF
--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -1,0 +1,72 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import src.http_app as http_app
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.interfaces import dashboard_backend as db
+from src.sim.simulation import Simulation
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+class DummyRequest:
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = SimpleNamespace(ip=0.0, du=0.0, mood_level=0.0)
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, new_state: SimpleNamespace) -> None:
+        self.state = new_state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+
+async def _clear_event_queue() -> None:
+    queue = db.get_event_queue()
+    while not queue.empty():
+        await queue.get()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+    agent = DummyAgent("a1")
+    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+
+    class CaptureESR:
+        def __init__(self, gen: object) -> None:
+            self.gen = gen
+
+    monkeypatch.setattr(http_app, "EventSourceResponse", CaptureESR)
+    await _clear_event_queue()
+    await sim.run_step()
+
+    queue = db.get_event_queue()
+    await queue.put(None)
+    resp = await http_app.stream_events(DummyRequest())
+    event = await resp.gen.__anext__()
+    payload = json.loads(event["data"])
+    assert payload["event_type"] == "agent_action"
+    with pytest.raises(StopAsyncIteration):
+        await resp.gen.__anext__()

--- a/tests/unit/interfaces/test_dashboard_semantic_summaries.py
+++ b/tests/unit/interfaces/test_dashboard_semantic_summaries.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+class DummyManager:
+    def __init__(self, summaries: list[str] | None = None, raise_exc: bool = False) -> None:
+        self.summaries = summaries or []
+        self.raise_exc = raise_exc
+        self.calls: list[tuple[str, int]] = []
+
+    def get_recent_summaries(self, agent_id: str, limit: int = 3) -> list[str]:
+        self.calls.append((agent_id, limit))
+        if self.raise_exc:
+            raise RuntimeError("boom")
+        return self.summaries[:limit]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_semantic_summaries_with_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = DummyManager(["s1", "s2"])
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
+
+    resp = await db.get_semantic_summaries("agent", limit=1)
+    data = json.loads(resp.body)
+    assert data == {"summaries": ["s1"]}
+    assert manager.calls == [("agent", 1)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_semantic_summaries_no_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", None)
+
+    resp = await db.get_semantic_summaries("agent")
+    data = json.loads(resp.body)
+    assert data == {"summaries": []}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_semantic_summaries_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = DummyManager(raise_exc=True)
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
+
+    resp = await db.get_semantic_summaries("agent")
+    data = json.loads(resp.body)
+    assert data == {"summaries": []}


### PR DESCRIPTION
## Summary
- add unit tests covering `get_semantic_summaries`
- add integration test exercising SSE output when a Simulation runs with a `SemanticMemoryManager`

## Testing
- `mypy src/interfaces/dashboard_backend.py`
- `pytest tests/unit/interfaces/test_dashboard_semantic_summaries.py tests/integration/interfaces/test_simulation_sse.py -q -c pytest.ini`

------
https://chatgpt.com/codex/tasks/task_e_68686c898974832682599f0fc45619e5