### PR TITLE
Add Semantic Memory options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
     * **Level 1 (Session Summaries):** Short-term memories are consolidated into session summaries.
     * **Level 2 (Chapter Summaries):** Level 1 summaries are further consolidated into longer-term chapter summaries.
     * **Persistence & Retrieval:** Both memory levels are persisted in a ChromaDB vector store and are retrievable via RAG, with dedicated test suites validating this functionality.
+* **Semantic Memory:** Higher-level summaries are stored in Neo4j via the SemanticMemoryManager.
 * **Retrieval Augmented Generation (RAG):** Agents utilize RAG to inject relevant past memories and knowledge board content into their context for decision-making.
 * **Shared Knowledge Board (v1):** A central repository where agents can post ideas and information, which is then perceived by other agents.
 * **Resource Management (IP/DU):** Agents manage and utilize Influence Points (IP) and Data Units (DU) for actions like posting to the knowledge board, proposing projects, and changing roles.
@@ -55,6 +56,7 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
 * **DSPy Integration:** Advanced prompt optimization using DSPy with local Ollama models.
 * **LLM Performance Monitoring:** Comprehensive monitoring of LLM call performance metrics.
 * **Memory Pruning System:** Sophisticated pruning to maintain optimal performance while preserving critical information.
+* **Semantic Memory:** Consolidation of episodic memories into topic-based summaries stored in Neo4j.
 * **AsyncDSPyManager:** Concurrency layer allowing parallel DSPy calls without blocking the event loop.
 
 ## Key Features

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,7 @@ The Agent Core components interact with:
 ### Overview
 
 The Agent Memory system (`src/agents/memory/`) provides sophisticated memory capabilities for agents, including hierarchical memory organization, vector-based storage and retrieval, and intelligent pruning mechanisms.
+Semantic summaries are managed separately in a Neo4j database via the `SemanticMemoryManager` and are blended with episodic memories during retrieval.
 
 ### Key Components
 
@@ -163,6 +164,10 @@ delete_collection() # Drop the entire class/collection
 **Configuration:**
 - Set `VECTOR_STORE_BACKEND=weaviate` and `WEAVIATE_URL` in your environment or `.env` file to use Weaviate.
 - The agent will use WeaviateVectorStoreManager for all memory operations if configured.
+
+#### SemanticMemoryManager
+
+The `SemanticMemoryManager` (`src/agents/memory/semantic_memory_manager.py`) consolidates episodic memories into higher-level summaries stored in a Neo4j database. This allows agents to recall key themes and topics beyond what fits in the vector store. The manager groups memories by topic and provides retrieval APIs used alongside episodic memory search.
 
 #### Memory Hierarchy
 

