### PR TITLE
Refactor event listener task handling

### DIFF
--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -14,6 +14,7 @@ from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
     emit_map_action_event,
+    get_event_queue,
 )
 
 from .event_bus import get_event_bus
@@ -249,7 +250,7 @@ class EventKernel:
         loop exits when the queue yields ``None``.
         """
         bus = get_event_bus()
-        queue = bus.subscribe()
+        queue = get_event_queue()
         try:
             while True:
                 try:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -845,9 +845,9 @@ class Simulation:
 
     async def start_event_listener(self: Self) -> None:
         """Start background processing of ``event_queue`` events."""
-        if self._event_listener_task is None:
+        if self._event_listener_task is None or self._event_listener_task.done():
             self._event_listener_task = asyncio.create_task(self._event_listener_loop())
-        if self._event_task is None:
+        if self._event_task is None or self._event_task.done():
             self._event_task = asyncio.create_task(
                 self.event_kernel.forward_external_events(self._handle_human_command)
             )
@@ -887,9 +887,6 @@ class Simulation:
 
         events = await self.event_kernel.dispatch(max_turns)
         self.vector = self.event_kernel.vector
-
-        # Stop the event listener after each step to avoid leaked tasks in tests
-        await self.stop_event_listener()
 
         return len(events)
 

--- a/tests/integration/sim/test_event_listener.py
+++ b/tests/integration/sim/test_event_listener.py
@@ -1,0 +1,54 @@
+import asyncio
+
+import pytest
+
+from src.sim.simulation import Simulation
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self.state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        return {}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_listener_tasks_reused_across_steps() -> None:
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    for _ in range(3):
+        await sim.run_step()
+
+    pending = [t.get_coro().__name__ for t in asyncio.all_tasks() if not t.done()]
+    assert pending.count("_event_listener_loop") <= 1
+    assert pending.count("forward_external_events") <= 1
+
+    await sim.stop_event_listener()
+    sim.close()


### PR DESCRIPTION
## Summary
- keep event listener tasks running across steps
- reuse the same SSE queue for forwarding external events
- ensure no duplicate listener tasks are created
- add regression test for event listener task reuse

## Testing
- `ruff check src/sim/simulation.py src/sim/event_kernel.py tests/integration/sim/test_event_listener.py`
- `pytest -q tests/unit/sim/test_event_task_start.py tests/integration/sim/test_event_task_cleanup.py tests/integration/sim/test_event_listener.py`

------
https://chatgpt.com/codex/tasks/task_e_687d40b971b883269a9f5e1d54b01185