### PR TITLE
Add missing dev dependency and fix DU accounting

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,12 +15,14 @@ environment and install these dependencies.
 `pip-compile` command used by `scripts/check_requirements.sh`.
 Run this script to verify that `requirements.txt` matches
 `requirements.in` whenever dependencies change.
-The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, `requests` for HTTP utilities, and `numpy>=2` for compatibility with certain examples.
+The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, `requests` for HTTP utilities, `aiosqlite` for async SQLite tests, and `numpy>=2` for compatibility with certain examples.
 
 If these optional packages are not installed, running `pytest` directly will
 raise warnings because `pytest.ini` specifies `-n auto` and
 `asyncio_mode=strict`. Use `scripts/run_tests.py` instead, which automatically
-detects available plugins and strips those options.
+detects available plugins, strips those options, and emits a warning when
+`numpy`, `sqlalchemy`, `requests`, or `aiosqlite` are missing. Tests requiring
+these packages are skipped automatically.
 
 ## Test Markers and Suite Structure
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -42,3 +42,9 @@ respx
 ipython<9
 starlette
 pydantic-settings==2.0.3
+
+# Optional runtime libraries used in certain tests
+numpy
+requests
+sqlalchemy
+aiosqlite

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -169,6 +169,8 @@ networkx==3.4.2
     # via pytest-depends
 nodeenv==1.9.1
     # via pre-commit
+numpy==1.26.4
+    # via -r requirements-dev.in
 packaging==24.2
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -285,6 +287,8 @@ referencing==0.36.2
     #   -c /workspace/Culture/requirements.txt
     #   jsonschema
     #   jsonschema-specifications
+requests==2.32.4
+    # via -r requirements-dev.in
 respx==0.22.0
     # via -r requirements-dev.in
 rich==14.0.0
@@ -310,6 +314,10 @@ sniffio==1.3.1
     # via
     #   -c /workspace/Culture/requirements.txt
     #   anyio
+sqlalchemy==2.0.41
+    # via -r requirements-dev.in
+aiosqlite==0.21.0
+    # via -r requirements-dev.in
 stack-data==0.6.3
     # via ipython
 starlette==0.37.2

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Run pytest with optional plugin-based adjustments."""
+"""Run pytest with optional plugin-based adjustments.
+
+This helper detects available plugins like ``pytest-xdist`` and ``pytest-asyncio``
+and removes incompatible options from ``pytest.ini`` when they are missing. It
+also checks for a few optional runtime libraries (``numpy``, ``sqlalchemy``,
+``requests``) and prints a warning when they are not installed so that tests
+depending on them can be skipped cleanly.
+"""
 
 from __future__ import annotations
 
@@ -44,6 +51,7 @@ def main(argv: list[str]) -> int:
         "fastapi",
         "pytest_asyncio",
         "sqlalchemy",
+        "aiosqlite",
         "zstandard",
         "requests",
         "hypothesis",
@@ -72,6 +80,15 @@ def main(argv: list[str]) -> int:
                 f"WARNING: dependency installation failed ({exc}). "
                 "Continuing with existing packages."
             )
+
+    optional = ["numpy", "sqlalchemy", "requests", "aiosqlite"]
+    missing_optional = [mod for mod in optional if not have_module(mod)]
+    if missing_optional:
+        joined = ", ".join(missing_optional)
+        print(
+            f"WARNING: optional packages missing: {joined}. "
+            "Tests depending on them will be skipped."
+        )
 
     cfg = ConfigParser()
     cfg.read(INI_FILE)

--- a/src/agents/graphs/interaction_handlers.py
+++ b/src/agents/graphs/interaction_handlers.py
@@ -105,7 +105,6 @@ def handle_create_project_node(state: AgentTurnState) -> dict[str, Any]:
                 ledger.resolve_auction(aid)
             except Exception:  # pragma: no cover - optional
                 logger.debug("Ledger auction failed", exc_info=True)
-            agent_state.du -= config.DU_COST_CREATE_PROJECT
         start_du = agent_state.du
 
         project_id = simulation.create_project(
@@ -154,7 +153,6 @@ def handle_join_project_node(state: AgentTurnState) -> dict[str, Any]:
                 ledger.resolve_auction(aid)
             except Exception:  # pragma: no cover - optional
                 logger.debug("Ledger auction failed", exc_info=True)
-            agent_state.du -= config.DU_COST_JOIN_PROJECT
         start_du = agent_state.du
 
         if simulation.join_project(project_id, agent_state.agent_id):

--- a/src/shared/pydantic_compat.py
+++ b/src/shared/pydantic_compat.py
@@ -50,5 +50,5 @@ except Exception:  # pragma: no cover - optional dependency
 
     _SettingsConfigDict = _FallbackSettingsConfigDict
 
-BaseSettings = _PydanticBaseSettings  # type: ignore[assignment]
-SettingsConfigDict = _SettingsConfigDict  # type: ignore[assignment]
+BaseSettings = cast(Any, _PydanticBaseSettings)
+SettingsConfigDict = cast(Any, _SettingsConfigDict)


### PR DESCRIPTION
## Summary
- include `aiosqlite` in dev requirements and runtime checks
- warn when `aiosqlite` is missing during test runs
- fix double DU deduction in project handlers
- resolve mypy issue in pydantic compatibility layer

## Testing
- `bash scripts/lint.sh --format`
- `SKIP_DEP_INSTALL=1 pytest tests/integration/agents/test_project_handlers.py::test_project_handlers_modify_state -m integration -q`
- `SKIP_DEP_INSTALL=1 pytest tests/integration/interfaces/test_token_sql.py::test_token_sql -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_686d28b46e6483269b8f3e9e88b9d90a