### PR TITLE
Track vote spending

### DIFF
--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -39,6 +39,7 @@ class GovernanceService:
 
         votes = await asyncio.gather(*[self.vote(a, text) for a in agents])
         weights: list[float] = []
+        ip_spent = 0.0
         if vote_weights is None:
             for a in agents:
                 base_ip = getattr(a.state, "ip", 0.0)
@@ -52,7 +53,9 @@ class GovernanceService:
             for a in agents:
                 w = int(vote_weights.get(a.agent_id, 1))
                 weights.append(float(w))
-                spend_tasks.append(ledger.spend(a.agent_id, ip=float(w * w), reason="vote"))
+                cost = float(w * w)
+                ip_spent += cost
+                spend_tasks.append(ledger.spend(a.agent_id, ip=cost, reason="vote"))
             await asyncio.gather(*spend_tasks, return_exceptions=True)
 
         yes_weight = sum(w for w, v in zip(weights, votes) if v)
@@ -67,6 +70,7 @@ class GovernanceService:
                 approved,
                 yes_weight,
                 no_weight,
+                ip_spent,
             )
         except Exception:
             pass

--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -103,10 +103,15 @@ class Ledger:
                 approved INTEGER,
                 yes_weight REAL,
                 no_weight REAL,
+                ip_spent REAL DEFAULT 0,
                 ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
             """
         )
+        cur = self.conn.execute("PRAGMA table_info(law_proposals)")
+        cols = [r[1] for r in cur.fetchall()]
+        if "ip_spent" not in cols:
+            self.conn.execute("ALTER TABLE law_proposals ADD COLUMN ip_spent REAL DEFAULT 0")
         self.conn.commit()
         self.gas_price_per_call = float(settings.GAS_PRICE_PER_CALL)
         self.gas_price_per_token = float(settings.GAS_PRICE_PER_TOKEN)
@@ -415,13 +420,14 @@ class Ledger:
         approved: bool,
         yes_weight: float,
         no_weight: float,
-    ) -> None:
+        ip_spent: float = 0.0,
+    ) -> int:
         """Store a law proposal and its result."""
         cur = self.conn.cursor()
         cur.execute(
             """
-            INSERT INTO law_proposals(proposer_id, text, approved, yes_weight, no_weight)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO law_proposals(proposer_id, text, approved, yes_weight, no_weight, ip_spent)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
                 proposer_id,
@@ -429,15 +435,19 @@ class Ledger:
                 int(bool(approved)),
                 float(yes_weight),
                 float(no_weight),
+                float(ip_spent),
             ),
         )
         self.conn.commit()
+        return int(cur.lastrowid)
 
     def get_law_proposals(self, limit: int | None = None) -> list[dict[str, object]]:
         """Return stored law proposals."""
         cur = self.conn.cursor()
-        query = "SELECT proposer_id, text, approved, yes_weight, no_weight, ts FROM law_proposals ORDER BY id DESC"
-        rows = cur.execute(query + (" LIMIT ?" if limit else ""), ([int(limit)] if limit else [])).fetchall()
+        query = "SELECT proposer_id, text, approved, yes_weight, no_weight, ip_spent, ts FROM law_proposals ORDER BY id DESC"
+        rows = cur.execute(
+            query + (" LIMIT ?" if limit else ""), ([int(limit)] if limit else [])
+        ).fetchall()
         return [
             {
                 "proposer_id": str(r[0]),
@@ -445,7 +455,8 @@ class Ledger:
                 "approved": bool(r[2]),
                 "yes_weight": float(r[3]),
                 "no_weight": float(r[4]),
-                "ts": r[5],
+                "ip_spent": float(r[5]),
+                "ts": r[6],
             }
             for r in rows
         ]

--- a/tests/integration/governance/test_dashboard_api.py
+++ b/tests/integration/governance/test_dashboard_api.py
@@ -17,7 +17,7 @@ async def test_laws_and_votes_endpoints(monkeypatch: pytest.MonkeyPatch, tmp_pat
     board.add_law("be nice")
 
     ledger = Ledger(tmp_path / "ledger.sqlite")
-    ledger.record_law_proposal("a1", "be nice", True, 1.0, 0.0)
+    ledger.record_law_proposal("a1", "be nice", True, 1.0, 0.0, 0.0)
 
     monkeypatch.setattr(db, "law_board", board)
     monkeypatch.setattr(db, "ledger", ledger)

--- a/tests/integration/governance/test_staked_ip_proposals.py
+++ b/tests/integration/governance/test_staked_ip_proposals.py
@@ -88,6 +88,7 @@ async def test_weights_include_staked_ip(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     proposals = ledger.get_law_proposals()
     assert proposals and proposals[0]["approved"] is True
+    assert proposals[0]["ip_spent"] == pytest.approx(0.0)
 
     resp = await db.api_get_proposals(limit=1)
     data = json.loads(resp.body)

--- a/tests/integration/governance/test_weighted_votes.py
+++ b/tests/integration/governance/test_weighted_votes.py
@@ -89,3 +89,4 @@ async def test_weighted_votes_deduct_ip(monkeypatch: pytest.MonkeyPatch, tmp_pat
     proposals = ledger.get_law_proposals()
     assert proposals[0]["yes_weight"] == pytest.approx(3.0)
     assert proposals[0]["no_weight"] == pytest.approx(2.0)
+    assert proposals[0]["ip_spent"] == pytest.approx(11.0)


### PR DESCRIPTION
## Summary
- record IP spent in ledger proposals
- track total vote spending in governance service
- test vote spending via ledger endpoints

## Testing
- `ruff format src/governance/service.py src/infra/ledger.py tests/integration/governance/test_dashboard_api.py tests/integration/governance/test_staked_ip_proposals.py tests/integration/governance/test_weighted_votes.py`
- `ruff check src/governance/service.py src/infra/ledger.py tests/integration/governance/test_dashboard_api.py tests/integration/governance/test_staked_ip_proposals.py tests/integration/governance/test_weighted_votes.py`
- `pytest tests/integration/governance/test_weighted_votes.py tests/integration/governance/test_dashboard_api.py tests/integration/governance/test_staked_ip_proposals.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6871dbf9c57083268389023af2c2e3f2