### PR TITLE
Add integration marks and fix async test dependencies

### DIFF
--- a/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
+++ b/tests/integration/conflict_resolution/test_conflict_resolution_scenario.py
@@ -16,6 +16,8 @@ if str(project_root) not in sys.path:
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 try:
     import dspy  # pragma: no cover - optional dependency
 except Exception:

--- a/tests/integration/graph/test_project_actions.py
+++ b/tests/integration/graph/test_project_actions.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 pytest.importorskip("langgraph")
 pytest.importorskip("chromadb")
 

--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 import src.http_app as http_app
@@ -70,3 +72,48 @@ async def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -
     assert payload["event_type"] == "agent_action"
     with pytest.raises(StopAsyncIteration):
         await resp.gen.__anext__()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_messages_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
+    monkeypatch.setattr(db, "message_sse_queue", queue)
+
+    msg = db.AgentMessage(agent_id="agent-1", content="hello", step=1)
+    await db.enqueue_message(msg)
+
+    async with httpx.AsyncClient(app=http_app.app, base_url="http://test") as client:
+        async with client.stream("GET", "/stream/messages") as resp:
+            data_line = None
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    data_line = line.removeprefix("data: ")
+                    break
+    assert data_line is not None
+    payload = json.loads(data_line)
+    assert payload["content"] == "hello"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_semantic_summaries_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+    agent = DummyAgent("agent-1")
+    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+
+    await _clear_event_queue()
+    await sim.run_step()
+
+    async with httpx.AsyncClient(app=http_app.app, base_url="http://test") as client:
+        resp = await client.get("/api/agents/agent-1/semantic_summaries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data.get("summaries"), list)

--- a/tests/integration/test_multi_agent_collaboration.py
+++ b/tests/integration/test_multi_agent_collaboration.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 pytest.importorskip("langgraph")
 pytest.importorskip("chromadb")
 


### PR DESCRIPTION
## Summary
- mark project actions, conflict resolution, and collaboration tests as integration
- ensure SSE and semantic summary tests verify streaming via httpx.AsyncClient

## Testing
- `ruff check tests/integration/conflict_resolution/test_conflict_resolution_scenario.py tests/integration/test_multi_agent_collaboration.py tests/integration/interfaces/test_simulation_sse.py tests/integration/graph/test_project_actions.py`
- `pytest -m "not integration and not ollama" -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8a15bd608326a55dfbf1408ea7c6