### PR TITLE
Add optional vLLM integration job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,3 +31,43 @@ jobs:
         run: ruff check .
       - name: Run unit tests
         run: pytest -m "unit" -q
+
+  vllm-integration:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+          pip install pytest-asyncio==0.23.8
+          bash scripts/install_optional_deps.sh
+      - name: Install vLLM
+        id: install_vllm
+        run: |
+          if pip install vllm; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Launch vLLM server
+        if: steps.install_vllm.outputs.available == 'true'
+        run: |
+          scripts/start_vllm.sh &
+          echo $! > vllm.pid
+          sleep 30
+      - name: Run vertical slice test
+        if: steps.install_vllm.outputs.available == 'true'
+        env:
+          VLLM_API_BASE: http://localhost:8001
+        run: pytest tests/integration/agents/test_vertical_slice_real_llm.py -m integration -q
+      - name: Stop vLLM server
+        if: steps.install_vllm.outputs.available == 'true'
+        run: kill $(cat vllm.pid)


### PR DESCRIPTION
## Summary
- run vLLM integration test in CI if dependencies are available

## Testing
- `ruff check .`
- `pytest -m "unit" -q`

------
https://chatgpt.com/codex/tasks/task_e_68747096775483268132b8faf9e50e2e