### PR TITLE
Refactor WorldMap methods to async

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -48,3 +48,4 @@ numpy
 requests
 sqlalchemy
 aiosqlite
+scikit-learn

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,8 @@
 #
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+aiosqlite==0.21.0
+    # via -r requirements-dev.in
 annotated-types==0.7.0
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -35,12 +37,17 @@ certifi==2025.6.15
     #   -c /workspace/Culture/requirements.txt
     #   httpcore
     #   httpx
+    #   requests
 cffi==1.17.1
     # via
     #   -c /workspace/Culture/requirements.txt
     #   cryptography
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.4.2
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   requests
 click==8.2.1
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -88,6 +95,10 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.44
     # via -r requirements-dev.in
+greenlet==3.2.3
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   sqlalchemy
 h11==0.16.0
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -107,6 +118,7 @@ idna==3.10
     #   -c /workspace/Culture/requirements.txt
     #   anyio
     #   httpx
+    #   requests
 iniconfig==2.1.0
     # via pytest
 ipykernel==6.29.5
@@ -117,6 +129,10 @@ ipython==8.37.0
     #   ipykernel
 jedi==0.19.2
     # via ipython
+joblib==1.5.1
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   scikit-learn
 jsonschema==4.24.0
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -170,7 +186,11 @@ networkx==3.4.2
 nodeenv==1.9.1
     # via pre-commit
 numpy==1.26.4
-    # via -r requirements-dev.in
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   -r requirements-dev.in
+    #   scikit-learn
+    #   scipy
 packaging==24.2
     # via
     #   -c /workspace/Culture/requirements.txt
@@ -247,7 +267,9 @@ pytest==7.4.0
     #   pytest-xdist
     #   syrupy
 pytest-asyncio==0.23.8
-    # via -r requirements-dev.in
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   -r requirements-dev.in
 pytest-clarity==1.0.1
     # via -r requirements-dev.in
 pytest-cov==4.1.0
@@ -288,7 +310,9 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.4
-    # via -r requirements-dev.in
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   -r requirements-dev.in
 respx==0.22.0
     # via -r requirements-dev.in
 rich==14.0.0
@@ -302,6 +326,10 @@ rpds-py==0.25.1
     #   referencing
 ruff==0.12.1
     # via -r requirements-dev.in
+scikit-learn==1.7.1
+    # via -r requirements-dev.in
+scipy==1.15.3
+    # via scikit-learn
 scramp==1.4.5
     # via pg8000
 six==1.17.0
@@ -315,9 +343,9 @@ sniffio==1.3.1
     #   -c /workspace/Culture/requirements.txt
     #   anyio
 sqlalchemy==2.0.41
-    # via -r requirements-dev.in
-aiosqlite==0.21.0
-    # via -r requirements-dev.in
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   -r requirements-dev.in
 stack-data==0.6.3
     # via ipython
 starlette==0.37.2
@@ -330,6 +358,8 @@ testing-common-database==2.0.3
     # via testing-postgresql
 testing-postgresql==1.3.0
     # via -r requirements-dev.in
+threadpoolctl==3.6.0
+    # via scikit-learn
 tomli==2.2.1
     # via
     #   black
@@ -369,6 +399,7 @@ types-urllib3==1.26.25.14
 typing-extensions==4.14.0
     # via
     #   -c /workspace/Culture/requirements.txt
+    #   aiosqlite
     #   anyio
     #   exceptiongroup
     #   ipython
@@ -377,11 +408,16 @@ typing-extensions==4.14.0
     #   pydantic-core
     #   referencing
     #   rich
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.1
     # via
     #   -c /workspace/Culture/requirements.txt
     #   pydantic
+urllib3==2.5.0
+    # via
+    #   -c /workspace/Culture/requirements.txt
+    #   requests
 virtualenv==20.31.2
     # via pre-commit
 wcwidth==0.2.13

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -135,13 +135,13 @@ class Simulation:
         # Initialize world map and place agents
         self.world_map = WorldMap()
         for idx, ag in enumerate(self.agents):
