### PR TITLE
Handle coroutine plugins

### DIFF
--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from importlib import metadata
 from typing import Any, Callable
@@ -78,6 +79,8 @@ async def load_plugins(
         try:
             plugin = ep.load()
             result = plugin()
+            if asyncio.iscoroutine(result):
+                result = await result
             if isinstance(result, dict) and {
                 "name",
                 "script_url",

--- a/tests/unit/extensions/test_plugin_loader.py
+++ b/tests/unit/extensions/test_plugin_loader.py
@@ -50,3 +50,41 @@ async def test_load_plugins_registers_widget(monkeypatch: pytest.MonkeyPatch) ->
     await load_plugins(backend_url="http://backend")
 
     assert recorded == [("Widget", "http://x/y.js", "http://backend")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_plugins_awaits_coroutine(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[bool] = []
+
+    async def plugin() -> None:
+        called.append(True)
+
+    ep = types.SimpleNamespace(load=lambda: plugin, name="dummy")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+
+    await load_plugins()
+
+    assert called
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_plugin_registers_widget(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: list[tuple[str, str, str]] = []
+
+    async def plugin() -> dict[str, str]:
+        return {"name": "Widget", "script_url": "http://x/y.js"}
+
+    async def register_widget_backend(
+        name: str, script_url: str, backend_url: str = "http://localhost:8000"
+    ) -> None:
+        recorded.append((name, script_url, backend_url))
+
+    ep = types.SimpleNamespace(load=lambda: plugin, name="widget")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
+
+    await load_plugins(backend_url="http://backend")
+
+    assert recorded == [("Widget", "http://x/y.js", "http://backend")]


### PR DESCRIPTION
## Summary
- support coroutine returns in `load_plugins`
- add unit tests for coroutine-returning plugins

## Testing
- `ruff check src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py`
- `mypy src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py`
- `pytest -k test_plugin_loader -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a234cbc83269cccaad4a19eee93