### PR TITLE
Add gather-build integration test

### DIFF
--- a/src/infra/__init__.py
+++ b/src/infra/__init__.py
@@ -1,4 +1,3 @@
-
 """Infrastructure package exports."""
 
 from . import llm_client

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -442,9 +442,7 @@ async def emit_map_action_event(
 
 async def emit_map_change_event(world_map: dict[str, Any]) -> None:
     """Convenience helper to enqueue world map updates."""
-    await emit_event(
-        SimulationEvent(event_type="map_change", data={"world_map": world_map})
-    )
+    await emit_event(SimulationEvent(event_type="map_change", data={"world_map": world_map}))
 
 
 __all__ = [

--- a/src/langgraph/__init__.py
+++ b/src/langgraph/__init__.py
@@ -1,4 +1,5 @@
 """Stub langgraph package for tests."""
+
 from .graph import END, START
 
 __all__ = ["END", "START"]

--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - handle missing package
         def driver(*_a: object, **_k: object) -> None:
             raise RuntimeError("neo4j not installed")
 
+
 try:  # pragma: no cover - optional dependency
     from neo4j.exceptions import Neo4jError
 except Exception:  # pragma: no cover - handle missing package

--- a/tests/integration/governance/test_voting_scenarios.py
+++ b/tests/integration/governance/test_voting_scenarios.py
@@ -117,6 +117,7 @@ async def test_law_fails_majority_no(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not any("Law approved" in e for e in entries)
     assert not calls
 
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_quadratic_yes_overrides_majority(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integration/sim/test_world_map_actions.py
+++ b/tests/integration/sim/test_world_map_actions.py
@@ -149,3 +149,35 @@ async def test_build_action_success_and_failure(
     assert sim_obj.world_map.buildings[(0, 0)] == StructureType.HUT.value
     rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
     assert rows == [("build",)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_gather_then_build_updates_ledger_and_map(
+    sim: tuple[Simulation, Ledger, DummyAgent],
+) -> None:
+    sim_obj, ledger, agent = sim
+    async with sim_obj.world_map.lock:
+        sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
+    await process_map_action(
+        sim_obj,
+        0,
+        agent.agent_id,
+        agent.state,
+        {"action": "gather", "resource": ResourceToken.WOOD.value},
+    )
+
+    assert ledger.get_tokens(agent.agent_id, "wood") == 1
+
+    await process_map_action(
+        sim_obj,
+        0,
+        agent.agent_id,
+        agent.state,
+        {"action": "build", "structure": StructureType.HUT.value},
+    )
+
+    assert sim_obj.world_map.buildings[(0, 0)] == StructureType.HUT.value
+    assert ledger.get_tokens(agent.agent_id, "wood") == 0
+    rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
+    assert rows == [("gather",), ("build",)]

--- a/tests/unit/interfaces/test_discord_errors.py
+++ b/tests/unit/interfaces/test_discord_errors.py
@@ -27,9 +27,12 @@ class DummyException(Exception):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_send_simulation_update_logs_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    with patch("src.interfaces.discord_bot.discord.Client", DummyClient), patch(
-        "src.interfaces.discord_bot.discord.DiscordException",
-        DummyException,
+    with (
+        patch("src.interfaces.discord_bot.discord.Client", DummyClient),
+        patch(
+            "src.interfaces.discord_bot.discord.DiscordException",
+            DummyException,
+        ),
     ):
         bot = SimulationDiscordBot("token", 999)
         bot.is_ready = True
@@ -42,4 +45,3 @@ async def test_send_simulation_update_logs_error(monkeypatch: pytest.MonkeyPatch
         result = await bot.send_simulation_update(content="hi")
         assert result is False
         assert error_called.is_set()
-

--- a/tests/unit/test_sitecustomize.py
+++ b/tests/unit/test_sitecustomize.py
@@ -9,7 +9,9 @@ import pytest
 pytestmark = pytest.mark.unit
 
 
-def reload_sitecustomize(monkeypatch: pytest.MonkeyPatch, platform: str, fake_uvloop: types.SimpleNamespace | None) -> list:
+def reload_sitecustomize(
+    monkeypatch: pytest.MonkeyPatch, platform: str, fake_uvloop: types.SimpleNamespace | None
+) -> list:
     monkeypatch.setattr(sys, "platform", platform, raising=False)
     if fake_uvloop is not None:
         monkeypatch.setitem(sys.modules, "uvloop", fake_uvloop)
@@ -48,6 +50,8 @@ def test_sitecustomize_handles_missing_uvloop(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.parametrize("platform", ["win32", "darwin"])
-def test_sitecustomize_skips_uvloop_on_non_linux(monkeypatch: pytest.MonkeyPatch, platform: str) -> None:
+def test_sitecustomize_skips_uvloop_on_non_linux(
+    monkeypatch: pytest.MonkeyPatch, platform: str
+) -> None:
     called = reload_sitecustomize(monkeypatch, platform, None)
     assert not called


### PR DESCRIPTION
## Summary
- add a scenario to build a structure after gathering resources
- apply `black` formatting across the repo

## Testing
- `ruff check src/ tests/`
- `black --check src/ tests/`
- `mypy src/`
- `pytest -m "integration" tests/integration/sim/test_world_map_actions.py::test_gather_then_build_updates_ledger_and_map -q`

------
https://chatgpt.com/codex/tasks/task_e_6874709611e08326ac3daa43fdb52e3c