### PR TITLE
Fix Simulation event handling startup

### DIFF
--- a/langgraph/graph/graph.py
+++ b/langgraph/graph/graph.py
@@ -3,5 +3,5 @@ START = "START"
 
 
 class StateGraph:
-    def __init__(self) -> None:  # noqa: ANN101
+    def __init__(self) -> None:
         self.nodes: dict[str, object] = {}

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -20,22 +20,22 @@ else:  # pragma: no cover - optional runtime dependency
     except Exception:
 
         class FastAPI:
-            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: ANN101
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:  # noqa: ANN101
+            def get(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def post(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:  # noqa: ANN101
+            def post(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def websocket(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:  # noqa: ANN101
+            def websocket(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
@@ -45,7 +45,7 @@ else:  # pragma: no cover - optional runtime dependency
             pass
 
         class Response:  # pragma: no cover - minimal stub
-            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: ANN101
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 pass
 
         class WebSocket:  # pragma: no cover - minimal stub
@@ -55,7 +55,7 @@ else:  # pragma: no cover - optional runtime dependency
             pass
 
         class JSONResponse:  # pragma: no cover - minimal stub
-            def __init__(self, content: object, *args: object, **kwargs: object) -> None:  # noqa: ANN101
+            def __init__(self, content: object, *args: object, **kwargs: object) -> None:
                 self.body = json.dumps(content).encode("utf-8")
 
 
@@ -69,7 +69,7 @@ else:  # pragma: no cover - optional dependency
     except Exception:
 
         class EventSourceResponse:  # pragma: no cover - minimal stub
-            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: ANN101
+            def __init__(self, *args: object, **kwargs: object) -> None:
                 self.gen = None
 
 

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -3,6 +3,7 @@ import argparse
 import asyncio
 import logging
 import random
+import threading
 import time
 from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
@@ -97,6 +98,9 @@ class Simulation:
 
         # Background task for processing incoming events
         self._event_listener_task: asyncio.Task[None] | None = None
+        self._event_task: asyncio.Task[Any] | None = None
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+        self._event_loop_thread: threading.Thread | None = None
 
         # Lock for concurrent access to message queues
         self._msg_lock = asyncio.Lock()
@@ -204,13 +208,26 @@ class Simulation:
 
         # Background task for forwarding external events (e.g., Discord messages)
         try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            self._event_task = None
-        else:
+            loop = asyncio.get_running_loop()
+            self._event_loop = loop
             self._event_task = asyncio.create_task(
                 self.event_kernel.forward_external_events(self._handle_human_command)
             )
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+
+            def _run() -> None:
+                asyncio.set_event_loop(loop)
+                get_event_queue()
+                self._event_task = loop.create_task(
+                    self.event_kernel.forward_external_events(self._handle_human_command)
+                )
+                loop.run_forever()
+
+            self._event_loop = loop
+            thread = threading.Thread(target=_run, daemon=True)
+            self._event_loop_thread = thread
+            thread.start()
 
     # Add method to update collective metrics
     def _update_collective_metrics(self: Self) -> None:
@@ -936,6 +953,13 @@ class Simulation:
                 logger.exception("Failed to close vector store manager: %s", exc)
         if self._event_task:
             self._event_task.cancel()
+        if self._event_loop:
+            if self._event_loop.is_running():
+                self._event_loop.call_soon_threadsafe(self._event_loop.stop)
+            if self._event_loop_thread:
+                self._event_loop_thread.join(timeout=0.1)
+            self._event_loop = None
+            self._event_loop_thread = None
         try:
             get_event_queue().put_nowait(None)
         except asyncio.QueueFull:  # pragma: no cover - defensive

--- a/tests/unit/sim/test_event_task_start.py
+++ b/tests/unit/sim/test_event_task_start.py
@@ -1,0 +1,64 @@
+import asyncio
+import time
+
+import pytest
+
+from src.interfaces.dashboard_backend import SimulationEvent, get_event_queue
+from src.sim.simulation import Simulation
+
+
+class DummyAgent:
+    def __init__(self) -> None:
+        self.agent_id = "A"
+        self.state = type(
+            "S",
+            (),
+            {
+                "ip": 0.0,
+                "du": 0.0,
+                "short_term_memory": [],
+                "messages_sent_count": 0,
+                "last_message_step": None,
+                "collective_ip": 0.0,
+                "collective_du": 0.0,
+            },
+        )()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: object) -> None:
+        self.state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        return {}
+
+
+@pytest.mark.unit
+def test_event_task_runs_without_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    received: list[str] = []
+
+    async def handler(self: Simulation, text: str) -> None:
+        received.append(text)
+
+    monkeypatch.setattr(Simulation, "_handle_human_command", handler)
+    sim = Simulation([DummyAgent()])
+
+    async def send() -> None:
+        queue = get_event_queue()
+        await queue.put(
+            SimulationEvent(event_type="broadcast", data={"content": "hi"})
+        )
+
+    fut = asyncio.run_coroutine_threadsafe(send(), sim._event_loop)
+    fut.result()
+    time.sleep(0.05)
+    sim.close()
+
+    assert received == ["hi"]


### PR DESCRIPTION
## Summary
- ensure background event loop creates tasks correctly
- update regression test to run outside a running loop

## Testing
- `ruff check`
- `pytest -m "not integration and not ollama" tests/unit/sim/test_event_task_start.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_686ecea2a99083268c22adc88dcf3133