### PR TITLE
Fix vLLM client base URL

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -151,8 +151,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse:
-        ...
+    ) -> LLMChatResponse: ...
 
 
 class LLMClientConfig(BaseModel):
@@ -258,7 +257,8 @@ def _create_vllm_client() -> OllamaClientProtocol:
             messages: list[LLMMessage],
             options: dict[str, Any] | None = None,
         ) -> LLMChatResponse:
-            url = f"{LLM_API_BASE.rstrip('/')}/v1/chat/completions"
+            base = VLLM_API_BASE or LLM_API_BASE
+            url = f"{base.rstrip('/')}/v1/chat/completions"
             payload: JSONDict = {
                 "model": model,
                 "messages": cast(list[JSONValue], messages),
@@ -289,7 +289,7 @@ def _create_ollama_client() -> OllamaClientProtocol:
 
 client: OllamaClientProtocol | None
 if USE_VLLM:
-    logger.info(f"Using vLLM API base: {LLM_API_BASE}")
+    logger.info(f"Using vLLM API base: {VLLM_API_BASE or LLM_API_BASE}")
     client = _create_vllm_client()
 else:
     try:

--- a/tests/unit/infra/test_llm_client_vllm.py
+++ b/tests/unit/infra/test_llm_client_vllm.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.infra import config, llm_client
+from src.shared import decorator_utils
 
 
 @pytest.mark.unit
@@ -21,14 +22,16 @@ def test_generate_text_vllm(monkeypatch: pytest.MonkeyPatch) -> None:
         }
         return resp
 
-    monkeypatch.setattr(llm_client, "LLM_API_BASE", "http://vllm:8001")
+    monkeypatch.setattr(llm_client, "LLM_API_BASE", "http://ollama:1234")
     monkeypatch.setattr(llm_client, "VLLM_API_BASE", "http://vllm:8001")
     monkeypatch.setattr(llm_client, "USE_VLLM", True)
     monkeypatch.setattr(llm_client, "client", llm_client._create_vllm_client())  # type: ignore[attr-defined]
-    monkeypatch.setattr(config.settings, "LLM_API_BASE", "http://vllm:8001")  # type: ignore[attr-defined]
+    monkeypatch.setattr(config.settings, "LLM_API_BASE", "http://ollama:1234")  # type: ignore[attr-defined]
     monkeypatch.setattr(config.settings, "VLLM_API_BASE", "http://vllm:8001")  # type: ignore[attr-defined]
-    monkeypatch.setitem(config._CONFIG, "LLM_API_BASE", "http://vllm:8001")
+    monkeypatch.setitem(config._CONFIG, "LLM_API_BASE", "http://ollama:1234")
     monkeypatch.setitem(config._CONFIG, "VLLM_API_BASE", "http://vllm:8001")
+    monkeypatch.setattr(decorator_utils.llm_perf_logger, "info", lambda *a: None)
+    monkeypatch.setattr(decorator_utils.json, "dumps", lambda *a, **k: "{}")  # type: ignore[attr-defined]
     monkeypatch.setattr(llm_client.requests, "post", fake_post)  # type: ignore[attr-defined]
 
     result = llm_client.generate_text("hello")
@@ -56,9 +59,53 @@ def test_generate_text_vllm_env_switch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VLLM_API_BASE", "http://vllm:8002")
     config.load_config(validate_required=False)
     module = importlib.reload(llm_client)
+    monkeypatch.setattr(decorator_utils.llm_perf_logger, "info", lambda *a: None)
+    monkeypatch.setattr(decorator_utils.json, "dumps", lambda *a, **k: "{}")  # type: ignore[attr-defined]
+    monkeypatch.setattr(module, "LLM_API_BASE", "http://ollama:1234")
+    monkeypatch.setattr(module, "VLLM_API_BASE", "http://vllm:8002")
+    monkeypatch.setattr(module, "USE_VLLM", True)
+    monkeypatch.setattr(module, "client", module._create_vllm_client())  # type: ignore[attr-defined]
+    monkeypatch.setattr(config.settings, "LLM_API_BASE", "http://ollama:1234")  # type: ignore[attr-defined]
+    monkeypatch.setattr(config.settings, "VLLM_API_BASE", "http://vllm:8002")  # type: ignore[attr-defined]
+    monkeypatch.setitem(config._CONFIG, "LLM_API_BASE", "http://ollama:1234")
+    monkeypatch.setitem(config._CONFIG, "VLLM_API_BASE", "http://vllm:8002")
     monkeypatch.setattr(module.requests, "post", fake_post)  # type: ignore[attr-defined]
 
     result = module.generate_text("hello")
 
     assert result == "hi"
     assert captured["url"] == "http://vllm:8002/v1/chat/completions"
+
+
+@pytest.mark.unit
+@pytest.mark.disable_global_llm_mock
+def test_vllm_client_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``VLLM_API_BASE`` is unset, fallback to ``LLM_API_BASE``."""
+    captured: dict[str, str] = {}
+
+    def fake_post(url: str, *args: object, **kwargs: object) -> MagicMock:
+        captured["url"] = url
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+        return resp
+
+    monkeypatch.setattr(llm_client, "LLM_API_BASE", "http://ollama:1234")
+    monkeypatch.setattr(llm_client, "VLLM_API_BASE", "")
+    monkeypatch.setattr(llm_client, "USE_VLLM", True)
+    monkeypatch.setattr(llm_client, "client", llm_client._create_vllm_client())  # type: ignore[attr-defined]
+    monkeypatch.setattr(decorator_utils.llm_perf_logger, "info", lambda *a: None)
+    monkeypatch.setattr(decorator_utils.json, "dumps", lambda *a, **k: "{}")  # type: ignore[attr-defined]
+    monkeypatch.setattr(config.settings, "LLM_API_BASE", "http://ollama:1234")  # type: ignore[attr-defined]
+    monkeypatch.setattr(config.settings, "VLLM_API_BASE", "")  # type: ignore[attr-defined]
+    monkeypatch.setitem(config._CONFIG, "LLM_API_BASE", "http://ollama:1234")
+    monkeypatch.setitem(config._CONFIG, "VLLM_API_BASE", "")
+    monkeypatch.setattr(llm_client.requests, "post", fake_post)  # type: ignore[attr-defined]
+
+    result = llm_client.generate_text("hello")
+
+    assert result == "hi"
+    assert captured["url"] == "http://ollama:1234/v1/chat/completions"


### PR DESCRIPTION
## Summary
- build the vLLM endpoint from `VLLM_API_BASE` or fall back to `LLM_API_BASE`
- improve log message about the vLLM API base
- update unit tests for vLLM client base URL resolution

## Testing
- `ruff check src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `ruff format src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `mypy src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `pytest -m unit tests/unit/infra/test_llm_client_vllm.py`

------
https://chatgpt.com/codex/tasks/task_e_687d30a41d1c832695950d7381733e61