### PR TITLE
Add episodic->semantic memory pipeline

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -85,29 +85,17 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     if not manager or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
-    if hasattr(manager, "retrieve_relevant_memories"):
-        memories = await cast(MemoryService, manager).retrieve_relevant_memories(
-            state["agent_id"], query="", k=5
+    if hasattr(manager, "get_context_pipeline"):
+        memories, semantic = await cast(MemoryService, manager).get_context_pipeline(
+            state["agent_id"], query="", k=5, semantic_limit=2
         )
+        memories_content = [m.get("content", "") for m in memories] + semantic
     else:
         memories = await cast(MemoryRetriever, manager).aretrieve_relevant_memories(
             state["agent_id"], query="", k=5
         )
-    try:
-        if hasattr(manager, "run_semantic_job"):
-            await cast(MemoryService, manager).run_semantic_job(
-                state["agent_id"], episodic_memories=memories
-            )
-    except Exception:  # pragma: no cover - defensive
-        logger.error("Semantic consolidation failed", exc_info=True)
-    memories_content = [m.get("content", "") for m in memories]
-
-    semantic: list[str] = []
-    if hasattr(manager, "get_recent_semantic_summaries"):
-        semantic = cast(MemoryService, manager).get_recent_semantic_summaries(
-            state["agent_id"], limit=2
-        )
-        memories_content.extend(semantic)
+        memories_content = [m.get("content", "") for m in memories]
+        semantic = []
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -67,6 +67,42 @@ class MemoryService:
             return []
         return self.semantic_manager.get_recent_summaries(agent_id, limit)
 
+    async def retrieve_episodic_and_update_semantic(
+        self: Self, agent_id: str, query: str = "", k: int = 5
+    ) -> list[dict[str, Any]]:
+        """Retrieve episodic memories then consolidate them into semantic form."""
+        episodic = []
+        if self.vector_store:
+            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+        if self.semantic_manager:
+            try:
+                await self.semantic_manager.run_nightly_job(agent_id, episodic)
+            except Exception:  # pragma: no cover - defensive
+                import logging
+
+                logging.getLogger(__name__).error("Semantic consolidation failed", exc_info=True)
+        return episodic
+
+    def blend_with_recent_semantic(
+        self: Self, agent_id: str, episodic_summary: str, limit: int = 3
+    ) -> str:
+        """Blend an episodic summary with recent semantic summaries."""
+        if not self.semantic_manager:
+            return episodic_summary
+        return self.semantic_manager.blend_episodic_and_semantic(agent_id, episodic_summary, limit)
+
+    async def get_context_pipeline(
+        self: Self,
+        agent_id: str,
+        query: str = "",
+        k: int = 5,
+        semantic_limit: int = 3,
+    ) -> tuple[list[dict[str, Any]], list[str]]:
+        """Full retrieval pipeline returning episodic memories and semantic summaries."""
+        episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
+        semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
+        return episodic, semantic
+
     async def run_semantic_job(
         self: Self,
         agent_id: str,

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -105,6 +105,7 @@ class Simulation:
         # Background task for processing incoming events
         self._event_listener_task: asyncio.Task[None] | None = None
         self._event_task: asyncio.Task[Any] | None = None
+        self._stop_listener_task: asyncio.Task[None] | None = None
         self._event_loop: asyncio.AbstractEventLoop | None = None
         self._event_loop_thread: threading.Thread | None = None
 
@@ -134,9 +135,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -182,9 +183,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -486,7 +487,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -944,7 +947,7 @@ class Simulation:
             asyncio.run(self.stop_event_listener())
         else:
             if loop.is_running():
-                loop.create_task(self.stop_event_listener())
+                self._stop_listener_task = loop.create_task(self.stop_event_listener())
             else:
                 loop.run_until_complete(self.stop_event_listener())
         if hasattr(self.knowledge_board, "close"):

--- a/tests/integration/memory/test_semantic_update_on_retrieval.py
+++ b/tests/integration/memory/test_semantic_update_on_retrieval.py
@@ -1,20 +1,13 @@
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 pytest.importorskip("chromadb")
 
-from src.agents.graphs.graph_nodes import retrieve_and_summarize_memories_node
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
-
-
-class DummyAgent:
-    async def async_generate_l1_summary(self, role_prompt: str, memories: str, context: str):
-        return SimpleNamespace(summary="S")
 
 
 @pytest.mark.integration
@@ -29,19 +22,12 @@ async def test_semantic_summary_updates_on_retrieval(chroma_test_dir: Path) -> N
     manager = SemanticMemoryManager(vector, driver)
     service = MemoryService(vector_store=vector, semantic_manager=manager)
 
-    state = {
-        "agent_id": "agent",
-        "memory_service": service,
-        "agent_instance": DummyAgent(),
-        "current_role": "r",
-    }
-
     vector.add_memory("agent", 1, "thought", "one", memory_type="raw")
-    await retrieve_and_summarize_memories_node(state)
+    await service.get_context_pipeline("agent", semantic_limit=1)
     first = manager.get_recent_summaries("agent", limit=1)
     assert first and "one" in first[0]
 
     vector.add_memory("agent", 2, "thought", "two", memory_type="raw")
-    await retrieve_and_summarize_memories_node(state)
+    await service.get_context_pipeline("agent", semantic_limit=1)
     second = manager.get_recent_summaries("agent", limit=1)
     assert second and "two" in second[0]


### PR DESCRIPTION
## Summary
- add new pipeline methods in `MemoryService` for episodic retrieval blended with semantic summaries
- refactor `retrieve_and_summarize_memories_node` to use new API
- expose stop listener task in `Simulation.close`
- update semantic memory integration test for new pipeline

## Testing
- `bash scripts/lint.sh`
- `mypy src/agents/memory/memory_service.py src/agents/graphs/graph_nodes.py src/sim/simulation.py`
- `pytest tests/unit/graphs/test_graph_nodes.py -q`
- `pytest -m "integration and memory" tests/integration/memory/test_semantic_update_on_retrieval.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68746490cae48326b9e0d1b660cf7a33