### PR TITLE
Implement staked IP voting with ledger records

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -7,3 +7,9 @@ python src/app.py --proposal "Agents must greet each other" --proposer-id agent_
 ```
 
 This calls the `forward_proposal` method on the `Simulation` instance, which delegates to `propose_law` for voting. The result is recorded on the knowledge board if approved.
+
+Votes are weighted by the amount of influence points (IP) agents have staked. Past proposals and their outcomes can be viewed using the dashboard API:
+
+```bash
+python examples/governance/list_proposals_example.py
+```

--- a/examples/governance/list_proposals_example.py
+++ b/examples/governance/list_proposals_example.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Fetch stored law proposals from the dashboard API."""
+import requests
+
+
+def main() -> None:
+    resp = requests.get("http://localhost:8000/api/proposals")
+    print("Proposals:", resp.json())
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()

--- a/src/governance/voting.py
+++ b/src/governance/voting.py
@@ -5,6 +5,7 @@ import math
 from collections.abc import Iterable
 
 from src.agents.core.base_agent import Agent
+from src.infra.ledger import ledger
 from src.utils.policy import evaluate_with_opa
 
 from .law_board import law_board
@@ -23,10 +24,27 @@ async def propose_law(proposer: Agent, text: str, agents: Iterable[Agent]) -> bo
         return False
 
     votes = await asyncio.gather(*[_vote(a, text) for a in agents])
-    weights = [math.sqrt(getattr(a.state, "ip", 0.0)) for a in agents]
+    weights = []
+    for a in agents:
+        base_ip = getattr(a.state, "ip", 0.0)
+        try:
+            staked = ledger.get_staked_ip(a.agent_id)
+        except Exception:
+            staked = 0.0
+        weights.append(math.sqrt(base_ip + staked))
     yes_weight = sum(w for w, v in zip(weights, votes) if v)
     no_weight = sum(w for w, v in zip(weights, votes) if not v)
     approved = yes_weight > no_weight
     if approved:
         law_board.add_law(text)
+    try:
+        ledger.record_law_proposal(
+            proposer.agent_id,
+            text,
+            approved,
+            yes_weight,
+            no_weight,
+        )
+    except Exception:
+        pass
     return approved

--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -26,7 +26,8 @@ class Ledger:
                 agent_id TEXT PRIMARY KEY,
                 ip REAL DEFAULT 0,
                 du REAL DEFAULT 0,
-                staked_du REAL DEFAULT 0
+                staked_du REAL DEFAULT 0,
+                staked_ip REAL DEFAULT 0
             )
             """
         )
@@ -90,6 +91,19 @@ class Ledger:
             CREATE TABLE IF NOT EXISTS genealogy (
                 parent_id TEXT,
                 child_id TEXT PRIMARY KEY
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS law_proposals (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                proposer_id TEXT,
+                text TEXT,
+                approved INTEGER,
+                yes_weight REAL,
+                no_weight REAL,
+                ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
             """
         )
@@ -212,6 +226,44 @@ class Ledger:
         """Return the amount of staked DU for ``agent_id``."""
         cur = self.conn.execute(
             "SELECT staked_du FROM agent_balances WHERE agent_id=?",
+            (agent_id,),
+        )
+        row = cur.fetchone()
+        return float(row[0]) if row else 0.0
+
+    def stake_ip(self, agent_id: str, amount: float) -> None:
+        """Stake IP for ``agent_id`` and record the transaction."""
+        if amount <= 0:
+            return
+        self.log_change(agent_id, -amount, 0.0, "stake_ip")
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO agent_balances(agent_id, staked_ip)
+            VALUES(?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                staked_ip = staked_ip + excluded.staked_ip
+            """,
+            (agent_id, float(amount)),
+        )
+        self.conn.commit()
+
+    def unstake_ip(self, agent_id: str, amount: float) -> None:
+        """Unstake IP for ``agent_id`` and record the transaction."""
+        if amount <= 0:
+            return
+        self.log_change(agent_id, amount, 0.0, "unstake_ip")
+        cur = self.conn.cursor()
+        cur.execute(
+            "UPDATE agent_balances SET staked_ip = MAX(staked_ip - ?, 0) WHERE agent_id=?",
+            (float(amount), agent_id),
+        )
+        self.conn.commit()
+
+    def get_staked_ip(self, agent_id: str) -> float:
+        """Return the amount of staked IP for ``agent_id``."""
+        cur = self.conn.execute(
+            "SELECT staked_ip FROM agent_balances WHERE agent_id=?",
             (agent_id,),
         )
         row = cur.fetchone()
@@ -355,6 +407,48 @@ class Ledger:
             (parent_id, child_id),
         )
         self.conn.commit()
+
+    def record_law_proposal(
+        self,
+        proposer_id: str,
+        text: str,
+        approved: bool,
+        yes_weight: float,
+        no_weight: float,
+    ) -> None:
+        """Store a law proposal and its result."""
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO law_proposals(proposer_id, text, approved, yes_weight, no_weight)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                proposer_id,
+                text,
+                int(bool(approved)),
+                float(yes_weight),
+                float(no_weight),
+            ),
+        )
+        self.conn.commit()
+
+    def get_law_proposals(self, limit: int | None = None) -> list[dict[str, object]]:
+        """Return stored law proposals."""
+        cur = self.conn.cursor()
+        query = "SELECT proposer_id, text, approved, yes_weight, no_weight, ts FROM law_proposals ORDER BY id DESC"
+        rows = cur.execute(query + (" LIMIT ?" if limit else ""), ([int(limit)] if limit else [])).fetchall()
+        return [
+            {
+                "proposer_id": str(r[0]),
+                "text": str(r[1]),
+                "approved": bool(r[2]),
+                "yes_weight": float(r[3]),
+                "no_weight": float(r[4]),
+                "ts": r[5],
+            }
+            for r in rows
+        ]
 
     # -------------------------------------------------------------
     # Auction management

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from src.infra.ledger import ledger
+
 from .widget_registry import WidgetRegistry
 
 if TYPE_CHECKING:
@@ -211,6 +213,16 @@ async def api_propose_law(proposal: LawProposal) -> Response:
     return JSONResponse({"approved": approved})
 
 
+@app.get("/api/proposals")
+async def api_get_proposals(limit: int = 10) -> Response:
+    """Return stored law proposals."""
+    try:
+        proposals = ledger.get_law_proposals(limit)
+    except Exception:  # pragma: no cover - defensive
+        proposals = []
+    return JSONResponse({"proposals": proposals})
+
+
 async def register_widget(widget: dict[str, Any]) -> Response:
     """Register a widget provided by the UI or a plugin."""
     name = widget.get("name")
@@ -337,6 +349,7 @@ __all__ = [
     "EventSourceResponse",
     "LawProposal",
     "SimulationEvent",
+    "api_get_proposals",
     "api_propose_law",
     "app",
     "emit_event",

--- a/tests/integration/governance/test_staked_ip_proposals.py
+++ b/tests/integration/governance/test_staked_ip_proposals.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from src.governance.law_board import LawBoard
+from src.infra import config
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 1.0
+    du: float = 0.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        pass
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_weights_include_staked_ip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    import importlib
+
+    voting_mod = importlib.import_module("src.governance.voting")
+    monkeypatch.setattr(voting_mod, "law_board", board)
+    monkeypatch.setattr(voting_mod, "ledger", ledger)
+    monkeypatch.setattr(db, "ledger", ledger)
+
+    monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+    async def allow_policy(_p: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(voting_mod, "evaluate_with_opa", allow_policy)
+
+    votes = [True, False]
+
+    async def fake_vote(_a: DummyAgent, _t: str) -> bool:
+        return votes.pop(0)
+
+    monkeypatch.setattr(voting_mod, "_vote", fake_vote)
+
+    ledger.log_change("a1", 10.0, 0.0, "fund")
+    ledger.log_change("a2", 10.0, 0.0, "fund")
+    ledger.stake_ip("a1", 9.0)
+
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+
+    approved = await voting_mod.propose_law(agents[0], "law", agents)
+    assert approved is True
+
+    proposals = ledger.get_law_proposals()
+    assert proposals and proposals[0]["approved"] is True
+
+    resp = await db.api_get_proposals(limit=1)
+    data = json.loads(resp.body)
+    assert data["proposals"][0]["approved"] is True
+


### PR DESCRIPTION
## Summary
- extend ledger with staked_ip balances and store law proposals
- weigh votes by staked IP and expose a `/api/proposals` endpoint
- example script shows how to list proposals
- add integration test for staked IP voting
- fix async patches in new test

## Testing
- `ruff check .`
- `python scripts/run_tests.py -m integration tests/integration/governance/test_staked_ip_proposals.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbd524d5483268170bab01d5047a4