### PR TITLE
Add lock for world map updates

### DIFF
--- a/src/sim/world_map.py
+++ b/src/sim/world_map.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 from enum import Enum
 from heapq import heappop, heappush
@@ -24,6 +25,7 @@ class WorldMap:
     """Simple grid-based world map for agent interactions."""
 
     def __init__(self, width: int = 50, height: int = 50) -> None:
+        self.lock = asyncio.Lock()
         self.width = width
         self.height = height
         self.agent_positions: dict[str, tuple[int, int]] = {}

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -25,118 +25,119 @@ async def process_map_action(
     """Execute a world map action for the given agent."""
     action_type = map_action.get("action")
     details: dict[str, Any] = {}
-    if action_type == "move":
-        if "x" in map_action and "y" in map_action:
-            tx = int(map_action.get("x", 0))
-            ty = int(map_action.get("y", 0))
-            pos = sim.world_map.move_to(agent_id, tx, ty, vector=sim.vector.to_dict())
+    async with sim.world_map.lock:
+        if action_type == "move":
+            if "x" in map_action and "y" in map_action:
+                tx = int(map_action.get("x", 0))
+                ty = int(map_action.get("y", 0))
+                pos = sim.world_map.move_to(agent_id, tx, ty, vector=sim.vector.to_dict())
+            else:
+                dx = int(map_action.get("dx", 0))
+                dy = int(map_action.get("dy", 0))
+                pos = sim.world_map.move(agent_id, dx, dy, vector=sim.vector.to_dict())
+            details = {"position": pos}
+            start_ip = current_state.ip
+            if config.MAP_MOVE_DU_COST > 0:
+                try:
+                    from src.infra.ledger import ledger
+
+                    aid = ledger.open_auction("move")
+                    ledger.place_bid(aid, agent_id, config.MAP_MOVE_DU_COST)
+                    ledger.resolve_auction(aid)
+                except Exception:  # pragma: no cover - optional
+                    logger.debug("Ledger auction failed", exc_info=True)
+                current_state.du -= config.MAP_MOVE_DU_COST
+            start_du = current_state.du
+            current_state.ip -= config.MAP_MOVE_IP_COST
+            current_state.ip += config.MAP_MOVE_IP_REWARD
+            current_state.du += config.MAP_MOVE_DU_REWARD
+            try:
+                from src.infra.ledger import ledger
+
+                ledger.log_change(
+                    agent_id,
+                    current_state.ip - start_ip,
+                    current_state.du - start_du,
+                    "move",
+                )
+            except Exception:  # pragma: no cover - optional
+                logger.debug("Ledger logging failed", exc_info=True)
+        elif action_type == "gather":
+            res = map_action.get("resource")
+            success = False
+            if isinstance(res, str):
+                success = sim.world_map.gather(
+                    agent_id,
+                    ResourceToken(res),
+                    vector=sim.vector.to_dict(),
+                )
+            details = {"resource": res, "success": success}
+            if success:
+                start_ip = current_state.ip
+                if config.MAP_GATHER_DU_COST > 0:
+                    try:
+                        from src.infra.ledger import ledger
+
+                        aid = ledger.open_auction("gather")
+                        ledger.place_bid(aid, agent_id, config.MAP_GATHER_DU_COST)
+                        ledger.resolve_auction(aid)
+                    except Exception:  # pragma: no cover - optional
+                        logger.debug("Ledger auction failed", exc_info=True)
+                    current_state.du -= config.MAP_GATHER_DU_COST
+                start_du = current_state.du
+                current_state.ip -= config.MAP_GATHER_IP_COST
+                current_state.ip += config.MAP_GATHER_IP_REWARD
+                current_state.du += config.MAP_GATHER_DU_REWARD
+                try:
+                    from src.infra.ledger import ledger
+
+                    ledger.log_change(
+                        agent_id,
+                        current_state.ip - start_ip,
+                        current_state.du - start_du,
+                        "gather",
+                    )
+                except Exception:  # pragma: no cover - optional
+                    logger.debug("Ledger logging failed", exc_info=True)
+        elif action_type == "build":
+            struct = map_action.get("structure")
+            success = False
+            if isinstance(struct, str):
+                success = sim.world_map.build(
+                    agent_id,
+                    StructureType(struct),
+                    vector=sim.vector.to_dict(),
+                )
+            details = {"structure": struct, "success": success}
+            if success:
+                start_ip = current_state.ip
+                if config.MAP_BUILD_DU_COST > 0:
+                    try:
+                        from src.infra.ledger import ledger
+
+                        aid = ledger.open_auction("build")
+                        ledger.place_bid(aid, agent_id, config.MAP_BUILD_DU_COST)
+                        ledger.resolve_auction(aid)
+                    except Exception:  # pragma: no cover - optional
+                        logger.debug("Ledger auction failed", exc_info=True)
+                    current_state.du -= config.MAP_BUILD_DU_COST
+                start_du = current_state.du
+                current_state.ip -= config.MAP_BUILD_IP_COST
+                current_state.ip += config.MAP_BUILD_IP_REWARD
+                current_state.du += config.MAP_BUILD_DU_REWARD
+                try:
+                    from src.infra.ledger import ledger
+
+                    ledger.log_change(
+                        agent_id,
+                        current_state.ip - start_ip,
+                        current_state.du - start_du,
+                        "build",
+                    )
+                except Exception:  # pragma: no cover - optional
+                    logger.debug("Ledger logging failed", exc_info=True)
         else:
-            dx = int(map_action.get("dx", 0))
-            dy = int(map_action.get("dy", 0))
-            pos = sim.world_map.move(agent_id, dx, dy, vector=sim.vector.to_dict())
-        details = {"position": pos}
-        start_ip = current_state.ip
-        if config.MAP_MOVE_DU_COST > 0:
-            try:
-                from src.infra.ledger import ledger
-
-                aid = ledger.open_auction("move")
-                ledger.place_bid(aid, agent_id, config.MAP_MOVE_DU_COST)
-                ledger.resolve_auction(aid)
-            except Exception:  # pragma: no cover - optional
-                logger.debug("Ledger auction failed", exc_info=True)
-            current_state.du -= config.MAP_MOVE_DU_COST
-        start_du = current_state.du
-        current_state.ip -= config.MAP_MOVE_IP_COST
-        current_state.ip += config.MAP_MOVE_IP_REWARD
-        current_state.du += config.MAP_MOVE_DU_REWARD
-        try:
-            from src.infra.ledger import ledger
-
-            ledger.log_change(
-                agent_id,
-                current_state.ip - start_ip,
-                current_state.du - start_du,
-                "move",
-            )
-        except Exception:  # pragma: no cover - optional
-            logger.debug("Ledger logging failed", exc_info=True)
-    elif action_type == "gather":
-        res = map_action.get("resource")
-        success = False
-        if isinstance(res, str):
-            success = sim.world_map.gather(
-                agent_id,
-                ResourceToken(res),
-                vector=sim.vector.to_dict(),
-            )
-        details = {"resource": res, "success": success}
-        if success:
-            start_ip = current_state.ip
-            if config.MAP_GATHER_DU_COST > 0:
-                try:
-                    from src.infra.ledger import ledger
-
-                    aid = ledger.open_auction("gather")
-                    ledger.place_bid(aid, agent_id, config.MAP_GATHER_DU_COST)
-                    ledger.resolve_auction(aid)
-                except Exception:  # pragma: no cover - optional
-                    logger.debug("Ledger auction failed", exc_info=True)
-                current_state.du -= config.MAP_GATHER_DU_COST
-            start_du = current_state.du
-            current_state.ip -= config.MAP_GATHER_IP_COST
-            current_state.ip += config.MAP_GATHER_IP_REWARD
-            current_state.du += config.MAP_GATHER_DU_REWARD
-            try:
-                from src.infra.ledger import ledger
-
-                ledger.log_change(
-                    agent_id,
-                    current_state.ip - start_ip,
-                    current_state.du - start_du,
-                    "gather",
-                )
-            except Exception:  # pragma: no cover - optional
-                logger.debug("Ledger logging failed", exc_info=True)
-    elif action_type == "build":
-        struct = map_action.get("structure")
-        success = False
-        if isinstance(struct, str):
-            success = sim.world_map.build(
-                agent_id,
-                StructureType(struct),
-                vector=sim.vector.to_dict(),
-            )
-        details = {"structure": struct, "success": success}
-        if success:
-            start_ip = current_state.ip
-            if config.MAP_BUILD_DU_COST > 0:
-                try:
-                    from src.infra.ledger import ledger
-
-                    aid = ledger.open_auction("build")
-                    ledger.place_bid(aid, agent_id, config.MAP_BUILD_DU_COST)
-                    ledger.resolve_auction(aid)
-                except Exception:  # pragma: no cover - optional
-                    logger.debug("Ledger auction failed", exc_info=True)
-                current_state.du -= config.MAP_BUILD_DU_COST
-            start_du = current_state.du
-            current_state.ip -= config.MAP_BUILD_IP_COST
-            current_state.ip += config.MAP_BUILD_IP_REWARD
-            current_state.du += config.MAP_BUILD_DU_REWARD
-            try:
-                from src.infra.ledger import ledger
-
-                ledger.log_change(
-                    agent_id,
-                    current_state.ip - start_ip,
-                    current_state.du - start_du,
-                    "build",
-                )
-            except Exception:  # pragma: no cover - optional
-                logger.debug("Ledger logging failed", exc_info=True)
-    else:
-        details = {}
+            details = {}
 
     map_event_data = {
         "type": "map_action",

--- a/tests/integration/sim/test_world_map_actions.py
+++ b/tests/integration/sim/test_world_map_actions.py
@@ -74,7 +74,8 @@ async def test_move_action_updates_position_and_ledger(
 @pytest.mark.integration
 async def test_move_blocked_by_obstacle(sim: tuple[Simulation, Ledger, DummyAgent]) -> None:
     sim_obj, ledger, agent = sim
-    sim_obj.world_map.add_obstacle(1, 0)
+    async with sim_obj.world_map.lock:
+        sim_obj.world_map.add_obstacle(1, 0)
     await process_map_action(
         sim_obj, 0, agent.agent_id, agent.state, {"action": "move", "dx": 1, "dy": 0}
     )
@@ -90,7 +91,8 @@ async def test_gather_action_success_and_failure(
     sim: tuple[Simulation, Ledger, DummyAgent],
 ) -> None:
     sim_obj, ledger, agent = sim
-    sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
+    async with sim_obj.world_map.lock:
+        sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
     await process_map_action(
         sim_obj,
         0,
@@ -134,7 +136,8 @@ async def test_build_action_success_and_failure(
     rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
     assert rows == []
 
-    sim_obj.world_map.agent_resources[agent.agent_id] = {"wood": 1}
+    async with sim_obj.world_map.lock:
+        sim_obj.world_map.agent_resources[agent.agent_id] = {"wood": 1}
     await process_map_action(
         sim_obj,
         0,


### PR DESCRIPTION
## Summary
- guard world map mutations with an asyncio.Lock
- update map action processing to use the lock
- ensure integration tests acquire the lock

## Testing
- `bash scripts/lint.sh > /tmp/lint.log && tail -n 20 /tmp/lint.log`
- `python scripts/run_tests.py -m "integration" tests/integration/sim/test_world_map_actions.py > /tmp/test.log && tail -n 5 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6871c3cddc0c8326b97cfdc687dab00d