-            self.world_map.add_agent(ag.agent_id, x=idx, y=0)
+            asyncio.run(self.world_map.add_agent(ag.agent_id, x=idx, y=0))
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -188,9 +188,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -505,9 +505,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(

--- a/src/sim/world_map.py
+++ b/src/sim/world_map.py
@@ -45,19 +45,21 @@ class WorldMap:
         if self.in_bounds(x, y):
             self.obstacles.add((x, y))
 
-    def add_agent(self, agent_id: str, x: int = 0, y: int = 0) -> None:
+    async def add_agent(self, agent_id: str, x: int = 0, y: int = 0) -> None:
         """Place ``agent_id`` on the map and initialize its inventory."""
 
-        self.agent_positions[agent_id] = (x, y)
-        self.agent_resources.setdefault(agent_id, {})
+        async with self.lock:
+            self.agent_positions[agent_id] = (x, y)
+            self.agent_resources.setdefault(agent_id, {})
 
-    def add_resource(self, x: int, y: int, resource: ResourceToken, amount: int = 1) -> None:
+    async def add_resource(self, x: int, y: int, resource: ResourceToken, amount: int = 1) -> None:
         """Add ``amount`` of ``resource`` to the specified cell."""
 
-        cell = self.resources.setdefault((x, y), {})
-        cell[resource.value] = cell.get(resource.value, 0) + amount
+        async with self.lock:
+            cell = self.resources.setdefault((x, y), {})
+            cell[resource.value] = cell.get(resource.value, 0) + amount
 
-    def move(
+    async def move(
         self,
         agent_id: str,
         dx: int,
@@ -67,19 +69,20 @@ class WorldMap:
     ) -> tuple[int, int]:
         """Move ``agent_id`` by ``dx`` and ``dy`` within map bounds."""
 
-        x, y = self.agent_positions.get(agent_id, (0, 0))
-        new_x = min(max(x + dx, 0), self.width - 1)
-        new_y = min(max(y + dy, 0), self.height - 1)
-        if not self.passable(new_x, new_y):
-            return x, y
-        self.agent_positions[agent_id] = (new_x, new_y)
-        if vector is not None:
-            self.vector.merge(VersionVector(vector))
-        else:
-            self.vector.increment(agent_id)
-        return new_x, new_y
+        async with self.lock:
+            x, y = self.agent_positions.get(agent_id, (0, 0))
+            new_x = min(max(x + dx, 0), self.width - 1)
+            new_y = min(max(y + dy, 0), self.height - 1)
+            if not self.passable(new_x, new_y):
+                return x, y
+            self.agent_positions[agent_id] = (new_x, new_y)
+            if vector is not None:
+                self.vector.merge(VersionVector(vector))
+            else:
+                self.vector.increment(agent_id)
+            return new_x, new_y
 
-    def move_to(
+    async def move_to(
         self,
         agent_id: str,
         dest_x: int,
@@ -89,19 +92,20 @@ class WorldMap:
     ) -> tuple[int, int]:
         """Move ``agent_id`` one step toward ``dest_x``, ``dest_y`` using A*."""
 
-        start = self.agent_positions.get(agent_id, (0, 0))
-        path = self.find_path(start, (dest_x, dest_y))
-        if len(path) < 2:
+        async with self.lock:
+            start = self.agent_positions.get(agent_id, (0, 0))
+            path = self.find_path(start, (dest_x, dest_y))
+            if len(path) < 2:
+                return start
+            nxt = path[1]
+            if self.passable(*nxt):
+                self.agent_positions[agent_id] = nxt
+                if vector is not None:
+                    self.vector.merge(VersionVector(vector))
+                else:
+                    self.vector.increment(agent_id)
+                return nxt
             return start
-        nxt = path[1]
-        if self.passable(*nxt):
-            self.agent_positions[agent_id] = nxt
-            if vector is not None:
-                self.vector.merge(VersionVector(vector))
-            else:
-                self.vector.increment(agent_id)
-            return nxt
-        return start
 
     def neighbors(self, pos: tuple[int, int]) -> Iterable[tuple[int, int]]:
         x, y = pos
@@ -149,7 +153,7 @@ class WorldMap:
         path.reverse()
         return path
 
-    def gather(
+    async def gather(
         self,
         agent_id: str,
         resource: ResourceToken,
@@ -158,31 +162,32 @@ class WorldMap:
     ) -> bool:
         """Collect ``resource`` from the agent's current position."""
 
-        pos = self.agent_positions.get(agent_id)
-        if pos is None:
-            return False
-        cell = self.resources.get(pos)
-        res_key = resource.value
-        if not cell or cell.get(res_key, 0) <= 0:
-            return False
-        cell[res_key] -= 1
-        if cell[res_key] == 0:
-            del cell[res_key]
-        bag = self.agent_resources.setdefault(agent_id, {})
-        bag[res_key] = bag.get(res_key, 0) + 1
-        try:
-            from src.infra.ledger import ledger
+        async with self.lock:
+            pos = self.agent_positions.get(agent_id)
+            if pos is None:
+                return False
+            cell = self.resources.get(pos)
+            res_key = resource.value
+            if not cell or cell.get(res_key, 0) <= 0:
+                return False
+            cell[res_key] -= 1
+            if cell[res_key] == 0:
+                del cell[res_key]
+            bag = self.agent_resources.setdefault(agent_id, {})
+            bag[res_key] = bag.get(res_key, 0) + 1
+            try:
+                from src.infra.ledger import ledger
 
-            ledger.add_tokens(agent_id, res_key, 1)
-        except Exception:  # pragma: no cover - optional
-            pass
-        if vector is not None:
-            self.vector.merge(VersionVector(vector))
-        else:
-            self.vector.increment(agent_id)
-        return True
+                ledger.add_tokens(agent_id, res_key, 1)
+            except Exception:  # pragma: no cover - optional
+                pass
+            if vector is not None:
+                self.vector.merge(VersionVector(vector))
+            else:
+                self.vector.increment(agent_id)
+            return True
 
-    def build(
+    async def build(
         self,
         agent_id: str,
         structure: StructureType,
@@ -191,28 +196,29 @@ class WorldMap:
     ) -> bool:
         """Construct a ``structure`` at the agent's current location."""
 
-        pos = self.agent_positions.get(agent_id)
-        if pos is None:
-            return False
-        bag = self.agent_resources.get(agent_id, {})
-        wood = bag.get(ResourceToken.WOOD.value, 0)
-        if wood < 1:
-            return False
-        bag[ResourceToken.WOOD.value] = wood - 1
-        if bag[ResourceToken.WOOD.value] == 0:
-            del bag[ResourceToken.WOOD.value]
-        self.buildings[pos] = structure.value
-        try:
-            from src.infra.ledger import ledger
+        async with self.lock:
+            pos = self.agent_positions.get(agent_id)
+            if pos is None:
+                return False
+            bag = self.agent_resources.get(agent_id, {})
+            wood = bag.get(ResourceToken.WOOD.value, 0)
+            if wood < 1:
+                return False
+            bag[ResourceToken.WOOD.value] = wood - 1
+            if bag[ResourceToken.WOOD.value] == 0:
+                del bag[ResourceToken.WOOD.value]
+            self.buildings[pos] = structure.value
+            try:
+                from src.infra.ledger import ledger
 
-            ledger.remove_tokens(agent_id, ResourceToken.WOOD.value, 1)
-        except Exception:  # pragma: no cover - optional
-            pass
-        if vector is not None:
-            self.vector.merge(VersionVector(vector))
-        else:
-            self.vector.increment(agent_id)
-        return True
+                ledger.remove_tokens(agent_id, ResourceToken.WOOD.value, 1)
+            except Exception:  # pragma: no cover - optional
+                pass
+            if vector is not None:
+                self.vector.merge(VersionVector(vector))
+            else:
+                self.vector.increment(agent_id)
+            return True
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -26,16 +26,15 @@ async def process_map_action(
     """Execute a world map action for the given agent."""
     action_type = map_action.get("action")
     details: dict[str, Any] = {}
-    async with sim.world_map.lock:
-        if action_type == "move":
-            if "x" in map_action and "y" in map_action:
-                tx = int(map_action.get("x", 0))
-                ty = int(map_action.get("y", 0))
-                pos = sim.world_map.move_to(agent_id, tx, ty, vector=sim.vector.to_dict())
-            else:
-                dx = int(map_action.get("dx", 0))
-                dy = int(map_action.get("dy", 0))
-                pos = sim.world_map.move(agent_id, dx, dy, vector=sim.vector.to_dict())
+    if action_type == "move":
+        if "x" in map_action and "y" in map_action:
+            tx = int(map_action.get("x", 0))
+            ty = int(map_action.get("y", 0))
+            pos = await sim.world_map.move_to(agent_id, tx, ty, vector=sim.vector.to_dict())
+        else:
+            dx = int(map_action.get("dx", 0))
+            dy = int(map_action.get("dy", 0))
+            pos = await sim.world_map.move(agent_id, dx, dy, vector=sim.vector.to_dict())
             details = {"position": pos}
             start_ip = current_state.ip
             if config.MAP_MOVE_DU_COST > 0:
@@ -63,15 +62,15 @@ async def process_map_action(
                 )
             except Exception:  # pragma: no cover - optional
                 logger.debug("Ledger logging failed", exc_info=True)
-        elif action_type == "gather":
-            res = map_action.get("resource")
-            success = False
-            if isinstance(res, str):
-                success = sim.world_map.gather(
-                    agent_id,
-                    ResourceToken(res),
-                    vector=sim.vector.to_dict(),
-                )
+    elif action_type == "gather":
+        res = map_action.get("resource")
+        success = False
+        if isinstance(res, str):
+            success = await sim.world_map.gather(
+                agent_id,
+                ResourceToken(res),
+                vector=sim.vector.to_dict(),
+            )
             details = {"resource": res, "success": success}
             if success:
                 start_ip = current_state.ip
@@ -100,15 +99,15 @@ async def process_map_action(
                     )
                 except Exception:  # pragma: no cover - optional
                     logger.debug("Ledger logging failed", exc_info=True)
-        elif action_type == "build":
-            struct = map_action.get("structure")
-            success = False
-            if isinstance(struct, str):
-                success = sim.world_map.build(
-                    agent_id,
-                    StructureType(struct),
-                    vector=sim.vector.to_dict(),
-                )
+    elif action_type == "build":
+        struct = map_action.get("structure")
+        success = False
+        if isinstance(struct, str):
+            success = await sim.world_map.build(
+                agent_id,
+                StructureType(struct),
+                vector=sim.vector.to_dict(),
+            )
             details = {"structure": struct, "success": success}
             if success:
                 start_ip = current_state.ip

--- a/tests/integration/sim/test_world_map_actions.py
+++ b/tests/integration/sim/test_world_map_actions.py
@@ -91,8 +91,7 @@ async def test_gather_action_success_and_failure(
     sim: tuple[Simulation, Ledger, DummyAgent],
 ) -> None:
     sim_obj, ledger, agent = sim
-    async with sim_obj.world_map.lock:
-        sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
+    await sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
     await process_map_action(
         sim_obj,
         0,
@@ -136,8 +135,7 @@ async def test_build_action_success_and_failure(
     rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
     assert rows == []
 
-    async with sim_obj.world_map.lock:
-        sim_obj.world_map.agent_resources[agent.agent_id] = {"wood": 1}
+    sim_obj.world_map.agent_resources[agent.agent_id] = {"wood": 1}
     await process_map_action(
         sim_obj,
         0,
@@ -157,8 +155,7 @@ async def test_gather_then_build_updates_ledger_and_map(
     sim: tuple[Simulation, Ledger, DummyAgent],
 ) -> None:
     sim_obj, ledger, agent = sim
-    async with sim_obj.world_map.lock:
-        sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
+    await sim_obj.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
     await process_map_action(
         sim_obj,
         0,

--- a/tests/unit/sim/test_world_map.py
+++ b/tests/unit/sim/test_world_map.py
@@ -11,25 +11,25 @@ pytestmark = pytest.mark.unit
 
 def test_move_within_bounds() -> None:
     m = WorldMap(width=3, height=3)
-    m.add_agent("A")
-    m.move("A", 1, 1)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.move("A", 1, 1))
     assert m.agent_positions["A"] == (1, 1)
 
 
 def test_gather_resource() -> None:
     m = WorldMap()
-    m.add_agent("A")
-    m.add_resource(0, 0, ResourceToken.WOOD, 1)
-    assert m.gather("A", ResourceToken.WOOD)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.add_resource(0, 0, ResourceToken.WOOD, 1))
+    assert asyncio.run(m.gather("A", ResourceToken.WOOD))
     assert m.agent_resources["A"]["wood"] == 1
     assert m.resources[(0, 0)].get("wood", 0) == 0
 
 
 def test_build_structure() -> None:
     m = WorldMap()
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
     m.agent_resources["A"] = {"wood": 1}
-    assert m.build("A", StructureType.HUT)
+    assert asyncio.run(m.build("A", StructureType.HUT))
     assert m.buildings[(0, 0)] == StructureType.HUT.value
     assert m.agent_resources["A"].get("wood", 0) == 0
 
@@ -103,7 +103,7 @@ def test_gather_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
     agent = ActionAgent({"action": "gather", "resource": ResourceToken.WOOD.value})
     sim = Simulation([agent])  # type: ignore[arg-type,list-item]
-    sim.world_map.add_resource(0, 0, ResourceToken.WOOD, 1)
+    asyncio.run(sim.world_map.add_resource(0, 0, ResourceToken.WOOD, 1))
 
     asyncio.run(sim.run_step(max_turns=2))
     sim.close()
@@ -138,64 +138,64 @@ def test_build_updates_balance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
 def test_pathfinding_large_map() -> None:
     m = WorldMap(width=20, height=20)
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
     # create a wall of obstacles except for a gap
     for y in range(10):
         if y != 5:
             m.add_obstacle(5, y)
     # move towards the other side of the wall
     for _ in range(20):
-        m.move_to("A", 10, 0)
+        asyncio.run(m.move_to("A", 10, 0))
     x, y = m.agent_positions["A"]
     assert (x, y) == (10, 0)
 
 
 def test_gather_after_pathfinding() -> None:
     m = WorldMap(width=15, height=15)
-    m.add_agent("A")
-    m.add_resource(10, 10, ResourceToken.WOOD, 1)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.add_resource(10, 10, ResourceToken.WOOD, 1))
     for _ in range(20):
-        m.move_to("A", 10, 10)
+        asyncio.run(m.move_to("A", 10, 10))
     assert m.agent_positions["A"] == (10, 10)
-    assert m.gather("A", ResourceToken.WOOD)
+    assert asyncio.run(m.gather("A", ResourceToken.WOOD))
     assert m.agent_resources["A"].get("wood", 0) == 1
 
 
 def test_move_to_with_diagonal_obstacles() -> None:
     m = WorldMap(width=6, height=6)
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
     for i in range(1, 5):
         m.add_obstacle(i, i)
     for _ in range(15):
-        m.move_to("A", 5, 5)
+        asyncio.run(m.move_to("A", 5, 5))
     assert m.agent_positions["A"] == (5, 5)
 
 
 def test_move_out_of_bounds() -> None:
     m = WorldMap(width=3, height=3)
-    m.add_agent("A")
-    m.move("A", -1, -1)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.move("A", -1, -1))
     assert m.agent_positions["A"] == (0, 0)
-    m.move("A", 10, 0)
+    asyncio.run(m.move("A", 10, 0))
     assert m.agent_positions["A"] == (2, 0)
-    pos = m.move_to("A", 5, 5)
+    pos = asyncio.run(m.move_to("A", 5, 5))
     assert pos == (2, 0)
     assert m.agent_positions["A"] == (2, 0)
 
 
 def test_resource_depletion() -> None:
     m = WorldMap()
-    m.add_agent("A")
-    m.add_resource(0, 0, ResourceToken.WOOD, 1)
-    assert m.gather("A", ResourceToken.WOOD)
-    assert not m.gather("A", ResourceToken.WOOD)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.add_resource(0, 0, ResourceToken.WOOD, 1))
+    assert asyncio.run(m.gather("A", ResourceToken.WOOD))
+    assert not asyncio.run(m.gather("A", ResourceToken.WOOD))
     assert m.agent_resources["A"].get("wood", 0) == 1
     assert m.resources[(0, 0)].get("wood") is None
 
 
 def test_move_to_complex_obstacles() -> None:
     m = WorldMap(width=10, height=10)
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
     for i in range(1, 9):
         if i != 3:
             m.add_obstacle(i, 5)
@@ -203,5 +203,5 @@ def test_move_to_complex_obstacles() -> None:
         if i != 7:
             m.add_obstacle(5, i)
     for _ in range(25):
-        m.move_to("A", 9, 9)
+        asyncio.run(m.move_to("A", 9, 9))
     assert m.agent_positions["A"] == (9, 9)

--- a/tests/unit/world_map/test_actions.py
+++ b/tests/unit/world_map/test_actions.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,9 +20,9 @@ def ledger_stub(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 
 def test_move_updates_vector_and_position() -> None:
     m = WorldMap(width=3, height=3)
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
 
-    pos = m.move("A", 1, 1)
+    pos = asyncio.run(m.move("A", 1, 1))
 
     assert pos == (1, 1)
     assert m.agent_positions["A"] == (1, 1)
@@ -33,10 +34,10 @@ def test_move_updates_vector_and_position() -> None:
 
 def test_gather_updates_resources_and_vector(ledger_stub: MagicMock) -> None:
     m = WorldMap()
-    m.add_agent("A")
-    m.add_resource(0, 0, ResourceToken.WOOD, 1)
+    asyncio.run(m.add_agent("A"))
+    asyncio.run(m.add_resource(0, 0, ResourceToken.WOOD, 1))
 
-    result = m.gather("A", ResourceToken.WOOD)
+    result = asyncio.run(m.gather("A", ResourceToken.WOOD))
 
     assert result is True
     assert m.agent_resources["A"].get("wood", 0) == 1
@@ -51,10 +52,10 @@ def test_gather_updates_resources_and_vector(ledger_stub: MagicMock) -> None:
 
 def test_build_updates_buildings_and_vector(ledger_stub: MagicMock) -> None:
     m = WorldMap()
-    m.add_agent("A")
+    asyncio.run(m.add_agent("A"))
     m.agent_resources["A"] = {"wood": 1}
 
-    result = m.build("A", StructureType.HUT)
+    result = asyncio.run(m.build("A", StructureType.HUT))
 
     assert result is True
     assert m.buildings[(0, 0)] == StructureType.HUT.value

--- a/tests/unit/world_map/test_concurrent_moves.py
+++ b/tests/unit/world_map/test_concurrent_moves.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import pytest
+
+from src.sim.world_map import WorldMap
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_concurrent_moves() -> None:
+    m = WorldMap(width=5, height=5)
+    await m.add_agent("A")
+
+    async def mover() -> None:
+        for _ in range(50):
+            await m.move("A", 1, 0)
+
+    await asyncio.gather(*(mover() for _ in range(5)))
+
+    assert m.agent_positions["A"] == (4, 0)


### PR DESCRIPTION
## Summary
- make world map methods async and lock internally
- await world map methods in process_map_action
- adjust simulation initialization for async add_agent
- update unit and integration tests
- add concurrent move test
- include scikit-learn in dev requirements

## Testing
- `ruff check src/sim/world_map.py src/sim/world_map_actions.py src/sim/simulation.py tests/unit/world_map/test_actions.py tests/unit/sim/test_world_map.py tests/integration/sim/test_world_map_actions.py tests/unit/world_map/test_concurrent_moves.py`
- `ruff format --check src/sim/world_map.py src/sim/world_map_actions.py src/sim/simulation.py tests/unit/world_map/test_actions.py tests/unit/sim/test_world_map.py tests/integration/sim/test_world_map_actions.py tests/unit/world_map/test_concurrent_moves.py`
- `pytest tests/unit/world_map/test_concurrent_moves.py tests/unit/sim/test_world_map.py tests/unit/world_map/test_actions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e49725d348326aa1fc74e26f2668e