### PR TITLE
Add plug‑in hooks and example extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Windows / WSL2 Setup](docs/windows_setup.md)
 - [Running Tests](#running-tests)
 - [culture-ui Frontend](#culture-ui-frontend)
+- [Extensions and Plug-ins](#extensions-and-plug-ins)
 
 ## Vision: The Crucible of Emergent AI
 
@@ -331,6 +332,11 @@ A Husky pre-commit hook runs `pnpm lint` and `pnpm type-check` automatically.
 
 See [culture-ui/README.md](culture-ui/README.md) for additional details.
 UI requirements are summarized in [docs/culture_ui_requirements.md](docs/culture_ui_requirements.md).
+
+## Extensions and Plug-ins
+
+Culture exposes simple hooks for registering dashboard widgets and agent behaviors.
+See [docs/plugins.md](docs/plugins.md) for details.
 
 ## Project Structure
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,39 @@
+# Extensions and Plug-ins
+
+Culture allows third-party packages to contribute UI widgets and agent behaviors.
+This document shows how to create plug-ins using the hooks exposed in
+`src/extensions`.
+
+## Widget Registration
+
+Use `register_widget_backend` to inform the backend about a widget:
+
+```python
+from src.extensions import register_widget_backend
+
+register_widget_backend(
+    name="ExampleWidget",
+    script_url="http://localhost:5173/example.js",
+)
+```
+
+The backend stores the widget metadata so the dashboard can load it dynamically.
+
+## Agent Behavior Hooks
+
+Plug-ins can extend agent behavior by registering a callback executed after each
+agent turn:
+
+```python
+from src.extensions import register_agent_behavior
+
+def log_turn(agent: object, output: dict[str, object]) -> None:
+    print(f"[PLUGIN] {agent.agent_id}: {output}")
+
+register_agent_behavior(log_turn)
+```
+
+Each callback receives the agent instance and the dictionary returned from
+`Agent.run_turn`. Multiple behaviors can be registered and will be invoked in the
+order added.
+

--- a/examples/plugins/custom_agent_behavior.py
+++ b/examples/plugins/custom_agent_behavior.py
@@ -1,0 +1,11 @@
+"""Example plug-in adding custom behavior after each agent turn."""
+
+from src.extensions import register_agent_behavior
+
+
+def log_turn(agent: object, output: dict[str, object]) -> None:
+    """Simple behavior that logs the agent's message."""
+    print(f"[PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
+
+
+register_agent_behavior(log_turn)

--- a/examples/plugins/register_widget_example.py
+++ b/examples/plugins/register_widget_example.py
@@ -1,16 +1,15 @@
 """Example plug-in registering a custom widget with the Culture UI."""
 
-import requests
+from src.extensions import register_widget_backend
 
 
 def main() -> None:
     """Register a widget named ``ExampleWidget`` using the backend API."""
-    resp = requests.post(
-        "http://localhost:8000/api/register_widget",
-        json={"name": "ExampleWidget", "script_url": "http://localhost:5173/example.js"},
-        timeout=10,
+    register_widget_backend(
+        name="ExampleWidget",
+        script_url="http://localhost:5173/example.js",
     )
-    print("Registration response:", resp.json())
+    print("Widget registered via backend API")
 
 
 if __name__ == "__main__":  # pragma: no cover - example script

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from pydantic import BaseModel
 from typing_extensions import Self
 
+from src.extensions import BEHAVIOR_REGISTRY
+
 if TYPE_CHECKING:
     from src.agents.memory.vector_store import ChromaVectorStoreManager
 else:  # pragma: no cover - optional dependency
@@ -680,6 +682,7 @@ class Agent:
                         f"Agent {self.agent_id} updated last_action_intent to: {self._state.last_action_intent}"
                     )
 
+                BEHAVIOR_REGISTRY.run(self, turn_output)
                 return turn_output
             else:
                 logger.warning(

--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -1,0 +1,45 @@
+"""Hooks for extending Culture via external packages."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import httpx
+
+
+class BehaviorRegistry:
+    """Registry for callables that modify agent behavior."""
+
+    def __init__(self) -> None:
+        self._behaviors: list[Callable[[Any, dict[str, Any]], None]] = []
+
+    def register(self, func: Callable[[Any, dict[str, Any]], None]) -> None:
+        self._behaviors.append(func)
+
+    def run(self, agent: Any, output: dict[str, Any]) -> None:
+        for func in list(self._behaviors):
+            func(agent, output)
+
+
+BEHAVIOR_REGISTRY = BehaviorRegistry()
+
+
+def register_agent_behavior(func: Callable[[Any, dict[str, Any]], None]) -> None:
+    """Register a callback executed after each agent turn."""
+
+    BEHAVIOR_REGISTRY.register(func)
+
+
+def register_widget_backend(
+    name: str,
+    script_url: str,
+    backend_url: str = "http://localhost:8000",
+) -> None:
+    """Register a UI widget with the Culture backend."""
+
+    resp = httpx.post(
+        f"{backend_url.rstrip('/')}/api/register_widget",
+        json={"name": name, "script_url": script_url},
+        timeout=10,
+    )
+    resp.raise_for_status()

--- a/tests/unit/extensions/test_extensions.py
+++ b/tests/unit/extensions/test_extensions.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.extensions import BEHAVIOR_REGISTRY, register_agent_behavior
+
+
+@pytest.mark.unit
+def test_behavior_registry_runs() -> None:
+    calls: list[dict[str, object]] = []
+
+    def plugin(agent: object, output: dict[str, object]) -> None:
+        calls.append(output)
+
+    BEHAVIOR_REGISTRY._behaviors.clear()
+    register_agent_behavior(plugin)
+    BEHAVIOR_REGISTRY.run(object(), {"msg": "hi"})
+    assert calls and calls[0]["msg"] == "hi"


### PR DESCRIPTION
## Summary
- add `extensions` package with `register_widget_backend` and `register_agent_behavior`
- integrate behavior hook in `Agent.run_turn`
- document how to create plug‑ins
- update widget example and add behavior example
- include unit tests for new hook

## Testing
- `ruff check src/extensions tests/unit/extensions/test_extensions.py`
- `black --check src/extensions tests/unit/extensions/test_extensions.py`
- `mypy src/extensions tests/unit/extensions/test_extensions.py`
- `pytest tests/unit/extensions/test_extensions.py tests/unit/interfaces/test_dashboard_backend_register_widget.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f188eb8408326a81a9b027a0487c3