### PR TITLE
Add VLLM_API_BASE config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Follow these steps to run the example simulation locally:
    ```bash
    cp .env.example .env
    ```
-   Edit `OLLAMA_API_BASE` if your Ollama server runs on a different URL. Set
-   `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` if you plan to use the Discord
-   bot.
+   Edit `OLLAMA_API_BASE` or `VLLM_API_BASE` if your LLM server runs on a
+   different URL. Set `DISCORD_BOT_TOKEN` and `DISCORD_CHANNEL_ID` if you plan
+   to use the Discord bot.
 4. **Install or update Ollama and pull the model**
    ```bash
    curl https://ollama.ai/install.sh | sh
@@ -696,7 +696,8 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
    ```
 6. **Configure environment variables:**
    - Copy `.env.example` to `.env` and edit as needed:
-    - `OLLAMA_API_BASE` (e.g., http://localhost:11434, or http://localhost:$VLLM_PORT for vLLM)
+   - `OLLAMA_API_BASE` (e.g., http://localhost:11434, or http://localhost:$VLLM_PORT for vLLM)
+   - `VLLM_API_BASE` (URL of the vLLM server if used)
     - `OLLAMA_REQUEST_TIMEOUT` (request timeout in seconds)
     - `VLLM_MODEL` (e.g., mistralai/Mistral-7B-Instruct-v0.2) for the vLLM backend
     - `VLLM_PORT` (e.g., 8001) for the vLLM backend

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -18,6 +18,7 @@ CONFIG_OVERRIDES: dict[str, Any] = {}
 # Default values
 DEFAULT_CONFIG: dict[str, object] = {
     "OLLAMA_API_BASE": "http://localhost:11434",
+    "VLLM_API_BASE": "",
     "DEFAULT_LLM_MODEL": "mistral:latest",
     "DEFAULT_TEMPERATURE": 0.7,
     "MEMORY_THRESHOLD_L1": 0.2,

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -61,7 +61,6 @@ from pydantic.fields import FieldInfo
 
 if TYPE_CHECKING:
     from src.agents.core.agent_state import AgentState
-import os
 
 from src.shared.decorator_utils import monitor_llm_call
 
@@ -72,7 +71,7 @@ from .config import (
 )
 from .ledger import ledger
 
-VLLM_API_BASE = os.environ.get("VLLM_API_BASE")
+VLLM_API_BASE = cast(str | None, get_config("VLLM_API_BASE"))
 USE_VLLM = bool(VLLM_API_BASE)
 
 if TYPE_CHECKING:
@@ -309,7 +308,7 @@ else:
 def get_llm_client() -> OllamaClientProtocol:
     """Return the initialized LLM client, retrying and switching backends if needed."""
     global client, VLLM_API_BASE, USE_VLLM
-    env_base = os.environ.get("VLLM_API_BASE")
+    env_base = cast(str | None, get_config("VLLM_API_BASE"))
 
     if env_base and (not USE_VLLM or env_base != VLLM_API_BASE):
         VLLM_API_BASE = env_base

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -11,6 +11,7 @@ class ConfigSettings(BaseSettings):
     """Configuration loaded from environment variables and ``.env`` file."""
 
     OLLAMA_API_BASE: str = "http://localhost:11434"
+    VLLM_API_BASE: str = ""
     DEFAULT_LLM_MODEL: str = "mistral:latest"
     # Backwards compatibility with older config keys
     MODEL_NAME: str = "mistral:latest"

--- a/tests/unit/infra/test_llm_client_vllm.py
+++ b/tests/unit/infra/test_llm_client_vllm.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from src.infra import llm_client
+from src.infra import config, llm_client
 
 
 @pytest.mark.unit
@@ -24,6 +24,8 @@ def test_generate_text_vllm(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(llm_client, "VLLM_API_BASE", "http://vllm:8001")
     monkeypatch.setattr(llm_client, "USE_VLLM", True)
     monkeypatch.setattr(llm_client, "client", llm_client._create_vllm_client())
+    monkeypatch.setattr(config.settings, "VLLM_API_BASE", "http://vllm:8001")
+    monkeypatch.setitem(config._CONFIG, "VLLM_API_BASE", "http://vllm:8001")
     monkeypatch.setattr(llm_client.requests, "post", fake_post)
 
     result = llm_client.generate_text("hello")
@@ -49,6 +51,7 @@ def test_generate_text_vllm_env_switch(monkeypatch: pytest.MonkeyPatch) -> None:
         return resp
 
     monkeypatch.setenv("VLLM_API_BASE", "http://vllm:8002")
+    config.load_config(validate_required=False)
     module = importlib.reload(llm_client)
     monkeypatch.setattr(module.requests, "post", fake_post)
 

--- a/tests/unit/infra/test_settings_env.py
+++ b/tests/unit/infra/test_settings_env.py
@@ -19,3 +19,18 @@ def test_env_file_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.chdir(tmp_path)
     cfg = config.load_config(validate_required=True)
     assert cfg["OLLAMA_API_BASE"] == "http://from_env"
+
+
+@pytest.mark.unit
+def test_vllm_env_file_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("OLLAMA_API_BASE=http://from_env\nVLLM_API_BASE=http://vllm_env\n")
+    monkeypatch.chdir(tmp_path)
+    settings = ConfigSettings()
+    assert settings.VLLM_API_BASE == "http://vllm_env"
+
+    monkeypatch.setenv("REDPANDA_BROKER", "broker")
+    monkeypatch.setenv("OPA_URL", "http://opa")
+    monkeypatch.chdir(tmp_path)
+    cfg = config.load_config(validate_required=True)
+    assert cfg["VLLM_API_BASE"] == "http://vllm_env"


### PR DESCRIPTION
## Summary
- support VLLM_API_BASE setting via pydantic settings
- expose VLLM_API_BASE in DEFAULT_CONFIG
- use get_config for VLLM_API_BASE in llm_client
- document setting in README
- test loading from .env and llm client switching

## Testing
- `ruff check tests/unit/infra/test_llm_client_vllm.py tests/unit/infra/test_settings_env.py src/infra/llm_client.py src/infra/settings.py src/infra/config.py`
- `python scripts/run_tests.py tests/unit/infra/test_settings_env.py tests/unit/infra/test_llm_client_vllm.py`

------
https://chatgpt.com/codex/tasks/task_e_68732a21f77c83268df8515cbbf8e3c8