### PR TITLE
Add agent resources endpoint and UI

### DIFF
--- a/culture-ui/src/AgentResources.test.tsx
+++ b/culture-ui/src/AgentResources.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import AgentResources from './pages/AgentResources'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('AgentResources', () => {
+  it('displays resources from API', async () => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            agents: { 'agent-1': { ip: 1, du: 2, tokens: { TOK: 3 } } },
+          }),
+      }) as unknown as Response,
+    ))
+
+    render(<AgentResources />)
+
+    expect(await screen.findByText('agent-1')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('TOK:3')).toBeInTheDocument()
+  })
+})

--- a/culture-ui/src/pages/AgentResources.tsx
+++ b/culture-ui/src/pages/AgentResources.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { registerWidget } from '../lib/widgetRegistry'
+
+interface ResourceInfo {
+  ip: number
+  du: number
+  tokens: Record<string, number>
+}
+
+export default function AgentResources() {
+  const [data, setData] = useState<Record<string, ResourceInfo>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch('/api/token_balances')
+        const json = (await res.json()) as { agents: Record<string, ResourceInfo> }
+        if (!cancelled) setData(json.agents || {})
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Agent Resources</h1>
+      <table className="min-w-full border" data-testid="resource-table">
+        <thead>
+          <tr>
+            <th className="border px-2">Agent</th>
+            <th className="border px-2">IP</th>
+            <th className="border px-2">DU</th>
+            <th className="border px-2">Tokens</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(data).map(([id, info]) => (
+            <tr key={id}>
+              <td className="border px-2">{id}</td>
+              <td className="border px-2">{info.ip}</td>
+              <td className="border px-2">{info.du}</td>
+              <td className="border px-2">
+                {Object.entries(info.tokens || {})
+                  .map(([tok, amt]) => `${tok}:${amt}`)
+                  .join(', ')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+registerWidget('AgentResources', AgentResources)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from pydantic import BaseModel
 
 from src.governance.service import governance
+from src.infra.ledger import ledger
 
 from .widget_registry import WidgetRegistry
 
@@ -229,6 +230,26 @@ async def api_get_proposals(limit: int = 10) -> Response:
     return JSONResponse({"proposals": proposals})
 
 
+@app.get("/api/token_balances")
+async def api_token_balances() -> Response:
+    """Return DU/IP and token balances for all agents."""
+
+    def _load() -> dict[str, dict[str, Any]]:
+        cur = ledger.conn.execute("SELECT agent_id, ip, du FROM agent_balances")
+        balances: dict[str, dict[str, Any]] = {
+            row[0]: {"ip": float(row[1]), "du": float(row[2]), "tokens": {}}
+            for row in cur.fetchall()
+        }
+        cur = ledger.conn.execute("SELECT agent_id, token, amount FROM agent_tokens")
+        for agent_id, token, amount in cur.fetchall():
+            agent = balances.setdefault(agent_id, {"ip": 0.0, "du": 0.0, "tokens": {}})
+            agent["tokens"][token] = int(amount)
+        return balances
+
+    agents = await asyncio.to_thread(_load)
+    return JSONResponse({"agents": agents})
+
+
 async def register_widget(widget: dict[str, Any]) -> Response:
     """Register a widget provided by the UI or a plugin."""
     name = widget.get("name")
@@ -357,6 +378,7 @@ __all__ = [
     "SimulationEvent",
     "api_get_proposals",
     "api_propose_law",
+    "api_token_balances",
     "app",
     "emit_event",
     "emit_map_action_event",


### PR DESCRIPTION
## Summary
- expose `/api/token_balances` in dashboard backend to return DU/IP and token balances
- show agent resource balances in new `AgentResources` page
- test the AgentResources component with Vitest

## Testing
- `pre-commit run --files src/interfaces/dashboard_backend.py culture-ui/src/pages/AgentResources.tsx culture-ui/src/AgentResources.test.tsx`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687025668f188326b658659086abf2c6