### PR TITLE
Add fixture to mock dashboard emit_event in kernel tests

### DIFF
--- a/tests/unit/sim/test_event_kernel.py
+++ b/tests/unit/sim/test_event_kernel.py
@@ -10,6 +10,14 @@ from src.sim.version_vector import VersionVector
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def patch_dashboard_emit_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    monkeypatch.setattr("src.interfaces.dashboard_backend.emit_event", _noop)
+
+
 def _make_cb(order: list[int], n: int):
     async def _cb() -> None:
         order.append(n)


### PR DESCRIPTION
## Summary
- patch `emit_event` in `test_event_kernel` with an autouse fixture to avoid network usage
- rename fixture for clarity

## Testing
- `ruff check tests/unit/sim/test_event_kernel.py`
- `pytest -m "unit and not dspy" tests/unit/sim/test_event_kernel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686dbd57348c83268da85a4b8a252a28