### PR TITLE
Expose law & vote APIs

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -29,3 +29,13 @@ python src/app.py \
   --proposal "Allow concerts" --proposer-id agent_1 \
   --vote-weights agent_1=3,agent_2=1
 ```
+
+## Dashboard API
+
+The dashboard backend exposes a few read-only endpoints for governance data.
+
+### `GET /api/laws`
+Returns a list of laws that have been passed and recorded on the law board.
+
+### `GET /api/votes`
+Lists recent law proposals with their vote totals as stored in the ledger.

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import BaseModel
 
+from src.governance.law_board import law_board
 from src.governance.service import governance
 from src.infra.ledger import ledger
 from src.sim.quests import get_quests
@@ -157,6 +158,23 @@ class LawProposal(BaseModel):
     text: str
 
 
+class LawsResponse(BaseModel):
+    laws: list[str]
+
+
+class VoteRecord(BaseModel):
+    proposer_id: str
+    text: str
+    approved: bool
+    yes_weight: float
+    no_weight: float
+    ts: Any
+
+
+class VotesResponse(BaseModel):
+    votes: list[VoteRecord]
+
+
 app = FastAPI()
 
 
@@ -236,6 +254,22 @@ async def api_get_proposals(limit: int = 10) -> Response:
     """Return stored law proposals."""
     proposals = governance.get_proposals(limit)
     return JSONResponse({"proposals": proposals})
+
+
+@app.get("/api/laws", response_model=LawsResponse)
+async def api_get_laws() -> Response:
+    """Return passed laws from the law board."""
+
+    laws = law_board.get_laws()
+    return JSONResponse({"laws": laws})
+
+
+@app.get("/api/votes", response_model=VotesResponse)
+async def api_get_votes(limit: int = 10) -> Response:
+    """Return stored voting history."""
+
+    votes = ledger.get_law_proposals(limit)
+    return JSONResponse({"votes": votes})
 
 
 @app.get("/api/token_balances")
@@ -410,9 +444,14 @@ __all__ = [
     "WIDGET_REGISTRY",
     "EventSourceResponse",
     "LawProposal",
+    "LawsResponse",
     "SimulationEvent",
+    "VoteRecord",
+    "VotesResponse",
     "api_auctions",
+    "api_get_laws",
     "api_get_proposals",
+    "api_get_votes",
     "api_propose_law",
     "api_token_balances",
     "app",

--- a/tests/integration/governance/test_dashboard_api.py
+++ b/tests/integration/governance/test_dashboard_api.py
@@ -1,0 +1,34 @@
+import httpx
+import pytest
+from httpx import ASGITransport
+
+pytest.importorskip("fastapi")
+
+from src import http_app
+from src.governance.law_board import LawBoard
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_laws_and_votes_endpoints(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    board = LawBoard(tmp_path / "laws.sqlite")
+    board.add_law("be nice")
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    ledger.record_law_proposal("a1", "be nice", True, 1.0, 0.0)
+
+    monkeypatch.setattr(db, "law_board", board)
+    monkeypatch.setattr(db, "ledger", ledger)
+
+    transport = ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/laws")
+        assert resp.status_code == 200
+        assert resp.json()["laws"] == ["be nice"]
+
+        resp = await client.get("/api/votes")
+        assert resp.status_code == 200
+        votes = resp.json().get("votes")
+        assert votes and votes[0]["text"] == "be nice"


### PR DESCRIPTION
## Summary
- add `/api/laws` and `/api/votes` endpoints
- document the new endpoints in governance docs
- test that the new API routes return data

## Testing
- `bash scripts/lint.sh`
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py -m integration tests/integration/governance/test_dashboard_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68714341ef8483269bb04acf05eee29c