### PR TITLE
Add helper export for plug-in docs

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { WidgetInfo } from './widgetRegistry'
+
 export interface Mission {
   id: number
   name: string
@@ -21,5 +23,24 @@ export async function proposeLaw(
   })
   const data = (await res.json()) as { approved: boolean }
   return data.approved
+}
+
+
+export type WidgetRegistration = WidgetInfo & Record<string, unknown>
+
+export async function registerWidgetBackend(widget: WidgetRegistration): Promise<string[]> {
+  const res = await fetch('/api/register_widget', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: widget.name,
+      ...(widget.scriptUrl ? { script_url: widget.scriptUrl } : {}),
+      ...Object.fromEntries(
+        Object.entries(widget).filter(([k]) => k !== 'name' && k !== 'scriptUrl'),
+      ),
+    }),
+  })
+  const data = (await res.json()) as { widgets: string[] }
+  return data.widgets
 }
 

--- a/culture-ui/src/lib/index.ts
+++ b/culture-ui/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './widgetRegistry';

--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -72,3 +72,31 @@ The response returns the complete set of registered widget names:
 ```json
 { "widgets": ["MyWidget"] }
 ```
+
+## Plug-in Development
+
+External plug-ins can add new dashboard widgets without modifying the core UI. A plug-in typically serves a JavaScript bundle and registers its widget with the backend:
+
+```http
+POST /api/register_widget
+{ "name": "MyWidget", "script_url": "http://localhost:5173/my_widget.js" }
+```
+
+Additional metadata keys may be included. The response contains the updated list of widget names:
+
+```json
+{ "widgets": ["MyWidget", "OtherWidget"] }
+```
+
+Once registered, the UI automatically loads the provided `script_url` so the widget behaves like a built-in panel.
+On the frontend, import and call the `registerWidgetBackend` helper exported
+from `culture-ui`:
+
+```ts
+import { registerWidgetBackend } from 'culture-ui/lib'
+
+await registerWidgetBackend({
+  name: 'MyWidget',
+  scriptUrl: 'http://localhost:5173/my_widget.js',
+})
+```

--- a/examples/plugins/register_widget_example.py
+++ b/examples/plugins/register_widget_example.py
@@ -1,0 +1,17 @@
+"""Example plug-in registering a custom widget with the Culture UI."""
+
+import requests
+
+
+def main() -> None:
+    """Register a widget named ``ExampleWidget`` using the backend API."""
+    resp = requests.post(
+        "http://localhost:8000/api/register_widget",
+        json={"name": "ExampleWidget", "script_url": "http://localhost:5173/example.js"},
+        timeout=10,
+    )
+    print("Registration response:", resp.json())
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()


### PR DESCRIPTION
## Summary
- export APIs from `culture-ui/lib/index.ts`
- document how to import `registerWidgetBackend` in plug-ins

## Testing
- `ruff check examples/plugins/register_widget_example.py`
- `black --check examples/plugins/register_widget_example.py`
- `SKIP=unit-tests pre-commit run --files culture-ui/src/lib/api.ts culture-ui/src/lib/index.ts examples/plugins/register_widget_example.py docs/culture_ui_requirements.md`
- `pnpm --filter ./culture-ui lint`
- `pnpm --filter ./culture-ui test`
- `python scripts/run_tests.py tests/unit/interfaces/test_dashboard_backend_register_widget.py::test_register_widget_adds_name -q`


------
https://chatgpt.com/codex/tasks/task_e_686da044ff808326a1b3885d4e9ee3f1