### PR TITLE
Unify SimulationEvent schema

### DIFF
--- a/culture-ui/src/AgentTimeline.test.tsx
+++ b/culture-ui/src/AgentTimeline.test.tsx
@@ -24,7 +24,7 @@ describe('AgentTimeline widget', () => {
     const es = MockEventSource.instances[0]
     act(() => {
       es.emitMessage(
-        '{"event_type":"update","data":{"step":1,"world_map":{"agents":{"agent-1":[3,4]}}}}',
+        '{"type":"update","data":{"step":1,"world_map":{"agents":{"agent-1":[3,4]}}}}',
       )
     })
 

--- a/culture-ui/src/LiveMap.test.tsx
+++ b/culture-ui/src/LiveMap.test.tsx
@@ -18,7 +18,7 @@ describe('LiveMap', () => {
 
     const es = MockEventSource.instances[0]
     act(() => {
-      es.emitMessage('{"event_type":"map_change","data":{"world_map":{"agents":{"agent-1":[1,2]}}}}')
+      es.emitMessage('{"type":"map_change","data":{"world_map":{"agents":{"agent-1":[1,2]}}}}')
     })
 
     expect(await screen.findByText('agent-1: 1, 2')).toBeInTheDocument()

--- a/culture-ui/src/Storyboard.test.tsx
+++ b/culture-ui/src/Storyboard.test.tsx
@@ -91,7 +91,7 @@ describe('Storyboard widget', () => {
         '{"data":{"world_map":{"agents":{"a1":[0,0]}}}}',
       )
       ws.sendMessage(
-        '{"event_type":"memory_prune","data":{"step":1}}',
+        '{"type":"memory_prune","data":{"step":1}}',
       )
     })
 

--- a/culture-ui/src/lib/useEventSource.test.tsx
+++ b/culture-ui/src/lib/useEventSource.test.tsx
@@ -189,7 +189,7 @@ describe('useEventSource integration with FastAPI', () => {
     render(<TestComponent />)
     await waitFor(() => {
       expect(screen.getByTestId('value').textContent).toBe(
-        JSON.stringify({ event_type: 'test', data: { value: 1 } }),
+        JSON.stringify({ type: 'test', data: { value: 1 } }),
       )
     })
   })

--- a/culture-ui/src/widgets/AgentTimeline.tsx
+++ b/culture-ui/src/widgets/AgentTimeline.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useEventSource } from '../lib/useEventSource'
 
 interface SimEvent {
-  event_type?: string
+  type?: string
   data?: {
     step?: number
     world_map?: { agents?: Record<string, [number, number]> }

--- a/culture-ui/src/widgets/BreakpointList.test.tsx
+++ b/culture-ui/src/widgets/BreakpointList.test.tsx
@@ -38,7 +38,7 @@ describe('BreakpointList', () => {
     const es = MockEventSource.instances[0]
     act(() => {
       es.emitMessage(
-        '{"event_type":"breakpoint_hit","data":{"tags":["nsfw"],"step":1}}',
+        '{"type":"breakpoint_hit","data":{"tags":["nsfw"],"step":1}}',
       )
     })
 

--- a/culture-ui/src/widgets/BreakpointList.tsx
+++ b/culture-ui/src/widgets/BreakpointList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useEventSource } from '../lib/useEventSource'
 
 interface BreakpointEvent {
-  event_type?: string
+  type?: string
   data?: { tags?: string[]; step?: number }
 }
 
@@ -15,7 +15,7 @@ export default function BreakpointList() {
   const event = useEventSource<BreakpointEvent>()
 
   useEffect(() => {
-    if (event?.event_type === 'breakpoint_hit') {
+    if (event?.type === 'breakpoint_hit') {
       const hit = event.data?.tags?.join(', ') ?? ''
       setToast(`Breakpoint hit: ${hit}`)
       const t = setTimeout(() => setToast(null), 3000)

--- a/culture-ui/src/widgets/LiveMap.tsx
+++ b/culture-ui/src/widgets/LiveMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 interface MapEvent {
-  event_type: string
+  type: string
   data?: {
     world_map?: {
       agents?: Record<string, [number, number]>

--- a/culture-ui/src/widgets/Storyboard.tsx
+++ b/culture-ui/src/widgets/Storyboard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 interface SnapshotEvent {
-  event_type?: string
+  type?: string
   data?: {
     world_map?: { agents?: Record<string, [number, number]> }
     agents?: Array<{ agent_id: string; mood?: number }>
@@ -54,9 +54,9 @@ export default function Storyboard() {
       }
       setMoods((cur) => ({ ...cur, ...m }))
     }
-    if (event?.event_type?.startsWith('memory')) {
+    if (event?.type?.startsWith('memory')) {
       setMemoryEvents((cur) =>
-        [{ type: event.event_type!, step: event.data?.step }, ...cur].slice(0, 20),
+        [{ type: event.type!, step: event.data?.step }, ...cur].slice(0, 20),
       )
     }
   }, [event])

--- a/culture-ui/src/widgets/TimelineWidget.tsx
+++ b/culture-ui/src/widgets/TimelineWidget.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useEventSource } from '../lib/useEventSource'
 
 interface SimEvent {
-  event_type: string
+  type: string
   data?: { step?: number }
 }
 

--- a/culture-ui/tests/live-map.pw.ts
+++ b/culture-ui/tests/live-map.pw.ts
@@ -27,7 +27,7 @@ test('live map widget updates from map events', async ({ page }) => {
       .instance
     es.dispatchEvent(
       new MessageEvent('message', {
-        data: '{"event_type":"map_change","data":{"world_map":{"agents":{"agent-1":[5,6]}}}}',
+        data: '{"type":"map_change","data":{"world_map":{"agents":{"agent-1":[5,6]}}}}',
       }),
     )
   })

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 
 # Skip self argument annotation warnings in stub classes
@@ -29,24 +31,22 @@ else:  # pragma: no cover - optional runtime dependency
     except Exception:
 
         class FastAPI:
-            def __init__(self: "FastAPI", *args: object, **kwargs: object) -> None:
+            def __init__(self: FastAPI, *args: object, **kwargs: object) -> None:
                 pass
 
-            def get(self: "FastAPI", *args: object, **kwargs: object) -> Callable[[Any], Any]:
+            def get(self: FastAPI, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def post(self: "FastAPI", *args: object, **kwargs: object) -> Callable[[Any], Any]:
+            def post(self: FastAPI, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
                 return dec
 
-            def websocket(
-                self: "FastAPI", *args: object, **kwargs: object
-            ) -> Callable[[Any], Any]:
+            def websocket(self: FastAPI, *args: object, **kwargs: object) -> Callable[[Any], Any]:
                 def dec(fn: Any) -> Any:
                     return fn
 
@@ -56,7 +56,7 @@ else:  # pragma: no cover - optional runtime dependency
             pass
 
         class Response:  # pragma: no cover - minimal stub
-            def __init__(self: "Response", *args: object, **kwargs: object) -> None:
+            def __init__(self: Response, *args: object, **kwargs: object) -> None:
                 pass
 
         class WebSocket:  # pragma: no cover - minimal stub
@@ -67,7 +67,7 @@ else:  # pragma: no cover - optional runtime dependency
 
         class JSONResponse:  # pragma: no cover - minimal stub
             def __init__(
-                self: "JSONResponse", content: object, *args: object, **kwargs: object
+                self: JSONResponse, content: object, *args: object, **kwargs: object
             ) -> None:
                 self.body = json.dumps(content).encode("utf-8")
 
@@ -80,15 +80,15 @@ else:  # pragma: no cover - optional dependency
     except Exception:
 
         class EventSourceResponse:  # pragma: no cover - minimal stub
-            def __init__(self: "EventSourceResponse", *args: object, **kwargs: object) -> None:
+            def __init__(self: EventSourceResponse, *args: object, **kwargs: object) -> None:
                 self.gen = None
 
 
 # Global queue for agent messages with bounded size
-message_sse_queue: asyncio.Queue["AgentMessage"] = asyncio.Queue(maxsize=1000)
+message_sse_queue: asyncio.Queue[AgentMessage] = asyncio.Queue(maxsize=1000)
 
 
-async def enqueue_message(msg: "AgentMessage") -> None:
+async def enqueue_message(msg: AgentMessage) -> None:
     """Add a message to the SSE queue, dropping the oldest if full."""
     if message_sse_queue.full():
         try:
@@ -103,11 +103,11 @@ async def enqueue_message(msg: "AgentMessage") -> None:
 # subscribed to the global :class:`~src.sim.event_bus.EventBus` instance. The
 # same queue is returned on subsequent calls within the same loop to match the
 # previous behaviour.
-_event_queue: asyncio.Queue["SimulationEvent | None"] | None = None
+_event_queue: asyncio.Queue[SimulationEvent | None] | None = None
 _event_queue_loop: asyncio.AbstractEventLoop | None = None
 
 
-def get_event_queue() -> asyncio.Queue["SimulationEvent | None"]:
+def get_event_queue() -> asyncio.Queue[SimulationEvent | None]:
     """Return a shared event queue bound to the active loop."""
     global _event_queue, _event_queue_loop
     try:
@@ -153,7 +153,7 @@ class AgentMessage(BaseModel):
 class SimulationEvent(BaseModel):
     """Generic simulation event structure for dashboards."""
 
-    event_type: str
+    type: str
     data: dict[str, Any] | None = None
 
 
@@ -232,7 +232,7 @@ async def api_map(request: Request) -> Response:
                 event: SimulationEvent | None = await queue.get()
                 if event is None:
                     break
-                if event.event_type == "map_change":
+                if event.type == "map_change":
                     yield {"data": event.model_dump_json()}
         finally:
             bus.unsubscribe(queue)
@@ -443,7 +443,8 @@ try:
     @app.post("/control")
     async def control(request: Request) -> Response:
         try:
-            command = await request.json()
+            body = await request.body()
+            command = json.loads(body)
             if not isinstance(command, dict):
                 raise ValueError
         except Exception:
@@ -491,7 +492,7 @@ async def emit_event(event: SimulationEvent) -> None:
         SIM_STATE["paused"] = True
         await bus.publish(
             SimulationEvent(
-                event_type="breakpoint_hit",
+                type="breakpoint_hit",
                 data={
                     "tags": list(tags & BREAKPOINT_TAGS),
                     "step": event.data.get("step") if event.data else None,
@@ -509,7 +510,7 @@ async def emit_map_action_event(
     """Convenience helper to enqueue map actions."""
     await emit_event(
         SimulationEvent(
-            event_type="map_action",
+            type="map_action",
             data={"agent_id": agent_id, "step": step, "action": action, **details},
         )
     )
@@ -517,7 +518,7 @@ async def emit_map_action_event(
 
 async def emit_map_change_event(world_map: dict[str, Any]) -> None:
     """Convenience helper to enqueue world map updates."""
-    await emit_event(SimulationEvent(event_type="map_change", data={"world_map": world_map}))
+    await emit_event(SimulationEvent(type="map_change", data={"world_map": world_map}))
 
 
 __all__ = [

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -185,7 +185,7 @@ class SimulationDiscordBot:
                 data = {"author": str(getattr(message, "author", "")), "content": content}
                 if recipient:
                     data["recipient_id"] = recipient
-                await self.event_queue.put(SimulationEvent(event_type=evt_type, data=data))
+                await self.event_queue.put(SimulationEvent(type=evt_type, data=data))
 
     async def _select_client(self: Self, agent_id: Optional[str]) -> Any:
         """Return the Discord client for the given agent."""
@@ -654,7 +654,7 @@ async def slash_stats(interaction: Any) -> None:
 @bot.tree.command(name="pause")
 async def slash_pause(interaction: Any) -> None:
     """Pause the simulation via a control command."""
-    await event_queue.put(SimulationEvent(event_type="control", data={"command": "pause"}))
+    await event_queue.put(SimulationEvent(type="control", data={"command": "pause"}))
     await interaction.response.send_message("pause", ephemeral=True)
 
 
@@ -662,7 +662,7 @@ async def slash_pause(interaction: Any) -> None:
 @bot.tree.command(name="resume")
 async def slash_resume(interaction: Any) -> None:
     """Resume the simulation via a control command."""
-    await event_queue.put(SimulationEvent(event_type="control", data={"command": "resume"}))
+    await event_queue.put(SimulationEvent(type="control", data={"command": "resume"}))
     await interaction.response.send_message("resume", ephemeral=True)
 
 
@@ -671,7 +671,7 @@ async def slash_resume(interaction: Any) -> None:
 async def slash_set_speed(interaction: Any, value: float) -> None:
     """Adjust the simulation speed via a control command."""
     await event_queue.put(
-        SimulationEvent(event_type="control", data={"command": "set_speed", "value": value})
+        SimulationEvent(type="control", data={"command": "set_speed", "value": value})
     )
     await interaction.response.send_message(f"speed {value}", ephemeral=True)
 

--- a/src/sim/event_bus.py
+++ b/src/sim/event_bus.py
@@ -1,31 +1,34 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING
 
 from typing_extensions import Self
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from src.interfaces.dashboard_backend import SimulationEvent
 
 
 class EventBus:
     """Simple publish/subscribe event bus."""
 
     def __init__(self: Self) -> None:
-        self._queues: list[asyncio.Queue[Any | None]] = []
+        self._queues: list[asyncio.Queue[SimulationEvent | None]] = []
 
-    def subscribe(self: Self) -> asyncio.Queue[Any | None]:
+    def subscribe(self: Self) -> asyncio.Queue[SimulationEvent | None]:
         """Return a new queue subscribed to published events."""
-        q: asyncio.Queue[Any | None] = asyncio.Queue()
+        q: asyncio.Queue[SimulationEvent | None] = asyncio.Queue()
         self._queues.append(q)
         return q
 
-    def unsubscribe(self: Self, q: asyncio.Queue[Any | None]) -> None:
+    def unsubscribe(self: Self, q: asyncio.Queue[SimulationEvent | None]) -> None:
         """Remove ``q`` from the subscriber list if present."""
         try:
             self._queues.remove(q)
         except ValueError:  # pragma: no cover - defensive
             pass
 
-    async def publish(self: Self, event: Any) -> None:
+    async def publish(self: Self, event: SimulationEvent) -> None:
         """Publish ``event`` to all subscribers."""
         for q in list(self._queues):
             await q.put(event)

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -238,7 +238,7 @@ class EventKernel:
                 },
             )
         else:
-            await emit_event(SimulationEvent(event_type=event["type"], data=event_with_hash))
+            await emit_event(SimulationEvent(type=event["type"], data=event_with_hash))
 
     async def forward_external_events(
         self: Self, handler: Callable[[str], Awaitable[None]]
@@ -261,7 +261,7 @@ class EventKernel:
                     raise
                 if evt is None:
                     break
-                if evt.event_type == "broadcast" and evt.data:
+                if evt.type == "broadcast" and evt.data:
                     content = evt.data.get("content")
                     if isinstance(content, str):
                         await handler(content)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -653,7 +653,7 @@ class Simulation:
             }
             event["trace_hash"] = compute_trace_hash(event)
         trace_hash = event["trace_hash"]
-        await emit_event(SimulationEvent(event_type="agent_action", data=event))
+        await emit_event(SimulationEvent(type="agent_action", data=event))
 
         if self.current_step % int(config.SNAPSHOT_INTERVAL_STEPS) == 0:
             snapshot = {
@@ -685,7 +685,7 @@ class Simulation:
             save_snapshot(self.current_step, snapshot)
             upload_snapshot(self.current_step)
             snapshot_event = log_event({"type": "snapshot", **snapshot})
-            await emit_event(SimulationEvent(event_type="snapshot", data=snapshot_event))
+            await emit_event(SimulationEvent(type="snapshot", data=snapshot_event))
 
         # Advance to the next agent for the next turn
         self.current_agent_index = next_agent_index
@@ -823,12 +823,12 @@ class Simulation:
         """Route a ``SimulationEvent`` to agents as a message."""
         if not evt.data:
             return
-        if evt.event_type == "control":
+        if evt.type == "control":
             await self.handle_control_command(evt.data)
             return
         sender = str(evt.data.get("author", "external"))
         content = str(evt.data.get("content", ""))
-        recipient = evt.data.get("recipient_id") if evt.event_type == "direct_message" else None
+        recipient = evt.data.get("recipient_id") if evt.type == "direct_message" else None
         msg: SimulationMessage = {
             "step": self.current_step,
             "sender_id": sender,

--- a/tests/integration/interfaces/test_dashboard_backend_api.py
+++ b/tests/integration/interfaces/test_dashboard_backend_api.py
@@ -131,7 +131,7 @@ async def test_stream_events_sse(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(http_app, "EventSourceResponse", CaptureESR)
 
     queue = db.get_event_queue()
-    await queue.put(db.SimulationEvent(event_type="tick", data={"step": 1}))
+    await queue.put(db.SimulationEvent(type="tick", data={"step": 1}))
     await queue.put(None)
     resp = await http_app.stream_events(DummyRequest())
     event = await resp.gen.__anext__()
@@ -192,7 +192,7 @@ async def test_websocket_events() -> None:
 
     ws = DummyWebSocket()
     queue = db.get_event_queue()
-    await queue.put(db.SimulationEvent(event_type="start", data={"step": 2}))
+    await queue.put(db.SimulationEvent(type="start", data={"step": 2}))
     await queue.put(None)
     await db.websocket_events(ws)
     payload = json.loads(ws.sent[0])

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -11,8 +11,8 @@ from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
 
 
 class SimulationEvent:
-    def __init__(self, event_type: str, data: dict[str, object] | None = None) -> None:
-        self.event_type = event_type
+    def __init__(self, type: str, data: dict[str, object] | None = None) -> None:
+        self.type = type
         self.data = data
 
 
@@ -183,7 +183,7 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         msg.author = "user1"
         await on_msg(msg)
         stored = await q_events.get()
-        assert stored.event_type == "broadcast"
+        assert stored.type == "broadcast"
         assert (stored.data or {})["content"] == "hello"
 
         await q_msgs.put(AgentMessage(agent_id="agent1", content="hi", step=0))

--- a/tests/integration/interfaces/test_discord_message_flow.py
+++ b/tests/integration/interfaces/test_discord_message_flow.py
@@ -90,7 +90,7 @@ async def test_event_queue_broadcast_cost(monkeypatch: pytest.MonkeyPatch, tmp_p
     queue = db.get_event_queue()
     await queue.put(
         db.SimulationEvent(
-            event_type="broadcast", data={"author": "human", "content": "/broadcast hello"}
+            type="broadcast", data={"author": "human", "content": "/broadcast hello"}
         )
     )
     await asyncio.sleep(0.1)
@@ -123,7 +123,7 @@ async def test_event_queue_kb_post(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     queue = db.get_event_queue()
     await queue.put(
         db.SimulationEvent(
-            event_type="broadcast", data={"author": "human", "content": "/kb important fact"}
+            type="broadcast", data={"author": "human", "content": "/kb important fact"}
         )
     )
     await asyncio.sleep(0.1)

--- a/tests/integration/interfaces/test_message_and_event_streams.py
+++ b/tests/integration/interfaces/test_message_and_event_streams.py
@@ -56,7 +56,7 @@ async def test_websocket_events_deliver_simulation_events(monkeypatch: pytest.Mo
     event_queue: asyncio.Queue[db.SimulationEvent | None] = asyncio.Queue()
     monkeypatch.setattr(db, "get_event_queue", lambda: event_queue)
 
-    await db.emit_event(db.SimulationEvent(event_type="update", data={"step": 3}))
+    await db.emit_event(db.SimulationEvent(type="update", data={"step": 3}))
     await event_queue.put(None)
 
     ws = DummyWebSocket()
@@ -126,8 +126,8 @@ async def test_websocket_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
     event_queue: asyncio.Queue[db.SimulationEvent | None] = asyncio.Queue()
     monkeypatch.setattr(db, "get_event_queue", lambda: event_queue)
 
-    await event_queue.put(db.SimulationEvent(event_type="one", data={"step": 1}))
-    await event_queue.put(db.SimulationEvent(event_type="two", data={"step": 2}))
+    await event_queue.put(db.SimulationEvent(type="one", data={"step": 1}))
+    await event_queue.put(db.SimulationEvent(type="two", data={"step": 2}))
     await event_queue.put(None)
 
     class DisconnectingWebSocket(DummyWebSocket):
@@ -147,4 +147,4 @@ async def test_websocket_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
 
     ws2 = DummyWebSocket()
     await db.websocket_events(ws2)
-    assert [json.loads(t)["event_type"] for t in ws2.sent] == ["two"]
+    assert [json.loads(t)["type"] for t in ws2.sent] == ["two"]

--- a/tests/integration/interfaces/test_simulation_sse.py
+++ b/tests/integration/interfaces/test_simulation_sse.py
@@ -77,7 +77,7 @@ async def test_simulation_emits_sse(monkeypatch: pytest.MonkeyPatch, tmp_path) -
     resp = await http_app.stream_events(DummyRequest())
     event = await resp.gen.__anext__()
     payload = json.loads(event["data"])
-    assert payload["event_type"] == "agent_action"
+    assert payload["type"] == "agent_action"
     with pytest.raises(StopAsyncIteration):
         await resp.gen.__anext__()
 

--- a/tests/integration/interfaces/test_websocket_events.py
+++ b/tests/integration/interfaces/test_websocket_events.py
@@ -48,7 +48,7 @@ async def _start_server() -> tuple[uvicorn.Server, asyncio.Task[None], int]:
 async def test_ws_events_receive_and_close(monkeypatch: pytest.MonkeyPatch) -> None:
     events: list[str] = []
     bus = DummyBus(events)
-    await bus.queue.put(db.SimulationEvent(event_type="tick", data={"step": 1}))
+    await bus.queue.put(db.SimulationEvent(type="tick", data={"step": 1}))
     await bus.queue.put(None)
     monkeypatch.setattr(db, "get_event_bus", lambda: bus)
 

--- a/tests/integration/sim/test_async_batch.py
+++ b/tests/integration/sim/test_async_batch.py
@@ -88,7 +88,7 @@ async def test_events_enqueued_during_run_step() -> None:
     queue = get_event_queue()
     evt = await asyncio.wait_for(queue.get(), 0.1)
     assert isinstance(evt, SimulationEvent)
-    assert evt.event_type == "agent_action"
+    assert evt.type == "agent_action"
     assert evt.data is not None
     assert evt.data["agent_id"] == "agent1"
     assert evt.data["step"] == 1

--- a/tests/integration/sim/test_event_task_cleanup.py
+++ b/tests/integration/sim/test_event_task_cleanup.py
@@ -49,7 +49,7 @@ async def test_simulation_shutdown_cleans_background_tasks(
     await sim.start_event_listener()
 
     queue = get_event_queue()
-    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await queue.put(SimulationEvent(type="broadcast", data={"content": "hi"}))
     await asyncio.sleep(0.05)
 
     sim.close()

--- a/tests/integration/sim/test_world_map.py
+++ b/tests/integration/sim/test_world_map.py
@@ -78,8 +78,8 @@ async def test_agent_move_updates_map_and_events() -> None:
     second = await asyncio.wait_for(queue.get(), 0.1)
     assert isinstance(first, SimulationEvent)
     assert isinstance(second, SimulationEvent)
-    assert first.event_type == "agent_action"
-    assert second.event_type == "map_action"
+    assert first.type == "agent_action"
+    assert second.type == "map_action"
     assert second.data is not None
     assert second.data["agent_id"] == agent.agent_id
 

--- a/tests/integration/simulation/test_discord_message_flow.py
+++ b/tests/integration/simulation/test_discord_message_flow.py
@@ -69,7 +69,7 @@ async def test_discord_message_triggers_agent_reply(monkeypatch: pytest.MonkeyPa
     agent = DummyAgent("A")
     sim = sim_module.Simulation([agent])
 
-    await q_events.put(db.SimulationEvent(event_type="broadcast", data={"content": "hello"}))
+    await q_events.put(db.SimulationEvent(type="broadcast", data={"content": "hello"}))
     await asyncio.sleep(0.05)
 
     await sim.run_step(1)

--- a/tests/unit/interfaces/test_dashboard_map_action.py
+++ b/tests/unit/interfaces/test_dashboard_map_action.py
@@ -45,7 +45,7 @@ async def test_map_action_sse(monkeypatch: pytest.MonkeyPatch) -> None:
     resp = await http_app.stream_events(DummyRequest())
     event = await resp.gen.__anext__()
     data = json.loads(event["data"])
-    assert data["event_type"] == "map_action"
+    assert data["type"] == "map_action"
     assert data["data"]["agent_id"] == "A"
     with pytest.raises(StopAsyncIteration):
         await resp.gen.__anext__()
@@ -61,5 +61,5 @@ async def test_map_action_websocket() -> None:
     await queue.put(None)
     await db.websocket_events(ws)
     payload = json.loads(ws.sent[0])
-    assert payload["event_type"] == "map_action"
+    assert payload["type"] == "map_action"
     assert payload["data"]["agent_id"] == "B"

--- a/tests/unit/interfaces/test_event_queue_creation.py
+++ b/tests/unit/interfaces/test_event_queue_creation.py
@@ -16,7 +16,7 @@ async def _clear_event_queue() -> None:
 async def test_get_event_queue_running_loop() -> None:
     await _clear_event_queue()
     q1 = db.get_event_queue()
-    await q1.put(db.SimulationEvent(event_type="a", data={}))
+    await q1.put(db.SimulationEvent(type="a", data={}))
     q2 = db.get_event_queue()
     assert q1 is q2
     _ = await q1.get()

--- a/tests/unit/sim/test_event_kernel.py
+++ b/tests/unit/sim/test_event_kernel.py
@@ -168,7 +168,7 @@ async def test_forward_external_events(monkeypatch: pytest.MonkeyPatch) -> None:
         received.append(text)
 
     task = asyncio.create_task(kernel.forward_external_events(handler))
-    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await queue.put(SimulationEvent(type="broadcast", data={"content": "hi"}))
     await queue.put(None)
     await task
 

--- a/tests/unit/sim/test_event_task_start.py
+++ b/tests/unit/sim/test_event_task_start.py
@@ -57,7 +57,7 @@ async def test_event_task_runs_without_running_loop(monkeypatch: pytest.MonkeyPa
     await sim.start_event_listener()
 
     queue = get_event_queue()
-    await queue.put(SimulationEvent(event_type="broadcast", data={"content": "hi"}))
+    await queue.put(SimulationEvent(type="broadcast", data={"content": "hi"}))
     await asyncio.sleep(0.05)
 
     await sim.stop_event_listener()


### PR DESCRIPTION
## Summary
- centralize `SimulationEvent` model and update event bus
- refactor Discord bot and map actions to use the unified event format
- rename `event_type` to `type` in UI widgets and tests
- update remaining tests to use `type` field
- avoid deprecated Pydantic usage in control endpoint

## Testing
- `pre-commit run ruff --files src/interfaces/dashboard_backend.py`
- `pre-commit run ruff-format --files src/interfaces/dashboard_backend.py`
- `pre-commit run mypy --files src/interfaces/dashboard_backend.py`
- `pre-commit run forbid-direct-dspy-imports --files src/interfaces/dashboard_backend.py`
- `pytest -m "unit" -q`
- `pnpm --filter ./ test`


------
https://chatgpt.com/codex/tasks/task_e_687e626dca1c8326823f25617f2173ef