### PR TITLE
Refactor discord bot run loop

### DIFF
--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -92,28 +92,32 @@ class SemanticMemoryManager:
 
         topic_groups: dict[int, list[dict[str, Any]]] = defaultdict(list)
 
-        centroids: list[NDArray[np.float64]] = []
+        centroid_list: list[NDArray[np.float64]] = []
 
         for mem, emb in zip(memories, embeddings):
-            if not centroids:
+            if not centroid_list:
                 topic_groups[0].append(mem)
-                centroids.append(emb)
+                centroid_list.append(emb)
                 continue
             sims = (
-                centroids @ emb / (np.linalg.norm(centroids, axis=1) * np.linalg.norm(emb) + 1e-8)
+                centroid_list
+                @ emb
+                / (np.linalg.norm(centroid_list, axis=1) * np.linalg.norm(emb) + 1e-8)
             )
             idx = int(np.argmax(sims))
-            if sims[idx] < threshold and len(centroids) < num_topics:
-                topic_groups[len(centroids)].append(mem)
-                centroids.append(emb)
+            if sims[idx] < threshold and len(centroid_list) < num_topics:
+                topic_groups[len(centroid_list)].append(mem)
+                centroid_list.append(emb)
             else:
                 topic_groups[idx].append(mem)
-                c = centroids[idx]
-                centroids[idx] = (c * (len(topic_groups[idx]) - 1) + emb) / len(topic_groups[idx])
+                c = centroid_list[idx]
+                centroid_list[idx] = (c * (len(topic_groups[idx]) - 1) + emb) / len(
+                    topic_groups[idx]
+                )
 
         self.topic_groups[agent_id] = topic_groups
         self.topic_centroids[agent_id] = (
-            np.stack(centroids) if centroids else np.empty((0, embeddings.shape[1]))
+            np.stack(centroid_list) if centroid_list else np.empty((0, embeddings.shape[1]))
         )
         return topic_groups
 

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -134,6 +134,7 @@ class SimulationDiscordBot:
         self.event_queue = get_event_queue()
         self.message_queue = message_sse_queue
         self._forward_task: asyncio.Task[Any] | None = None
+        self._client_tasks: list[asyncio.Task[Any]] = []
 
         # Set up event handlers for all clients
         for _token, client in self.clients.items():
@@ -492,23 +493,17 @@ class SimulationDiscordBot:
         except asyncio.CancelledError:  # pragma: no cover - task cancelled on stop
             pass
 
-    async def run_bot(self: Self) -> None:
-        """
-        Start the Discord bot and connect to Discord.
-        This is a blocking call that should be run in an asyncio task.
-        """
-        try:
-            logger.info(f"Starting Discord bot(s), connecting to channel ID: {self.channel_id}")
-            tasks = []
-            for token, client in self.clients.items():
-                setattr(client, "token", token)
-                tasks.append(client.start(token))
-            self._forward_task = asyncio.create_task(self._forward_agent_messages())
-            await asyncio.gather(*tasks)
-            # Mark bot as ready when all clients have started
-            self.is_ready = True
-        except (discord.DiscordException, OSError) as e:
-            logger.error(f"Error starting Discord bot: {e}")
+    def run_bot(self: Self) -> list[asyncio.Task[Any]]:
+        """Start the Discord bot and return running tasks."""
+        logger.info(f"Starting Discord bot(s), connecting to channel ID: {self.channel_id}")
+        tasks: list[asyncio.Task[Any]] = []
+        for token, client in self.clients.items():
+            setattr(client, "token", token)
+            tasks.append(asyncio.create_task(client.start(token)))
+        self._client_tasks = tasks
+        self._forward_task = asyncio.create_task(self._forward_agent_messages())
+        self.is_ready = True
+        return [*tasks, self._forward_task]
 
     async def stop_bot(self: Self) -> None:
         """Stop the Discord bot and close the connection."""
@@ -535,6 +530,14 @@ class SimulationDiscordBot:
                             logger.warning("Attempted to send message to a None channel.")
             for client in self.clients.values():
                 await client.close()
+            for t in self._client_tasks:
+                if not t.done():
+                    t.cancel()
+                    try:
+                        await t
+                    except asyncio.CancelledError:  # pragma: no cover - expected
+                        pass
+            self._client_tasks.clear()
             if self._forward_task:
                 self._forward_task.cancel()
                 try:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -216,27 +216,9 @@ class Simulation:
         # self.messages_to_perceive_this_round: list[dict[str, Any]] = [] # Already initialized above
 
         # Background task for forwarding external events (e.g., Discord messages)
