### PR TITLE
Add event stream integration tests

### DIFF
--- a/tests/integration/interfaces/test_event_endpoints_async_client.py
+++ b/tests/integration/interfaces/test_event_endpoints_async_client.py
@@ -1,0 +1,150 @@
+import asyncio
+import socket
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+import websockets
+
+pytest.importorskip("fastapi")
+import fastapi
+
+if not hasattr(fastapi.FastAPI(), "__call__"):
+    pytest.skip("FastAPI ASGI app not available", allow_module_level=True)
+
+from src import http_app
+from src.interfaces import dashboard_backend as db
+from src.sim.simulation import Simulation
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = SimpleNamespace(ip=0.0, du=0.0)
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, new_state: SimpleNamespace) -> None:
+        self.state = new_state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict[str, Any] | None = None,
+        memory_service: object | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict[str, Any]:
+        return {"step": simulation_step}
+
+
+async def _clear_event_queue() -> None:
+    queue = db.get_event_queue()
+    while not queue.empty():
+        await queue.get()
+
+
+from collections.abc import AsyncGenerator
+
+
+class SimpleESR:
+    def __init__(self, gen: AsyncGenerator[dict[str, str], None]) -> None:
+        self.gen = gen
+
+    async def __call__(self, scope: dict, receive: callable, send: callable) -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/event-stream")],
+            }
+        )
+        async for event in self.gen:
+            data = f"event: {event['event']}\ndata: {event['data']}\n\n".encode()
+            await send({"type": "http.response.body", "body": data, "more_body": True})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_events_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(http_app, "EventSourceResponse", SimpleESR)
+
+    async def _allow(_: str) -> bool:
+        return True
+
+    monkeypatch.setattr("src.governance.policy.evaluate_policy", _allow)
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", _allow)
+    await _clear_event_queue()
+    agent = DummyAgent("agent1")
+    sim = Simulation([agent])  # type: ignore[list-item]
+
+    await sim.run_step()
+
+    queue = db.get_event_queue()
+    await queue.put(None)
+
+    transport = httpx.ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream("GET", "/stream/events") as resp:
+            data_line = None
+            async for line in resp.aiter_lines():
+                if line.startswith("data: "):
+                    data_line = line.removeprefix("data: ")
+                    break
+    assert data_line is not None
+    event = db.SimulationEvent.model_validate_json(data_line)
+    assert event.data is not None
+    assert event.data["agent_id"] == "agent1"
+
+
+async def _start_server() -> tuple[uvicorn.Server, asyncio.Task[None], int]:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    host, port = sock.getsockname()
+    sock.close()
+    config = uvicorn.Config(
+        http_app.app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        loop="asyncio",
+        lifespan="off",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.01)
+    return server, task, port
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_events_async_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(http_app, "EventSourceResponse", SimpleESR)
+
+    async def _allow(_: str) -> bool:
+        return True
+
+    monkeypatch.setattr("src.governance.policy.evaluate_policy", _allow)
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", _allow)
+    await _clear_event_queue()
+    agent = DummyAgent("agent1")
+    sim = Simulation([agent])  # type: ignore[list-item]
+
+    await sim.run_step()
+
+    queue = db.get_event_queue()
+    await queue.put(None)
+
+    server, task, port = await _start_server()
+    async with websockets.connect(f"ws://127.0.0.1:{port}/ws/events") as ws:
+        data = await asyncio.wait_for(ws.recv(), 1)
+    event = db.SimulationEvent.model_validate_json(data)
+    assert event.data is not None
+    assert event.data["agent_id"] == "agent1"
+    server.should_exit = True
+    await task


### PR DESCRIPTION
## Summary
- add async-client tests for `/stream/events` and `/ws/events`
- mock `EventSourceResponse` and `evaluate_policy`
- skip tests if FastAPI isn't installed

## Testing
- `ruff check tests/integration/interfaces/test_event_endpoints_async_client.py --fix`
- `ruff format tests/integration/interfaces/test_event_endpoints_async_client.py`
- `pytest tests/integration/interfaces/test_event_endpoints_async_client.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_68713f4320208326a4953bbf40667bc1