### PR TITLE
Add MUS and pruning tests

### DIFF
--- a/tests/unit/memory/test_memory_tracking_manager.py
+++ b/tests/unit/memory/test_memory_tracking_manager.py
@@ -2,7 +2,9 @@
 """Unit tests for MemoryTrackingManager."""
 
 import asyncio
+import math
 import unittest
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -100,6 +102,44 @@ class TestMemoryTrackingManager(unittest.TestCase):
 
         assert len(calls) == 1
         assert all(calls)
+
+    def test_mus_varies_with_retrievals_and_scores(self: Self) -> None:
+        """MUS should reflect retrieval count and relevance scores."""
+        mem_id = self.vector_store.add_memory(
+            agent_id=self.agent_id,
+            step=2,
+            event_type="thought",
+            content="Another memory",
+        )
+        self.manager.record_retrieval([mem_id], [0.5])
+        self.manager.record_retrieval([mem_id], [0.8])
+        metadata = self.vector_store.collection.get(ids=[mem_id], include=["metadatas"])
+        meta = metadata["metadatas"][0]
+        expected = (
+            0.4 * math.log(1 + meta["retrieval_count"])
+            + 0.4 * (meta["accumulated_relevance_score"] / meta["retrieval_relevance_count"])
+            + 0.2 * 1.0
+        )
+        mus = self.manager.calculate_mus(mem_id)
+        self.assertAlmostEqual(mus, expected, places=5)
+
+    def test_calculate_mus_from_metadata_dict(self: Self) -> None:
+        """Direct metadata input should return expected MUS."""
+        now = datetime.utcnow()
+        metadata = {
+            "retrieval_count": 4,
+            "accumulated_relevance_score": 2.0,
+            "retrieval_relevance_count": 2,
+            "last_retrieved_timestamp": (now - timedelta(days=2)).isoformat(),
+        }
+        expected = (
+            0.4 * math.log(1 + metadata["retrieval_count"])
+            + 0.4
+            * (metadata["accumulated_relevance_score"] / metadata["retrieval_relevance_count"])
+            + 0.2 * (1.0 / (1.0 + 2))
+        )
+        mus = self.manager.calculate_mus(metadata)
+        self.assertAlmostEqual(mus, expected, places=5)
 
 
 if __name__ == "__main__":

--- a/tests/unit/memory/test_prune_memories_hybrid.py
+++ b/tests/unit/memory/test_prune_memories_hybrid.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.infra import config
+
+pytest.importorskip("chromadb")
+
+
+@pytest.mark.unit
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+def test_prune_memories_hybrid(monkeypatch: pytest.MonkeyPatch, chroma_test_dir):
+    store = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir,
+        embedding_function=lambda texts: [[0.0] for _ in texts],
+    )
+
+    now = datetime.utcnow()
+    older = (now - timedelta(days=10)).isoformat()
+    very_old = (now - timedelta(days=60)).isoformat()
+
+    l1_low = store.add_memory(
+        "agent",
+        1,
+        "summary",
+        "low l1",
+        memory_type="consolidated_summary",
+        metadata={"simulation_step_timestamp": older, "mus_value": 0.1},
+    )
+    l1_high = store.add_memory(
+        "agent",
+        2,
+        "summary",
+        "high l1",
+        memory_type="consolidated_summary",
+        metadata={"simulation_step_timestamp": older, "mus_value": 0.8},
+    )
+    l2_low = store.add_memory(
+        "agent",
+        3,
+        "summary",
+        "low l2",
+        memory_type="chapter_summary",
+        metadata={"simulation_step_end_timestamp": older, "mus_value": 0.2},
+    )
+    l2_new_high = store.add_memory(
+        "agent",
+        4,
+        "summary",
+        "new high",
+        memory_type="chapter_summary",
+        metadata={"simulation_step_end_timestamp": now.isoformat(), "mus_value": 0.6},
+    )
+    l2_very_old = store.add_memory(
+        "agent",
+        5,
+        "summary",
+        "very old",
+        memory_type="chapter_summary",
+        metadata={"simulation_step_end_timestamp": very_old, "mus_value": 0.5},
+    )
+
+    monkeypatch.setattr(store, "_calculate_mus", lambda m: float(m.get("mus_value", 0.0)))
+    monkeypatch.setitem(config.CONFIG_OVERRIDES, "MEMORY_PRUNING_USAGE_COUNT_THRESHOLD", 5)
+
+    pruned = store.prune_memories_hybrid(
+        l1_mus_threshold=0.5,
+        l2_mus_threshold=0.3,
+        l2_age_days=30,
+        l1_min_age_days=0,
+        l2_min_age_days=0,
+    )
+
+    remaining = [d["id"] for d in store.collection.docs]
+
+    assert pruned == 3
+    assert l1_low not in remaining
+    assert l2_low not in remaining
+    assert l2_very_old not in remaining
+    assert l1_high in remaining
+    assert l2_new_high in remaining


### PR DESCRIPTION
## Summary
- expand MemoryTrackingManager unit tests for MUS calculations
- add coverage for ChromaVectorStoreManager.prune_memories_hybrid

## Testing
- `ruff check --fix tests/unit/memory/test_memory_tracking_manager.py tests/unit/memory/test_prune_memories_hybrid.py`
- `black tests/unit/memory/test_memory_tracking_manager.py tests/unit/memory/test_prune_memories_hybrid.py`
- `pytest tests/unit/memory/test_memory_tracking_manager.py::TestMemoryTrackingManager::test_mus_varies_with_retrievals_and_scores tests/unit/memory/test_memory_tracking_manager.py::TestMemoryTrackingManager::test_calculate_mus_from_metadata_dict tests/unit/memory/test_prune_memories_hybrid.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaf52ef408326b5d84836dc6f6e4d