### PR TITLE
Implement multi-layer memory retrieval

### DIFF
--- a/src/agents/memory/__init__.py
+++ b/src/agents/memory/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.memory_tracking_manager import MemoryTrackingManager
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 
 if TYPE_CHECKING:
@@ -19,6 +20,11 @@ else:  # pragma: no cover - optional dependency
     except Exception:
         ChromaVectorStoreManager = None
 
-__all__ = ["MemoryService", "MemoryTrackingManager", "SemanticMemoryManager"]
+__all__ = [
+    "MemoryService",
+    "MemoryTrackingManager",
+    "MultiLayerRetriever",
+    "SemanticMemoryManager",
+]
 if ChromaVectorStoreManager is not None:
     __all__.insert(0, "ChromaVectorStoreManager")

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from typing_extensions import Self
 
+from .multi_layer_retriever import MultiLayerRetriever
 from .semantic_memory_manager import SemanticMemoryManager
 from .vector_store import ChromaVectorStoreManager
 
@@ -20,6 +21,7 @@ class MemoryService:
     ) -> None:
         self.vector_store = vector_store
         self.semantic_manager = semantic_manager
+        self.retriever = MultiLayerRetriever(vector_store, semantic_manager)
 
     def add_memory(
         self: Self,
@@ -39,21 +41,7 @@ class MemoryService:
     async def retrieve_relevant_memories(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        episodic: list[dict[str, Any]] = []
-        if self.vector_store:
-            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
-
-        semantic: list[dict[str, Any]] = []
-        if self.semantic_manager:
-            import asyncio
-
-            semantic = await asyncio.to_thread(
-                self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
-            )
-
-        combined = episodic + semantic
-        combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
-        return combined[:k]
+        return await self.retriever.retrieve(agent_id, query, k)
 
     def retrieve_semantic_context(
         self: Self, agent_id: str, query: str, k: int = 5
@@ -63,33 +51,18 @@ class MemoryService:
         return self.semantic_manager.retrieve_context(agent_id, query, k)
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
-        if not self.semantic_manager:
-            return []
-        return self.semantic_manager.get_recent_summaries(agent_id, limit)
+        return self.retriever.get_recent_semantic_summaries(agent_id, limit)
 
     async def retrieve_episodic_and_update_semantic(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        """Retrieve episodic memories then consolidate them into semantic form."""
-        episodic = []
-        if self.vector_store:
-            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
-        if self.semantic_manager:
-            try:
-                await self.semantic_manager.run_nightly_job(agent_id, episodic)
-            except Exception:  # pragma: no cover - defensive
-                import logging
-
-                logging.getLogger(__name__).error("Semantic consolidation failed", exc_info=True)
-        return episodic
+        return await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
 
     def blend_with_recent_semantic(
         self: Self, agent_id: str, episodic_summary: str, limit: int = 3
     ) -> str:
         """Blend an episodic summary with recent semantic summaries."""
-        if not self.semantic_manager:
-            return episodic_summary
-        return self.semantic_manager.blend_episodic_and_semantic(agent_id, episodic_summary, limit)
+        return self.retriever.blend_with_recent_semantic(agent_id, episodic_summary, limit)
 
     async def get_context_pipeline(
         self: Self,
@@ -108,9 +81,7 @@ class MemoryService:
         agent_id: str,
         episodic_memories: list[dict[str, Any]] | None = None,
     ) -> None:
-        if not self.semantic_manager:
-            return None
-        await self.semantic_manager.run_nightly_job(agent_id, episodic_memories)
+        await self.retriever.run_semantic_job(agent_id, episodic_memories)
         return None
 
     def consolidate_daily_memories(

--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -1,0 +1,78 @@
+"""Multi-layer retrieval combining episodic and semantic memories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import Self
+
+from .semantic_memory_manager import SemanticMemoryManager
+from .vector_store import ChromaVectorStoreManager
+
+
+class MultiLayerRetriever:
+    """Retrieve from both episodic and semantic layers."""
+
+    def __init__(
+        self: Self,
+        vector_store: ChromaVectorStoreManager | None = None,
+        semantic_manager: SemanticMemoryManager | None = None,
+    ) -> None:
+        self.vector_store = vector_store
+        self.semantic_manager = semantic_manager
+
+    async def retrieve(
+        self: Self, agent_id: str, query: str = "", k: int = 5
+    ) -> list[dict[str, Any]]:
+        episodic: list[dict[str, Any]] = []
+        if self.vector_store:
+            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+
+        semantic: list[dict[str, Any]] = []
+        if self.semantic_manager:
+            import asyncio
+
+            semantic = await asyncio.to_thread(
+                self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
+            )
+
+        combined = episodic + semantic
+        combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+        return combined[:k]
+
+    async def retrieve_and_update_semantic(
+        self: Self, agent_id: str, query: str = "", k: int = 5
+    ) -> list[dict[str, Any]]:
+        episodic = []
+        if self.vector_store:
+            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+        if self.semantic_manager:
+            try:
+                await self.semantic_manager.run_nightly_job(agent_id, episodic)
+            except Exception:  # pragma: no cover - defensive
+                import logging
+
+                logging.getLogger(__name__).error("Semantic consolidation failed", exc_info=True)
+        return episodic
+
+    def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
+        if not self.semantic_manager:
+            return []
+        return self.semantic_manager.get_recent_summaries(agent_id, limit)
+
+    def blend_with_recent_semantic(
+        self: Self, agent_id: str, episodic_summary: str, limit: int = 3
+    ) -> str:
+        if not self.semantic_manager:
+            return episodic_summary
+        return self.semantic_manager.blend_episodic_and_semantic(agent_id, episodic_summary, limit)
+
+    async def run_semantic_job(
+        self: Self,
+        agent_id: str,
+        episodic_memories: list[dict[str, Any]] | None = None,
+    ) -> None:
+        if not self.semantic_manager:
+            return None
+        await self.semantic_manager.run_nightly_job(agent_id, episodic_memories)
+        return None

--- a/tests/integration/memory/test_multilayer_retriever.py
+++ b/tests/integration/memory/test_multilayer_retriever.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("chromadb")
+
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+async def test_multilayer_retrieval_combines_layers(chroma_test_dir: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir, embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    driver = DummyDriver()
+    semantic = SemanticMemoryManager(vector, driver)
+    retriever = MultiLayerRetriever(vector, semantic)
+
+    vector.add_memory("agent", 1, "thought", "cat", memory_type="raw")
+    vector.add_memory("agent", 2, "thought", "dog", memory_type="raw")
+
+    await retriever.retrieve_and_update_semantic("agent", k=2)
+
+    vector.add_memory("agent", 3, "thought", "bird", memory_type="raw")
+    semantic.group_memories_by_topic("agent", num_topics=2)
+
+    episodic_only = await vector.aretrieve_relevant_memories("agent", "cat", k=5)
+    combined = await retriever.retrieve("agent", "cat", k=5)
+    assert len(combined) >= len(episodic_only)


### PR DESCRIPTION
## Summary
- add `MultiLayerRetriever` to combine episodic and semantic memory
- wire `MemoryService` to use the new retriever
- expose the retriever in the memory module's public API
- add integration test verifying multi-layer retrieval

## Testing
- `ruff check src/agents/memory/multi_layer_retriever.py src/agents/memory/memory_service.py src/agents/memory/__init__.py tests/integration/memory/test_multilayer_retriever.py`
- `ruff format src/agents/memory/multi_layer_retriever.py src/agents/memory/memory_service.py src/agents/memory/__init__.py tests/integration/memory/test_multilayer_retriever.py`
- `mypy src/agents/memory/multi_layer_retriever.py src/agents/memory/memory_service.py src/agents/memory/__init__.py tests/integration/memory/test_multilayer_retriever.py`
- `pytest -m integration tests/integration/memory/test_multilayer_retriever.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_687aa9c56a9483268a58961a573dfb1e