### PR TITLE
Improve LLM client initialization

### DIFF
--- a/scripts/benchmark_llm.py
+++ b/scripts/benchmark_llm.py
@@ -46,7 +46,11 @@ def time_calls(func: Callable[[], None], runs: int) -> list[float]:
 def benchmark(prompt: str, model: str, runs: int, vllm_base: str) -> None:
     # Benchmark Ollama
     os.environ.pop("VLLM_API_BASE", None)
-    llm_client.get_ollama_client()  # refresh client
+    try:
+        llm_client.get_ollama_client()  # refresh client
+    except llm_client.LLMClientInitError as exc:
+        print(f"Failed to initialize LLM client: {exc}")
+        return
 
     def ollama_call() -> None:
         llm_client.generate_text(prompt, model=model)
@@ -58,7 +62,11 @@ def benchmark(prompt: str, model: str, runs: int, vllm_base: str) -> None:
 
     # Benchmark vLLM
     os.environ["VLLM_API_BASE"] = vllm_base
-    llm_client.get_ollama_client()  # switch to vLLM
+    try:
+        llm_client.get_ollama_client()  # switch to vLLM
+    except llm_client.LLMClientInitError as exc:
+        print(f"Failed to initialize vLLM client: {exc}")
+        return
 
     def vllm_call() -> None:
         llm_client.generate_text(prompt, model=model)

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -14,9 +14,12 @@ else:
     try:  # pragma: no cover - pydantic>=2 preferred at runtime
         from pydantic import ConfigDict
     except ImportError:  # pragma: no cover - fallback for old pydantic
+
         class ConfigDict(dict[str, Any]):
             """Fallback ``ConfigDict`` for pydantic < 2."""
+
             pass
+
 
 from src.shared.pydantic_compat import _PYDANTIC_V2, field_validator, model_validator
 
@@ -35,8 +38,6 @@ if TYPE_CHECKING:
     from src.infra.llm_client import LLMClient, LLMClientConfig
 
 logger = logging.getLogger(__name__)
-
-
 
 
 # Helper function for the default_factory to keep the lambda clean
@@ -113,20 +114,27 @@ if TYPE_CHECKING:
     from src.infra.llm_client import (
         OllamaClientProtocol,
         get_default_llm_client,
+        LLMClientInitError,
     )
 else:
     try:
         from src.infra.llm_client import (
             OllamaClientProtocol,
             get_default_llm_client,
+            LLMClientInitError,
         )
     except Exception:  # pragma: no cover - fallback when llm_client is missing
+
         class OllamaClientProtocol(Protocol):
             """Fallback protocol used when the real client is unavailable."""
+
             ...
 
         def get_default_llm_client() -> OllamaClientProtocol | None:
             return None
+
+        class LLMClientInitError(RuntimeError):
+            pass
 
 
 class AgentStateData(BaseModel):
@@ -476,7 +484,11 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                 else:
                     model.llm_client = client
             else:
-                default_client = get_default_llm_client()
+                try:
+                    default_client = get_default_llm_client()
+                except LLMClientInitError as exc:
+                    logger.error(f"Failed to initialize default LLM client: {exc}")
+                    raise
                 if isinstance(model, dict):
                     model["llm_client"] = default_client
                 else:
@@ -510,7 +522,11 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             return model
         else:
             if not model.role_history:
-                role_name = model.current_role.name if isinstance(model.current_role, RoleProfile) else model.current_role
+                role_name = (
+                    model.current_role.name
+                    if isinstance(model.current_role, RoleProfile)
+                    else model.current_role
+                )
                 model.role_history = [(model.step_counter, role_name)]
             if not model.mood_history:
                 model.mood_history = [(model.step_counter, model.mood_level)]
@@ -562,9 +578,7 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                     },
                 ),
             )
