### PR TITLE
Add uvloop check and Windows workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.10'
+          - os: windows-latest
+            python: '3.11'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          # Ensure pytest-asyncio is available for async tests
+          pip install pytest-asyncio==0.23.8
+      - name: Run linters
+        run: ruff check .
+      - name: Run unit tests
+        run: pytest -m "unit" -q

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,5 +1,6 @@
 """Provide test-friendly stubs for optional dependencies."""
 
+import asyncio
 import os
 import sys
 import types
@@ -34,3 +35,11 @@ try:  # pragma: no cover - handle langgraph API changes
     sys.modules.setdefault("langgraph.graph.graph", _lg_graph)
 except Exception:
     pass
+
+if sys.platform.startswith("linux"):
+    try:  # pragma: no cover - optional dependency
+        import uvloop
+
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    except Exception:
+        pass

--- a/tests/unit/test_sitecustomize.py
+++ b/tests/unit/test_sitecustomize.py
@@ -1,0 +1,53 @@
+import asyncio
+import builtins
+import importlib
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def reload_sitecustomize(monkeypatch: pytest.MonkeyPatch, platform: str, fake_uvloop: types.SimpleNamespace | None) -> list:
+    monkeypatch.setattr(sys, "platform", platform, raising=False)
+    if fake_uvloop is not None:
+        monkeypatch.setitem(sys.modules, "uvloop", fake_uvloop)
+    else:
+        sys.modules.pop("uvloop", None)
+        orig_import = __import__
+
+        def _fake_import(name: str, *args: object, **kwargs: object):
+            if name == "uvloop":
+                raise ImportError
+            return orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+    called: list = []
+
+    def _set_policy(policy: object) -> None:
+        called.append(policy)
+
+    monkeypatch.setattr(asyncio, "set_event_loop_policy", _set_policy)
+    if "sitecustomize" in sys.modules:
+        importlib.reload(sys.modules["sitecustomize"])  # type: ignore
+    else:
+        importlib.import_module("sitecustomize")
+    return called
+
+
+def test_sitecustomize_uses_uvloop_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_uvloop = types.SimpleNamespace(EventLoopPolicy=lambda: "policy")
+    called = reload_sitecustomize(monkeypatch, "linux", fake_uvloop)
+    assert called and called[0] == "policy"
+
+
+def test_sitecustomize_handles_missing_uvloop(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = reload_sitecustomize(monkeypatch, "linux", None)
+    assert not called
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin"])
+def test_sitecustomize_skips_uvloop_on_non_linux(monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
+    called = reload_sitecustomize(monkeypatch, platform, None)
+    assert not called


### PR DESCRIPTION
## Summary
- add a new CI workflow that tests on ubuntu and windows
- enable uvloop in `sitecustomize` only on Linux
- test the sitecustomize uvloop logic
- refine the uvloop platform check and tests
- ensure pytest-asyncio is installed in CI
- add test coverage for missing uvloop on Linux

## Testing
- `ruff check sitecustomize.py tests/unit/test_sitecustomize.py`
- `pytest tests/unit/test_sitecustomize.py -q`
- `pytest -m "unit" -q` *(fails: KeyboardInterrupt after completion)*

------
https://chatgpt.com/codex/tasks/task_e_686dbd5602448326a60525d64fe0a5e3