### PR TITLE
Expand UI error tests

### DIFF
--- a/culture-ui/src/MemoryExplorer.test.tsx
+++ b/culture-ui/src/MemoryExplorer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
@@ -18,6 +18,7 @@ describe('MemoryExplorer', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -45,5 +46,32 @@ describe('MemoryExplorer', () => {
     expect(
       fetchMock.mock.calls.some((c) => c[0] === '/api/agents/agent-2/semantic_summaries'),
     ).toBe(true)
+  })
+
+  it('keeps previous summaries when fetch fails', async () => {
+    render(
+      <MemoryRouter initialEntries={["/memory"]}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('hello world')).toBeInTheDocument()
+
+    fetchMock.mockRejectedValueOnce(new Error('fail'))
+
+    const input = screen.getByLabelText('agent-select')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'agent-2')
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/agents/agent-2/semantic_summaries',
+      ),
+    )
+
+    expect(screen.queryByText('hello world')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('summaries').textContent?.trim(),
+    ).toBe('hello world')
   })
 })

--- a/culture-ui/src/Storyboard.test.tsx
+++ b/culture-ui/src/Storyboard.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import StoryboardPage from './pages/Storyboard'
 import { MockWebSocket, resetMockSources } from './lib/testUtils'
 import { vi } from 'vitest'
@@ -14,11 +14,12 @@ describe('Storyboard widget', () => {
     ;(
       globalThis as unknown as { WebSocket?: typeof WebSocket }
     ).WebSocket = MockWebSocket as unknown as typeof WebSocket
-    vi.stubGlobal('fetch', vi.fn(() =>
+    const fetchSpy = vi.fn(() =>
       Promise.resolve({
         json: () => Promise.resolve({ summaries: ['s1'] }),
       }) as unknown as Response,
-    ))
+    )
+    vi.stubGlobal('fetch', fetchSpy as unknown as typeof fetch)
 
     render(<StoryboardPage />)
 
@@ -36,6 +37,45 @@ describe('Storyboard widget', () => {
     })
 
     expect(await screen.findByText('s1')).toBeInTheDocument()
+    expect(fetchSpy).toHaveBeenCalledWith('/api/agents/a1/semantic_summaries')
+
+    act(() => {
+      screen.getByRole('button', { name: /map/i }).click()
+    })
+
+    expect(screen.getByText('a1: 5, 6 (mood 0.2)')).toBeInTheDocument()
+  })
+
+  it('handles fetch errors gracefully', async () => {
+    ;(
+      globalThis as unknown as { WebSocket?: typeof WebSocket }
+    ).WebSocket = MockWebSocket as unknown as typeof WebSocket
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('fail')))
+    vi.stubGlobal('fetch', fetchSpy as unknown as typeof fetch)
+
+    render(<StoryboardPage />)
+
+    const ws = MockWebSocket.instances[0]
+    act(() => {
+      ws.sendMessage(
+        '{"data":{"world_map":{"agents":{"a1":[5,6]}}}}',
+      )
+    })
+
+    expect(await screen.findByText('a1: 5, 6 (mood n/a)')).toBeInTheDocument()
+
+    act(() => {
+      screen.getByRole('button', { name: /summaries/i }).click()
+    })
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    expect(screen.getByTestId('summaries').textContent).toBe('')
+
+    act(() => {
+      screen.getByRole('button', { name: /map/i }).click()
+    })
+
+    expect(screen.getByText('a1: 5, 6 (mood n/a)')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary
- increase MemoryExplorer test coverage for fetch failures
- enhance Storyboard tests for tab switching and failure cases
- restore fetch mocks between MemoryExplorer tests

## Testing
- `pre-commit run --files culture-ui/src/MemoryExplorer.test.tsx culture-ui/src/Storyboard.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm --dir culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_687025770708832692a033c14b7563c7