### PR TITLE
Fix control JSON errors

### DIFF
--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import math
 from collections.abc import Iterable
+from typing import cast
 
 from typing_extensions import Self
 
@@ -63,7 +64,9 @@ class GovernanceService:
             for before, after in zip(start_balances, end_balances):
                 if isinstance(before, Exception) or isinstance(after, Exception):
                     continue
-                ip_spent += max(0.0, before[0] - after[0])
+                before_bal = cast(tuple[float, float], before)
+                after_bal = cast(tuple[float, float], after)
+                ip_spent += max(0.0, before_bal[0] - after_bal[0])
 
         yes_weight = sum(w for w, v in zip(weights, votes) if v)
         no_weight = sum(w for w, v in zip(weights, votes) if not v)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -441,7 +441,14 @@ async def handle_control_command(cmd: dict[str, Any]) -> dict[str, Any]:
 try:
 
     @app.post("/control")
-    async def control(command: dict[str, Any]) -> Response:
+    async def control(request: Request) -> Response:
+        try:
+            command = await request.json()
+            if not isinstance(command, dict):
+                raise ValueError
+        except Exception:
+            return JSONResponse({"error": "invalid"})
+
         result = await handle_control_command(command)
         return JSONResponse(result)
 
@@ -459,7 +466,9 @@ try:
                 data = await websocket.receive_text()
                 try:
                     cmd = json.loads(data)
-                except json.JSONDecodeError:
+                    if not isinstance(cmd, dict):
+                        raise ValueError
+                except (json.JSONDecodeError, ValueError):
                     await websocket.send_text(json.dumps({"error": "invalid"}))
                     continue
                 result = await handle_control_command(cmd)
@@ -525,7 +534,6 @@ __all__ = [
     "api_get_proposals",
     "api_get_votes",
     "api_map",
-
     "api_propose_law",
     "api_token_balances",
     "app",

--- a/tests/integration/interfaces/test_invalid_control_payloads.py
+++ b/tests/integration/interfaces/test_invalid_control_payloads.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+class DummyRequest:
+    def __init__(self, payload=None, exc=None):
+        self._payload = payload
+        self._exc = exc
+
+    async def json(self):
+        if self._exc is not None:
+            raise self._exc
+        return self._payload
+
+
+class DummyWebSocket:
+    def __init__(self, messages):
+        self.messages = messages
+        self.accepted = False
+        self.sent = []
+        self.closed = False
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive_text(self):
+        if self.messages:
+            return self.messages.pop(0)
+        raise db.WebSocketDisconnect()
+
+    async def send_text(self, text: str):
+        self.sent.append(text)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_invalid_json() -> None:
+    req = DummyRequest(exc=json.JSONDecodeError("x", "x", 0))
+    resp = await db.control(req)
+    assert json.loads(resp.body) == {"error": "invalid"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_invalid_structure() -> None:
+    req = DummyRequest(payload=[])
+    resp = await db.control(req)
+    assert json.loads(resp.body) == {"error": "invalid"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_control_invalid_json() -> None:
+    ws = DummyWebSocket(["{"])
+    await db.ws_control(ws)
+    assert json.loads(ws.sent[0]) == {"error": "invalid"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_control_invalid_structure() -> None:
+    ws = DummyWebSocket(["[]"])
+    await db.ws_control(ws)
+    assert json.loads(ws.sent[0]) == {"error": "invalid"}

--- a/tests/unit/interfaces/test_dashboard_backend_control.py
+++ b/tests/unit/interfaces/test_dashboard_backend_control.py
@@ -54,19 +54,27 @@ def load_dashboard_backend():
     return importlib.import_module("src.interfaces.dashboard_backend")
 
 
+class DummyRequest:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def json(self):
+        return self.payload
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_control_pause_resume() -> None:
     db = load_dashboard_backend()
-    resp = await db.control({"command": "pause"})
+    resp = await db.control(DummyRequest({"command": "pause"}))
     data = json.loads(resp.body)
     assert data["paused"] is True
 
-    resp = await db.control({"command": "set_speed", "value": 2})
+    resp = await db.control(DummyRequest({"command": "set_speed", "value": 2}))
     data = json.loads(resp.body)
     assert data["speed"] == 2
 
-    resp = await db.control({"command": "resume"})
+    resp = await db.control(DummyRequest({"command": "resume"}))
     data = json.loads(resp.body)
     assert data["paused"] is False
 
@@ -88,6 +96,9 @@ class DummyWS:
     async def send_text(self, text: str) -> None:
         self.sent.append(text)
 
+    async def close(self) -> None:
+        pass
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
@@ -103,7 +114,7 @@ async def test_ws_control() -> None:
 @pytest.mark.asyncio
 async def test_set_speed_invalid_value() -> None:
     db = load_dashboard_backend()
-    await db.control({"command": "set_speed", "value": 2})
-    resp = await db.control({"command": "set_speed", "value": "bad"})
+    await db.control(DummyRequest({"command": "set_speed", "value": 2}))
+    resp = await db.control(DummyRequest({"command": "set_speed", "value": "bad"}))
     data = json.loads(resp.body)
     assert data["speed"] == 2


### PR DESCRIPTION
## Summary
- handle invalid JSON payloads for control APIs
- add regression tests for invalid dashboard payloads
- update unit tests for new API signature
- fix mypy issue in governance service

## Testing
- `bash scripts/lint.sh`
- `python scripts/run_tests.py -m "unit or integration" tests/unit/interfaces/test_dashboard_backend_control.py tests/integration/interfaces/test_invalid_control_payloads.py`


------
https://chatgpt.com/codex/tasks/task_e_687e4973c9d88326b1dd2308b537a48c