### PR TITLE
Add plugin loader via entry points

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -37,3 +37,37 @@ Each callback receives the agent instance and the dictionary returned from
 `Agent.run_turn`. Multiple behaviors can be registered and will be invoked in the
 order added.
 
+## Loading Plug-ins via Entry Points
+
+Third-party packages can expose a plug-in through the `culture.plugins` entry
+point. Implement a function that registers behaviors or widgets and return a
+dictionary with optional widget information:
+
+```python
+# my_plugin/__init__.py
+from src.extensions import register_agent_behavior
+
+def greet(agent: object, output: dict[str, object]) -> None:
+    print("hello from plugin")
+
+def setup() -> dict[str, str] | None:
+    register_agent_behavior(greet)
+    return {"name": "ExampleWidget", "script_url": "http://localhost:5173/example.js"}
+```
+
+Declare the entry point in your package configuration:
+
+```toml
+[project.entry-points."culture.plugins"]
+my_plugin = "my_plugin:setup"
+```
+
+Call `load_plugins()` during application startup to execute all discovered
+plug-ins. Any dictionary returned is passed to `register_widget_backend`:
+
+```python
+from src.extensions import load_plugins
+
+load_plugins()
+```
+

--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -2,21 +2,33 @@
 
 from __future__ import annotations
 
+import logging
+from importlib import metadata
 from typing import Any, Callable
 
 import httpx
+from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BEHAVIOR_REGISTRY",
+    "load_plugins",
+    "register_agent_behavior",
+    "register_widget_backend",
+]
 
 
 class BehaviorRegistry:
     """Registry for callables that modify agent behavior."""
 
-    def __init__(self) -> None:
+    def __init__(self: Self) -> None:
         self._behaviors: list[Callable[[Any, dict[str, Any]], None]] = []
 
-    def register(self, func: Callable[[Any, dict[str, Any]], None]) -> None:
+    def register(self: Self, func: Callable[[Any, dict[str, Any]], None]) -> None:
         self._behaviors.append(func)
 
-    def run(self, agent: Any, output: dict[str, Any]) -> None:
+    def run(self: Self, agent: Any, output: dict[str, Any]) -> None:
         for func in list(self._behaviors):
             func(agent, output)
 
@@ -43,3 +55,34 @@ def register_widget_backend(
         timeout=10,
     )
     resp.raise_for_status()
+
+
+DEFAULT_PLUGIN_GROUP = "culture.plugins"
+
+
+def load_plugins(
+    group: str = DEFAULT_PLUGIN_GROUP, *, backend_url: str = "http://localhost:8000"
+) -> None:
+    """Load entry-point plugins and optionally register their widgets."""
+
+    try:
+        eps = metadata.entry_points()
+    except Exception as exc:  # pragma: no cover - extremely unlikely
+        logger.exception("Failed to load entry points: %s", exc)
+        return
+
+    for ep in eps.select(group=group):
+        try:
+            plugin = ep.load()
+            result = plugin()
+            if isinstance(result, dict) and {
+                "name",
+                "script_url",
+            }.issubset(result):
+                register_widget_backend(
+                    name=result["name"],
+                    script_url=result["script_url"],
+                    backend_url=backend_url,
+                )
+        except Exception as exc:  # pragma: no cover - safety net
+            logger.exception("Error loading plugin %s: %s", ep.name, exc)

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -3,6 +3,10 @@ import logging
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
+pytestmark = pytest.mark.integration
+
 
 class DummyVectorStore:
     async def aretrieve_relevant_memories(
@@ -14,7 +18,6 @@ class DummyVectorStore:
         return ["summary1"]
 
 
-import pytest
 from pytest import LogCaptureFixture
 
 pytest.importorskip("langgraph")

--- a/tests/unit/extensions/test_plugin_loader.py
+++ b/tests/unit/extensions/test_plugin_loader.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import types
+from importlib import metadata
+from typing import Any
+
+import pytest
+
+from src.extensions import load_plugins
+
+
+class DummyEntryPoints(list[Any]):
+    def select(self, group: str | None = None) -> list[Any]:
+        return self if group == "culture.plugins" else []
+
+
+@pytest.mark.unit
+def test_load_plugins_executes(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[bool] = []
+
+    def plugin() -> None:
+        called.append(True)
+
+    ep = types.SimpleNamespace(load=lambda: plugin, name="dummy")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+
+    load_plugins()
+
+    assert called
+
+
+@pytest.mark.unit
+def test_load_plugins_registers_widget(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[tuple[str, str, str]] = []
+
+    def plugin() -> dict[str, str]:
+        return {"name": "Widget", "script_url": "http://x/y.js"}
+
+    def register_widget_backend(
+        name: str, script_url: str, backend_url: str = "http://localhost:8000"
+    ) -> None:
+        recorded.append((name, script_url, backend_url))
+
+    ep = types.SimpleNamespace(load=lambda: plugin, name="widget")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
+
+    load_plugins(backend_url="http://backend")
+
+    assert recorded == [("Widget", "http://x/y.js", "http://backend")]


### PR DESCRIPTION
## Summary
- allow discovery of entry-point plugins in `src.extensions`
- support optional widget registration from loader
- document entry point usage in `plugins.md`
- test plugin discovery and widget registration
- mark async agent graph tests as integration

## Testing
- `ruff check src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py tests/integration/graph/test_async_agent_graph.py`
- `mypy src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py --ignore-missing-imports`
- `pytest -m "not integration and not ollama" tests/unit/extensions/test_plugin_loader.py tests/integration/graph/test_async_agent_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686f2de07a5c8326846971e398c534c1