### PR TITLE
Introduce MemoryService wrapper

### DIFF
--- a/src/agents/core/agent_graph_types.py
+++ b/src/agents/core/agent_graph_types.py
@@ -126,6 +126,7 @@ class AgentTurnState(TypedDict):
     agent_goal: str  # The agent\'s goal for the simulation
     updated_state: dict[str, object]  # Output field: The updated state after the turn
     vector_store_manager: object | None  # For persisting memories to vector store
+    memory_service: object | None  # Unified memory service
     rag_summary: str  # Summarized memories from vector store
     knowledge_board_content: list[str]  # Current entries on the knowledge board
     knowledge_board: object | None  # The knowledge board instance for posting entries

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -25,6 +25,7 @@ else:  # pragma: no cover - optional dependency
         from src.agents.memory.vector_store import ChromaVectorStoreManager
     except Exception:
         ChromaVectorStoreManager = None
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.weaviate_vector_store_manager import WeaviateVectorStoreManager
 from src.infra import config
 from src.infra.async_dspy_manager import AsyncDSPyManager
@@ -114,6 +115,7 @@ class Agent:
         agent_id: str | None = None,
         initial_state: dict[str, Any] | None = None,
         name: str | None = None,
+        memory_service: MemoryService | None = None,
         vector_store_manager: Optional[MemoryStore] = None,
         async_dspy_manager: Optional[AsyncDSPyManager] = None,
     ):
@@ -127,6 +129,8 @@ class Agent:
                 If None is provided, default values will be used.
             name (str, optional): A name for the agent. If None is provided,
                 a default name based on agent_id will be used.
+            memory_service (MemoryService | None): Unified memory service. If ``None``,
+                one will be created from ``vector_store_manager``.
             vector_store_manager (Optional[MemoryStore], optional): Manager for vector-based memory
                 storage and retrieval. Used to persist memory events.
             async_dspy_manager (Optional[AsyncDSPyManager], optional): Manager for DSPy program execution.
@@ -285,9 +289,15 @@ class Agent:
             sys.modules.pop("src.agents.graphs.basic_agent_graph", None)
             importlib.import_module("src.agents.graphs.basic_agent_graph")
 
+        # Memory service initialization
+        if memory_service is None:
+            mem_vs = vector_store_manager
+        else:
+            mem_vs = memory_service.vector_store
+
         # Vector Store Manager Initialization
