### PR TITLE
Add example plugin with docs and tests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -71,3 +71,19 @@ from src.extensions import load_plugins
 load_plugins()
 ```
 
+
+## Installing the Example Plug-in
+
+An example package is included in `examples/example_plugin`. Install it in editable mode:
+
+```bash
+pip install -e examples/example_plugin
+```
+
+After installation call `load_plugins()` so Culture can register its hooks:
+
+```python
+from src.extensions import load_plugins
+
+load_plugins()
+```

--- a/examples/example_plugin/README.md
+++ b/examples/example_plugin/README.md
@@ -1,0 +1,14 @@
+# Example Culture Plug-in
+
+This example package shows how a third-party distribution can extend Culture.
+It registers a simple agent behavior and a UI widget using the
+`culture.plugins` entry point.
+
+Install the package in editable mode:
+
+```bash
+pip install -e examples/example_plugin
+```
+
+Then call `load_plugins()` at application startup to register the hooks.
+

--- a/examples/example_plugin/example_plugin/__init__.py
+++ b/examples/example_plugin/example_plugin/__init__.py
@@ -1,0 +1,17 @@
+"""Example plug-in providing both widget and agent hooks."""
+
+from src.extensions import register_agent_behavior
+
+
+def log_turn(agent: object, output: dict[str, object]) -> None:
+    """Log the agent's output to stdout."""
+    print(f"[EXAMPLE_PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
+
+
+def setup() -> dict[str, str]:
+    """Entry point used by :func:`load_plugins`."""
+    register_agent_behavior(log_turn)
+    return {
+        "name": "ExampleWidget",
+        "script_url": "http://localhost:5173/example.js",
+    }

--- a/examples/example_plugin/pyproject.toml
+++ b/examples/example_plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "example-plugin"
+version = "0.1.0"
+description = "Example Culture plug-in"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.entry-points."culture.plugins"]
+example_plugin = "example_plugin:setup"

--- a/scripts/check_pydantic_v2_compat.py
+++ b/scripts/check_pydantic_v2_compat.py
@@ -27,6 +27,19 @@ def tracked_python_files() -> list[Path]:
     return [Path(p) for p in proc.stdout.splitlines()]
 
 
+def target_files() -> list[Path]:
+    """Return files to lint, falling back to all tracked Python files."""
+    if len(sys.argv) > 1:
+        return [Path(p) for p in sys.argv[1:] if p.endswith(".py")]
+    staged = subprocess.run(
+        ["git", "diff", "--name-only", "--cached", "--diff-filter=ACM", "*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    return [Path(p) for p in staged] or tracked_python_files()
+
+
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.issues: list[tuple[int, str]] = []
@@ -72,7 +85,7 @@ def check_file(path: Path) -> list[str]:
 
 def main() -> int:
     has_errors = False
-    for file in tracked_python_files():
+    for file in target_files():
         for issue in check_file(file):
             print(issue, file=sys.stderr)
             has_errors = True

--- a/tests/unit/extensions/test_example_plugin.py
+++ b/tests/unit/extensions/test_example_plugin.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import types
+from importlib import metadata
+
+import pytest
+
+from examples.example_plugin import example_plugin
+from src.extensions import BEHAVIOR_REGISTRY, load_plugins
+
+
+class DummyEntryPoints(list[object]):
+    def select(self, group: str | None = None) -> list[object]:
+        return self if group == "culture.plugins" else []
+
+
+@pytest.mark.unit
+def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    BEHAVIOR_REGISTRY._behaviors.clear()
+    widgets: list[tuple[str, str, str]] = []
+
+    def register_widget_backend(
+        name: str, script_url: str, backend_url: str = "http://localhost:8000"
+    ) -> None:
+        widgets.append((name, script_url, backend_url))
+
+    ep = types.SimpleNamespace(load=lambda: example_plugin.setup, name="example_plugin")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
+
+    load_plugins(backend_url="http://backend")
+
+    assert example_plugin.log_turn in BEHAVIOR_REGISTRY._behaviors
+    assert widgets == [("ExampleWidget", "http://localhost:5173/example.js", "http://backend")]


### PR DESCRIPTION
## Summary
- add example plugin demonstrating agent and widget hooks
- document how to install and load the example
- test plugin loading via `load_plugins`
- limit pydantic compatibility check to only changed files

## Testing
- `ruff check examples/example_plugin/example_plugin/__init__.py tests/unit/extensions/test_example_plugin.py`
- `ruff check scripts/check_pydantic_v2_compat.py`
- `python -m pytest tests/unit/extensions/test_example_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68707637a994832684341fcc443e387a