### PR TITLE
Unify memory retrieval via semantic scores

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -38,7 +38,6 @@ from .graph_nodes import (
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
-    retrieve_semantic_context_node,
 )
 from .interaction_handlers import (
     handle_ask_clarification_node,
@@ -64,7 +63,6 @@ def build_graph() -> Any:
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)
     graph_builder.add_node("retrieve_and_summarize_memories", retrieve_and_summarize_memories_node)
-    graph_builder.add_node("retrieve_semantic_context", retrieve_semantic_context_node)
     graph_builder.add_node("generate_thought_and_message", generate_thought_and_message_node)
 
     graph_builder.add_node("handle_propose_idea", handle_propose_idea_node)
@@ -86,8 +84,7 @@ def build_graph() -> Any:
     graph_builder.set_entry_point("analyze_perception_sentiment")
     graph_builder.add_edge("analyze_perception_sentiment", "prepare_relationship_prompt")
     graph_builder.add_edge("prepare_relationship_prompt", "retrieve_and_summarize_memories")
-    graph_builder.add_edge("retrieve_and_summarize_memories", "retrieve_semantic_context")
-    graph_builder.add_edge("retrieve_semantic_context", "generate_thought_and_message")
+    graph_builder.add_edge("retrieve_and_summarize_memories", "generate_thought_and_message")
 
     graph_builder.add_conditional_edges(
         "generate_thought_and_message",

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -31,13 +31,13 @@ ActionIntentLiteral = Literal[
 
 class MemoryRetriever(Protocol):
     async def aretrieve_relevant_memories(
-        self, agent_id: str, query: str, k: int
+        self: Any, agent_id: str, query: str, k: int
     ) -> list[dict[str, Any]]: ...
 
 
 class SummaryAgent(Protocol):
     async def async_generate_l1_summary(
-        self, role_prompt: str, memories: str, context: str
+        self: Any, role_prompt: str, memories: str, context: str
     ) -> Any: ...
 
 
@@ -101,18 +101,6 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     except Exception:  # pragma: no cover - defensive
         logger.error("Semantic consolidation failed", exc_info=True)
     memories_content = [m.get("content", "") for m in memories]
-    import asyncio
-
-    semantic_memories: list[dict[str, Any]] = []
-    if hasattr(manager, "retrieve_semantic_context"):
-        semantic_memories = await asyncio.to_thread(
-            cast(MemoryService, manager).retrieve_semantic_context,
-            state["agent_id"],
-            "",
-            5,
-        )
-        memories.extend(semantic_memories)
-        memories_content.extend(m.get("content", "") for m in semantic_memories)
 
     semantic: list[str] = []
     if hasattr(manager, "get_recent_semantic_summaries"):
@@ -129,24 +117,6 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     )
     summary = getattr(summary_result, "summary", "")
     return {"rag_summary": summary, "memory_history_list": memories}
-
-
-async def retrieve_semantic_context_node(state: AgentTurnState) -> dict[str, Any]:
-    """Retrieve semantically grouped context for the agent."""
-    service = cast(MemoryService | None, state.get("memory_service"))
-    if not service:
-        return {"semantic_context": ""}
-    query = state.get("rag_summary", "")
-    import asyncio
-
-    memories = await asyncio.to_thread(
-        service.retrieve_semantic_context,
-        state["agent_id"],
-        query,
-        5,
-    )
-    context = "\n".join(m.get("content", "") for m in memories)
-    return {"semantic_context": context}
 
 
 def generate_structured_output_from_intent(

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -44,21 +44,12 @@ class MemoryService:
             episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
 
         semantic: list[dict[str, Any]] = []
-        if self.semantic_manager and self.vector_store:
+        if self.semantic_manager:
             import asyncio
 
-            import numpy as np
-
             semantic = await asyncio.to_thread(
-                self.semantic_manager.retrieve_context, agent_id, query, k
+                self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
             )
-            q_emb = np.array(self.vector_store.get_embedding(query), dtype=float)
-            for mem in semantic:
-                emb = np.array(
-                    self.vector_store.get_embedding(mem.get("content", "")), dtype=float
-                )
-                score = float(emb @ q_emb / (np.linalg.norm(emb) * np.linalg.norm(q_emb) + 1e-8))
-                mem["relevance_score"] = score
 
         combined = episodic + semantic
         combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)

--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -140,6 +140,27 @@ class SemanticMemoryManager:
         memories = self.topic_groups[agent_id].get(best, [])
         return memories[:k]
 
+    def retrieve_context_with_scores(
+        self: Self, agent_id: str, query: str, k: int = 5
+    ) -> list[dict[str, Any]]:
+        """Return semantic context with relevance scores."""
+        memories = self.retrieve_context(agent_id, query, k)
+        if not memories:
+            return []
+
+        import numpy as np
+
+        query_emb = np.array(self.vector_store.get_embedding(query), dtype=float)
+        for mem in memories:
+            emb = np.array(self.vector_store.get_embedding(mem.get("content", "")), dtype=float)
+            score = float(
+                emb @ query_emb / (np.linalg.norm(emb) * np.linalg.norm(query_emb) + 1e-8)
+            )
+            mem["relevance_score"] = score
+
+        memories.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+        return memories[:k]
+
     def get_recent_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         """Return recent semantic summaries for an agent."""
         if self.driver is None:

--- a/tests/unit/graphs/test_agent_graph_builder.py
+++ b/tests/unit/graphs/test_agent_graph_builder.py
@@ -1,7 +1,6 @@
 import pytest
 
 # - allow runtime dependency checks before imports
-
 pytest.importorskip("langgraph")
 
 from langgraph.graph.graph import END, START
@@ -20,7 +19,6 @@ def test_build_graph_structure() -> None:
         "analyze_perception_sentiment",
         "prepare_relationship_prompt",
         "retrieve_and_summarize_memories",
-        "retrieve_semantic_context",
         "generate_thought_and_message",
         "route_action_intent",
         "handle_propose_idea",
@@ -36,8 +34,7 @@ def test_build_graph_structure() -> None:
         (START, "analyze_perception_sentiment"),
         ("analyze_perception_sentiment", "prepare_relationship_prompt"),
         ("prepare_relationship_prompt", "retrieve_and_summarize_memories"),
-        ("retrieve_and_summarize_memories", "retrieve_semantic_context"),
-        ("retrieve_semantic_context", "generate_thought_and_message"),
+        ("retrieve_and_summarize_memories", "generate_thought_and_message"),
         ("generate_thought_and_message", "route_action_intent"),
         ("handle_idle", "finalize_message_agent"),
         ("finalize_message_agent", "maybe_consolidate_memories"),


### PR DESCRIPTION
## Summary
- combine episodic and semantic context retrieval
- remove obsolete semantic context node from agent graph
- adjust agent graph builder
- update unit tests for new graph structure

## Testing
- `ruff check src/agents/memory/semantic_memory_manager.py src/agents/memory/memory_service.py src/agents/graphs/graph_nodes.py src/agents/graphs/agent_graph_builder.py tests/unit/graphs/test_agent_graph_builder.py`
- `ruff format src/agents/memory/semantic_memory_manager.py src/agents/memory/memory_service.py src/agents/graphs/graph_nodes.py src/agents/graphs/agent_graph_builder.py tests/unit/graphs/test_agent_graph_builder.py`
- `pytest -k "" tests/unit/graphs/test_agent_graph_builder.py tests/unit/graphs/test_graph_nodes.py tests/integration/memory/test_semantic_update_on_retrieval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687143411d98832695a4f8affa6b2e06