-        if vector_store_manager:
-            self.vector_store_manager = vector_store_manager
+        if mem_vs:
+            self.vector_store_manager = mem_vs
         else:
             backend = (
                 config.VECTOR_STORE_BACKEND
@@ -307,6 +317,8 @@ class Agent:
                 self.vector_store_manager = ChromaVectorStoreManager(
                     persist_directory=getattr(config, "VECTOR_STORE_DIR", "./chroma_db")
                 )
+
+        self.memory_service = memory_service or MemoryService(self.vector_store_manager)
 
         # Async DSPy Manager Initialization
         if async_dspy_manager:
@@ -391,6 +403,7 @@ class Agent:
         self: Self,
         simulation_step: int,
         environment_perception: dict[str, Any] | None = None,
+        memory_service: MemoryService | None = None,
         vector_store_manager: (
             MemoryStore | None
         ) = None,  # Accepts any vector store manager implementation
@@ -403,6 +416,8 @@ class Agent:
             simulation_step (int): The current step number from the simulation.
             environment_perception (Dict[str, Any], optional): Perception data from the
                 environment.
+            memory_service (MemoryService | None): Unified memory service. If ``None``,
+                the agent's ``memory_service`` attribute is used.
             vector_store_manager (Optional[MemoryStore], optional): Manager for vector-based memory
                 storage and retrieval. Used to persist memory events.
             knowledge_board (Optional[KnowledgeBoard], optional): Knowledge board instance
@@ -451,10 +466,13 @@ class Agent:
         # Start with any memories retrieved in previous turns
         memory_history_list: list[dict[str, Any]] = list(self._memory_history)
 
-        active_store = vector_store_manager or getattr(self, "vector_store_manager", None)
-        if active_store is not None and hasattr(active_store, "aretrieve_relevant_memories"):
+        active_service = memory_service or getattr(self, "memory_service", None)
+        if active_service is None and vector_store_manager is not None:
+            active_service = MemoryService(vector_store_manager)
+
+        if active_service is not None:
             try:
-                retrieved_memories = await cast(Any, active_store).aretrieve_relevant_memories(
+                retrieved_memories = await active_service.retrieve_relevant_memories(
                     self.agent_id,
                     query="",
                     k=5,
@@ -512,6 +530,7 @@ class Agent:
             "agent_goal": agent_goal,  # Use the extracted agent goal
             "updated_state": {},  # Initialize empty
             "vector_store_manager": vector_store_manager,  # Pass the vector store manager
+            "memory_service": active_service,
             "rag_summary": "(No memory summary available yet)",  # Initialize with default summary
             "knowledge_board_content": knowledge_board_content,  # Pass the knowledge board content
             "knowledge_board": knowledge_board,  # Pass the knowledge board instance

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -20,6 +20,7 @@ from src.agents.core.roles import ensure_profile
 
 # Import L1SummaryGenerator for DSPy-based L1 summary generation
 from src.agents.dspy_programs.l1_summary_generator import L1SummaryGenerator
+from src.agents.memory.memory_service import MemoryService
 
 # Import L2SummaryGenerator for DSPy-based L2 summary generation
 from src.infra import config  # Import config for role change parameters
@@ -298,9 +299,9 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
                     memory_summary,
                     {"step": sim_step, "type": "consolidated_summary"},
                 )
-                vector_store = state.get("vector_store_manager")
-                if vector_store and hasattr(vector_store, "add_memory"):
-                    vector_store.add_memory(
+                service = state.get("memory_service")
+                if service and hasattr(service, "add_memory"):
+                    cast(MemoryService, service).add_memory(
                         agent_id,
                         sim_step,
                         "consolidated_summary",
@@ -371,14 +372,18 @@ def route_action_intent(state: AgentTurnState) -> str:
 
 
 def _maybe_consolidate_memories(state: AgentTurnState) -> dict[str, Any]:
-    manager = state.get("semantic_manager")
+    manager = state.get("memory_service")
     step = int(state.get("simulation_step", 0))
     interval = int(
         config.get_config_value_with_override("SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 24)
     )
     if manager and interval > 0 and step % interval == 0:
         try:
-            manager.consolidate_memories(state["agent_id"])
+            cast(MemoryService, manager).consolidate_daily_memories(
+                state["agent_id"],
+                max(0, step - interval + 1),
+                step,
+            )
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Semantic consolidation failed: %s", exc, exc_info=True)
     return dict(state)

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, Protocol, cast
 
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.base_agent import Agent
-from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.memory_service import MemoryService
 from src.infra.llm_client import (
     analyze_sentiment,
     generate_structured_output,
@@ -77,45 +77,26 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 
 
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
-    manager = cast(MemoryRetriever | None, state.get("vector_store_manager"))
+    manager = cast(MemoryService | None, state.get("memory_service"))
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
-    semantic_manager = cast(SemanticMemoryManager | None, state.get("semantic_manager"))
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
-    memories = await manager.aretrieve_relevant_memories(state["agent_id"], query="", k=5)
+    memories = await manager.retrieve_relevant_memories(state["agent_id"], query="", k=5)
     memories_content = [m.get("content", "") for m in memories]
+    import asyncio
 
-    if semantic_manager:
-        import asyncio
+    semantic_memories = await asyncio.to_thread(
+        manager.retrieve_semantic_context,
+        state["agent_id"],
+        "",
+        5,
+    )
+    memories.extend(semantic_memories)
+    memories_content.extend(m.get("content", "") for m in semantic_memories)
 
-        semantic_memories = await asyncio.to_thread(
-            semantic_manager.retrieve_context,
-            state["agent_id"],
-            "",
-            5,
-        )
-        memories.extend(semantic_memories)
-        memories_content.extend(m.get("content", "") for m in semantic_memories)
-
-        tracker = getattr(manager, "tracking_manager", None)
-        if tracker:
-            mem_ids = [
-                m.get("memory_id") or m.get("id")
-                for m in semantic_memories
-                if m.get("memory_id") or m.get("id")
-            ]
-            try:
-                tracker.update_usage_stats(mem_ids)
-            except Exception:  # pragma: no cover - defensive
-                pass
-
-    if hasattr(manager, "get_semantic_summaries"):
-        try:
-            semantic = cast(Any, manager).get_semantic_summaries(state["agent_id"], limit=2)
-            memories_content.extend(semantic)
-        except Exception:  # pragma: no cover - defensive
-            pass
+    semantic = manager.get_recent_semantic_summaries(state["agent_id"], limit=2)
+    memories_content.extend(semantic)
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(
@@ -129,14 +110,14 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
 
 async def retrieve_semantic_context_node(state: AgentTurnState) -> dict[str, Any]:
     """Retrieve semantically grouped context for the agent."""
-    semantic_manager = cast(SemanticMemoryManager | None, state.get("semantic_manager"))
-    if not semantic_manager:
+    service = cast(MemoryService | None, state.get("memory_service"))
+    if not service:
         return {"semantic_context": ""}
     query = state.get("rag_summary", "")
     import asyncio
 
     memories = await asyncio.to_thread(
-        semantic_manager.retrieve_context,
+        service.retrieve_semantic_context,
         state["agent_id"],
         query,
         5,

--- a/src/agents/memory/__init__.py
+++ b/src/agents/memory/__init__.py
@@ -7,6 +7,7 @@ including persistence, retrieval, and memory utility operations.
 
 from typing import TYPE_CHECKING
 
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 
@@ -18,6 +19,6 @@ else:  # pragma: no cover - optional dependency
     except Exception:
         ChromaVectorStoreManager = None
 
-__all__ = ["MemoryTrackingManager", "SemanticMemoryManager"]
+__all__ = ["MemoryService", "MemoryTrackingManager", "SemanticMemoryManager"]
 if ChromaVectorStoreManager is not None:
     __all__.insert(0, "ChromaVectorStoreManager")

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -1,0 +1,109 @@
+"""Unified memory service for agent operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import Self
+
+from .semantic_memory_manager import SemanticMemoryManager
+from .vector_store import ChromaVectorStoreManager
+
+
+class MemoryService:
+    """Wrap vector store and semantic memory managers."""
+
+    def __init__(
+        self: Self,
+        vector_store: ChromaVectorStoreManager | None = None,
+        semantic_manager: SemanticMemoryManager | None = None,
+    ) -> None:
+        self.vector_store = vector_store
+        self.semantic_manager = semantic_manager
+
+    def add_memory(
+        self: Self,
+        agent_id: str,
+        step: int,
+        event_type: str,
+        content: str,
+        memory_type: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        if not self.vector_store:
+            return ""
+        return self.vector_store.add_memory(
+            agent_id, step, event_type, content, memory_type, metadata
+        )
+
+    async def retrieve_relevant_memories(
+        self: Self, agent_id: str, query: str = "", k: int = 5
+    ) -> list[dict[str, Any]]:
+        if not self.vector_store:
+            return []
+        return await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+
+    def retrieve_semantic_context(
+        self: Self, agent_id: str, query: str, k: int = 5
+    ) -> list[dict[str, Any]]:
+        if not self.semantic_manager:
+            return []
+        return self.semantic_manager.retrieve_context(agent_id, query, k)
+
+    def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
+        if not self.semantic_manager:
+            return []
+        return self.semantic_manager.get_recent_summaries(agent_id, limit)
+
+    async def run_semantic_job(self: Self, agent_id: str) -> None:
+        if not self.semantic_manager:
+            return None
+        await self.semantic_manager.run_nightly_job(agent_id)
+        return None
+
+    def consolidate_daily_memories(
+        self: Self, agent_id: str, start_step: int, end_step: int
+    ) -> None:
+        if not self.vector_store:
+            return None
+        self.vector_store.consolidate_daily_memories(agent_id, start_step, end_step)
+        return None
+
+    async def aconsolidate_daily_memories(
+        self: Self, agent_id: str, start_step: int, end_step: int
+    ) -> None:
+        if not self.vector_store:
+            return None
+        await self.vector_store.aconsolidate_daily_memories(agent_id, start_step, end_step)
+        return None
+
+    def prune_expired(self: Self, ttl_seconds: int) -> int:
+        if not self.vector_store:
+            return 0
+        return self.vector_store.prune(ttl_seconds)
+
+    def prune_mus(
+        self: Self,
+        l1_threshold: float = 0.2,
+        l2_threshold: float = 0.3,
+        l2_age_days: int = 30,
+        l1_min_age_days: int = 0,
+        l2_min_age_days: int = 0,
+    ) -> int:
+        if not self.vector_store:
+            return 0
+        return self.vector_store.prune_memories_hybrid(
+            l1_threshold,
+            l2_threshold,
+            l2_age_days,
+            l1_min_age_days,
+            l2_min_age_days,
+        )
+
+    def close(self: Self) -> None:
+        if self.vector_store and hasattr(self.vector_store, "close"):
+            try:
+                self.vector_store.close()
+            except Exception:
+                pass
+        return None

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 from src.agents.core import ResourceManager
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentActionIntent
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaDBException
 from src.governance import evaluate_policy
@@ -61,6 +62,7 @@ class Simulation:
     def __init__(
         self: Self,
         agents: list["Agent"],
+        memory_service: MemoryService | None = None,
         vector_store_manager: Optional["ChromaVectorStoreManager"] = None,
         semantic_manager: Optional["SemanticMemoryManager"] = None,
         scenario: str = "",
@@ -71,9 +73,12 @@ class Simulation:
 
         Args:
             agents (list[Agent]): A list of Agent instances participating
-                                  in the simulation.
+                in the simulation.
+            memory_service (MemoryService | None): Unified memory service. If
+                ``None``, one will be created from ``vector_store_manager`` and
+                ``semantic_manager``.
             vector_store_manager (Optional[ChromaVectorStoreManager]): Manager for
-                                  vector-based agent memory storage and retrieval.
+                vector-based agent memory storage and retrieval.
             scenario (str): Description of the simulation scenario that provides
                 context for agent interactions.
             discord_bot (Optional[SimulationDiscordBot]): Discord bot for sending
@@ -128,9 +133,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -139,9 +144,13 @@ class Simulation:
         self.collective_du: float = 0.0
         logger.info("Simulation initialized with collective IP/DU tracking.")
 
-        # --- Store the vector store manager ---
-        self.vector_store_manager = vector_store_manager
-        if vector_store_manager:
+        # --- Initialize memory service ---
+        if memory_service is None:
+            memory_service = MemoryService(vector_store_manager, semantic_manager)
+        self.memory_service = memory_service
+        self.vector_store_manager = memory_service.vector_store
+        self.semantic_manager = memory_service.semantic_manager
+        if self.vector_store_manager:
             logger.info("Simulation initialized with vector store manager for memory persistence.")
         else:
             logger.warning(
@@ -149,7 +158,6 @@ class Simulation:
                 "Memory will not be persisted."
             )
 
-        self.semantic_manager = semantic_manager
         self._last_semantic_job_step = 0
         self._last_memory_prune_step = 0
         self._last_consolidation_step = 0
@@ -173,9 +181,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -512,13 +520,14 @@ class Simulation:
         async with self._msg_lock:
             perception_data["perceived_messages"] = list(self.messages_to_perceive_this_round)
         if self.knowledge_board:
-            perception_data[
-                "knowledge_board_content"
-            ] = self.knowledge_board.get_recent_entries_for_prompt()
+            perception_data["knowledge_board_content"] = (
+                self.knowledge_board.get_recent_entries_for_prompt()
+            )
 
         agent_output = await agent.run_turn(
             simulation_step=self.current_step,
             environment_perception=perception_data,
+            memory_service=self.memory_service,
             vector_store_manager=self.vector_store_manager,
             knowledge_board=self.knowledge_board,
         )
@@ -684,7 +693,7 @@ class Simulation:
         turn_counter_this_run_step += 1
 
         if (
-            self.vector_store_manager
+            self.memory_service.vector_store
             and config.MEMORY_STORE_PRUNE_INTERVAL_STEPS > 0
             and self.current_step - self._last_memory_prune_step
             >= config.MEMORY_STORE_PRUNE_INTERVAL_STEPS
@@ -696,7 +705,7 @@ class Simulation:
             self._last_memory_prune_step = self.current_step
 
         if (
-            self.vector_store_manager
+            self.memory_service.vector_store
             and config.MEMORY_STORE_PRUNE_INTERVAL_STEPS > 0
             and self.current_step % len(self.agents) == 0
             and self.current_step > self._last_consolidation_step
@@ -721,7 +730,7 @@ class Simulation:
         ):
             for ag in self.agents:
                 try:
-                    await self.semantic_manager.run_nightly_job(ag.agent_id)
+                    await self.memory_service.run_semantic_job(ag.agent_id)
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.error("Failed semantic nightly job: %s", exc)
             self._last_semantic_job_step = self.current_step
@@ -738,10 +747,12 @@ class Simulation:
         return lambda: self._run_agent_turn(agent_index)
 
     async def _prune_memory_event(self: Self) -> None:
-        if not self.vector_store_manager:
+        if not self.memory_service.vector_store:
             return
         try:
-            self.vector_store_manager.prune(int(config.MEMORY_STORE_TTL_SECONDS))
+            self.memory_service.prune_expired(int(config.MEMORY_STORE_TTL_SECONDS))
+            # Additionally prune memories based on MUS thresholds
+            self.memory_service.prune_mus()
             event = {
                 "type": "memory_prune",
                 "step": self.current_step,
@@ -751,11 +762,11 @@ class Simulation:
             logger.error("Failed to prune memory store: %s", exc)
 
     async def _consolidate_memory_event(self: Self, start_step: int) -> None:
-        if not self.vector_store_manager:
+        if not self.memory_service.vector_store:
             return
         for ag in self.agents:
             try:
-                await self.vector_store_manager.aconsolidate_daily_memories(
+                await self.memory_service.aconsolidate_daily_memories(
                     ag.agent_id,
                     start_step,
                     self.current_step,
@@ -918,6 +929,7 @@ class Simulation:
             agent.run_turn(
                 simulation_step=start_step + idx,
                 environment_perception={},
+                memory_service=self.memory_service,
                 vector_store_manager=self.vector_store_manager,
                 knowledge_board=self.knowledge_board,
             )
@@ -944,11 +956,9 @@ class Simulation:
                     close_fn()
             except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
                 logger.exception("Failed to close knowledge board: %s", exc)
-        if self.vector_store_manager and hasattr(self.vector_store_manager, "close"):
+        if hasattr(self.memory_service, "close"):
             try:
-                close_fn = getattr(self.vector_store_manager, "close")
-                if callable(close_fn):
-                    close_fn()
+                self.memory_service.close()
             except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
                 logger.exception("Failed to close vector store manager: %s", exc)
         if self._event_task:


### PR DESCRIPTION
## Summary
- add a MemoryService module wrapping vector store and semantic memory managers
- integrate MemoryService in Simulation and BaseAgent
- update graph nodes and graphs to rely on MemoryService
- extend memory pruning to use MUS thresholds

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest tests/unit/memory/test_role_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686f0fb7aa7c8326b99bd13a9cfa0734