### PR TITLE
Enable strict TS checks in culture-ui

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run type check
         run: pnpm --filter culture-ui type-check
 
+      - name: Run tsc noEmit
+        run: pnpm --filter culture-ui run tsc
+
       - name: Run tests
         run: pnpm --filter culture-ui test
 

--- a/culture-ui/package.json
+++ b/culture-ui/package.json
@@ -12,6 +12,7 @@
     "test:e2e": "playwright test",
     "preview": "vite preview",
     "type-check": "tsc -b",
+    "tsc": "tsc --noEmit",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/culture-ui/tsconfig.json
+++ b/culture-ui/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "strict": true
   },
   "files": [],
   "references": [


### PR DESCRIPTION
## Summary
- enforce TypeScript strict mode in culture-ui
- add a `tsc --noEmit` script and run it in CI
- use `pnpm run tsc` explicitly in the workflow

## Testing
- `pnpm --filter culture-ui tsc`
- `pnpm --filter culture-ui test`
- `pnpm --filter culture-ui lint`
- `pre-commit run --files culture-ui/tsconfig.json culture-ui/package.json .github/workflows/ui.yml`

------
https://chatgpt.com/codex/tasks/task_e_68747097982483269a30bf678d005184