### PR TITLE
Refactor simulation event kernel

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -562,11 +562,8 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                     },
                 ),
             )
-        return cast(
-            dict[str, Any],
-            base_model.dict(
-                exclude={"llm_client", "mock_llm_client", "memory_store_manager"}
-            ),
+        return base_model.dict(
+            exclude={"llm_client", "mock_llm_client", "memory_store_manager"}
         )
 
     @classmethod

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import heapq
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Any, Callable
 
 from typing_extensions import Self
 
+from src.infra.event_log import log_event
 from src.infra.snapshot import compute_trace_hash
+from src.interfaces.dashboard_backend import (
+    SimulationEvent,
+    emit_event,
+    emit_map_action_event,
+    get_event_queue,
+)
 
 from .version_vector import VersionVector
 
@@ -211,3 +219,44 @@ class EventKernel:
 
     def empty(self: Self) -> bool:
         return not self._queue
+
+    async def emit_environment_event(self: Self, event: dict[str, Any]) -> None:
+        """Log and forward an environment event."""
+        event_with_hash = log_event(event)
+        if event_with_hash is None:
+            event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
+        if event.get("type") == "map_action":
+            await emit_map_action_event(
+                event.get("agent_id", ""),
+                event.get("step", 0),
+                event.get("action", ""),
+                **{
+                    k: v
+                    for k, v in event.items()
+                    if k not in {"type", "agent_id", "step", "action", "trace_hash"}
+                },
+            )
+        else:
+            await emit_event(SimulationEvent(event_type=event["type"], data=event_with_hash))
+
+    async def forward_external_events(
+        self: Self, handler: Callable[[str], Awaitable[None]]
+    ) -> None:
+        """Forward broadcast events from the shared queue to ``handler``.
+
+        This coroutine listens indefinitely on the global event queue and
+        passes the ``content`` of any broadcast events to ``handler``. The
+        loop exits when the queue yields ``None``.
+        """
+        queue = get_event_queue()
+        try:
+            while True:
+                evt: SimulationEvent | None = await queue.get()
+                if evt is None:
+                    break
+                if evt.event_type == "broadcast" and evt.data:
+                    content = evt.data.get("content")
+                    if isinstance(content, str):
+                        await handler(content)
+        except asyncio.CancelledError:
+            pass

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -29,7 +29,6 @@ from src.infra.snapshot import (
 from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
-    emit_map_action_event,
     get_event_queue,
 )
 from src.shared.typing import SimulationMessage
@@ -209,7 +208,9 @@ class Simulation:
         except RuntimeError:
             self._event_task = None
         else:
-            self._event_task = asyncio.create_task(self._forward_external_events())
+            self._event_task = asyncio.create_task(
+                self.event_kernel.forward_external_events(self._handle_human_command)
+            )
 
     # Add method to update collective metrics
     def _update_collective_metrics(self: Self) -> None:
@@ -281,22 +282,6 @@ class Simulation:
         async with self._msg_lock:
             self.pending_messages_for_next_round.append(msg)
             self.messages_to_perceive_this_round.append(msg)
-
-    async def _forward_external_events(self: Self) -> None:
-        """Background task that forwards events from ``event_queue``."""
-        queue = get_event_queue()
-        try:
-            queue = get_event_queue()
-            while True:
-                evt: SimulationEvent | None = await queue.get()
-                if evt is None:
-                    break
-                if evt.event_type == "broadcast" and evt.data:
-                    content = evt.data.get("content")
-                    if isinstance(content, str):
-                        await self._handle_human_command(content)
-        except asyncio.CancelledError:  # pragma: no cover - task cancelled
-            pass
 
     async def spawn_agent(
         self: Self,
@@ -693,27 +678,6 @@ class Simulation:
     def _create_agent_event(self: Self, agent_index: int) -> Callable[[], Awaitable[None]]:
         return lambda: self._run_agent_turn(agent_index)
 
-    async def _emit_environment_event(self: Self, event: dict[str, Any]) -> None:
-        event_with_hash = log_event(event)
-        if event_with_hash is None:
-            event_with_hash = {
-                **event,
-                "trace_hash": compute_trace_hash(event),
-            }
-        if event.get("type") == "map_action":
-            await emit_map_action_event(
-                event.get("agent_id", ""),
-                event.get("step", 0),
-                event.get("action", ""),
-                **{
-                    k: v
-                    for k, v in event.items()
-                    if k not in {"type", "agent_id", "step", "action", "trace_hash"}
-                },
-            )
-        else:
-            await emit_event(SimulationEvent(event_type=event["type"], data=event_with_hash))
-
     async def _prune_memory_event(self: Self) -> None:
         if not self.vector_store_manager:
             return
@@ -723,7 +687,7 @@ class Simulation:
                 "type": "memory_prune",
                 "step": self.current_step,
             }
-            await self._emit_environment_event(event)
+            await self.event_kernel.emit_environment_event(event)
         except (ChromaDBException, ValidationError, OSError) as exc:
             logger.error("Failed to prune memory store: %s", exc)
 
@@ -744,7 +708,7 @@ class Simulation:
             "step": self.current_step,
             "start": start_step,
         }