-        return base_model.dict(
-            exclude={"llm_client", "mock_llm_client", "memory_store_manager"}
-        )
+        return base_model.dict(exclude={"llm_client", "mock_llm_client", "memory_store_manager"})
 
     @classmethod
     def from_dict(cls: type[Self], data: dict[str, Any]) -> "AgentState":
@@ -577,7 +591,11 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             clean_data["current_role"] = create_role_profile(cur)
         obj = cls(**clean_data)
         if not obj.llm_client:
-            obj.llm_client = get_default_llm_client()
+            try:
+                obj.llm_client = get_default_llm_client()
+            except LLMClientInitError as exc:
+                logger.error(f"Failed to initialize default LLM client: {exc}")
+                raise
         if not obj.role_history:
             obj.role_history = [(obj.step_counter, obj.current_role.name)]
         if not obj.mood_history:

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -29,7 +29,7 @@ from src.agents.memory.weaviate_vector_store_manager import WeaviateVectorStoreM
 from src.infra import config
 from src.infra.async_dspy_manager import AsyncDSPyManager
 from src.infra.config import get_config
-from src.infra.llm_client import get_ollama_client
+from src.infra.llm_client import LLMClientInitError, get_ollama_client
 
 from .embedding_utils import compute_embedding
 from .roles import ensure_profile
@@ -164,7 +164,11 @@ class Agent:
         reputation = initial_state.get("reputation", {})
 
         # LLM Client Initialization - MOVED EARLIER
-        self.llm_client = get_ollama_client()
+        try:
+            self.llm_client = get_ollama_client()
+        except LLMClientInitError as exc:
+            logger.error(f"Agent failed to initialize LLM client: {exc}")
+            raise
 
         # Get project id and ensure current_project_id and current_project_affiliation are in sync
 

--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ from src.infra.checkpoint import (
     restore_rng_state,
     save_checkpoint,
 )
-from src.infra.llm_client import get_ollama_client
+from src.infra.llm_client import LLMClientInitError, get_ollama_client
 from src.infra.logging_config import setup_logging
 from src.infra.settings import settings
 from src.infra.warning_filters import configure_warning_filters
@@ -88,9 +88,10 @@ def create_simulation(
 ) -> Simulation:
     """Construct a Simulation instance with basic defaults."""
 
-    ollama_client = get_ollama_client()
-    if not ollama_client:
-        logging.error("Failed to connect to Ollama. Please ensure Ollama is running.")
+    try:
+        ollama_client = get_ollama_client()
+    except LLMClientInitError as exc:
+        logging.error("Failed to connect to LLM backend: %s", exc)
         sys.exit(1)
 
     discord_bot = None

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -93,6 +93,12 @@ _APIError = APIError
 
 logger = logging.getLogger(__name__)
 
+
+# Exception raised when the LLM client cannot be initialized.
+class LLMClientInitError(RuntimeError):
+    """Raised when both vLLM and Ollama client initialization fail."""
+
+
 # Define generic type variables for Pydantic models and call signatures
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -164,7 +170,10 @@ class LLMClient:
 
     def __init__(self: LLMClient, config: LLMClientConfig) -> None:
         self.config = config