-        try:
-            loop = asyncio.get_running_loop()
-            self._event_loop = loop
-            self._event_task = asyncio.create_task(
-                self.event_kernel.forward_external_events(self._handle_human_command)
-            )
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-
-            def _run() -> None:
-                asyncio.set_event_loop(loop)
-                get_event_queue()
-                self._event_task = loop.create_task(
-                    self.event_kernel.forward_external_events(self._handle_human_command)
-                )
-                loop.run_forever()
-
-            self._event_loop = loop
-            thread = threading.Thread(target=_run, daemon=True)
-            self._event_loop_thread = thread
-            thread.start()
+        self._event_task = None
+        self._event_loop = None
+        self._event_loop_thread = None
 
     # Add method to update collective metrics
     def _update_collective_metrics(self: Self) -> None:
@@ -814,6 +796,10 @@ class Simulation:
         """Start background processing of ``event_queue`` events."""
         if self._event_listener_task is None:
             self._event_listener_task = asyncio.create_task(self._event_listener_loop())
+        if self._event_task is None:
+            self._event_task = asyncio.create_task(
+                self.event_kernel.forward_external_events(self._handle_human_command)
+            )
 
     async def stop_event_listener(self: Self) -> None:
         """Stop the background event listener task."""

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -91,7 +91,8 @@ async def test_multi_token_start_and_send() -> None:
         ),
     ):
         bot = SimulationDiscordBot(tokens, 123, token_lookup=lookup)
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
         await bot.send_simulation_update(content="hi", agent_id="agent_b")
         await bot.stop_bot()
 
@@ -116,7 +117,8 @@ async def test_multi_token_message_forwarding() -> None:
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
     ):
         bot = SimulationDiscordBot(tokens, 999)
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
 
         for token in tokens:
             assert "on_message" in bot.clients[token]._events
@@ -172,7 +174,8 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
     ):
         bot = SimulationDiscordBot("token", 123)
         assert "on_message" in bot.client._events
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
 
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()
@@ -211,7 +214,8 @@ async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -
         ),
     ):
         bot = SimulationDiscordBot("token", 456)
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()
         msg.content = "hello world"

--- a/tests/integration/interfaces/test_discord_sharded_bot.py
+++ b/tests/integration/interfaces/test_discord_sharded_bot.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -37,7 +38,8 @@ async def test_sharded_start_and_send() -> None:
         DummyShardedClient,
     ):
         bot = SimulationShardedDiscordBot("tok", 456)
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
         await bot.send_simulation_update(content="hello")
         await bot.stop_bot()
 

--- a/tests/integration/simulation/test_discord_bot_integration.py
+++ b/tests/integration/simulation/test_discord_bot_integration.py
@@ -104,7 +104,8 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         agent = DummyAgent("A")
         sim = Simulation([agent], discord_bot=bot)
 
-        await bot.run_bot()
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
 
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()

--- a/tests/unit/sim/test_event_task_start.py
+++ b/tests/unit/sim/test_event_task_start.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 
 import pytest
 
@@ -41,24 +40,27 @@ class DummyAgent:
 
 
 @pytest.mark.unit
-def test_event_task_runs_without_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_event_task_runs_without_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     received: list[str] = []
 
     async def handler(self: Simulation, text: str) -> None:
         received.append(text)
 
     monkeypatch.setattr(Simulation, "_handle_human_command", handler)
+
+    async def dummy_listener(self: Simulation) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(Simulation, "_event_listener_loop", dummy_listener)
     sim = Simulation([DummyAgent()])
+    await sim.start_event_listener()
 
-    async def send() -> None:
-        queue = get_event_queue()
-        await queue.put(
-            SimulationEvent(event_type="broadcast", data={"content": "hi"})
-        )
+    queue = get_event_queue()
+    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await asyncio.sleep(0.05)
 
-    fut = asyncio.run_coroutine_threadsafe(send(), sim._event_loop)
-    fut.result()
-    time.sleep(0.05)
+    await sim.stop_event_listener()
     sim.close()
 
     assert received == ["hi"]


### PR DESCRIPTION
## Summary
- expose running tasks from `SimulationDiscordBot.run_bot`
- stop event tasks without dedicated thread
- adjust unit and integration tests for new `run_bot` behavior
- fix typing issue in semantic memory manager
- patch unit test to prevent event listener from consuming events

## Testing
- `pre-commit run ruff-format --files tests/unit/sim/test_event_task_start.py src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_bot.py tests/integration/interfaces/test_discord_sharded_bot.py tests/integration/simulation/test_discord_bot_integration.py`
- `pre-commit run ruff --files tests/unit/sim/test_event_task_start.py src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_bot.py tests/integration/interfaces/test_discord_sharded_bot.py tests/integration/simulation/test_discord_bot_integration.py`
- `pre-commit run mypy --files tests/unit/sim/test_event_task_start.py src/interfaces/discord_bot.py src/sim/simulation.py`
- `pytest tests/unit/sim/test_event_task_start.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6871d355d5f483268fd4a53a57facb96