### PR TITLE
Add quest generation and API endpoint

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from src.governance.service import governance
 from src.infra.ledger import ledger
+from src.sim.quests import get_quests
 
 from .widget_registry import WidgetRegistry
 
@@ -193,6 +194,13 @@ async def get_missions() -> Response:
     with open(MISSIONS_PATH, encoding="utf-8") as f:
         missions = json.load(f)
     return JSONResponse(missions)
+
+
+@app.get("/api/quests")
+async def get_quests_api() -> Response:
+    """Return the list of generated quests."""
+    quests = [q.model_dump() for q in get_quests()]
+    return JSONResponse({"quests": quests})
 
 
 @app.get("/api/agents/{agent_id}/semantic_summaries")
@@ -384,6 +392,7 @@ __all__ = [
     "emit_map_action_event",
     "enqueue_message",
     "get_event_queue",
+    "get_quests_api",
     "message_sse_queue",
     "register_widget",
 ]

--- a/src/sim/quests/__init__.py
+++ b/src/sim/quests/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from src.infra import llm_client
+
+
+class Quest(BaseModel):
+    """Simple quest data structure."""
+
+    id: int
+    title: str
+    description: str
+    progress: int = 0
+    status: str = "pending"
+
+
+QUESTS: list[Quest] = []
+
+
+def generate_quest(
+    prompt: str,
+    *,
+    model: str = "mistral:latest",
+    temperature: float = 0.2,
+) -> Quest | None:
+    """Generate a quest using the LLM client and store it."""
+
+    result = llm_client.generate_structured_output(
+        prompt,
+        Quest,
+        model=model,
+        temperature=temperature,
+    )
+    if result is None:
+        return None
+    if isinstance(result, Quest):
+        quest = result
+    elif isinstance(result, dict):
+        quest = Quest(**result)
+    else:
+        # Defensive: unexpected return type
+        try:
+            quest = Quest.model_validate(result)  # type: ignore[arg-type]
+        except Exception:
+            return None
+    QUESTS.append(quest)
+    return quest
+
+
+def get_quests() -> list[Quest]:
+    """Return the list of generated quests."""
+
+    return list(QUESTS)

--- a/tests/unit/interfaces/test_dashboard_backend_quests.py
+++ b/tests/unit/interfaces/test_dashboard_backend_quests.py
@@ -1,0 +1,17 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+from src.sim.quests import Quest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_get_quests_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    quests = [Quest(id=1, title="Q", description="D", progress=0, status="pending")]
+    monkeypatch.setattr(db, "get_quests", lambda: quests)
+
+    response = await db.get_quests_api()
+    assert json.loads(response.body) == {"quests": [q.model_dump() for q in quests]}

--- a/tests/unit/sim/quests/test_generator.py
+++ b/tests/unit/sim/quests/test_generator.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.sim.quests import QUESTS, Quest, generate_quest
+from tests.utils.mock_llm import MockLLM
+
+pytestmark = pytest.mark.unit
+
+
+def test_generate_quest_adds_to_list() -> None:
+    QUESTS.clear()
+    responses = {
+        "structured_output": {
+            "id": 1,
+            "title": "Quest",
+            "description": "Do something",
+            "progress": 0,
+            "status": "pending",
+        }
+    }
+    with MockLLM(responses):
+        quest = generate_quest("Create quest")
+    assert quest == Quest(
+        id=1, title="Quest", description="Do something", progress=0, status="pending"
+    )
+    assert QUESTS == [quest]


### PR DESCRIPTION
## Summary
- implement basic Quest generator using LLM client
- expose generated quests at `/api/quests`
- add unit tests for quest generation and API endpoint

## Testing
- `ruff check src/interfaces/dashboard_backend.py src/sim/quests/__init__.py tests/unit/sim/quests/test_generator.py tests/unit/interfaces/test_dashboard_backend_quests.py`
- `timeout 60 mypy src/interfaces/dashboard_backend.py src/sim/quests/__init__.py tests/unit/sim/quests/test_generator.py tests/unit/interfaces/test_dashboard_backend_quests.py`
- `pytest tests/unit/sim/quests/test_generator.py tests/unit/interfaces/test_dashboard_backend_quests.py -m "unit" -q`

------
https://chatgpt.com/codex/tasks/task_e_68707634e1b88326be464bb1526f6603