-        self._client = get_ollama_client()
+        try:
+            self._client = get_ollama_client()
+        except LLMClientInitError:
+            raise
 
     @monitor_llm_call(model_param="model", context="ollama_chat")
     def chat(
@@ -277,13 +286,17 @@ def _create_vllm_client() -> OllamaClientProtocol:
     return _Client()
 
 
+def _create_ollama_client() -> OllamaClientProtocol:
+    return cast(OllamaClientProtocol, ollama.Client(host=OLLAMA_API_BASE))
+
+
 client: OllamaClientProtocol | None
 if USE_VLLM:
     logger.info(f"Using vLLM API base: {VLLM_API_BASE}")
     client = _create_vllm_client()
 else:
     try:
-        client = cast(OllamaClientProtocol, ollama.Client(host=OLLAMA_API_BASE))
+        client = _create_ollama_client()
         logger.info(f"Ollama client initialized for host: {OLLAMA_API_BASE}")
     except (APIError, RequestException) as e:
         logger.error(
@@ -293,34 +306,48 @@ else:
         client = None
 
 
-def get_ollama_client() -> OllamaClientProtocol | None:
-    """Return the initialized LLM client, switching backends if needed."""
+def get_ollama_client() -> OllamaClientProtocol:
+    """Return the initialized LLM client, retrying and switching backends if needed."""
     global client, VLLM_API_BASE, USE_VLLM
     env_base = os.environ.get("VLLM_API_BASE")
 
-    if env_base:
-        if not USE_VLLM or env_base != VLLM_API_BASE:
-            VLLM_API_BASE = env_base
-            USE_VLLM = True
-            logger.info("Switching to vLLM client for base %s", VLLM_API_BASE)
-            client = _create_vllm_client()
-    elif USE_VLLM:
+    if env_base and (not USE_VLLM or env_base != VLLM_API_BASE):
+        VLLM_API_BASE = env_base
+        USE_VLLM = True
+        logger.info("Switching to vLLM client for base %s", VLLM_API_BASE)
+        client = None
+    elif not env_base and USE_VLLM:
         USE_VLLM = False
         VLLM_API_BASE = None
-        try:
-            client = cast(OllamaClientProtocol, ollama.Client(host=OLLAMA_API_BASE))
-            logger.info("Switching to Ollama client for host %s", OLLAMA_API_BASE)
-        except (APIError, RequestException) as e:  # pragma: no cover - optional
-            logger.error(
-                "Failed to initialize Ollama client for host %s: %s",
-                OLLAMA_API_BASE,
-                e,
-                exc_info=True,
-            )
-            client = None
+        logger.info("Switching to Ollama client for host %s", OLLAMA_API_BASE)
+        client = None
 
     if client is None:
-        logger.error("Ollama client is not available. Check connection and configuration.")
+        primary = _create_vllm_client if USE_VLLM else _create_ollama_client
+        secondary = _create_ollama_client if USE_VLLM else _create_vllm_client
+
+        client, err = _retry_with_backoff(primary)
+        if client is None:
+            logger.error(
+                "Failed to initialize %s client: %s",
+                "vLLM" if USE_VLLM else "Ollama",
+                err,
+                exc_info=True,
+            )
+            client, err = _retry_with_backoff(secondary)
+            if client is None:
+                logger.error(
+                    "Failed to initialize %s client: %s",
+                    "Ollama" if USE_VLLM else "vLLM",
+                    err,
+                    exc_info=True,
+                )
+                raise LLMClientInitError("Failed to initialize vLLM and Ollama clients")
+            USE_VLLM = not USE_VLLM
+            if USE_VLLM:
+                VLLM_API_BASE = env_base
+            else:
+                VLLM_API_BASE = None
     return client
 
 
@@ -384,8 +411,6 @@ def generate_text(
 
     def call() -> LLMChatResponse:
         local_client = get_ollama_client()
-        if not local_client:
-            raise RuntimeError("Ollama client not initialized")
         messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
         return local_client.chat(
             model=model,
@@ -393,7 +418,11 @@ def generate_text(
             options={"temperature": temperature},
         )
 
-    response, error = _retry_with_backoff(call)
+    try:
+        response, error = _retry_with_backoff(call)
+    except LLMClientInitError as exc:
+        logger.error(f"Failed to initialize LLM client: {exc}")
+        return None
 
     if error:
         logger.error(f"Failed to generate text after retries: {error}")
@@ -448,9 +477,13 @@ def summarize_memory_context(
             else f"This is a mock summary of {len(memories)} memories related to '{goal}'."
         )
 
-    ollama_client = get_ollama_client()
-    if not ollama_client:
-        logger.warning("Attempted to summarize memories but Ollama client is unavailable.")
+    try:
+        ollama_client = get_ollama_client()
+    except LLMClientInitError as exc:
+        logger.warning(
+            "Attempted to summarize memories but %s",
+            exc,
+        )
         return "(Memory summarization failed: LLM client unavailable)"
 
     # Format memories as a bulleted list for the prompt
@@ -533,9 +566,13 @@ def analyze_sentiment(
                 return 0.0
         return float(val) if isinstance(val, (int, float)) else 0.0
 
-    ollama_client = get_ollama_client()
-    if not ollama_client or not text:
-        return None  # Client not available or empty text
+    if not text:
+        return None
+    try:
+        ollama_client = get_ollama_client()
+    except LLMClientInitError as exc:
+        logger.error(f"Sentiment analysis failed to init client: {exc}")
+        return None
 
     # Simple prompt for sentiment classification
     prompt = (
@@ -716,9 +753,10 @@ def generate_structured_output(
             logger.error(f"Error generating mock structured output: {e}")
             return None
     # Get the Ollama client instance
-    ollama_client = get_ollama_client()
-    if not ollama_client:
-        logger.warning("Attempted to generate structured output but Ollama client is unavailable.")
+    try:
+        ollama_client = get_ollama_client()
+    except LLMClientInitError as exc:
+        logger.warning("Attempted to generate structured output but %s", exc)
         return None
     # Ensure response_model is a subclass of BaseModel for type safety
     if not issubclass(response_model, BaseModel):
@@ -801,7 +839,7 @@ def generate_structured_output(
         return None
 
 
-def get_default_llm_client() -> OllamaClientProtocol | None:
+def get_default_llm_client() -> OllamaClientProtocol:
     """
     Creates and returns a default LLM client instance for use in simulations.
     This function is a convenience wrapper that returns the global client.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,14 @@ from pathlib import Path
 from typing import Callable, Optional
 from unittest.mock import MagicMock, patch
 
+pytest_plugins = ["tests.pytest_asyncio_stub"]
+
+# Provide a minimal module so tests can import pytest_asyncio
+if "pytest_asyncio" not in sys.modules:
+    import types
+
+    sys.modules["pytest_asyncio"] = types.ModuleType("pytest_asyncio")
+
 try:
     import numpy as np
 except Exception:

--- a/tests/pytest_asyncio_stub.py
+++ b/tests/pytest_asyncio_stub.py
@@ -1,0 +1,46 @@
+import asyncio
+import inspect
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from _pytest.config import Config
+
+
+def pytest_configure(config: Config) -> None:
+    config.addinivalue_line("markers", "asyncio: mark test to run with asyncio")
+
+
+@pytest.fixture
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Create and set a new event loop for each test."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
+    marker = pyfuncitem.get_closest_marker("asyncio")
+    if marker is not None and inspect.iscoroutinefunction(pyfuncitem.obj):
+        loop_obj = pyfuncitem.funcargs.get("event_loop")
+        if loop_obj is None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            close_loop = True
+        else:
+            loop = cast(asyncio.AbstractEventLoop, loop_obj)
+            close_loop = False
+        try:
+            args = [pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames]
+            loop.run_until_complete(pyfuncitem.obj(*args))
+        finally:
+            if close_loop:
+                loop.close()
+                asyncio.set_event_loop(None)
+        return True
+    return None


### PR DESCRIPTION
## Summary
- add `LLMClientInitError` and retry logic in `get_ollama_client`
- propagate initialization failures through app and agents
- handle initialization errors in benchmarking script
- run ruff formatting
- add minimal pytest-asyncio stub to run async tests without external dependency

## Testing
- `ruff check tests/pytest_asyncio_stub.py tests/conftest.py`
- `black --check tests/pytest_asyncio_stub.py tests/conftest.py`
- `mypy tests/pytest_asyncio_stub.py`
- `pytest tests/unit/interfaces/test_discord_bot.py::test_stats_command -q`

------
https://chatgpt.com/codex/tasks/task_e_686ecea2a0248326b57e3db62a24c9e0