### PR TITLE
Add quick lint/test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,10 +817,23 @@ This command activates `.venv` if available, installs the required packages, and
 executes `scripts/vertical_slice.sh` (or the Windows `.bat` version).
 
 ### Running Tests
-Run the full test suite (after installing development dependencies):
-```bash
-python -m pytest tests/
-```
+Run the full test suite after installing development dependencies and starting an LLM backend.
+
+1. **Launch Ollama or vLLM**
+   ```bash
+   # Ollama
+   ollama serve &
+   # or vLLM
+   scripts/start_vllm.sh
+   ```
+2. **Run linters**
+   ```bash
+   ./scripts/lint.sh --format    # Windows: scripts\lint.bat --format
+   ```
+3. **Execute tests**
+   ```bash
+   python -m pytest tests/
+   ```
 `pytest-xdist` enables parallel execution via the `-n auto` option in `pytest.ini`.
 `scripts/run_tests.py` checks for this plugin and strips `-n auto` if it isn't installed, so tests still run serially without it.
 These tests also rely on optional packages (`chromadb`, `weaviate-client`, `langgraph`) which are included in `requirements.txt` and installed in CI.
@@ -843,10 +856,15 @@ and download the file from the **Artifacts** section.
 ### Contributing
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on code style, review, and testing.
 
-For advanced testing, parallelization, and CI details, see [docs/testing.md](docs/testing.md).
+For advanced testing, parallelization, and optional heavy suites, see [docs/testing.md](docs/testing.md).
 CI workflows are skipped when a commit only modifies documentation (`*.md` files or files under `docs/`) or contains only code comments. A dedicated `changes` job detects comment-only changes and prevents unnecessary runs.
 Outdated runs on the same branch are automatically canceled, and heavy test suites run on a self-hosted Linux runner.
 See [docs/ci_status.md](docs/ci_status.md) for tips on checking CI status with the GitHub interface or the `gh` CLI. Because this repository has no remote configured by default, you'll need to add your GitHub remote before checking statuses.
+
+### Troubleshooting
+* **LLM connection errors** – Ensure `ollama serve` or `scripts/start_vllm.sh` is running and that `LLM_API_BASE` points to the correct URL.
+* **Missing dependencies** – Reinstall with `pip install -r requirements.txt -r requirements-dev.txt`.
+* **Port conflicts** – Set `VLLM_PORT` to a free port when launching the vLLM server.
 
 ## Code Quality and Type Safety
 


### PR DESCRIPTION
## Summary
- document how to start Ollama or vLLM before running tests
- outline lint and test commands in README
- link to docs/testing.md for optional heavy tests
- add short troubleshooting section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d40d480ec83269166f7a14a3a7f82