-        await self._emit_environment_event(event)
+        await self.event_kernel.emit_environment_event(event)
 
     async def _event_listener_loop(self: Self) -> None:
         """Continuously process events from the shared queue."""

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -146,7 +146,7 @@ async def process_map_action(
         **details,
     }
     await sim.event_kernel.schedule_immediate(
-        lambda data=map_event_data: sim._emit_environment_event(data),
+        lambda data=map_event_data: sim.event_kernel.emit_environment_event(data),
         vector=sim.vector,
     )
     if sim.discord_bot:

--- a/tests/unit/sim/test_event_kernel.py
+++ b/tests/unit/sim/test_event_kernel.py
@@ -1,5 +1,9 @@
+import asyncio
+from typing import Any
+
 import pytest
 
+from src.interfaces.dashboard_backend import SimulationEvent
 from src.sim.event_kernel import EventKernel
 from src.sim.version_vector import VersionVector
 
@@ -100,3 +104,60 @@ async def test_schedule_in_future() -> None:
     events += await kernel.dispatch(1)
     assert order == [1, 2, 3]
     assert [e.step for e in events] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_emit_environment_event_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    kernel = EventKernel()
+    events: dict[str, Any] = {}
+
+    async def fake_emit_event(evt: Any) -> None:
+        events["event"] = evt
+
+    async def fake_emit_map_action(agent_id: str, step: int, action: str, **details: Any) -> None:
+        events["map_called"] = True
+
+    monkeypatch.setattr("src.interfaces.dashboard_backend.emit_event", fake_emit_event)
+    monkeypatch.setattr(
+        "src.sim.event_kernel.emit_map_action_event",
+        fake_emit_map_action,
+    )
+    monkeypatch.setattr(
+        "src.infra.event_log.log_event",
+        lambda e: {**e, "trace_hash": "x"},
+    )
+
+    event = {
+        "type": "map_action",
+        "agent_id": "A",
+        "step": 1,
+        "action": "move",
+        "position": (1, 0),
+    }
+
+    await kernel.emit_environment_event(event)
+
+    assert events.get("map_called") is True
+
+
+@pytest.mark.asyncio
+async def test_forward_external_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue: asyncio.Queue[SimulationEvent | None] = asyncio.Queue()
+
+    monkeypatch.setattr(
+        "src.interfaces.dashboard_backend.get_event_queue",
+        lambda: queue,
+    )
+
+    kernel = EventKernel()
+    received: list[str] = []
+
+    async def handler(text: str) -> None:
+        received.append(text)
+
+    task = asyncio.create_task(kernel.forward_external_events(handler))
+    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await queue.put(None)
+    await task
+
+    assert received == ["hi"]


### PR DESCRIPTION
## Summary
- migrate external event forwarding and emission into EventKernel
- simplify Simulation by delegating to EventKernel
- adjust world map actions to use EventKernel
- fix AgentState serialization cast
- extend EventKernel unit tests
- improve documentation for broadcast forwarding

## Testing
- `pytest tests/unit/sim/test_event_kernel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686868f4ab8c8326b6e4358918552502