### PR TITLE
Add world map events and UI updates

### DIFF
--- a/culture-ui/package.json
+++ b/culture-ui/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "test": "vitest run",
+    "test": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
     "test:e2e": "playwright test",
     "preview": "vite preview",
     "type-check": "tsc -b",

--- a/culture-ui/src/WorldMap.test.tsx
+++ b/culture-ui/src/WorldMap.test.tsx
@@ -1,9 +1,26 @@
-import { render, screen } from '@testing-library/react'
-import WorldMap from './widgets/WorldMap'
+import { act, render, screen } from '@testing-library/react'
+import WorldMap from './pages/WorldMap'
+import { MockEventSource, resetMockSources } from './lib/testUtils'
+import { vi } from 'vitest'
 
-describe('WorldMap', () => {
-  it('renders canvas placeholder', () => {
+afterEach(() => {
+  resetMockSources()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('WorldMapPage', () => {
+  it('renders positions and resources from events', async () => {
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
     render(<WorldMap />)
-    expect(screen.getByTestId('world-map-canvas')).toBeInTheDocument()
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage(
+        '{"data":{"world_map":{"agents":{"agent-1":[1,2]},"resources":{"[0,0]":{"wood":1}}}}}'
+      )
+    })
+    expect(await screen.findByText('agent-1: 1, 2')).toBeInTheDocument()
+    expect(await screen.findByText('[0,0]: wood:1')).toBeInTheDocument()
   })
 })

--- a/culture-ui/src/pages/WorldMap.tsx
+++ b/culture-ui/src/pages/WorldMap.tsx
@@ -1,14 +1,47 @@
-import WorldMap from '../widgets/WorldMap'
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
 import { registerWidget } from '../lib/widgetRegistry'
 
+interface WorldMapData {
+  agents?: Record<string, [number, number]>
+  resources?: Record<string, Record<string, number>>
+}
+
+interface SimEvent {
+  data?: { world_map?: WorldMapData }
+}
+
 export default function WorldMapPage() {
+  const event = useEventSource<SimEvent>()
+  const [map, setMap] = useState<WorldMapData>({})
+
+  useEffect(() => {
+    if (event?.data?.world_map) setMap(event.data.world_map)
+  }, [event])
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">World Map</h1>
-      <WorldMap />
+      <div data-testid="world-map">
+        <ul>
+          {Object.entries(map.agents ?? {}).map(([id, [x, y]]) => (
+            <li key={id}>
+              {id}: {x}, {y}
+            </li>
+          ))}
+        </ul>
+        <ul>
+          {Object.entries(map.resources ?? {}).map(([pos, res]) => (
+            <li key={pos}>
+              {pos}: {Object.entries(res)
+                .map(([r, a]) => `${r}:${a}`)
+                .join(', ')}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }
 
 registerWidget('WorldMap', WorldMapPage)
-

--- a/culture-ui/tests/live-map.pw.ts
+++ b/culture-ui/tests/live-map.pw.ts
@@ -2,17 +2,8 @@ import { test, expect } from '@playwright/test'
 
 test.skip(true, 'e2e tests are skipped in this environment')
 
-test.beforeEach(async ({ page }) => {
-  await page.route('/api/agents/agent-1/semantic_summaries', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ summaries: ['p1'] }),
-    })
-  })
-})
 
-test('live map widget loads and updates', async ({ page }) => {
+test('world map page updates from events', async ({ page }) => {
   await page.addInitScript(() => {
     class MockEventSource extends EventTarget {
       static instance: MockEventSource
@@ -28,19 +19,19 @@ test('live map widget loads and updates', async ({ page }) => {
     window.EventSource = MockEventSource as unknown as typeof EventSource
   })
 
-  await page.goto('/live-map')
-  await expect(page.getByRole('heading', { name: 'Live Map' })).toBeVisible()
+  await page.goto('/world-map')
+  await expect(page.getByRole('heading', { name: 'World Map' })).toBeVisible()
 
   await page.evaluate(() => {
     const es = (window as unknown as { EventSource: { instance: EventTarget } }).EventSource
       .instance
     es.dispatchEvent(
       new MessageEvent('message', {
-        data: '{"data":{"world_map":{"agents":{"agent-1":[3,4]}}}}',
+        data: '{"data":{"world_map":{"agents":{"agent-1":[3,4]},"resources":{"[0,0]":{"wood":2}}}}}',
       }),
     )
   })
 
-  await expect(page.getByTestId('map-display')).toContainText('agent-1: 3, 4')
-  await expect(page.getByTestId('summaries')).toContainText('p1')
+  await expect(page.getByTestId('world-map')).toContainText('agent-1: 3, 4')
+  await expect(page.getByTestId('world-map')).toContainText('[0,0]: wood:2')
 })

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -440,6 +440,13 @@ async def emit_map_action_event(
     )
 
 
+async def emit_map_change_event(world_map: dict[str, Any]) -> None:
+    """Convenience helper to enqueue world map updates."""
+    await emit_event(
+        SimulationEvent(event_type="map_change", data={"world_map": world_map})
+    )
+
+
 __all__ = [
     "WIDGET_REGISTRY",
     "EventSourceResponse",
@@ -457,6 +464,7 @@ __all__ = [
     "app",
     "emit_event",
     "emit_map_action_event",
+    "emit_map_change_event",
     "enqueue_message",
     "get_event_queue",
     "get_quests_api",

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from src.infra import config
+from src.interfaces.dashboard_backend import emit_map_change_event
 from src.sim.world_map import ResourceToken, StructureType
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -150,6 +151,7 @@ async def process_map_action(
         lambda data=map_event_data: sim.event_kernel.emit_environment_event(data),
         vector=sim.vector,
     )
+    await emit_map_change_event(sim.world_map.to_dict())
     if sim.discord_bot:
         embed = sim.discord_bot.create_map_action_embed(
             agent_id=agent_id,


### PR DESCRIPTION
## Summary
- emit `map_change` events from the dashboard backend
- propagate map change notifications from simulation actions
- implement a simple World Map page showing agent positions and resources
- update E2E and unit tests for the new page
- set higher Node memory limit when running vitest

## Testing
- `ruff check src/interfaces/dashboard_backend.py src/sim/world_map_actions.py`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871dbfa128483269d16526be4f55177