### PR TITLE
Improve semantic summary error handling

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -2,13 +2,18 @@ import asyncio
 
 # Skip self argument annotation warnings in stub classes
 import json
+import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from pydantic import BaseModel
+
 from src.governance.service import governance
 
 from .widget_registry import WidgetRegistry
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
@@ -20,22 +25,24 @@ else:  # pragma: no cover - optional runtime dependency
     except Exception:
 
         class FastAPI:
-            def __init__(self, *args: object, **kwargs: object) -> None:
+            def __init__(self: "FastAPI", *args: object, **kwargs: object) -> None:
                 pass
 
-            def get(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
+            def get(self: "FastAPI", *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def post(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
+            def post(self: "FastAPI", *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def websocket(self, *args: object, **kwargs: object) -> Callable[[Any], Any]:
+            def websocket(
+                self: "FastAPI", *args: object, **kwargs: object
+            ) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
@@ -45,7 +52,7 @@ else:  # pragma: no cover - optional runtime dependency
             pass
 
         class Response:  # pragma: no cover - minimal stub
-            def __init__(self, *args: object, **kwargs: object) -> None:
+            def __init__(self: "Response", *args: object, **kwargs: object) -> None:
                 pass
 
         class WebSocket:  # pragma: no cover - minimal stub
@@ -55,11 +62,11 @@ else:  # pragma: no cover - optional runtime dependency
             pass
 
         class JSONResponse:  # pragma: no cover - minimal stub
-            def __init__(self, content: object, *args: object, **kwargs: object) -> None:
+            def __init__(
+                self: "JSONResponse", content: object, *args: object, **kwargs: object
+            ) -> None:
                 self.body = json.dumps(content).encode("utf-8")
 
-
-from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from sse_starlette.sse import EventSourceResponse
@@ -69,7 +76,7 @@ else:  # pragma: no cover - optional dependency
     except Exception:
 
         class EventSourceResponse:  # pragma: no cover - minimal stub
-            def __init__(self, *args: object, **kwargs: object) -> None:
+            def __init__(self: "EventSourceResponse", *args: object, **kwargs: object) -> None:
                 self.gen = None
 
 
@@ -191,12 +198,14 @@ async def get_missions() -> Response:
 async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
     """Return recent semantic summaries for an agent."""
     manager = SIM_STATE.get("semantic_manager")
-    summaries: list[str] = []
     if manager is not None:
         try:
             summaries = manager.get_semantic_summaries(agent_id, limit=limit)
-        except Exception:  # pragma: no cover - defensive
-            summaries = []
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Failed to get semantic summaries for %s", agent_id, exc_info=exc)
+            return JSONResponse({"error": "summary retrieval failed"}, status_code=500)
+    else:
+        summaries = []
     return JSONResponse({"summaries": summaries})
 
 

--- a/tests/integration/interfaces/test_dashboard_backend.py
+++ b/tests/integration/interfaces/test_dashboard_backend.py
@@ -1,0 +1,25 @@
+import httpx
+import pytest
+from httpx import ASGITransport
+
+pytest.importorskip("fastapi")
+
+from src import http_app
+from src.interfaces import dashboard_backend as db
+
+
+class FailingManager:
+    def get_semantic_summaries(self, agent_id: str, limit: int = 3) -> list[str]:
+        raise RuntimeError("boom")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_semantic_summaries_error_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", FailingManager())
+    transport = ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/agents/agent-1/semantic_summaries")
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["error"] == "summary retrieval failed"

--- a/tests/unit/interfaces/test_dashboard_semantic_summaries.py
+++ b/tests/unit/interfaces/test_dashboard_semantic_summaries.py
@@ -48,4 +48,4 @@ async def test_get_semantic_summaries_error(monkeypatch: pytest.MonkeyPatch) -> 
 
     resp = await db.get_semantic_summaries("agent")
     data = json.loads(resp.body)
-    assert data == {"summaries": []}
+    assert data["error"] == "summary retrieval failed"


### PR DESCRIPTION
## Summary
- log errors when retrieving semantic summaries fails
- return HTTP 500 error from semantic summary endpoint when failure occurs
- adjust unit tests for new error response
- add integration test for semantic summary failure

## Testing
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py -m "not integration and not ollama" tests/unit/interfaces/test_dashboard_semantic_summaries.py`
- `pytest tests/integration/interfaces/test_dashboard_backend.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25f5de0c83269b838c604ec8ff06