### PR TITLE
Extend semantic consolidation after memory retrieval

### DIFF
--- a/docs/hierarchical_memory_README.md
+++ b/docs/hierarchical_memory_README.md
@@ -53,6 +53,15 @@ The implementation uses ChromaDB as a vector store to persist memories for long-
 - Metadata filtering to distinguish between different memory types
 - Long-term persistence across simulation runs
 
+## Retrieval Flow
+
+1. Episodic memories are stored in the vector store via `MemoryService`.
+2. During a turn, the agent retrieves the most relevant episodic memories.
+3. These retrieved memories are passed back to `SemanticMemoryManager` which
+   immediately consolidates them into a higher level summary.
+4. The latest semantic summaries are then used alongside episodic memories for
+   generation.
+
 ## Testing
 
 Integration tests verify the memory consolidation functionality.

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -77,26 +77,49 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 
 
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
-    manager = cast(MemoryService | None, state.get("memory_service"))
+    manager = cast(
+        MemoryService | MemoryRetriever | None,
+        state.get("memory_service") or state.get("vector_store_manager"),
+    )
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
-    memories = await manager.retrieve_relevant_memories(state["agent_id"], query="", k=5)
+    if hasattr(manager, "retrieve_relevant_memories"):
+        memories = await cast(MemoryService, manager).retrieve_relevant_memories(
+            state["agent_id"], query="", k=5
+        )
+    else:
+        memories = await cast(MemoryRetriever, manager).aretrieve_relevant_memories(
+            state["agent_id"], query="", k=5
+        )
+    try:
+        if hasattr(manager, "run_semantic_job"):
+            await cast(MemoryService, manager).run_semantic_job(
+                state["agent_id"], episodic_memories=memories
+            )
+    except Exception:  # pragma: no cover - defensive
+        logger.error("Semantic consolidation failed", exc_info=True)
     memories_content = [m.get("content", "") for m in memories]
     import asyncio
 
-    semantic_memories = await asyncio.to_thread(
-        manager.retrieve_semantic_context,
-        state["agent_id"],
-        "",
-        5,
-    )
-    memories.extend(semantic_memories)
-    memories_content.extend(m.get("content", "") for m in semantic_memories)
+    semantic_memories: list[dict[str, Any]] = []
+    if hasattr(manager, "retrieve_semantic_context"):
+        semantic_memories = await asyncio.to_thread(
+            cast(MemoryService, manager).retrieve_semantic_context,
+            state["agent_id"],
+            "",
+            5,
+        )
+        memories.extend(semantic_memories)
+        memories_content.extend(m.get("content", "") for m in semantic_memories)
 
-    semantic = manager.get_recent_semantic_summaries(state["agent_id"], limit=2)
-    memories_content.extend(semantic)
+    semantic: list[str] = []
+    if hasattr(manager, "get_recent_semantic_summaries"):
+        semantic = cast(MemoryService, manager).get_recent_semantic_summaries(
+            state["agent_id"], limit=2
+        )
+        memories_content.extend(semantic)
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -55,10 +55,14 @@ class MemoryService:
             return []
         return self.semantic_manager.get_recent_summaries(agent_id, limit)
 
-    async def run_semantic_job(self: Self, agent_id: str) -> None:
+    async def run_semantic_job(
+        self: Self,
+        agent_id: str,
+        episodic_memories: list[dict[str, Any]] | None = None,
+    ) -> None:
         if not self.semantic_manager:
             return None
-        await self.semantic_manager.run_nightly_job(agent_id)
+        await self.semantic_manager.run_nightly_job(agent_id, episodic_memories)
         return None
 
     def consolidate_daily_memories(

--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -33,11 +33,18 @@ class SemanticMemoryManager:
         self.topic_groups: dict[str, dict[int, list[dict[str, Any]]]] = {}
         self.topic_centroids: dict[str, NDArray[np.float64]] = {}
 
-
-    def consolidate_memories(self: Self, agent_id: str) -> str:
-        """Consolidate an agent's episodic memories into a semantic summary."""
-        memories = self.vector_store.retrieve_filtered_memories(
-            agent_id, filters={"memory_type": "raw"}, limit=None
+    def consolidate_memories(
+        self: Self,
+        agent_id: str,
+        episodic_memories: list[dict[str, Any]] | None = None,
+    ) -> str:
+        """Consolidate episodic memories into a semantic summary."""
+        memories = (
+            episodic_memories
+            if episodic_memories is not None
+            else self.vector_store.retrieve_filtered_memories(
+                agent_id, filters={"memory_type": "raw"}, limit=None
+            )
         )
         if not memories:
             return ""
@@ -150,11 +157,15 @@ class SemanticMemoryManager:
             )
             return [record["summary"] for record in records]
 
-    async def run_nightly_job(self: Self, agent_id: str) -> None:
+    async def run_nightly_job(
+        self: Self,
+        agent_id: str,
+        episodic_memories: list[dict[str, Any]] | None = None,
+    ) -> None:
         """Asynchronously consolidate memories and persist the summary."""
         import asyncio
 
-        summary = await asyncio.to_thread(self.consolidate_memories, agent_id)
+        summary = await asyncio.to_thread(self.consolidate_memories, agent_id, episodic_memories)
         if self.driver is not None and summary:
             now = datetime.utcnow().isoformat()
             with self.driver.session() as session:

--- a/tests/integration/memory/test_semantic_update_on_retrieval.py
+++ b/tests/integration/memory/test_semantic_update_on_retrieval.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from src.agents.graphs.graph_nodes import retrieve_and_summarize_memories_node
+from src.agents.memory.memory_service import MemoryService
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+class DummyAgent:
+    async def async_generate_l1_summary(self, role_prompt: str, memories: str, context: str):
+        return SimpleNamespace(summary="S")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+async def test_semantic_summary_updates_on_retrieval(chroma_test_dir: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir, embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    driver = DummyDriver()
+    manager = SemanticMemoryManager(vector, driver)
+    service = MemoryService(vector_store=vector, semantic_manager=manager)
+
+    state = {
+        "agent_id": "agent",
+        "memory_service": service,
+        "agent_instance": DummyAgent(),
+        "current_role": "r",
+    }
+
+    vector.add_memory("agent", 1, "thought", "one", memory_type="raw")
+    await retrieve_and_summarize_memories_node(state)
+    first = manager.get_recent_summaries("agent", limit=1)
+    assert first and "one" in first[0]
+
+    vector.add_memory("agent", 2, "thought", "two", memory_type="raw")
+    await retrieve_and_summarize_memories_node(state)
+    second = manager.get_recent_summaries("agent", limit=1)
+    assert second and "two" in second[0]


### PR DESCRIPTION
## Summary
- extend `SemanticMemoryManager` to consolidate a provided list of episodic memories
- allow `run_nightly_job` and `MemoryService.run_semantic_job` to accept episodic memories
- trigger semantic consolidation from `retrieve_and_summarize_memories_node`
- document the memory retrieval flow
- test that semantic summaries update when episodic memories are retrieved

## Testing
- `ruff check src/agents/graphs/graph_nodes.py`
- `ruff format src/agents/graphs/graph_nodes.py`
- `pytest tests/unit/graphs/test_graph_nodes.py::test_retrieve_and_summarize_memories_node_with_manager tests/integration/memory/test_semantic_update_on_retrieval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2ddfff188326b1cb8509f9f97958