### PR TITLE
Add SSE concurrency and WebSocket reconnect tests

### DIFF
--- a/tests/integration/interfaces/test_message_and_event_streams.py
+++ b/tests/integration/interfaces/test_message_and_event_streams.py
@@ -64,3 +64,87 @@ async def test_websocket_events_deliver_simulation_events(monkeypatch: pytest.Mo
     assert ws.accepted is True
     payload = json.loads(ws.sent[0])
     assert payload["data"]["step"] == 3
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_multiple_sse_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
+    monkeypatch.setattr(db, "message_sse_queue", queue)
+
+    class CaptureESR:
+        def __init__(self, gen: object) -> None:
+            self.gen = gen
+
+    monkeypatch.setattr(db, "EventSourceResponse", CaptureESR)
+
+    msg1 = db.AgentMessage(agent_id="a", content="one", step=1)
+    msg2 = db.AgentMessage(agent_id="b", content="two", step=2)
+    await db.enqueue_message(msg1)
+    await db.enqueue_message(msg2)
+
+    resp1 = await db.stream_messages(DummyRequest())
+    resp2 = await db.stream_messages(DummyRequest())
+
+    event1, event2 = await asyncio.gather(
+        resp1.gen.__anext__(),
+        resp2.gen.__anext__(),
+    )
+
+    contents = {json.loads(event1["data"])["content"], json.loads(event2["data"])["content"]}
+    assert contents == {"one", "two"}
+    assert queue.empty()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_messages_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
+    monkeypatch.setattr(db, "message_sse_queue", queue)
+
+    class CaptureESR:
+        def __init__(self, gen: object) -> None:
+            self.gen = gen
+
+    monkeypatch.setattr(db, "EventSourceResponse", CaptureESR)
+
+    class BadMessage(db.AgentMessage):
+        def json(self, *args: object, **kwargs: object) -> str:  # type: ignore[override]
+            raise ValueError("boom")
+
+    await queue.put(BadMessage(agent_id="bad", content="x", step=1))
+
+    resp = await db.stream_messages(DummyRequest())
+    event = await resp.gen.__anext__()
+    assert event["event"] == "error"
+    assert json.loads(event["data"])["error"] == "boom"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_websocket_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    event_queue: asyncio.Queue[db.SimulationEvent | None] = asyncio.Queue()
+    monkeypatch.setattr(db, "get_event_queue", lambda: event_queue)
+
+    await event_queue.put(db.SimulationEvent(event_type="one", data={"step": 1}))
+    await event_queue.put(db.SimulationEvent(event_type="two", data={"step": 2}))
+    await event_queue.put(None)
+
+    class DisconnectingWebSocket(DummyWebSocket):
+        def __init__(self) -> None:
+            super().__init__()
+            self.count = 0
+
+        async def send_text(self, text: str) -> None:
+            await super().send_text(text)
+            self.count += 1
+            if self.count == 1:
+                raise db.WebSocketDisconnect()
+
+    ws1 = DisconnectingWebSocket()
+    await db.websocket_events(ws1)
+    assert len(ws1.sent) == 1
+
+    ws2 = DummyWebSocket()
+    await db.websocket_events(ws2)
+    assert [json.loads(t)["event_type"] for t in ws2.sent] == ["two"]


### PR DESCRIPTION
## Summary
- extend `test_message_and_event_streams` coverage
  - test multiple SSE clients concurrently
  - test error handling for SSE
  - test reconnect logic for WebSocket events

## Testing
- `bash scripts/lint.sh --format`
- `python scripts/run_tests.py -m integration tests/integration/interfaces/test_message_and_event_streams.py`

------
https://chatgpt.com/codex/tasks/task_e_687076365c088326926f2b2e5e37bb30