### PR TITLE
Extract governance service

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -13,3 +13,7 @@ Votes are weighted by the amount of influence points (IP) agents have staked. Pa
 ```bash
 python examples/governance/list_proposals_example.py
 ```
+
+The core voting logic lives in ``src.governance.service`` where
+``GovernanceService`` exposes methods for proposing laws, weighting votes via
+the ledger, and retrieving previous proposals.

--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -2,6 +2,14 @@
 
 from .law_board import law_board
 from .policy import evaluate_policy, load_policy
+from .service import GovernanceService, governance
 from .voting import propose_law
 
-__all__ = ["evaluate_policy", "law_board", "load_policy", "propose_law"]
+__all__ = [
+    "GovernanceService",
+    "evaluate_policy",
+    "governance",
+    "law_board",
+    "load_policy",
+    "propose_law",
+]

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Iterable
+
+from src.agents.core.base_agent import Agent
+from src.infra.ledger import ledger
+from src.utils.policy import evaluate_with_opa
+
+from .law_board import law_board
+
+
+class GovernanceService:
+    """Service coordinating law proposals and voting."""
+
+    async def vote(self, agent: Agent, proposal: str) -> bool:
+        """Return the agent's vote (True=approve) using the OPA policy."""
+        allowed, _ = await evaluate_with_opa(proposal)
+        return allowed
+
+    async def propose_law(self, proposer: Agent, text: str, agents: Iterable[Agent]) -> bool:
+        """Propose ``text`` to ``agents`` and persist the result."""
+        allowed, _ = await evaluate_with_opa(text)
+        if not allowed:
+            return False
+
+        votes = await asyncio.gather(*[self.vote(a, text) for a in agents])
+        weights: list[float] = []
+        for a in agents:
+            base_ip = getattr(a.state, "ip", 0.0)
+            try:
+                staked = ledger.get_staked_ip(a.agent_id)
+            except Exception:
+                staked = 0.0
+            weights.append(math.sqrt(base_ip + staked))
+
+        yes_weight = sum(w for w, v in zip(weights, votes) if v)
+        no_weight = sum(w for w, v in zip(weights, votes) if not v)
+        approved = yes_weight > no_weight
+        if approved:
+            law_board.add_law(text)
+        try:
+            ledger.record_law_proposal(
+                proposer.agent_id,
+                text,
+                approved,
+                yes_weight,
+                no_weight,
+            )
+        except Exception:
+            pass
+        return approved
+
+    def get_proposals(self, limit: int | None = None) -> list[dict[str, object]]:
+        """Return stored law proposals."""
+        try:
+            return ledger.get_law_proposals(limit)
+        except Exception:
+            return []
+
+
+governance = GovernanceService()
+
+__all__ = ["GovernanceService", "governance"]

--- a/src/governance/voting.py
+++ b/src/governance/voting.py
@@ -1,50 +1,17 @@
 from __future__ import annotations
 
-import asyncio
-import math
 from collections.abc import Iterable
 
 from src.agents.core.base_agent import Agent
-from src.infra.ledger import ledger
-from src.utils.policy import evaluate_with_opa
 
-from .law_board import law_board
+from .service import governance
 
 
 async def _vote(agent: Agent, proposal: str) -> bool:
-    """Simple voting behavior: agent votes according to OPA evaluation."""
-    allowed, _ = await evaluate_with_opa(proposal)
-    return allowed
+    """Proxy to :class:`GovernanceService.vote`."""
+    return await governance.vote(agent, proposal)
 
 
 async def propose_law(proposer: Agent, text: str, agents: Iterable[Agent]) -> bool:
-    """Propose a law and collect weighted votes from all agents."""
-    allowed, _ = await evaluate_with_opa(text)
-    if not allowed:
-        return False
-
-    votes = await asyncio.gather(*[_vote(a, text) for a in agents])
-    weights = []
-    for a in agents:
-        base_ip = getattr(a.state, "ip", 0.0)
-        try:
-            staked = ledger.get_staked_ip(a.agent_id)
-        except Exception:
-            staked = 0.0
-        weights.append(math.sqrt(base_ip + staked))
-    yes_weight = sum(w for w, v in zip(weights, votes) if v)
-    no_weight = sum(w for w, v in zip(weights, votes) if not v)
-    approved = yes_weight > no_weight
-    if approved:
-        law_board.add_law(text)
-    try:
-        ledger.record_law_proposal(
-            proposer.agent_id,
-            text,
-            approved,
-            yes_weight,
-            no_weight,
-        )
-    except Exception:
-        pass
-    return approved
+    """Delegate to :class:`GovernanceService`."""
+    return await governance.propose_law(proposer, text, agents)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
-from src.infra.ledger import ledger
+from src.governance.service import governance
 
 from .widget_registry import WidgetRegistry
 
