### PR TITLE
Add weighted proposal API endpoint and Discord command

### DIFF
--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -49,14 +49,21 @@ class GovernanceService:
                     staked = 0.0
                 weights.append(math.sqrt(base_ip + staked))
         else:
+            start_balances = await asyncio.gather(
+                *[ledger.get_balance_async(a.agent_id) for a in agents],
+                return_exceptions=True,
+            )
             spend_tasks = []
             for a in agents:
                 w = int(vote_weights.get(a.agent_id, 1))
                 weights.append(float(w))
                 cost = float(w * w)
-                ip_spent += cost
                 spend_tasks.append(ledger.spend(a.agent_id, ip=cost, reason="vote"))
-            await asyncio.gather(*spend_tasks, return_exceptions=True)
+            end_balances = await asyncio.gather(*spend_tasks, return_exceptions=True)
+            for before, after in zip(start_balances, end_balances):
+                if isinstance(before, Exception) or isinstance(after, Exception):
+                    continue
+                ip_spent += max(0.0, before[0] - after[0])
 
         yes_weight = sum(w for w, v in zip(weights, votes) if v)
         no_weight = sum(w for w, v in zip(weights, votes) if not v)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -162,6 +162,14 @@ class LawProposal(BaseModel):
     text: str
 
 
+class Proposal(BaseModel):
+    """Proposal with optional vote weights."""
+
+    proposer_id: str
+    text: str
+    vote_weights: dict[str, int] | None = None
+
+
 class LawsResponse(BaseModel):
     laws: list[str]
 
@@ -250,6 +258,26 @@ async def api_propose_law(proposal: LawProposal) -> Response:
             approved = await sim.propose_law(proposal.proposer_id, proposal.text)
         except Exception:  # pragma: no cover - defensive
             approved = False
+    return JSONResponse({"approved": approved})
+
+
+@app.post("/api/propose")
+async def api_propose(proposal: Proposal) -> Response:
+    """Submit a weighted law proposal to the active simulation."""
+    sim = SIM_STATE.get("simulation")
+    approved = False
+    if sim is not None:
+        proposer = next((a for a in sim.agents if a.agent_id == proposal.proposer_id), None)
+        if proposer is not None:
+            try:
+                approved = await governance.propose_law(
+                    proposer,
+                    proposal.text,
+                    sim.agents,
+                    proposal.vote_weights,
+                )
+            except Exception:  # pragma: no cover - defensive
+                approved = False
     return JSONResponse({"approved": approved})
 
 
@@ -460,6 +488,7 @@ __all__ = [
     "EventSourceResponse",
     "LawProposal",
     "LawsResponse",
+    "Proposal",
     "SimulationEvent",
     "VoteRecord",
     "VotesResponse",
@@ -467,6 +496,7 @@ __all__ = [
     "api_get_laws",
     "api_get_proposals",
     "api_get_votes",
+    "api_propose",
     "api_propose_law",
     "api_token_balances",
     "app",

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -11,6 +11,7 @@ import logging
 import typing
 from typing import TYPE_CHECKING, Any, Optional
 
+import httpx
 from typing_extensions import Self
 
 from src.infra import config
@@ -668,3 +669,29 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
         SimulationEvent(event_type="control", data={"command": "set_speed", "value": value})
     )
     await interaction.response.send_message(f"speed {value}", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="propose")
+async def slash_propose(interaction: Any, text: str) -> None:
+    """Propose a law via the dashboard API."""
+    agent_id = None
+    if active_bot is not None:
+        channel = getattr(interaction, "channel", None)
+        chan_id = getattr(channel, "id", None)
+        agent_id = active_bot.channel_to_agent.get(chan_id)
+    if not agent_id:
+        await interaction.response.send_message("Unknown channel", ephemeral=True)
+        return
+    ip, du = await ledger.get_balance_async(agent_id)
+    if ip <= 0 or du <= 0:
+        await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
+        return
+    payload = {"proposer_id": agent_id, "text": text}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post("http://localhost:8000/api/propose", json=payload)
+            approved = resp.json().get("approved", False)
+    except Exception:
+        approved = False
+    await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)

--- a/tests/integration/governance/test_propose_command.py
+++ b/tests/integration/governance/test_propose_command.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.interfaces import discord_bot as bot
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.response = SimpleNamespace(send_message=AsyncMock())
+        self.channel = SimpleNamespace(id=123)
+
+
+class DummyClient:
+    called: dict | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url: str, json: dict[str, object]) -> object:
+        DummyClient.called = {"url": url, "json": json}
+
+        class Resp:
+            def json(self_inner):
+                return {"approved": True}
+
+        return Resp()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_slash_propose_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bot.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(bot.ledger, "get_balance_async", AsyncMock(return_value=(1.0, 1.0)))
+    monkeypatch.setattr(bot, "active_bot", SimpleNamespace(channel_to_agent={123: "a1"}))
+
+    await bot.slash_propose.callback(DummyInteraction(), text="hello")
+
+    assert DummyClient.called["url"].endswith("/api/propose")
+    assert DummyClient.called["json"] == {"proposer_id": "a1", "text": "hello"}
+    DummyClient.called = {}

--- a/tests/integration/governance/test_propose_endpoint.py
+++ b/tests/integration/governance/test_propose_endpoint.py
@@ -1,0 +1,103 @@
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from src.governance.law_board import LawBoard
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        pass
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_propose_endpoint_records_spent_ip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    gservice = importlib.import_module("src.governance.service")
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(db, "ledger", ledger)
+    monkeypatch.setattr(db, "law_board", board)
+    monkeypatch.setattr(db, "governance", gservice.governance)
+
+    async def allow(_: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow)
+
+    votes = [True, True, False]
+
+    async def fake_vote(_agent: DummyAgent, _text: str) -> bool:
+        return votes.pop(0)
+
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
+
+    from src.sim.simulation import Simulation
+
+    agents = [DummyAgent("a1"), DummyAgent("a2"), DummyAgent("a3")]
+    sim = Simulation(agents=agents)
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+
+    for a in agents:
+        ledger.log_change(a.agent_id, 5.0, 0.0, "fund")
+
+    weights = {"a1": 3, "a2": 1, "a3": 1}
+
+    resp = await db.api_propose(db.Proposal(proposer_id="a1", text="law", vote_weights=weights))
+    data = json.loads(resp.body)
+    assert data["approved"] is True
+
+    assert ledger.get_balance("a1")[0] == pytest.approx(0.0)
+    assert ledger.get_balance("a2")[0] == pytest.approx(4.0)
+    assert ledger.get_balance("a3")[0] == pytest.approx(4.0)
+
+    proposals = ledger.get_law_proposals()
+    assert proposals[0]["ip_spent"] == pytest.approx(7.0)
+    assert proposals[0]["yes_weight"] == pytest.approx(4.0)
+    assert proposals[0]["no_weight"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- extend dashboard backend with `/api/propose` to accept vote weights
- validate vote costs through the ledger when proposing laws
- add a `propose` slash command for Discord
- test new governance endpoint and command

## Testing
- `ruff check . --fix`
- `black --quiet .`
- `pytest tests/integration/governance/test_propose_endpoint.py tests/integration/governance/test_propose_command.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_687d40cdeb788326a31113f5f6d779b8