### PR TITLE
Add Discord control commands

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -617,3 +617,29 @@ async def slash_stats(interaction: Any) -> None:
             return
     stats_text = f"LLM latency: {get_llm_latency()} ms; KB size: {get_kb_size()}"
     await interaction.response.send_message(stats_text, ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="pause")
+async def slash_pause(interaction: Any) -> None:
+    """Pause the simulation via a control command."""
+    await event_queue.put(SimulationEvent(event_type="control", data={"command": "pause"}))
+    await interaction.response.send_message("pause", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="resume")
+async def slash_resume(interaction: Any) -> None:
+    """Resume the simulation via a control command."""
+    await event_queue.put(SimulationEvent(event_type="control", data={"command": "resume"}))
+    await interaction.response.send_message("resume", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="set_speed")
+async def slash_set_speed(interaction: Any, value: float) -> None:
+    """Adjust the simulation speed via a control command."""
+    await event_queue.put(
+        SimulationEvent(event_type="control", data={"command": "set_speed", "value": value})
+    )
+    await interaction.response.send_message(f"speed {value}", ephemeral=True)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -98,6 +98,8 @@ class Simulation:
         self.simulation_complete = False
         self.event_kernel = EventKernel()
         self.vector = VersionVector()
+        self.paused: bool = False
+        self.speed: float = 1.0
         self.agent_initial_token_budget = int(config.get_config("AGENT_TOKEN_BUDGET"))
         # Add other simulation-wide state if needed (e.g., environment properties)
         # self.environment_state = {}
@@ -331,6 +333,19 @@ class Simulation:
         async with self._msg_lock:
             self.pending_messages_for_next_round.extend(msgs)
             self.messages_to_perceive_this_round.extend(msgs)
+
+    async def handle_control_command(self: Self, cmd: dict[str, Any]) -> None:
+        """Process a control command sent via the event queue."""
+        action = cmd.get("command")
+        if action == "pause":
+            self.paused = True
+        elif action == "resume":
+            self.paused = False
+        elif action == "set_speed":
+            try:
+                self.speed = float(cmd.get("value", 1))
+            except (TypeError, ValueError):
+                pass
 
     async def spawn_agent(
         self: Self,
@@ -779,6 +794,9 @@ class Simulation:
     async def _handle_incoming_event(self: Self, evt: SimulationEvent) -> None:
         """Route a ``SimulationEvent`` to agents as a message."""
         if not evt.data:
+            return
+        if evt.event_type == "control":
+            await self.handle_control_command(evt.data)
             return
         sender = str(evt.data.get("author", "external"))
         content = str(evt.data.get("content", ""))

--- a/tests/integration/interfaces/test_discord_control_commands.py
+++ b/tests/integration/interfaces/test_discord_control_commands.py
@@ -1,0 +1,72 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+from src.sim.simulation import Simulation
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self.state = state
+
+    async def run_turn(self, *args: object, **kwargs: object) -> dict:
+        return {}
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.response = SimpleNamespace(send_message=AsyncMock())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    queue: asyncio.Queue[db.SimulationEvent | None] = asyncio.Queue()
+    monkeypatch.setattr(db, "get_event_queue", lambda: queue)
+    import src.sim.simulation as sim_mod
+
+    monkeypatch.setattr(sim_mod, "get_event_queue", lambda: queue)
+    from src.interfaces import discord_bot as bot
+
+    monkeypatch.setattr(bot, "event_queue", queue)
+    monkeypatch.setattr(bot, "get_event_queue", lambda: queue)
+
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+    await sim.start_event_listener()
+
+    await bot.slash_pause.callback(DummyInteraction())
+    await asyncio.sleep(0.05)
+    assert sim.paused is True
+
+    await bot.slash_resume.callback(DummyInteraction())
+    await asyncio.sleep(0.05)
+    assert sim.paused is False
+
+    await bot.slash_set_speed.callback(DummyInteraction(), value=2.5)
+    await asyncio.sleep(0.05)
+    assert sim.speed == pytest.approx(2.5)
+
+    sim.close()
+    await queue.put(None)


### PR DESCRIPTION
## Summary
- add pause, resume and set_speed slash commands to discord bot
- allow Simulation to handle control commands through event queue
- test pause/resume/set_speed integration via Discord commands

## Testing
- `ruff check src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_control_commands.py`
- `black src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_control_commands.py --check`
- `pytest tests/integration/interfaces/test_discord_control_commands.py -m "integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_68747093aa8883269b3839cb1524a0b4