### PR TITLE
Refactor Discord bot init

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -106,8 +106,10 @@ def create_simulation(
         channel_id = settings.DISCORD_CHANNEL_ID
         if bot_token_raw and channel_id:
             tokens = [tok.strip() for tok in bot_token_raw.split(",") if tok.strip()]
-            bot = simulation_discord_bot_class(
-                tokens if len(tokens) > 1 else tokens[0], int(channel_id)
+            bot = asyncio.run(
+                simulation_discord_bot_class.create(
+                    tokens if len(tokens) > 1 else tokens[0], int(channel_id)
+                )
             )
             if bot.is_ready:
                 discord_bot = bot

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import typing
 from collections.abc import Iterable
 
 from typing_extensions import Self
@@ -63,7 +64,9 @@ class GovernanceService:
             for before, after in zip(start_balances, end_balances):
                 if isinstance(before, Exception) or isinstance(after, Exception):
                     continue
-                ip_spent += max(0.0, before[0] - after[0])
+                before_bal = typing.cast(tuple[float, float], before)
+                after_bal = typing.cast(tuple[float, float], after)
+                ip_spent += max(0.0, before_bal[0] - after_bal[0])
 
         yes_weight = sum(w for w, v in zip(weights, votes) if v)
         no_weight = sum(w for w, v in zip(weights, votes) if not v)

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -57,8 +57,9 @@ class SimulationDiscordBot:
     ``Simulation._handle_human_command``.
     """
 
-    def __init__(
-        self: Self,
+    @classmethod
+    async def create(
+        cls: type[Self],
         bot_token: str | list[str] | None,
         channel_id: int,
         token_lookup: (
@@ -66,15 +67,8 @@ class SimulationDiscordBot:
         ) = None,
         *,
         channel_map: dict[str, int] | None = None,
-    ) -> None:
-        """
-        Initialize the Discord bot with token and target channel.
-
-        Args:
-            bot_token (str | list[str] | None): Discord bot token(s) or ``None`` to
-                load from the database.
-            channel_id (int): The ID of the Discord channel to send updates to
-        """
+    ) -> Self:
+        """Asynchronously construct a ``SimulationDiscordBot`` instance."""
         tokens: list[str] = []
         if bot_token:
             tokens = [bot_token] if isinstance(bot_token, str) else list(bot_token)
@@ -86,23 +80,34 @@ class SimulationDiscordBot:
                 except ImportError:
                     logger.exception("Failed to import token store for loading tokens")
                 else:
-
-                    async def _load() -> list[str]:
-                        return await list_tokens()
-
                     try:
-                        try:
-                            loop = asyncio.get_running_loop()
-                        except RuntimeError:
-                            tokens = asyncio.run(_load())
-                        else:
-                            new_loop = asyncio.new_event_loop()
-                            try:
-                                tokens = new_loop.run_until_complete(_load())
-                            finally:
-                                new_loop.close()
+                        tokens = await list_tokens()
                     except Exception:
                         logger.exception("Failed to load tokens from store")
+
+        if not tokens:
+            raise RuntimeError("No Discord bot tokens provided")
+
+        return cls(tokens, channel_id, token_lookup=token_lookup, channel_map=channel_map)
+
+    def __init__(
+        self: Self,
+        bot_token: str | list[str],
+        channel_id: int,
+        token_lookup: (
+            Optional[typing.Callable[[str], typing.Awaitable[str | None] | str]] | None
+        ) = None,
+        *,
+        channel_map: dict[str, int] | None = None,
+    ) -> None:
+        """
+        Initialize the Discord bot with token and target channel.
+
+        Args:
+            bot_token (str | list[str]): Discord bot token(s).
+            channel_id (int): The ID of the Discord channel to send updates to
+        """
+        tokens = [bot_token] if isinstance(bot_token, str) else list(bot_token)
         if not tokens:
             raise RuntimeError("No Discord bot tokens provided")
         self.bot_tokens = tokens

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -63,9 +63,9 @@ class DummyDiscordClient:
 
 
 @pytest.fixture
-def simulation_bot() -> SimulationDiscordBot:
+async def simulation_bot() -> SimulationDiscordBot:
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient):
-        bot = SimulationDiscordBot("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123)
     return bot
 
 
@@ -90,7 +90,7 @@ async def test_multi_token_start_and_send() -> None:
             AsyncMock(side_effect=lambda content: (True, content)),
         ),
     ):
-        bot = SimulationDiscordBot(tokens, 123, token_lookup=lookup)
+        bot = await SimulationDiscordBot.create(tokens, 123, token_lookup=lookup)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         await bot.send_simulation_update(content="hi", agent_id="agent_b")
@@ -116,7 +116,7 @@ async def test_multi_token_message_forwarding() -> None:
         patch("src.interfaces.dashboard_backend.get_event_queue", lambda: q_events),
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
     ):
-        bot = SimulationDiscordBot(tokens, 999)
+        bot = await SimulationDiscordBot.create(tokens, 999)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
 
@@ -172,7 +172,7 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = SimulationDiscordBot("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123)
         assert "on_message" in bot.client._events
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
@@ -213,7 +213,7 @@ async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -
             q_msgs,
         ),
     ):
-        bot = SimulationDiscordBot("token", 456)
+        bot = await SimulationDiscordBot.create("token", 456)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         on_msg = bot.client._events["on_message"]

--- a/tests/integration/simulation/test_discord_bot_integration.py
+++ b/tests/integration/simulation/test_discord_bot_integration.py
@@ -100,7 +100,7 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         patch.object(Simulation, "_handle_human_command", wrapped),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = SimulationDiscordBot("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1)
         agent = DummyAgent("A")
         sim = Simulation([agent], discord_bot=bot)
 

--- a/tests/unit/interfaces/test_discord_errors.py
+++ b/tests/unit/interfaces/test_discord_errors.py
@@ -35,7 +35,7 @@ async def test_send_simulation_update_logs_error(monkeypatch: pytest.MonkeyPatch
             DummyException,
         ),
     ):
-        bot = SimulationDiscordBot("token", 999)
+        bot = await SimulationDiscordBot.create("token", 999)
         bot.is_ready = True
         error_called = asyncio.Event()
 
@@ -72,7 +72,7 @@ async def test_run_bot_retries_on_start_failure(monkeypatch: pytest.MonkeyPatch)
         patch("src.interfaces.discord_bot.discord.DiscordException", DummyException),
         patch("asyncio.sleep", sleep_mock),
     ):
-        bot = SimulationDiscordBot("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         await bot.stop_bot()
@@ -104,7 +104,7 @@ async def test_stop_bot_cancels_pending_tasks(monkeypatch: pytest.MonkeyPatch) -
         patch("src.interfaces.discord_bot.discord.Client", HangingClient),
         patch("src.interfaces.discord_bot.discord.DiscordException", DummyException),
     ):
-        bot = SimulationDiscordBot("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123)
         bot.message_queue = asyncio.Queue()
         tasks = bot.run_bot()
         await asyncio.sleep(0)

--- a/tests/unit/interfaces/test_discord_policy.py
+++ b/tests/unit/interfaces/test_discord_policy.py
@@ -37,7 +37,7 @@ async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.discord.Thread", DummyChannel),
         patch("src.interfaces.discord_bot.discord.DiscordException", Exception),
     ):
-        bot = SimulationDiscordBot("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1)
         bot.is_ready = True
         channel = DummyChannel()
         bot.client.get_channel = MagicMock(return_value=channel)
@@ -63,7 +63,7 @@ async def test_opa_modifies_message(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.discord.Thread", DummyChannel),
         patch("src.interfaces.discord_bot.discord.DiscordException", Exception),
     ):
-        bot = SimulationDiscordBot("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1)
         bot.is_ready = True
         channel = DummyChannel()
         bot.client.get_channel = MagicMock(return_value=channel)


### PR DESCRIPTION
## Summary
- load Discord tokens asynchronously in SimulationDiscordBot
- provide `SimulationDiscordBot.create` async factory
- use the factory in `create_simulation`
- fix mypy issue in governance service
- update tests for async bot creation

## Testing
- `bash scripts/lint.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4973289483269622f65e856d7a2f