### PR TITLE
Update SSE integration test

### DIFF
--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -1,19 +1,20 @@
+import asyncio
 import json
 from types import SimpleNamespace
+from typing import Callable
 
+import httpx
 import pytest
+from starlette.responses import Response
 
-import src.http_app as http_app
+# Skip this test if FastAPI is not available.
+pytest.importorskip("fastapi")
+
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.interfaces import dashboard_backend as db
 from src.sim.simulation import Simulation
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
-
-
-class DummyRequest:
-    async def is_disconnected(self) -> bool:
-        return False
 
 
 class DummyAgent:
@@ -44,29 +45,75 @@ async def _clear_event_queue() -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    vector = ChromaVectorStoreManager(
-        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
-    )
-    driver = DummyDriver()
-    manager = SemanticMemoryManager(vector, driver)
-    agent = DummyAgent("a1")
-    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    async def run_test() -> None:
+        class TestESR(Response):
+            def __init__(self, gen: object) -> None:
+                super().__init__("", media_type="text/event-stream")
+                self.gen = gen
 
-    class CaptureESR:
-        def __init__(self, gen: object) -> None:
-            self.gen = gen
+            async def __call__(self, scope: dict, receive: object, send: Callable) -> None:
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [(b"content-type", b"text/event-stream")],
+                    }
+                )
+                async for event in self.gen:
+                    body = f"data: {event['data']}\n\n".encode()
+                    await send({"type": "http.response.body", "body": body, "more_body": True})
+                    break
+                await send({"type": "http.response.body", "body": b"", "more_body": False})
+                if hasattr(self.gen, "aclose"):
+                    await self.gen.aclose()
 
-    monkeypatch.setattr(http_app, "EventSourceResponse", CaptureESR)
-    await _clear_event_queue()
-    await sim.run_step()
+        monkeypatch.setattr(db, "EventSourceResponse", TestESR)
 
-    queue = db.get_event_queue()
-    await queue.put(None)
-    resp = await http_app.stream_events(DummyRequest())
-    event = await resp.gen.__anext__()
-    payload = json.loads(event["data"])
-    assert payload["event_type"] == "agent_action"
-    with pytest.raises(StopAsyncIteration):
-        await resp.gen.__anext__()
+        import importlib
+        import sys
+
+        if "src.http_app" in sys.modules:
+            http_app = importlib.reload(sys.modules["src.http_app"])
+        else:
+            http_app = importlib.import_module("src.http_app")
+        vector = ChromaVectorStoreManager(
+            persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
+        )
+        driver = DummyDriver()
+        manager = SemanticMemoryManager(vector, driver)
+        agent = DummyAgent("agent-1")
+        sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+
+        monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
+        monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+
+        await _clear_event_queue()
+        await sim.run_step()
+
+        # Store a memory and create a semantic summary
+        vector.add_memory("agent-1", 1, "thought", "hello")
+        await manager.run_nightly_job("agent-1")
+
+        msg = db.AgentMessage(agent_id="agent-1", content="hello", step=1)
+        await db.enqueue_message(msg)
+
+        transport = httpx.ASGITransport(app=http_app.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            async with client.stream("GET", "/stream/messages") as resp:
+                payload = None
+                async for line in resp.aiter_lines():
+                    if line.startswith("data:"):
+                        payload = json.loads(line.split("data: ", 1)[1])
+                        break
+
+            assert payload is not None
+            assert payload["content"] == "hello"
+
+            resp2 = await client.get("/api/agents/agent-1/semantic_summaries")
+            assert resp2.status_code == 200
+            data = resp2.json()
+            assert "summaries" in data
+            assert isinstance(data["summaries"], list)
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- switch simulation SSE integration test to httpx.AsyncClient
- remove pytest-asyncio dependency by wrapping async logic in asyncio.run
- skip the SSE test when FastAPI isn't installed

## Testing
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py -m integration tests/integration/interfaces/test_simulation_sse.py::test_simulation_emits_sse -vv`
- `bash scripts/lint.sh --format`

------
https://chatgpt.com/codex/tasks/task_e_686d28b6afc48326b032a62f626b40cb