### PR TITLE
Add AgentTimeline widget

### DIFF
--- a/culture-ui/src/AgentTimeline.test.tsx
+++ b/culture-ui/src/AgentTimeline.test.tsx
@@ -1,0 +1,35 @@
+import { act, render, screen } from '@testing-library/react'
+import AgentTimelinePage from './pages/AgentTimeline'
+import { MockEventSource, resetMockSources } from './lib/testUtils'
+import { vi } from 'vitest'
+
+afterEach(() => {
+  resetMockSources()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('AgentTimeline widget', () => {
+  it('shows positions and summaries from events', async () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ summaries: ['sum1'] }),
+      }) as unknown as Response,
+    ))
+
+    render(<AgentTimelinePage />)
+
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage(
+        '{"event_type":"update","data":{"step":1,"world_map":{"agents":{"agent-1":[3,4]}}}}',
+      )
+    })
+
+    expect(await screen.findByText('agent-1: 3, 4')).toBeInTheDocument()
+    expect(await screen.findByText('sum1')).toBeInTheDocument()
+    expect(screen.getByRole('slider')).toHaveAttribute('max', '1')
+  })
+})

--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -12,6 +12,7 @@ import LawProposalPage from './pages/LawProposal'
 import TimelineWidgetPage from './pages/TimelineWidget'
 import KpiCardPage from './pages/KpiCard'
 import StoryboardPage from './pages/Storyboard'
+import AgentTimelinePage from './pages/AgentTimeline'
 import MemoryExplorer from './pages/MemoryExplorer'
 import DockManager from './components/DockManager'
 import { createDefaultLayout } from './lib/defaultLayout'
@@ -34,6 +35,7 @@ export default function App() {
             <Route path="/network-web" element={<NetworkWebPage />} />
             <Route path="/world-map" element={<WorldMapPage />} />
             <Route path="/timeline" element={<TimelineWidgetPage />} />
+            <Route path="/agent-timeline" element={<AgentTimelinePage />} />
             <Route path="/propose-law" element={<LawProposalPage />} />
             <Route path="/kpi-card" element={<KpiCardPage />} />
             <Route path="/storyboard" element={<StoryboardPage />} />

--- a/culture-ui/src/pages/AgentTimeline.tsx
+++ b/culture-ui/src/pages/AgentTimeline.tsx
@@ -1,0 +1,14 @@
+import AgentTimeline from '../widgets/AgentTimeline'
+import { registerWidget } from '../lib/widgetRegistry'
+
+export default function AgentTimelinePage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Agent Timeline</h1>
+      <AgentTimeline />
+    </div>
+  )
+}
+
+registerWidget('AgentTimeline', AgentTimelinePage)
+

--- a/culture-ui/src/widgets/AgentTimeline.tsx
+++ b/culture-ui/src/widgets/AgentTimeline.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
+
+interface SimEvent {
+  event_type?: string
+  data?: {
+    step?: number
+    world_map?: { agents?: Record<string, [number, number]> }
+  }
+}
+
+interface StepData {
+  positions: Record<string, [number, number]>
+}
+
+export default function AgentTimeline() {
+  const event = useEventSource<SimEvent>()
+  const [history, setHistory] = useState<Record<number, StepData>>({})
+  const [latestStep, setLatestStep] = useState(0)
+  const [scrubStep, setScrubStep] = useState(0)
+  const [summaries, setSummaries] = useState<string[]>([])
+
+  useEffect(() => {
+    const step = event?.data?.step
+    if (typeof step === 'number') {
+      setLatestStep(step)
+      if (event?.data?.world_map?.agents) {
+        setHistory((cur) => ({
+          ...cur,
+          [step]: { positions: event.data!.world_map!.agents! },
+        }))
+      }
+    }
+  }, [event])
+
+  const positions =
+    history[scrubStep]?.positions || history[latestStep]?.positions || {}
+
+  useEffect(() => {
+    const agentId = Object.keys(positions)[0]
+    if (!agentId) {
+      setSummaries([])
+      return
+    }
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(`/api/agents/${agentId}/semantic_summaries`)
+        const json = await res.json()
+        if (!cancelled) setSummaries(json.summaries || [])
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [positions])
+
+  return (
+    <div className="p-2" data-testid="agent-timeline">
+      <label htmlFor="agent-timeline-slider" className="block text-sm font-bold">
+        Step {scrubStep || latestStep}
+      </label>
+      <input
+        id="agent-timeline-slider"
+        type="range"
+        min={0}
+        max={latestStep}
+        value={scrubStep}
+        onChange={(e) => setScrubStep(Number(e.target.value))}
+      />
+      <div data-testid="positions" className="mt-2">
+        <ul>
+          {Object.entries(positions).map(([id, pos]) => (
+            <li key={id}>
+              {id}: {pos[0]}, {pos[1]}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div data-testid="summaries" className="mt-2">
+        {summaries.map((s, i) => (
+          <div key={i}>{s}</div>
+        ))}
+      </div>
+    </div>
+  )
+}
+

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -5,5 +5,6 @@ export { default as WorldMap } from './WorldMap'
 export { default as KpiCard } from './KpiCard'
 export { default as EventConsole } from './EventConsole'
 export { default as Storyboard } from './Storyboard'
+export { default as AgentTimeline } from './AgentTimeline'
 
 


### PR DESCRIPTION
## Summary
- visualize agent positions & memory summaries in AgentTimeline widget
- register AgentTimeline widget and page
- route `/agent-timeline` to new page
- test AgentTimeline widget

## Testing
- `pre-commit run --files culture-ui/src/widgets/AgentTimeline.tsx culture-ui/src/pages/AgentTimeline.tsx culture-ui/src/widgets/index.ts culture-ui/src/App.tsx culture-ui/src/AgentTimeline.test.tsx`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`
- `pytest -k 'nothing'`

------
https://chatgpt.com/codex/tasks/task_e_686f188e0bf883268fc7bdb2fbd7d5ae