### PR TITLE
Add semantic summary retrieval to vector store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+
 All notable changes to this project will be documented in this file.
+
+## [0.2.1] - 2025-07-08
+### Fixed
+- Added ``pytest-asyncio`` to runtime requirements so asynchronous tests run without plugin errors.
 
 ## [0.2.0] - 2025-07-01
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,6 +139,7 @@ add_memory()        # Add a new memory to the store
 retrieve_relevant_memories()  # Retrieve memories by semantic similarity
 retrieve_filtered_memories()  # Retrieve memories by metadata filters
 query_memories()    # Combined semantic and metadata filtering
+get_semantic_summaries()  # Fetch consolidated semantic summaries
 ```
 
 #### WeaviateVectorStoreManager
@@ -289,6 +290,7 @@ This node:
 - Retrieves relevant memories using RAG techniques
 - Summarizes retrieved memories for context
 - Balances recent and important older memories
+- Includes the latest semantic summaries via ``ChromaVectorStoreManager``
 
 #### generate_thought_and_message_node
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -406,6 +406,8 @@ pyyaml==6.0.2
     #   langchain-core
     #   optuna
     #   uvicorn
+pytest-asyncio==0.23.8
+    # via -r requirements-dev.in
 redis==6.2.0
     # via -r requirements.in
 referencing==0.36.2

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -79,14 +79,16 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
     manager = cast(MemoryRetriever | None, state.get("vector_store_manager"))
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
-    semantic_manager = cast(SemanticMemoryManager | None, state.get("semantic_manager"))
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
     memories = await manager.aretrieve_relevant_memories(state["agent_id"], query="", k=5)
     memories_content = [m.get("content", "") for m in memories]
-    if semantic_manager:
-        semantic = semantic_manager.get_recent_summaries(state["agent_id"], limit=2)
-        memories_content.extend(semantic)
+    if hasattr(manager, "get_semantic_summaries"):
+        try:
+            semantic = cast(Any, manager).get_semantic_summaries(state["agent_id"], limit=2)
+            memories_content.extend(semantic)
+        except Exception:  # pragma: no cover - defensive
+            pass
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -17,7 +17,15 @@ import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
+
+if TYPE_CHECKING:
+    from neo4j import Driver
+else:  # pragma: no cover - fallback if neo4j not installed
+    try:
+        from neo4j import Driver
+    except Exception:  # pragma: no cover - defensive
+        Driver = object
 
 from pydantic import ValidationError
 from typing_extensions import Self
@@ -96,6 +104,7 @@ class ChromaVectorStoreManager(MemoryStore):
         self: Self,
         persist_directory: str = "./chroma_db",
         embedding_function: Any | None = None,
+        semantic_driver: Driver | None = None,
     ) -> None:
         """Initialize the vector store manager.
 
@@ -105,6 +114,9 @@ class ChromaVectorStoreManager(MemoryStore):
                 provided, ``SentenceTransformerEmbeddingFunction`` is used. This
                 parameter allows tests to provide a lightweight stub so that the
                 heavy ``sentence-transformers`` dependency isn't required.
+            semantic_driver: Neo4j driver used for retrieving semantic summaries.
+                This is optional and can be ``None`` when semantic summaries are
+                not persisted via Neo4j.
         """
         # Ensure the directory exists
         persist_path = ensure_dir(persist_directory)
@@ -126,6 +138,7 @@ class ChromaVectorStoreManager(MemoryStore):
                 embedding_function = _dummy_embedding
 
         self.embedding_function: Any = embedding_function
+        self.semantic_driver = semantic_driver
 
         # Initialize the persistent ChromaDB client
         logger.info(f"Initializing ChromaDB client with persistence directory: {persist_path}")
@@ -1426,3 +1439,23 @@ class ChromaVectorStoreManager(MemoryStore):
                 exc_info=True,
             )
             return []
+
+    # ------------------------------------------------------------------
+    # Semantic summaries interface
+    # ------------------------------------------------------------------
+    def get_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
+        """Return recent semantic summaries stored via the semantic driver."""
+        if self.semantic_driver is None:
+            return []
+        with self.semantic_driver.session() as session:
+            records = session.run(
+                """
+                MATCH (a:Agent {id: $agent_id})-[:HAS_SEMANTIC]->(s:SemanticMemory)
+                RETURN s.summary AS summary
+                ORDER BY s.created_at DESC
+                LIMIT $limit
+                """,
+                agent_id=agent_id,
+                limit=limit,
+            )
+            return [record["summary"] for record in records]

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -182,7 +182,7 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
     summaries: list[str] = []
     if manager is not None:
         try:
-            summaries = manager.get_recent_summaries(agent_id, limit=limit)
+            summaries = manager.get_semantic_summaries(agent_id, limit=limit)
         except Exception:  # pragma: no cover - defensive
             summaries = []
     return JSONResponse({"summaries": summaries})

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -10,6 +10,9 @@ class DummyVectorStore:
     ) -> list[dict[str, str]]:
         return [{"content": "memory1"}]
 
+    def get_semantic_summaries(self, agent_id: str, limit: int = 2) -> list[str]:
+        return ["summary1"]
+
 
 import pytest
 from pytest import LogCaptureFixture
@@ -81,9 +84,9 @@ async def test_dspy_call_timeout_in_graph(
     mock_program_callable = AsyncMock(side_effect=mock_slow_dspy_call)
 
     logger.info(f"Simple agent dict before hasattr: {simple_agent.__dict__}")
-    assert hasattr(simple_agent, "action_intent_selector_program"), (
-        "Agent should have action_intent_selector_program before patch"
-    )
+    assert hasattr(
+        simple_agent, "action_intent_selector_program"
+    ), "Agent should have action_intent_selector_program before patch"
 
     # Prepare a minimal AgentTurnState
     initial_turn_state = AgentTurnState(
@@ -153,17 +156,17 @@ async def test_dspy_call_timeout_in_graph(
         final_structured_output = final_state.get("structured_output")
         assert final_structured_output is not None, "Final state should have structured_output"
         # Default fallback is often 'idle'
-        assert final_structured_output.action_intent == AgentActionIntent.IDLE.value, (
-            f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
-        )
+        assert (
+            final_structured_output.action_intent == AgentActionIntent.IDLE.value
+        ), f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
         assert (
             "timeout" in final_structured_output.thought.lower()
             or "fallback" in final_structured_output.thought.lower()
             or "default" in final_structured_output.thought.lower()
         ), f"Expected thought to indicate timeout/fallback, got: {final_structured_output.thought}"
-        assert final_state["memory_history_list"], (
-            "memory_history_list should contain retrieved memories"
-        )
+        assert final_state[
+            "memory_history_list"
+        ], "memory_history_list should contain retrieved memories"
 
 
 @pytest.mark.asyncio
@@ -250,24 +253,22 @@ async def test_dspy_call_exception_in_graph(
         #    The generate_thought_and_message_node should produce a default/fallback
         #    AgentActionOutput if async_select_action_intent raises an exception.
         final_structured_output_exc = final_state.get("structured_output")
-        assert final_structured_output_exc is not None, (
-            "Final state should have structured_output after exception"
-        )
+        assert (
+            final_structured_output_exc is not None
+        ), "Final state should have structured_output after exception"
         # Default fallback is often 'idle'
-        assert final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value, (
-            f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
-        )
+        assert (
+            final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value
+        ), f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
         assert (
             "error" in final_structured_output_exc.thought.lower()
             or "fallback" in final_structured_output_exc.thought.lower()
             or "exception" in final_structured_output_exc.thought.lower()
             or "default" in final_structured_output_exc.thought.lower()
-        ), (
-            f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
-        )
-        assert final_state["memory_history_list"], (
-            "memory_history_list should contain retrieved memories"
-        )
+        ), f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
+        assert final_state[
+            "memory_history_list"
+        ], "memory_history_list should contain retrieved memories"
 
         # 3. Optional: Verify the specific error log from the mock if it appears, but don't fail if not,
         #    as primary check is the fallback action.

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -58,6 +58,9 @@ class DummyManager:
     ) -> list[dict[str, str]]:
         return [{"content": "m1"}, {"content": "m2"}]
 
+    def get_semantic_summaries(self, agent_id: str, limit: int = 2) -> list[str]:
+        return ["sem1"]
+
 
 class DummyAgent:
     async def async_generate_l1_summary(

--- a/tests/unit/interfaces/test_dashboard_semantic_summaries.py
+++ b/tests/unit/interfaces/test_dashboard_semantic_summaries.py
@@ -11,7 +11,7 @@ class DummyManager:
         self.raise_exc = raise_exc
         self.calls: list[tuple[str, int]] = []
 
-    def get_recent_summaries(self, agent_id: str, limit: int = 3) -> list[str]:
+    def get_semantic_summaries(self, agent_id: str, limit: int = 3) -> list[str]:
         self.calls.append((agent_id, limit))
         if self.raise_exc:
             raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- expose `get_semantic_summaries` on `ChromaVectorStoreManager`
- use vector store interface in `retrieve_and_summarize_memories_node`
- update dashboard to call `get_semantic_summaries`
- adjust tests for updated interface
- document async test fix in CHANGELOG

## Testing
- `ruff check src/agents/graphs/graph_nodes.py src/agents/memory/vector_store.py src/interfaces/dashboard_backend.py tests/integration/graph/test_async_agent_graph.py tests/unit/graphs/test_graph_nodes.py tests/unit/interfaces/test_dashboard_semantic_summaries.py`
- `black --check src/agents/graphs/graph_nodes.py src/agents/memory/vector_store.py src/interfaces/dashboard_backend.py tests/integration/graph/test_async_agent_graph.py tests/unit/graphs/test_graph_nodes.py tests/unit/interfaces/test_dashboard_semantic_summaries.py`
- `mypy --install-types --non-interactive src/agents/graphs/graph_nodes.py src/agents/memory/vector_store.py`
- `pytest tests/unit/interfaces/test_dashboard_semantic_summaries.py -q`
- `pytest tests/unit/graphs/test_graph_nodes.py tests/integration/graph/test_async_agent_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686b2964617c8326afb700bcaf8ac92e