### PR TITLE
Add optional dependency warnings

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,19 +10,20 @@ To run the tests, install dependencies from both `requirements.txt` and `require
 pip install -r requirements.txt -r requirements-dev.txt
 ```
 You can also run `scripts/setup_test_env.sh` to automatically create a virtual
-environment and install these dependencies.
-`requirements-dev.txt` also installs **pip-tools**, which provides the
-`pip-compile` command used by `scripts/check_requirements.sh`.
-Run this script to verify that `requirements.txt` matches
-`requirements.in` whenever dependencies change.
-The development requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for asynchronous tests, `requests` for HTTP utilities, `aiosqlite` for async SQLite tests, and `numpy>=2` for compatibility with certain examples.
+environment and install these dependencies. `requirements-dev.txt` installs
+**pip-tools**, which provides the `pip-compile` command used by
+`scripts/check_requirements.sh`. Run this script to verify that `requirements.txt`
+matches `requirements.in` whenever dependencies change. The development
+requirements include `pytest-xdist` for parallel execution, `pytest-asyncio` for
+asynchronous tests, `requests` for HTTP utilities, `aiosqlite` for async SQLite
+tests, and `numpy>=2` for compatibility with certain examples.
 
-If these optional packages are not installed, running `pytest` directly will
-raise warnings because `pytest.ini` specifies `-n auto` and
-`asyncio_mode=strict`. Use `scripts/run_tests.py` instead, which automatically
-detects available plugins, strips those options, and emits a warning when
-`numpy`, `sqlalchemy`, `requests`, or `aiosqlite` are missing. Tests requiring
-these packages are skipped automatically.
+If any of these optional packages are missing, `scripts/run_tests.py` prints a
+warning and skips affected tests automatically. For example, the SQL token store
+tests require both `sqlalchemy` and `aiosqlite`; tests that patch the
+`requests` library or depend on `numpy` are treated the same way. Running
+`pytest` directly may fail because `pytest.ini` specifies `-n auto` and
+`asyncio_mode=strict`.
 
 ## Test Markers and Suite Structure
 

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -83,12 +83,32 @@ def main(argv: list[str]) -> int:
 
     optional = ["numpy", "sqlalchemy", "requests", "aiosqlite"]
     missing_optional = [mod for mod in optional if not have_module(mod)]
+
+    skip_map = {
+        "aiosqlite": [ROOT / "tests" / "integration" / "interfaces" / "test_token_sql.py"],
+        "sqlalchemy": [ROOT / "tests" / "integration" / "interfaces" / "test_token_sql.py"],
+        "numpy": [ROOT / "tests" / "unit" / "infra" / "test_checkpoint.py"],
+        "requests": [
+            ROOT / "tests" / "unit" / "utils" / "test_policy.py",
+            ROOT / "tests" / "unit" / "infra" / "test_llm_client_url.py",
+            ROOT / "tests" / "unit" / "infra" / "test_llm_client_vllm.py",
+            ROOT / "tests" / "unit" / "infra" / "test_dspy_ollama_config.py",
+            ROOT / "tests" / "unit" / "memory" / "test_role_history.py",
+            ROOT / "tests" / "unit" / "interfaces" / "test_discord_policy.py",
+            ROOT / "tests" / "integration" / "governance" / "test_law_board_integration.py",
+        ],
+    }
+    ignore_paths: set[Path] = set()
+    for mod in missing_optional:
+        ignore_paths.update(skip_map.get(mod, []))
+
     if missing_optional:
         joined = ", ".join(missing_optional)
-        print(
-            f"WARNING: optional packages missing: {joined}. "
-            "Tests depending on them will be skipped."
+        msg = (
+            f"WARNING: missing optional packages: {joined}. "
+            "Skipping tests that require them."
         )
+        print(msg)
 
     cfg = ConfigParser()
     cfg.read(INI_FILE)
@@ -126,6 +146,9 @@ def main(argv: list[str]) -> int:
         cmd.extend(["-c", temp_ini])
     else:
         cmd.extend(["-c", str(INI_FILE)])
+
+    for path in sorted(ignore_paths):
+        cmd.append(f"--ignore={path}")
 
     cmd.extend(strip_xdist_flags(argv) if not has_xdist else argv)
     return subprocess.call(cmd)


### PR DESCRIPTION
## Summary
- skip SQL token store tests when SQLAlchemy/aiosqlite are missing
- skip requests- and numpy-based tests when those packages are missing
- document missing-package behavior in the testing docs

## Testing
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py tests/test_pytest_sanity.py`
- `ruff check src/ tests/`
- `black --check src/ tests/`
- `mypy src/infra/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_686d8a1458e883268c0ee6566e88d9ee