### PR TITLE
Load plugins at app startup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ from typing import Optional
 from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.extensions import load_plugins
 from src.infra.checkpoint import (
     load_checkpoint,
     restore_environment,
@@ -230,6 +231,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     setup_logging()
+    # Load optional plugins before argument parsing
+    asyncio.run(load_plugins())
     args = parse_args()
     desc, file_steps, file_agents = load_scenario(args.scenario)
     if file_steps is not None:

--- a/tests/unit/app/test_plugin_loading.py
+++ b/tests/unit/app/test_plugin_loading.py
@@ -1,0 +1,26 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import app
+
+
+@pytest.mark.unit
+def test_main_invokes_load_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["prog"])
+    dummy_sim = SimpleNamespace(async_run=MagicMock(return_value="coro"))
+    monkeypatch.setattr(app, "create_simulation", MagicMock(return_value=dummy_sim))
+    monkeypatch.setattr(app.asyncio, "run", MagicMock())
+    monkeypatch.setattr(app, "load_checkpoint", MagicMock(return_value=(dummy_sim, None)))
+    monkeypatch.setattr(app, "save_checkpoint", MagicMock())
+    monkeypatch.setattr(app, "restore_rng_state", MagicMock())
+    monkeypatch.setattr(app, "restore_environment", MagicMock())
+
+    load_plugins_mock = MagicMock()
+    monkeypatch.setattr(app, "load_plugins", load_plugins_mock)
+
+    app.main()
+
+    load_plugins_mock.assert_called_once_with()

--- a/tests/unit/test_app_cli.py
+++ b/tests/unit/test_app_cli.py
@@ -47,6 +47,7 @@ def test_main_invokes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app, "create_simulation", create_sim)
     run_mock = MagicMock()
     monkeypatch.setattr(app.asyncio, "run", run_mock)
+    monkeypatch.setattr(app, "load_plugins", MagicMock())
 
     monkeypatch.setattr(app, "load_checkpoint", MagicMock(return_value=(dummy_sim, None)))
     monkeypatch.setattr(app, "save_checkpoint", MagicMock())
@@ -68,7 +69,10 @@ def test_main_invokes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
         semantic_password="test",
     )
     dummy_sim.async_run.assert_called_once_with(3)
-    run_mock.assert_called_once_with(dummy_sim.async_run.return_value)
+    assert run_mock.call_args_list == [
+        ((app.load_plugins.return_value,), {}),
+        ((dummy_sim.async_run.return_value,), {}),
+    ]
 
 
 def test_load_scenario_from_file(tmp_path) -> None:
@@ -92,6 +96,7 @@ def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
     monkeypatch.setattr(app, "create_simulation", create_sim)
     run_mock = MagicMock()
     monkeypatch.setattr(app.asyncio, "run", run_mock)
+    monkeypatch.setattr(app, "load_plugins", MagicMock())
 
     monkeypatch.setattr(app, "load_checkpoint", MagicMock(return_value=(dummy_sim, None)))
     monkeypatch.setattr(app, "save_checkpoint", MagicMock())
@@ -113,4 +118,7 @@ def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
         semantic_password="test",
     )
     dummy_sim.async_run.assert_called_once_with(2)
-    run_mock.assert_called_once_with(dummy_sim.async_run.return_value)
+    assert run_mock.call_args_list == [
+        ((app.load_plugins.return_value,), {}),
+        ((dummy_sim.async_run.return_value,), {}),
+    ]


### PR DESCRIPTION
## Summary
- load plugins during initialization of `main()`
- verify plugin loading in new unit tests
- adjust app CLI tests for new behavior
- document plugin initialization step

## Testing
- `ruff check src/app.py tests/unit/test_app_cli.py tests/unit/app/test_plugin_loading.py`
- `pytest tests/unit/test_app_cli.py::test_main_invokes_helpers tests/unit/test_app_cli.py::test_main_uses_scenario_file tests/unit/app/test_plugin_loading.py::test_main_invokes_load_plugins -q`


------
https://chatgpt.com/codex/tasks/task_e_687d30a4d5148326be3eeda90188b791