### PR TITLE
Refactor memory retrieval

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -77,25 +77,24 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 
 
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
-    manager = cast(
-        MemoryService | MemoryRetriever | None,
-        state.get("memory_service") or state.get("vector_store_manager"),
-    )
+    service = cast(MemoryService | None, state.get("memory_service"))
+    if service is None:
+        vector = cast(MemoryRetriever | None, state.get("vector_store_manager"))
+        semantic = cast(Any, state.get("semantic_manager"))
+        if vector or semantic:
+            service = MemoryService(cast(Any, vector), cast(Any, semantic))
+        else:
+            service = None
+
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
-    if not manager or not agent:
+    if not service or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
-    if hasattr(manager, "get_context_pipeline"):
-        memories, semantic = await cast(MemoryService, manager).get_context_pipeline(
-            state["agent_id"], query="", k=5, semantic_limit=2
-        )
-        memories_content = [m.get("content", "") for m in memories] + semantic
-    else:
-        memories = await cast(MemoryRetriever, manager).aretrieve_relevant_memories(
-            state["agent_id"], query="", k=5
-        )
-        memories_content = [m.get("content", "") for m in memories]
-        semantic = []
+    memories, semantic = await service.get_context_pipeline(
+        state["agent_id"], query="", k=5, semantic_limit=2
+    )
+    memories_content = [m.get("content", "") for m in memories] + list(semantic)
+
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))
     summary_result = await agent.async_generate_l1_summary(
@@ -105,10 +104,7 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     )
     summary = getattr(summary_result, "summary", "")
 
-    if hasattr(manager, "blend_with_recent_semantic"):
-        summary = cast(MemoryService, manager).blend_with_recent_semantic(
-            state["agent_id"], summary
-        )
+    summary = service.blend_with_recent_semantic(state["agent_id"], summary)
 
     return {"rag_summary": summary, "memory_history_list": memories}
 

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -18,6 +18,18 @@ class DummyVectorStore:
         return ["summary1"]
 
 
+class DummyService:
+    async def get_context_pipeline(
+        self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2
+    ) -> tuple[list[dict[str, str]], list[str]]:
+        return [{"content": "memory1"}], ["summary1"]
+
+    def blend_with_recent_semantic(
+        self, agent_id: str, episodic_summary: str, limit: int = 3
+    ) -> str:
+        return f"{episodic_summary}\nsummary1"
+
+
 from pytest import LogCaptureFixture
 
 pytest.importorskip("langgraph")
