### PR TITLE
Add async function plugin support

### DIFF
--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -98,9 +98,13 @@ async def load_plugins(
     for ep in eps.select(group=group):
         try:
             plugin: Plugin = ep.load()
-            result: PluginResult | Awaitable[PluginResult] = plugin()
+            result: Any = plugin()
             if asyncio.iscoroutine(result):
                 result = await result
+            elif callable(result):
+                result = result()
+                if asyncio.iscoroutine(result):
+                    result = await result
             if isinstance(result, dict) and {
                 "name",
                 "script_url",

--- a/tests/unit/extensions/test_plugin_loader.py
+++ b/tests/unit/extensions/test_plugin_loader.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import types
+from collections.abc import Awaitable
 from importlib import metadata
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
@@ -87,4 +88,32 @@ async def test_async_plugin_registers_widget(monkeypatch: pytest.MonkeyPatch) ->
 
     await load_plugins(backend_url="http://backend")
 
+    assert recorded == [("Widget", "http://x/y.js", "http://backend")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_plugin_returns_async_function(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[bool] = []
+    recorded: list[tuple[str, str, str]] = []
+
+    def plugin() -> Callable[[], Awaitable[dict[str, str]]]:
+        async def inner() -> dict[str, str]:
+            called.append(True)
+            return {"name": "Widget", "script_url": "http://x/y.js"}
+
+        return inner
+
+    async def register_widget_backend(
+        name: str, script_url: str, backend_url: str = "http://localhost:8000"
+    ) -> None:
+        recorded.append((name, script_url, backend_url))
+
+    ep = types.SimpleNamespace(load=lambda: plugin, name="widget")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
+
+    await load_plugins(backend_url="http://backend")
+
+    assert called
     assert recorded == [("Widget", "http://x/y.js", "http://backend")]


### PR DESCRIPTION
## Summary
- support plugins that return async functions in `load_plugins`
- test that `load_plugins` handles async function returns

## Testing
- `python -m ruff check src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py`
- `python -m mypy src/extensions/__init__.py tests/unit/extensions/test_plugin_loader.py`
- `pytest tests/unit/extensions/test_plugin_loader.py -m unit -q`

------
https://chatgpt.com/codex/tasks/task_e_68747095d33483269bdd1f98bf075726