### PR TITLE
Fix simulation shutdown cleanup

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -810,6 +810,13 @@ class Simulation:
             except asyncio.CancelledError:  # pragma: no cover - expected
                 pass
             self._event_listener_task = None
+        if self._event_task:
+            self._event_task.cancel()
+            try:
+                await self._event_task
+            except asyncio.CancelledError:  # pragma: no cover - expected
+                pass
+            self._event_task = None
 
     async def run_step(self: Self, max_turns: int = 1) -> int:
         """Dispatch up to ``max_turns`` events via the kernel."""
@@ -931,9 +938,15 @@ class Simulation:
 
     def close(self: Self) -> None:
         """Release resources held by the simulation."""
-        if self._event_listener_task and not self._event_listener_task.done():
-            self._event_listener_task.cancel()
-            self._event_listener_task = None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self.stop_event_listener())
+        else:
+            if loop.is_running():
+                loop.create_task(self.stop_event_listener())
+            else:
+                loop.run_until_complete(self.stop_event_listener())
         if hasattr(self.knowledge_board, "close"):
             try:
                 close_fn = getattr(self.knowledge_board, "close")
@@ -946,8 +959,6 @@ class Simulation:
                 self.memory_service.close()
             except (OSError, RuntimeError) as exc:  # pragma: no cover - defensive
                 logger.exception("Failed to close vector store manager: %s", exc)
-        if self._event_task:
-            self._event_task.cancel()
         if self._event_loop:
             if self._event_loop.is_running():
                 self._event_loop.call_soon_threadsafe(self._event_loop.stop)

--- a/tests/integration/sim/test_event_task_cleanup.py
+++ b/tests/integration/sim/test_event_task_cleanup.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from src.interfaces.dashboard_backend import SimulationEvent, get_event_queue
+from src.sim.simulation import Simulation
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self.state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        return {}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_simulation_shutdown_cleans_background_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    await sim.start_event_listener()
+
+    queue = get_event_queue()
+    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await asyncio.sleep(0.05)
+
+    sim.close()
+    await asyncio.sleep(0.05)
+
+    pending = {task.get_coro().__name__ for task in asyncio.all_tasks() if not task.done()}
+
+    assert "_event_listener_loop" not in pending
+    assert "forward_external_events" not in pending


### PR DESCRIPTION
## Summary
- cancel `_event_task` when stopping event listener
- ensure close() awaits `stop_event_listener`
- add integration test for cleanup of background tasks

## Testing
- `pytest -m integration tests/integration/sim/test_event_task_cleanup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a22ed0883268cf5505c40a28e50