@@ -216,10 +216,7 @@ async def api_propose_law(proposal: LawProposal) -> Response:
 @app.get("/api/proposals")
 async def api_get_proposals(limit: int = 10) -> Response:
     """Return stored law proposals."""
-    try:
-        proposals = ledger.get_law_proposals(limit)
-    except Exception:  # pragma: no cover - defensive
-        proposals = []
+    proposals = governance.get_proposals(limit)
     return JSONResponse({"proposals": proposals})
 
 

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -128,9 +128,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -173,9 +173,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -512,9 +512,9 @@ class Simulation:
         async with self._msg_lock:
             perception_data["perceived_messages"] = list(self.messages_to_perceive_this_round)
         if self.knowledge_board:
-            perception_data[
-                "knowledge_board_content"
-            ] = self.knowledge_board.get_recent_entries_for_prompt()
+            perception_data["knowledge_board_content"] = (
+                self.knowledge_board.get_recent_entries_for_prompt()
+            )
 
         agent_output = await agent.run_turn(
             simulation_step=self.current_step,
@@ -992,7 +992,7 @@ class Simulation:
 
     async def propose_law(self: Self, proposer_id: str, text: str) -> bool:
         """Allow an agent to propose a law and trigger a vote."""
-        from src.governance import propose_law as _propose
+        from src.governance.service import governance
 
         proposer = next((a for a in self.agents if a.agent_id == proposer_id), None)
         if proposer is None:
@@ -1007,7 +1007,7 @@ class Simulation:
                     self.vector.to_dict(),
                 )
 
-        approved = await _propose(proposer, text, self.agents)
+        approved = await governance.propose_law(proposer, text, self.agents)
         if approved and self.knowledge_board:
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(

--- a/tests/integration/governance/test_staked_ip_proposals.py
+++ b/tests/integration/governance/test_staked_ip_proposals.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -55,25 +56,26 @@ async def test_weights_include_staked_ip(monkeypatch: pytest.MonkeyPatch, tmp_pa
     ledger = Ledger(tmp_path / "ledger.sqlite")
     board = LawBoard(tmp_path / "laws.sqlite")
 
-    import importlib
-
     voting_mod = importlib.import_module("src.governance.voting")
-    monkeypatch.setattr(voting_mod, "law_board", board)
-    monkeypatch.setattr(voting_mod, "ledger", ledger)
-    monkeypatch.setattr(db, "ledger", ledger)
+    gservice = importlib.import_module("src.governance.service")
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(voting_mod, "governance", gservice.governance)
+    monkeypatch.setattr(db, "governance", gservice.governance)
 
     monkeypatch.setitem(config._CONFIG, "OPA_URL", "http://opa")
+
     async def allow_policy(_p: str) -> tuple[bool, str]:
         return True, ""
 
-    monkeypatch.setattr(voting_mod, "evaluate_with_opa", allow_policy)
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow_policy)
 
     votes = [True, False]
 
     async def fake_vote(_a: DummyAgent, _t: str) -> bool:
         return votes.pop(0)
 
-    monkeypatch.setattr(voting_mod, "_vote", fake_vote)
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
 
     ledger.log_change("a1", 10.0, 0.0, "fund")
     ledger.log_change("a2", 10.0, 0.0, "fund")
@@ -90,4 +92,3 @@ async def test_weights_include_staked_ip(monkeypatch: pytest.MonkeyPatch, tmp_pa
     resp = await db.api_get_proposals(limit=1)
     data = json.loads(resp.body)
     assert data["proposals"][0]["approved"] is True
-


### PR DESCRIPTION
## Summary
- create `GovernanceService` for voting and law proposals
- expose service through `governance` package
- update dashboard backend and simulation to use the service
- document the service in governance docs
- adjust staked IP test to monkeypatch new service

## Testing
- `bash scripts/lint.sh --format`
- `pytest tests/integration/governance/test_staked_ip_proposals.py::test_weights_include_staked_ip -m integration -q -s`
- `pytest tests/unit/core/test_agent_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686f0fb883488326ab50a70387839457