### PR TITLE
Add vLLM benchmark script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,20 @@ check the latest values with the `!stats` Discord command.
 For routine operations and troubleshooting, see [docs/runbook.md](docs/runbook.md).
 When running against a local vLLM server, set `VLLM_API_BASE` to its base URL.
 
+### Starting the vLLM Server
+`scripts/start_vllm.sh` launches the vLLM OpenAI-compatible API with sensible defaults.
+Run it from the project root, optionally overriding the model or port:
+
+```bash
+VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 scripts/start_vllm.sh
+```
+
+After the server is running, point the application to it:
+
+```bash
+export VLLM_API_BASE="http://localhost:$VLLM_PORT"
+```
+
 ### Walking Vertical Slice
 To verify your local setup with actual LLM calls, run the minimal demo script:
 ```bash

--- a/docs/llm_reliability_report.md
+++ b/docs/llm_reliability_report.md
@@ -24,3 +24,10 @@ This brief report summarizes the current state of LLM-based components in the pr
 1. Rerun the vertical slice periodically to obtain logs of summarization and intent selection.
 2. Monitor the resulting `LLM_CALL_METRICS` logs to evaluate latency, success rate, and directive adherence.
 
+## Latency Benchmark
+
+`scripts/benchmark_llm.py` measures the average latency of a simple prompt using
+both Ollama and vLLM. In the current environment the Ollama client fell back to
+a stub implementation, completing instantly, while attempts to contact the vLLM
+server failed after repeated connection errors (~7s for one retry cycle).
+

--- a/scripts/benchmark_llm.py
+++ b/scripts/benchmark_llm.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""Simple latency benchmark comparing Ollama and vLLM."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Callable
+
+# Add project root so we can import llm_client directly when executed from scripts/
+sys.path.append(str(os.path.dirname(os.path.dirname(__file__))))
+
+from src.infra import llm_client
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Benchmark Ollama vs vLLM latency")
+    parser.add_argument("prompt", type=str, nargs="?", default="Hello", help="Prompt text")
+    parser.add_argument("--runs", type=int, default=3, help="Number of runs per backend")
+    parser.add_argument("--model", type=str, default="mistral:latest", help="Model name")
+    parser.add_argument(
+        "--vllm_base",
+        type=str,
+        default=os.environ.get("VLLM_API_BASE", "http://localhost:8001"),
+        help="Base URL of the vLLM server",
+    )
+    return parser.parse_args()
+
+
+def time_calls(func: Callable[[], None], runs: int) -> list[float]:
+    times: list[float] = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        try:
+            func()
+        except Exception as exc:
+            print(f"Call failed: {exc}")
+            return []
+        times.append(time.perf_counter() - start)
+    return times
+
+
+def benchmark(prompt: str, model: str, runs: int, vllm_base: str) -> None:
+    # Benchmark Ollama
+    os.environ.pop("VLLM_API_BASE", None)
+    llm_client.get_ollama_client()  # refresh client
+
+    def ollama_call() -> None:
+        llm_client.generate_text(prompt, model=model)
+
+    ollama_times = time_calls(ollama_call, runs)
+    if not ollama_times:
+        print("Ollama calls failed; aborting benchmark")
+        return
+
+    # Benchmark vLLM
+    os.environ["VLLM_API_BASE"] = vllm_base
+    llm_client.get_ollama_client()  # switch to vLLM
+
+    def vllm_call() -> None:
+        llm_client.generate_text(prompt, model=model)
+
+    vllm_times = time_calls(vllm_call, runs)
+    if not vllm_times:
+        print("vLLM calls failed; aborting benchmark")
+        return
+
+    def avg(values: list[float]) -> float:
+        return sum(values) / len(values)
+
+    print(f"Ollama avg latency: {avg(ollama_times):.2f}s over {runs} runs")
+    print(f"vLLM  avg latency: {avg(vllm_times):.2f}s over {runs} runs")
+
+
+def main() -> None:
+    args = parse_args()
+    benchmark(args.prompt, args.model, args.runs, args.vllm_base)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/shared/pydantic_compat.py
+++ b/src/shared/pydantic_compat.py
@@ -43,12 +43,12 @@ try:
         SettingsConfigDict as _SettingsConfigDict,
     )
 except Exception:  # pragma: no cover - optional dependency
-    from pydantic import BaseModel as _PydanticBaseSettings
+    from pydantic import BaseModel as _PydanticBaseSettings  # type: ignore[assignment]
 
     class _FallbackSettingsConfigDict(dict[str, Any]):
         pass
 
-    _SettingsConfigDict = _FallbackSettingsConfigDict
+    _SettingsConfigDict = _FallbackSettingsConfigDict  # type: ignore[assignment]
 
 BaseSettings = cast(Any, _PydanticBaseSettings)
 SettingsConfigDict = cast(Any, _SettingsConfigDict)


### PR DESCRIPTION
## Summary
- document how to launch `start_vllm.sh`
- add `scripts/benchmark_llm.py` for comparing Ollama vs vLLM
- summarize benchmark results in reliability report
- fix mypy type errors in `pydantic_compat`

## Testing
- `ruff check src/shared/pydantic_compat.py scripts/benchmark_llm.py`
- `mypy scripts/benchmark_llm.py`
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py -m "not integration and not ollama" -k 'test_version' -vv`


------
https://chatgpt.com/codex/tasks/task_e_686dbd4fdc688326b17e13ef8aeb8174