### PR TITLE
Add widget registry tests

### DIFF
--- a/tests/unit/extensions/test_example_plugin.py
+++ b/tests/unit/extensions/test_example_plugin.py
@@ -7,6 +7,7 @@ import pytest
 
 from examples.example_plugin import example_plugin
 from src.extensions import BEHAVIOR_REGISTRY, load_plugins
+from src.interfaces import dashboard_backend as db
 
 
 class DummyEntryPoints(list[object]):
@@ -18,12 +19,14 @@ class DummyEntryPoints(list[object]):
 @pytest.mark.asyncio
 async def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
     BEHAVIOR_REGISTRY._behaviors.clear()
+    db.WIDGET_REGISTRY._widgets.clear()
     widgets: list[tuple[str, str, str]] = []
 
     async def register_widget_backend(
         name: str, script_url: str, backend_url: str = "http://localhost:8000"
     ) -> None:
         widgets.append((name, script_url, backend_url))
+        db.WIDGET_REGISTRY.register(name, {"script_url": script_url})
 
     ep = types.SimpleNamespace(load=lambda: example_plugin.setup, name="example_plugin")
     monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
@@ -33,3 +36,6 @@ async def test_example_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert example_plugin.log_turn in BEHAVIOR_REGISTRY._behaviors
     assert widgets == [("ExampleWidget", "http://localhost:5173/example.js", "http://backend")]
+    assert db.WIDGET_REGISTRY.get("ExampleWidget") == {
+        "script_url": "http://localhost:5173/example.js"
+    }

--- a/tests/unit/extensions/test_widget_registry.py
+++ b/tests/unit/extensions/test_widget_registry.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src.interfaces.widget_registry import WidgetRegistry
+
+
+@pytest.mark.unit
+def test_register_and_get() -> None:
+    reg = WidgetRegistry()
+    reg.register("test", {"foo": "bar"})
+    assert reg.get("test") == {"foo": "bar"}
+    assert reg.get("missing") is None
+
+
+@pytest.mark.unit
+def test_list_sorted() -> None:
+    reg = WidgetRegistry()
+    reg.register("b", {"meta": 2})
+    reg.register("a", {"meta": 1})
+    assert reg.list() == [
+        {"name": "a", "meta": 1},
+        {"name": "b", "meta": 2},
+    ]


### PR DESCRIPTION
## Summary
- cover WidgetRegistry with basic unit tests
- update example plugin test to verify plugin widget registration

## Testing
- `ruff check tests/unit/extensions/test_widget_registry.py tests/unit/extensions/test_example_plugin.py`
- `ruff format tests/unit/extensions/test_widget_registry.py tests/unit/extensions/test_example_plugin.py`
- `pytest tests/unit/extensions/test_widget_registry.py tests/unit/extensions/test_example_plugin.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d40d338e88326964ebc7ae9232fe8