### PR TITLE
Convert plugin registration to async

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,7 +11,7 @@ Use `register_widget_backend` to inform the backend about a widget:
 ```python
 from src.extensions import register_widget_backend
 
-register_widget_backend(
+await register_widget_backend(
     name="ExampleWidget",
     script_url="http://localhost:5173/example.js",
 )
@@ -68,7 +68,7 @@ plug-ins. Any dictionary returned is passed to `register_widget_backend`:
 ```python
 from src.extensions import load_plugins
 
-load_plugins()
+await load_plugins()
 ```
 
 
@@ -85,5 +85,5 @@ After installation call `load_plugins()` so Culture can register its hooks:
 ```python
 from src.extensions import load_plugins
 
-load_plugins()
+await load_plugins()
 ```

--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -42,25 +42,28 @@ def register_agent_behavior(func: Callable[[Any, dict[str, Any]], None]) -> None
     BEHAVIOR_REGISTRY.register(func)
 
 
-def register_widget_backend(
+async def register_widget_backend(
     name: str,
     script_url: str,
     backend_url: str = "http://localhost:8000",
 ) -> None:
     """Register a UI widget with the Culture backend."""
 
-    resp = httpx.post(
-        f"{backend_url.rstrip('/')}/api/register_widget",
-        json={"name": name, "script_url": script_url},
-        timeout=10,
-    )
-    resp.raise_for_status()
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(
+                f"{backend_url.rstrip('/')}/api/register_widget",
+                json={"name": name, "script_url": script_url},
+            )
+            resp.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network failures
+        logger.exception("Widget registration failed: %s", exc)
 
 
 DEFAULT_PLUGIN_GROUP = "culture.plugins"
 
 
-def load_plugins(
+async def load_plugins(
     group: str = DEFAULT_PLUGIN_GROUP, *, backend_url: str = "http://localhost:8000"
 ) -> None:
     """Load entry-point plugins and optionally register their widgets."""
@@ -79,7 +82,7 @@ def load_plugins(
                 "name",
                 "script_url",
             }.issubset(result):
-                register_widget_backend(
+                await register_widget_backend(
                     name=result["name"],
                     script_url=result["script_url"],
                     backend_url=backend_url,

--- a/tests/unit/extensions/test_example_plugin.py
+++ b/tests/unit/extensions/test_example_plugin.py
@@ -15,11 +15,12 @@ class DummyEntryPoints(list[object]):
 
 
 @pytest.mark.unit
-def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
     BEHAVIOR_REGISTRY._behaviors.clear()
     widgets: list[tuple[str, str, str]] = []
 
-    def register_widget_backend(
+    async def register_widget_backend(
         name: str, script_url: str, backend_url: str = "http://localhost:8000"
     ) -> None:
         widgets.append((name, script_url, backend_url))
@@ -28,7 +29,7 @@ def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
     monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
 
-    load_plugins(backend_url="http://backend")
+    await load_plugins(backend_url="http://backend")
 
     assert example_plugin.log_turn in BEHAVIOR_REGISTRY._behaviors
     assert widgets == [("ExampleWidget", "http://localhost:5173/example.js", "http://backend")]

--- a/tests/unit/extensions/test_plugin_loader.py
+++ b/tests/unit/extensions/test_plugin_loader.py
@@ -15,7 +15,8 @@ class DummyEntryPoints(list[Any]):
 
 
 @pytest.mark.unit
-def test_load_plugins_executes(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_load_plugins_executes(monkeypatch: pytest.MonkeyPatch) -> None:
     called: list[bool] = []
 
     def plugin() -> None:
@@ -24,19 +25,20 @@ def test_load_plugins_executes(monkeypatch: pytest.MonkeyPatch) -> None:
     ep = types.SimpleNamespace(load=lambda: plugin, name="dummy")
     monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
 
-    load_plugins()
+    await load_plugins()
 
     assert called
 
 
 @pytest.mark.unit
-def test_load_plugins_registers_widget(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_load_plugins_registers_widget(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded: list[tuple[str, str, str]] = []
 
     def plugin() -> dict[str, str]:
         return {"name": "Widget", "script_url": "http://x/y.js"}
 
-    def register_widget_backend(
+    async def register_widget_backend(
         name: str, script_url: str, backend_url: str = "http://localhost:8000"
     ) -> None:
         recorded.append((name, script_url, backend_url))
@@ -45,6 +47,6 @@ def test_load_plugins_registers_widget(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
     monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
 
-    load_plugins(backend_url="http://backend")
+    await load_plugins(backend_url="http://backend")
 
     assert recorded == [("Widget", "http://x/y.js", "http://backend")]

--- a/tests/unit/extensions/test_register_widget_backend.py
+++ b/tests/unit/extensions/test_register_widget_backend.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import types
+
+import httpx
+import pytest
+
+from src.extensions import register_widget_backend
+
+
+class DummyClient:
+    async def __aenter__(self) -> DummyClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
+        pass
+
+    async def post(self, *args: object, **kwargs: object) -> None:
+        raise httpx.HTTPError("boom")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_widget_backend_handles_http_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: DummyClient())
+    with caplog.at_level("ERROR"):
+        await register_widget_backend("Widget", "http://x/y.js")
+    assert "Widget registration failed" in caplog.text


### PR DESCRIPTION
## Summary
- support async widget registration via httpx
- update plugin loader to await widget registration
- update tests for async plugin hooks
- document new async API usage
- add regression test for failed widget registration

## Testing
- `ruff check src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py tests/unit/extensions/test_example_plugin.py tests/unit/extensions/test_register_widget_backend.py`
- `ruff format src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py tests/unit/extensions/test_example_plugin.py tests/unit/extensions/test_register_widget_backend.py`
- `mypy src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py tests/unit/extensions/test_example_plugin.py tests/unit/extensions/test_register_widget_backend.py`
- `python scripts/run_tests.py tests/unit/extensions/test_plugin_loader.py tests/unit/extensions/test_example_plugin.py tests/unit/extensions/test_register_widget_backend.py -m "not integration and not ollama"`


------
https://chatgpt.com/codex/tasks/task_e_6871c3cd2c4c832698d76493d942f6de