@@ -87,9 +99,9 @@ async def test_dspy_call_timeout_in_graph(
     mock_program_callable = AsyncMock(side_effect=mock_slow_dspy_call)
 
     logger.info(f"Simple agent dict before hasattr: {simple_agent.__dict__}")
-    assert hasattr(
-        simple_agent, "action_intent_selector_program"
-    ), "Agent should have action_intent_selector_program before patch"
+    assert hasattr(simple_agent, "action_intent_selector_program"), (
+        "Agent should have action_intent_selector_program before patch"
+    )
 
     # Prepare a minimal AgentTurnState
     initial_turn_state = AgentTurnState(
@@ -107,7 +119,7 @@ async def test_dspy_call_timeout_in_graph(
             simple_agent.state.goals[0]["description"] if simple_agent.state.goals else "Test Goal"
         ),
         updated_state={},  # Will be populated by graph
-        vector_store_manager=DummyVectorStore(),
+        memory_service=DummyService(),
         rag_summary="(No rag summary for this test)",
         knowledge_board_content=[],
         knowledge_board=None,  # Not strictly needed
@@ -159,17 +171,17 @@ async def test_dspy_call_timeout_in_graph(
         final_structured_output = final_state.get("structured_output")
         assert final_structured_output is not None, "Final state should have structured_output"
         # Default fallback is often 'idle'
-        assert (
-            final_structured_output.action_intent == AgentActionIntent.IDLE.value
-        ), f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
+        assert final_structured_output.action_intent == AgentActionIntent.IDLE.value, (
+            f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
+        )
         assert (
             "timeout" in final_structured_output.thought.lower()
             or "fallback" in final_structured_output.thought.lower()
             or "default" in final_structured_output.thought.lower()
         ), f"Expected thought to indicate timeout/fallback, got: {final_structured_output.thought}"
-        assert final_state[
-            "memory_history_list"
-        ], "memory_history_list should contain retrieved memories"
+        assert final_state["memory_history_list"], (
+            "memory_history_list should contain retrieved memories"
+        )
 
 
 @pytest.mark.asyncio
@@ -206,7 +218,7 @@ async def test_dspy_call_exception_in_graph(
             simple_agent.state.goals[0]["description"] if simple_agent.state.goals else "Test Goal"
         ),
         updated_state={},
-        vector_store_manager=DummyVectorStore(),
+        memory_service=DummyService(),
         rag_summary="(No rag summary for this test)",
         knowledge_board_content=[],
         knowledge_board=None,
@@ -256,22 +268,24 @@ async def test_dspy_call_exception_in_graph(
         #    The generate_thought_and_message_node should produce a default/fallback
         #    AgentActionOutput if async_select_action_intent raises an exception.
         final_structured_output_exc = final_state.get("structured_output")
-        assert (
-            final_structured_output_exc is not None
-        ), "Final state should have structured_output after exception"
+        assert final_structured_output_exc is not None, (
+            "Final state should have structured_output after exception"
+        )
         # Default fallback is often 'idle'
-        assert (
-            final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value
-        ), f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
+        assert final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value, (
+            f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
+        )
         assert (
             "error" in final_structured_output_exc.thought.lower()
             or "fallback" in final_structured_output_exc.thought.lower()
             or "exception" in final_structured_output_exc.thought.lower()
             or "default" in final_structured_output_exc.thought.lower()
-        ), f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
-        assert final_state[
-            "memory_history_list"
-        ], "memory_history_list should contain retrieved memories"
+        ), (
+            f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
+        )
+        assert final_state["memory_history_list"], (
+            "memory_history_list should contain retrieved memories"
+        )
 
         # 3. Optional: Verify the specific error log from the mock if it appears, but don't fail if not,
         #    as primary check is the fallback action.

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -52,14 +52,11 @@ async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
     assert out["memory_history_list"] == []
 
 
-class DummyManager:
-    async def aretrieve_relevant_memories(
-        self, agent_id: str, query: str = "", k: int = 5
-    ) -> list[dict[str, str]]:
-        return [{"content": "m1"}, {"content": "m2"}]
-
-    def get_semantic_summaries(self, agent_id: str, limit: int = 2) -> list[str]:
-        return ["sem1"]
+class DummyService:
+    async def get_context_pipeline(
+        self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2
+    ) -> tuple[list[dict[str, str]], list[str]]:
+        return [{"content": "m1"}, {"content": "m2"}], ["sem1"]
 
     def blend_with_recent_semantic(
         self, agent_id: str, episodic_summary: str, limit: int = 3
@@ -79,7 +76,7 @@ class DummyAgent:
 async def test_retrieve_and_summarize_memories_node_with_manager() -> None:
     state = {
         "agent_id": "a",
-        "vector_store_manager": DummyManager(),
+        "memory_service": DummyService(),
         "agent_instance": DummyAgent(),
         "current_role": "r",
     }


### PR DESCRIPTION
## Summary
- route graph memory retrieval through `MemoryService.get_context_pipeline`
- adjust integration and unit tests for new pipeline usage

## Testing
- `ruff check src/agents/graphs/graph_nodes.py tests/integration/graph/test_async_agent_graph.py tests/unit/graphs/test_graph_nodes.py`
- `ruff format src/agents/graphs/graph_nodes.py tests/integration/graph/test_async_agent_graph.py tests/unit/graphs/test_graph_nodes.py`
- `pytest tests/unit/graphs/test_graph_nodes.py tests/integration/graph/test_async_agent_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e626d47288326ac13e4e2b6856680