### PR TITLE
Add law proposal API and UI

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -8,6 +8,7 @@ import MemoryExplorerPage from './pages/MemoryExplorer'
 import LiveMapPage from './pages/LiveMap'
 import NetworkWebPage from './pages/NetworkWeb'
 import WorldMapPage from './pages/WorldMap'
+import LawProposalPage from './pages/LawProposal'
 import TimelineWidgetPage from './pages/TimelineWidget'
 import KpiCardPage from './pages/KpiCard'
 import MemoryExplorer from './pages/MemoryExplorer'
@@ -32,6 +33,7 @@ export default function App() {
             <Route path="/network-web" element={<NetworkWebPage />} />
             <Route path="/world-map" element={<WorldMapPage />} />
             <Route path="/timeline" element={<TimelineWidgetPage />} />
+            <Route path="/propose-law" element={<LawProposalPage />} />
             <Route path="/kpi-card" element={<KpiCardPage />} />
             <Route path="/memory" element={<MemoryExplorer />} />
           </Routes>

--- a/culture-ui/src/LawProposal.test.tsx
+++ b/culture-ui/src/LawProposal.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import LawProposal from './pages/LawProposal'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+test('submits proposal and shows result', async () => {
+  const user = userEvent.setup()
+  vi.stubGlobal('fetch', vi.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ approved: true })
+    }) as unknown as Response
+  ))
+
+  render(<LawProposal />)
+  await user.type(screen.getByPlaceholderText('Proposal text'), 'L')
+  await user.type(screen.getByPlaceholderText('Proposer ID'), 'A')
+  await user.click(screen.getByRole('button', { name: /submit/i }))
+  expect(await screen.findByTestId('result')).toHaveTextContent('Approved')
+})

--- a/culture-ui/src/components/Sidebar.tsx
+++ b/culture-ui/src/components/Sidebar.tsx
@@ -43,6 +43,11 @@ export default function Sidebar() {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/propose-law" className={linkClass}>
+            Propose Law
+          </NavLink>
+        </li>
+        <li>
           <NavLink to="/memory" className={linkClass}>
             Memory Explorer
           </NavLink>

--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -10,3 +10,16 @@ export async function fetchMissions(): Promise<Mission[]> {
   return (await res.json()) as Mission[]
 }
 
+export async function proposeLaw(
+  proposerId: string,
+  text: string,
+): Promise<boolean> {
+  const res = await fetch('/api/propose_law', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ proposer_id: proposerId, text }),
+  })
+  const data = (await res.json()) as { approved: boolean }
+  return data.approved
+}
+

--- a/culture-ui/src/pages/LawProposal.tsx
+++ b/culture-ui/src/pages/LawProposal.tsx
@@ -1,0 +1,46 @@
+import { useState, FormEvent } from 'react'
+import { registerWidget } from '../lib/widgetRegistry'
+import { proposeLaw } from '../lib/api'
+
+export default function LawProposal() {
+  const [text, setText] = useState('')
+  const [proposer, setProposer] = useState('agent_1')
+  const [result, setResult] = useState<string | null>(null)
+
+  async function submit(e: FormEvent) {
+    e.preventDefault()
+    setResult(null)
+    try {
+      const approved = await proposeLaw(proposer, text)
+      setResult(approved ? 'Approved' : 'Rejected')
+    } catch {
+      setResult('Error')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Propose Law</h1>
+      <form onSubmit={submit} className="space-y-2">
+        <input
+          placeholder="Proposal text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="border p-1 w-full"
+        />
+        <input
+          placeholder="Proposer ID"
+          value={proposer}
+          onChange={(e) => setProposer(e.target.value)}
+          className="border p-1 w-full"
+        />
+        <button type="submit" className="px-2 py-1 border rounded">
+          Submit
+        </button>
+      </form>
+      {result && <div data-testid="result">Result: {result}</div>}
+    </div>
+  )
+}
+
+registerWidget('LawProposal', LawProposal)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -107,7 +107,12 @@ def get_event_queue() -> asyncio.Queue["SimulationEvent | None"]:
 
 
 # Simulation control state
-SIM_STATE: dict[str, Any] = {"paused": False, "speed": 1.0, "semantic_manager": None}
+SIM_STATE: dict[str, Any] = {
+    "paused": False,
+    "speed": 1.0,
+    "semantic_manager": None,
+    "simulation": None,
+}
 BREAKPOINT_TAGS: set[str] = {"violence", "nsfw"}
 
 # Registry of widgets registered by the UI or plugins
@@ -134,6 +139,11 @@ class SimulationEvent(BaseModel):
 
     event_type: str
     data: dict[str, Any] | None = None
+
+
+class LawProposal(BaseModel):
+    proposer_id: str
+    text: str
 
 
 app = FastAPI()
@@ -186,6 +196,19 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
         except Exception:  # pragma: no cover - defensive
             summaries = []
     return JSONResponse({"summaries": summaries})
+
+
+@app.post("/api/propose_law")
+async def api_propose_law(proposal: LawProposal) -> Response:
+    """Submit a law proposal to the active simulation."""
+    sim = SIM_STATE.get("simulation")
+    approved = False
+    if sim is not None:
+        try:
+            approved = await sim.propose_law(proposal.proposer_id, proposal.text)
+        except Exception:  # pragma: no cover - defensive
+            approved = False
+    return JSONResponse({"approved": approved})
 
 
 async def register_widget(widget: dict[str, Any]) -> Response:
@@ -312,7 +335,9 @@ async def emit_map_action_event(
 __all__ = [
     "WIDGET_REGISTRY",
     "EventSourceResponse",
+    "LawProposal",
     "SimulationEvent",
+    "api_propose_law",
     "app",
     "emit_event",
     "emit_map_action_event",

--- a/tests/unit/interfaces/test_dashboard_backend_propose_law.py
+++ b/tests/unit/interfaces/test_dashboard_backend_propose_law.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+
+pytest.importorskip("pytest_asyncio")
+
+from src.interfaces import dashboard_backend as db
+
+
+class DummySim:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def propose_law(self, proposer_id: str, text: str) -> bool:
+        self.calls.append((proposer_id, text))
+        return True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_propose_law(monkeypatch: pytest.MonkeyPatch) -> None:
+    sim = DummySim()
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+    resp = await db.api_propose_law(db.LawProposal(proposer_id="a1", text="t"))
+    data = json.loads(resp.body)
+    assert data == {"approved": True}
+    assert sim.calls == [("a1", "t")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_propose_law_no_sim(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.SIM_STATE, "simulation", None)
+    resp = await db.api_propose_law(db.LawProposal(proposer_id="a1", text="t"))
+    data = json.loads(resp.body)
+    assert data == {"approved": False}


### PR DESCRIPTION
## Summary
- implement `/api/propose_law` endpoint in `dashboard_backend`
- expose `LawProposal` model and update `__all__`
- create React `LawProposal` page and add navigation
- provide API helper for posting law proposals
- add unit tests
- skip dashboard law proposal tests if `pytest_asyncio` is missing

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest tests/unit/interfaces/test_dashboard_backend_propose_law.py -q`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_686c7d79740483269d25c5c0e45e8e5f