### PR TITLE
Add Storyboard widget to culture-ui

### DIFF
--- a/culture-ui/README.md
+++ b/culture-ui/README.md
@@ -79,3 +79,12 @@ The UI includes pages for monitoring active missions and reviewing agent data:
 - **Agent Data Overview** – lists observations, messages and other data gathered by agents.
 
 Screenshots will be added to this README as these pages mature.
+
+## Storyboard Widget
+
+The Storyboard widget streams simulation events from `/stream/events` and
+displays agent coordinates and current mood values. A "Summaries" tab fetches
+recent memory summaries for the selected agent via
+`/api/agents/{id}/semantic_summaries`.
+
+Run the development server and navigate to `/storyboard` to see it in action.

--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -10,6 +10,7 @@ import NetworkWebPage from './pages/NetworkWeb'
 import WorldMapPage from './pages/WorldMap'
 import TimelineWidgetPage from './pages/TimelineWidget'
 import KpiCardPage from './pages/KpiCard'
+import StoryboardPage from './pages/Storyboard'
 import MemoryExplorer from './pages/MemoryExplorer'
 import DockManager from './components/DockManager'
 import { createDefaultLayout } from './lib/defaultLayout'
@@ -33,6 +34,7 @@ export default function App() {
             <Route path="/world-map" element={<WorldMapPage />} />
             <Route path="/timeline" element={<TimelineWidgetPage />} />
             <Route path="/kpi-card" element={<KpiCardPage />} />
+            <Route path="/storyboard" element={<StoryboardPage />} />
             <Route path="/memory" element={<MemoryExplorer />} />
           </Routes>
         </DockManager>

--- a/culture-ui/src/Storyboard.test.tsx
+++ b/culture-ui/src/Storyboard.test.tsx
@@ -1,0 +1,40 @@
+import { act, render, screen } from '@testing-library/react'
+import StoryboardPage from './pages/Storyboard'
+import { MockEventSource, resetMockSources } from './lib/testUtils'
+import { vi } from 'vitest'
+
+afterEach(() => {
+  resetMockSources()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Storyboard widget', () => {
+  it('shows coordinates, mood and summaries', async () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ summaries: ['s1'] }),
+      }) as unknown as Response,
+    ))
+
+    render(<StoryboardPage />)
+
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage(
+        '{"data":{"world_map":{"agents":{"a1":[5,6]}},"agents":[{"agent_id":"a1","mood":0.2}]}}',
+      )
+    })
+
+    expect(await screen.findByText('a1: 5, 6 (mood 0.2)')).toBeInTheDocument()
+
+    act(() => {
+      screen.getByRole('button', { name: /summaries/i }).click()
+    })
+
+    expect(await screen.findByText('s1')).toBeInTheDocument()
+  })
+})
+

--- a/culture-ui/src/lib/defaultLayout.ts
+++ b/culture-ui/src/lib/defaultLayout.ts
@@ -3,7 +3,7 @@ import { listWidgets } from './widgetRegistry'
 
 export function createDefaultLayout(): IJsonModel {
   const widgets = listWidgets()
-  const order = ['NetworkWeb', 'WorldMap', 'TimelineWidget', 'KpiCard', 'MemoryExplorer']
+  const order = ['NetworkWeb', 'WorldMap', 'Storyboard', 'TimelineWidget', 'KpiCard', 'MemoryExplorer']
   const sorted = [
     ...order.filter((n) => widgets.includes(n)),
     ...widgets.filter((n) => !order.includes(n)),

--- a/culture-ui/src/main.tsx
+++ b/culture-ui/src/main.tsx
@@ -11,6 +11,7 @@ import {
   WorldMap,
   KpiCard,
   EventConsole,
+  Storyboard,
 } from './widgets'
 
 widgetRegistry.register('TimelineWidget', TimelineWidget)
@@ -19,6 +20,7 @@ widgetRegistry.register('WorldMap', WorldMap)
 widgetRegistry.register('KpiCard', KpiCard)
 widgetRegistry.register('Breakpoints', BreakpointList)
 widgetRegistry.register('Events', EventConsole)
+widgetRegistry.register('Storyboard', Storyboard)
 
 void loadRemoteWidgets();
 

--- a/culture-ui/src/pages/Storyboard.tsx
+++ b/culture-ui/src/pages/Storyboard.tsx
@@ -1,0 +1,13 @@
+import Storyboard from '../widgets/Storyboard'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function StoryboardPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Storyboard</h1>
+      <Storyboard />
+    </div>
+  )
+}
+
+registerWidget('Storyboard', StoryboardPage)

--- a/culture-ui/src/widgets/Storyboard.tsx
+++ b/culture-ui/src/widgets/Storyboard.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
+
+interface SnapshotEvent {
+  data?: {
+    world_map?: { agents?: Record<string, [number, number]> }
+    agents?: Array<{ agent_id: string; mood?: number }>
+  }
+}
+
+export default function Storyboard() {
+  const event = useEventSource<SnapshotEvent>()
+  const [positions, setPositions] = useState<Record<string, [number, number]>>({})
+  const [moods, setMoods] = useState<Record<string, number>>({})
+  const [tab, setTab] = useState<'map' | 'summaries'>('map')
+  const [summaries, setSummaries] = useState<string[]>([])
+
+  const agentId = Object.keys(positions)[0] || Object.keys(moods)[0] || 'agent-1'
+
+  useEffect(() => {
+    if (event?.data?.world_map?.agents) {
+      setPositions(event.data.world_map.agents)
+    }
+    if (event?.data?.agents) {
+      const m: Record<string, number> = {}
+      for (const a of event.data.agents) {
+        if (typeof a.mood === 'number') m[a.agent_id] = a.mood
+      }
+      setMoods((cur) => ({ ...cur, ...m }))
+    }
+  }, [event])
+
+  useEffect(() => {
+    if (tab !== 'summaries') return
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(`/api/agents/${agentId}/semantic_summaries`)
+        const json = await res.json()
+        if (!cancelled) setSummaries(json.summaries || [])
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [tab, agentId])
+
+  return (
+    <div className="p-2" data-testid="storyboard">
+      <div className="space-x-2 mb-2">
+        <button onClick={() => setTab('map')}>Map</button>
+        <button onClick={() => setTab('summaries')}>Summaries</button>
+      </div>
+      {tab === 'map' ? (
+        <ul data-testid="map-info">
+          {Object.entries(positions).map(([id, pos]) => (
+            <li key={id}>
+              {id}: {pos[0]}, {pos[1]} (mood {moods[id] ?? 'n/a'})
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div data-testid="summaries">
+          {summaries.map((s, i) => (
+            <div key={i}>{s}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -4,5 +4,6 @@ export { default as NetworkWeb } from './NetworkWeb'
 export { default as WorldMap } from './WorldMap'
 export { default as KpiCard } from './KpiCard'
 export { default as EventConsole } from './EventConsole'
+export { default as Storyboard } from './Storyboard'
 
 


### PR DESCRIPTION
## Summary
- add Storyboard widget and page
- register Storyboard widget in main.tsx and default layout
- expose /storyboard route
- test Storyboard
- document widget setup

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui type-check`
- `pnpm --filter culture-ui test`

------
https://chatgpt.com/codex/tasks/task_e_686c7d78e3408326a271fbc7d99fe547