### PR TITLE
Blend episodic and semantic summaries in retrieval

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -39,9 +39,30 @@ class MemoryService:
     async def retrieve_relevant_memories(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        if not self.vector_store:
-            return []
-        return await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+        episodic: list[dict[str, Any]] = []
+        if self.vector_store:
+            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+
+        semantic: list[dict[str, Any]] = []
+        if self.semantic_manager and self.vector_store:
+            import asyncio
+
+            import numpy as np
+
+            semantic = await asyncio.to_thread(
+                self.semantic_manager.retrieve_context, agent_id, query, k
+            )
+            q_emb = np.array(self.vector_store.get_embedding(query), dtype=float)
+            for mem in semantic:
+                emb = np.array(
+                    self.vector_store.get_embedding(mem.get("content", "")), dtype=float
+                )
+                score = float(emb @ q_emb / (np.linalg.norm(emb) * np.linalg.norm(q_emb) + 1e-8))
+                mem["relevance_score"] = score
+
+        combined = episodic + semantic
+        combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+        return combined[:k]
 
     def retrieve_semantic_context(
         self: Self, agent_id: str, query: str, k: int = 5

--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -157,6 +157,14 @@ class SemanticMemoryManager:
             )
             return [record["summary"] for record in records]
 
+    def blend_episodic_and_semantic(
+        self: Self, agent_id: str, episodic_summary: str, limit: int = 3
+    ) -> str:
+        """Blend a new episodic summary with recent semantic summaries."""
+        recent = self.get_recent_summaries(agent_id, limit)
+        parts = [episodic_summary, *recent]
+        return "\n".join(part for part in parts if part)
+
     async def run_nightly_job(
         self: Self,
         agent_id: str,

--- a/tests/integration/memory/test_semantic_consolidation_node.py
+++ b/tests/integration/memory/test_semantic_consolidation_node.py
@@ -8,7 +8,7 @@ class DummyManager:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def consolidate_memories(self, agent_id: str) -> None:
+    def consolidate_daily_memories(self, agent_id: str, start_step: int, end_step: int) -> None:
         self.calls.append(agent_id)
 
 
@@ -17,7 +17,7 @@ class DummyManager:
 def test_consolidation_runs_when_due(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy = DummyManager()
     monkeypatch.setitem(config.CONFIG_OVERRIDES, "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 1)
-    state = {"agent_id": "agent1", "simulation_step": 1, "semantic_manager": dummy}
+    state = {"agent_id": "agent1", "simulation_step": 1, "memory_service": dummy}
     _maybe_consolidate_memories(state)
     assert dummy.calls == ["agent1"]
 
@@ -27,6 +27,6 @@ def test_consolidation_runs_when_due(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_consolidation_skipped_when_not_due(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy = DummyManager()
     monkeypatch.setitem(config.CONFIG_OVERRIDES, "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 5)
-    state = {"agent_id": "agent1", "simulation_step": 1, "semantic_manager": dummy}
+    state = {"agent_id": "agent1", "simulation_step": 1, "memory_service": dummy}
     _maybe_consolidate_memories(state)
     assert dummy.calls == []

--- a/tests/integration/memory/test_semantic_recent_summaries.py
+++ b/tests/integration/memory/test_semantic_recent_summaries.py
@@ -29,3 +29,5 @@ async def test_nightly_job_and_retrieval(chroma_test_dir: Path) -> None:
     assert driver.store[0]["agent"] == "agent"
     recent = manager.get_recent_summaries("agent", limit=1)
     assert recent == ["first\nsecond"]
+    blended = manager.blend_episodic_and_semantic("agent", "third", limit=1)
+    assert "third" in blended and "first" in blended

--- a/tests/integration/memory/test_simulation_semantic_job.py
+++ b/tests/integration/memory/test_simulation_semantic_job.py
@@ -24,6 +24,7 @@ class DummyAgent:
         self,
         simulation_step: int,
         environment_perception: dict | None = None,
+        memory_service: object | None = None,
         vector_store_manager: object | None = None,
         knowledge_board: object | None = None,
     ) -> dict:
@@ -42,6 +43,12 @@ def setup_semantic_manager(tmp_path):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_simulation_schedules_semantic_job(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    from src.sim import simulation as sim_module
+
+    async def _allow(action):
+        return True
+
+    monkeypatch.setattr(sim_module, "evaluate_policy", _allow)
     monkeypatch.setitem(config.CONFIG_OVERRIDES, "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 1)
     manager, vector, driver = setup_semantic_manager(tmp_path)
     agent = DummyAgent("a1")


### PR DESCRIPTION
## Summary
- add `blend_episodic_and_semantic` to `SemanticMemoryManager`
- combine semantic context with episodic results in `MemoryService.retrieve_relevant_memories`
- adapt integration tests for updated APIs and bypass policy calls

## Testing
- `bash scripts/lint.sh --format`
- `python -m pytest -m "integration" tests/integration/memory -q`

------
https://chatgpt.com/codex/tasks/task_e_687069fdbd448326aae9d32b067fa714