--- a/src/app.py
+++ b/src/app.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from src.agents.core.base_agent import Agent
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.infra.checkpoint import (
     load_checkpoint,
@@ -85,6 +86,10 @@ def create_simulation(
     use_discord: bool = False,
     use_vector_store: bool = False,
     vector_store_dir: str = "./chroma_db",
+    use_semantic_memory: bool = False,
+    semantic_db_uri: str = "bolt://localhost:7687",
+    semantic_user: str = "neo4j",
+    semantic_password: str = "test",
 ) -> Simulation:
     """Construct a Simulation instance with basic defaults."""
 
@@ -110,17 +115,30 @@ def create_simulation(
 
     agents = [Agent(agent_id=f"agent_{i + 1}", name=f"Agent_{i + 1}") for i in range(num_agents)]
 
+    vector_store = (
+        None
+        if not use_vector_store
+        else (
+            ChromaVectorStoreManager(persist_directory=vector_store_dir)
+            if ChromaVectorStoreManager is not None
+            else None
+        )
+    )
+
+    semantic_manager = None
+    if use_semantic_memory and vector_store is not None:
+        try:
+            from neo4j import GraphDatabase
+
+            driver = GraphDatabase.driver(semantic_db_uri, auth=(semantic_user, semantic_password))
+            semantic_manager = SemanticMemoryManager(vector_store, driver)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logging.error("Failed to connect to semantic DB: %s", exc)
+
     sim = Simulation(
         agents=agents,
-        vector_store_manager=(
-            None
-            if not use_vector_store
-            else (
-                ChromaVectorStoreManager(persist_directory=vector_store_dir)
-                if ChromaVectorStoreManager is not None
-                else None
-            )
-        ),
+        vector_store_manager=vector_store,
+        semantic_manager=semantic_manager,
         scenario=scenario,
         discord_bot=discord_bot,
     )
@@ -150,6 +168,29 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="./chroma_db",
         help="Directory for vector store persistence.",
+    )
+    parser.add_argument(
+        "--semantic-memory",
+        action="store_true",
+        help="Enable semantic memory consolidation.",
+    )
+    parser.add_argument(
+        "--semantic-db",
+        type=str,
+        default="bolt://localhost:7687",
+        help="Neo4j connection URI for semantic memory.",
+    )
+    parser.add_argument(
+        "--semantic-user",
+        type=str,
+        default="neo4j",
+        help="Neo4j username for semantic memory.",
+    )
+    parser.add_argument(
+        "--semantic-password",
+        type=str,
+        default="test",
+        help="Neo4j password for semantic memory.",
     )
     parser.add_argument(
         "--no-warning-filters",
@@ -222,6 +263,10 @@ def main() -> None:
             use_discord=args.discord,
             use_vector_store=args.vector_store,
             vector_store_dir=args.vector_dir,
+            use_semantic_memory=args.semantic_memory,
+            semantic_db_uri=args.semantic_db,
+            semantic_user=args.semantic_user,
+            semantic_password=args.semantic_password,
         )
 
     if args.replay and meta:

--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -9,10 +9,8 @@ import pytest
 pytest.importorskip("fastapi")
 
 from src import http_app
-from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
-from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.app import create_simulation
 from src.interfaces import dashboard_backend as db
-from src.sim.simulation import Simulation
 from tests.integration.interfaces.test_dashboard_backend_api import DummyRequest
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
 
@@ -47,13 +45,24 @@ async def _clear_event_queue() -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    vector = ChromaVectorStoreManager(
-        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
-    )
-    driver = DummyDriver()
-    manager = SemanticMemoryManager(vector, driver)
+    monkeypatch.setattr("neo4j.GraphDatabase.driver", lambda *a, **k: DummyDriver(), raising=False)
+
+    async def _allow(_: str) -> bool:
+        return True
+
+    monkeypatch.setattr("src.governance.evaluate_policy", _allow)
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", _allow)
     agent = DummyAgent("a1")
-    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+    sim = create_simulation(
+        num_agents=1,
+        steps=1,
+        scenario="sse",
+        use_vector_store=True,
+        vector_store_dir=tmp_path,
+        use_semantic_memory=True,
+        semantic_db_uri="bolt://dummy",
+    )
+    manager = sim.semantic_manager
 
     class CaptureESR:
         def __init__(self, gen: object) -> None:
@@ -82,7 +91,8 @@ async def test_stream_messages_async_client(monkeypatch: pytest.MonkeyPatch) -> 
     msg = db.AgentMessage(agent_id="agent-1", content="hello", step=1)
     await db.enqueue_message(msg)
 
-    async with httpx.AsyncClient(app=http_app.app, base_url="http://test") as client:
+    transport = httpx.ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         async with client.stream("GET", "/stream/messages") as resp:
             data_line = None
             async for line in resp.aiter_lines():
@@ -97,13 +107,24 @@ async def test_stream_messages_async_client(monkeypatch: pytest.MonkeyPatch) -> 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_semantic_summaries_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    vector = ChromaVectorStoreManager(
-        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
-    )
-    driver = DummyDriver()
-    manager = SemanticMemoryManager(vector, driver)
+    monkeypatch.setattr("neo4j.GraphDatabase.driver", lambda *a, **k: DummyDriver(), raising=False)
+
+    async def _allow(_: str) -> bool:
+        return True
+
+    monkeypatch.setattr("src.governance.evaluate_policy", _allow)
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", _allow)
     agent = DummyAgent("agent-1")
-    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+    sim = create_simulation(
+        num_agents=1,
+        steps=1,
+        scenario="sse",
+        use_vector_store=True,
+        vector_store_dir=tmp_path,
+        use_semantic_memory=True,
+        semantic_db_uri="bolt://dummy",
+    )
+    manager = sim.semantic_manager
 
     monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
     monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
@@ -111,7 +132,8 @@ async def test_semantic_summaries_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_
     await _clear_event_queue()
     await sim.run_step()
 
-    async with httpx.AsyncClient(app=http_app.app, base_url="http://test") as client:
+    transport = httpx.ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/api/agents/agent-1/semantic_summaries")
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/integration/memory/test_simulation_semantic_job.py
+++ b/tests/integration/memory/test_simulation_semantic_job.py
@@ -2,10 +2,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
-from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.app import create_simulation
 from src.infra import config
-from src.sim.simulation import Simulation
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
 
 
@@ -32,12 +30,7 @@ class DummyAgent:
 
 
 def setup_semantic_manager(tmp_path):
-    vector = ChromaVectorStoreManager(
-        persist_directory=tmp_path, embedding_function=lambda t: [[0.0] for _ in t]
-    )
-    driver = DummyDriver()
-    manager = SemanticMemoryManager(vector, driver)
-    return manager, vector, driver
+    return DummyDriver()
 
 
 @pytest.mark.integration
@@ -50,11 +43,20 @@ async def test_simulation_schedules_semantic_job(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(sim_module, "evaluate_policy", _allow)
     monkeypatch.setitem(config.CONFIG_OVERRIDES, "SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 1)
-    manager, vector, driver = setup_semantic_manager(tmp_path)
+    driver = setup_semantic_manager(tmp_path)
+    monkeypatch.setattr("neo4j.GraphDatabase.driver", lambda *a, **k: driver, raising=False)
     agent = DummyAgent("a1")
-    sim = Simulation([agent], vector_store_manager=vector, semantic_manager=manager)
+    sim = create_simulation(
+        num_agents=1,
+        steps=1,
+        scenario="semantic",
+        use_vector_store=True,
+        vector_store_dir=tmp_path,
+        use_semantic_memory=True,
+        semantic_db_uri="bolt://dummy",
+    )
 
-    vector.add_memory("a1", 0, "thought", "hello")
+    sim.memory_service.vector_store.add_memory("a1", 0, "thought", "hello")
 
     await sim.run_step()
     assert driver.store  # summary written

--- a/tests/unit/test_app_cli.py
+++ b/tests/unit/test_app_cli.py
@@ -18,10 +18,25 @@ pytestmark = pytest.mark.unit
 
 
 def test_parse_args(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(sys, "argv", ["prog", "--agents", "2", "--steps", "3"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--agents",
+            "2",
+            "--steps",
+            "3",
+            "--semantic-memory",
+            "--semantic-db",
+            "bolt://db",
+        ],
+    )
     args = app.parse_args()
     assert args.agents == 2
     assert args.steps == 3
+    assert args.semantic_memory is True
+    assert args.semantic_db == "bolt://db"
 
 
 def test_main_invokes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,6 +62,10 @@ def test_main_invokes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
         use_discord=False,
         use_vector_store=False,
         vector_store_dir="./chroma_db",
+        use_semantic_memory=False,
+        semantic_db_uri="bolt://localhost:7687",
+        semantic_user="neo4j",
+        semantic_password="test",
     )
     dummy_sim.async_run.assert_called_once_with(3)
     run_mock.assert_called_once_with(dummy_sim.async_run.return_value)
@@ -88,6 +107,10 @@ def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
         use_discord=False,
         use_vector_store=False,
         vector_store_dir="./chroma_db",
+        use_semantic_memory=False,
+        semantic_db_uri="bolt://localhost:7687",
+        semantic_user="neo4j",
+        semantic_password="test",
     )
     dummy_sim.async_run.assert_called_once_with(2)
     run_mock.assert_called_once_with(dummy_sim.async_run.return_value)


### PR DESCRIPTION
## Summary
- add semantic memory CLI options to `app.py`
- instantiate `SemanticMemoryManager` when semantic memory enabled
- document semantic memory in README and architecture docs
- update tests for new CLI options and semantics

## Testing
- `ruff check src/app.py tests/unit/test_app_cli.py tests/integration/interfaces/test_simulation_sse.py tests/integration/memory/test_simulation_semantic_job.py`
- `pytest tests/unit/test_app_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d35513408326bd36b3bfeb7ebce1