### PR TITLE
Unify memory retrieval paths

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -79,10 +79,37 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
     manager = cast(MemoryRetriever | None, state.get("vector_store_manager"))
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
+    semantic_manager = cast(SemanticMemoryManager | None, state.get("semantic_manager"))
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
+
     memories = await manager.aretrieve_relevant_memories(state["agent_id"], query="", k=5)
     memories_content = [m.get("content", "") for m in memories]
+
+    if semantic_manager:
+        import asyncio
+
+        semantic_memories = await asyncio.to_thread(
+            semantic_manager.retrieve_context,
+            state["agent_id"],
+            "",
+            5,
+        )
+        memories.extend(semantic_memories)
+        memories_content.extend(m.get("content", "") for m in semantic_memories)
+
+        tracker = getattr(manager, "tracking_manager", None)
+        if tracker:
+            mem_ids = [
+                m.get("memory_id") or m.get("id")
+                for m in semantic_memories
+                if m.get("memory_id") or m.get("id")
+            ]
+            try:
+                tracker.update_usage_stats(mem_ids)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
     if hasattr(manager, "get_semantic_summaries"):
         try:
             semantic = cast(Any, manager).get_semantic_summaries(state["agent_id"], limit=2)

--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -1,19 +1,19 @@
 import asyncio
 import json
 from types import SimpleNamespace
-from typing import Callable
 
 import httpx
 import pytest
-from starlette.responses import Response
 
 # Skip this test if FastAPI is not available.
 pytest.importorskip("fastapi")
 
+from src import http_app
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.interfaces import dashboard_backend as db
 from src.sim.simulation import Simulation
+from tests.integration.interfaces.test_dashboard_backend_api import DummyRequest
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
 
 

--- a/tests/unit/memory/test_memory_tracking_manager.py
+++ b/tests/unit/memory/test_memory_tracking_manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Unit tests for MemoryTrackingManager."""
 
+import asyncio
 import unittest
 from pathlib import Path
 
@@ -48,6 +49,57 @@ class TestMemoryTrackingManager(unittest.TestCase):
         self.manager.record_retrieval([mem_id], [0.9])
         mus = self.manager.calculate_mus(mem_id)
         self.assertGreaterEqual(mus, 0.0)
+
+    @pytest.mark.asyncio
+    def test_unified_retrieval_usage_updates(self: Self) -> None:
+        """Ensure usage stats are updated for vector and semantic retrieval."""
+        from types import SimpleNamespace
+
+        from src.agents.graphs.graph_nodes import retrieve_and_summarize_memories_node
+        from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+
+        semantic_manager = SemanticMemoryManager(self.vector_store, driver=None)
+        for i in range(2):
+            self.vector_store.add_memory(
+                agent_id=self.agent_id,
+                step=i,
+                event_type="thought",
+                content=f"m{i}",
+            )
+
+        semantic_manager.group_memories_by_topic(self.agent_id, num_topics=1)
+
+        calls: list[list[str]] = []
+
+        from unittest.mock import patch
+
+        patcher = patch.object(
+            self.vector_store.tracking_manager,
+            "update_usage_stats",
+            lambda ids, relevance_scores=None, increment_count=True: calls.append(list(ids)),
+        )
+        patcher.start()
+
+        class DummyAgent:
+            async def async_generate_l1_summary(
+                self, role_prompt: str, memories: str, context: str
+            ) -> SimpleNamespace:
+                return SimpleNamespace(summary="S")
+
+        state = {
+            "agent_id": self.agent_id,
+            "vector_store_manager": self.vector_store,
+            "semantic_manager": semantic_manager,
+            "agent_instance": DummyAgent(),
+            "state": SimpleNamespace(role_prompt="r"),
+        }
+
+        asyncio.get_event_loop().run_until_complete(retrieve_and_summarize_memories_node(state))
+
+        patcher.stop()
+
+        assert len(calls) == 2
+        assert all(calls)
 
 
 if __name__ == "__main__":

--- a/tests/unit/memory/test_memory_tracking_manager.py
+++ b/tests/unit/memory/test_memory_tracking_manager.py
@@ -78,7 +78,6 @@ class TestMemoryTrackingManager(unittest.TestCase):
             "update_usage_stats",
             lambda ids, relevance_scores=None, increment_count=True: calls.append(list(ids)),
         )
-        patcher.start()
 
         class DummyAgent:
             async def async_generate_l1_summary(
@@ -94,9 +93,10 @@ class TestMemoryTrackingManager(unittest.TestCase):
             "state": SimpleNamespace(role_prompt="r"),
         }
 
-        asyncio.get_event_loop().run_until_complete(retrieve_and_summarize_memories_node(state))
-
-        patcher.stop()
+        with patcher:
+            asyncio.get_event_loop().run_until_complete(
+                retrieve_and_summarize_memories_node(state)
+            )
 
         assert len(calls) == 2
         assert all(calls)


### PR DESCRIPTION
## Summary
- retrieve memories via vector store and semantic grouping in tandem
- record memory usage for semantic retrievals
- patch missing imports in SSE tests
- test unified retrieval updates usage tracking

## Testing
- `ruff check src/ tests/`
- `black --check src/ tests/`
- `mypy src/`
- `pytest tests/unit/memory -q`

------
https://chatgpt.com/codex/tasks/task_e_686da0439e4c83269fc0f26c65b7f10f