### PR TITLE
Add vLLM configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@
 # -- LLM Configuration --
 # Base URL for your LLM backend (e.g., http://localhost:11434)
 LLM_API_BASE=http://localhost:11434  # required
+# Base URL for the vLLM server. When set, overrides ``LLM_API_BASE``
+VLLM_API_BASE=http://localhost:8001
 # Timeout in seconds for Ollama API requests
 OLLAMA_REQUEST_TIMEOUT=10
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Follow these steps to run the example simulation locally:
    ollama pull mistral:latest
    ollama serve &
    ```
+   Alternatively you can start a vLLM server:
+   ```bash
+   VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 \
+   scripts/start_vllm.sh
+   export LLM_API_BASE="http://localhost:$VLLM_PORT"
+   ```
 5. **Run the vertical slice demo**
    ```bash
    make local-slice

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -466,10 +466,10 @@ Infrastructure components are used throughout the system:
 All infrastructure code in `src/infra/` is strictly compliant with Mypy (strict mode) and Ruff, with only justified ignores for `ollama.Client` return types due to third-party stub limitations. DSPy integration is robust and fully async-capable.
 
 ### Migration Note (2025-05-29)
-The configuration system now provides a single `LLM_API_BASE` setting. The old
-`OLLAMA_API_BASE` and `VLLM_API_BASE` environment variables are deprecated and
-only used to populate `LLM_API_BASE` for backward compatibility. Runtime modules
-read from configuration instead of inspecting environment variables.
+The configuration system exposes a unified `LLM_API_BASE` setting. You can also
+set `VLLM_API_BASE` to point to a vLLM server. When this variable is provided,
+`get_llm_client()` prefers the vLLM endpoint and falls back to Ollama. Both
+variables remain supported for flexibility.
 
 ## 8. Simulation Environment
 

--- a/docs/configuration_system.md
+++ b/docs/configuration_system.md
@@ -39,9 +39,11 @@ The configuration is organized into the following categories:
 - `DEFAULT_MODEL` - Default LLM model to use
 - `DEFAULT_TEMPERATURE` - Temperature setting for LLM responses
 
-### Ollama Settings
+### LLM Service Settings
 
-- `OLLAMA_API_BASE` - Base URL for Ollama API
+- `LLM_API_BASE` - Base URL for the Ollama server
+- `VLLM_API_BASE` - Base URL for the vLLM server. When set, the client
+  prefers this endpoint and falls back to Ollama.
 - `OLLAMA_REQUEST_TIMEOUT` - Timeout in seconds for Ollama requests
 
 ### Redis Settings

--- a/src/agents/core/roles.py
+++ b/src/agents/core/roles.py
@@ -50,6 +50,18 @@ class RoleProfile(BaseModel):
     embedding: list[float]
     reputation: float = 0.0
 
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - simple comparison
+        if isinstance(other, RoleProfile):
+            return (
+                self.name == other.name
+                and self.description == other.description
+                and self.embedding == other.embedding
+                and self.reputation == other.reputation
+            )
+        if isinstance(other, str):
+            return self.name == other
+        return NotImplemented
+
 
 def create_role_profile(role_name: str) -> RoleProfile:
     """Return a ``RoleProfile`` for the given role name."""

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -1288,8 +1288,7 @@ class ChromaVectorStoreManager(MemoryStore):
                     age_days = min_age_days
             else:
                 logger.debug(
-                    f"L2 summary {doc_id} missing simulation_step_end_timestamp, "
-                    f"assuming age 0."
+                    f"L2 summary {doc_id} missing simulation_step_end_timestamp, assuming age 0."
                 )
                 age_days = min_age_days
 

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import math
-import typing
 from collections.abc import Iterable
 from typing import cast
 

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -241,15 +241,13 @@ def load_config(*, validate_required: bool = True) -> dict[str, Any]:
     new_settings = ConfigSettings()
     if validate_required:
         raw_data = new_settings.model_dump() if _PYDANTIC_V2 else new_settings.dict()
-        missing = [key for key in REQUIRED_CONFIG_KEYS if str(raw_data.get(key, "")).strip() == ""]
-
-    if validate_required:
         missing = [k for k in REQUIRED_CONFIG_KEYS if not raw_data.get(k)]
         if missing:
             raise RuntimeError("Missing mandatory configuration keys: " + ", ".join(missing))
-    settings = new_settings
     data: dict[str, Any]
-    data = settings.model_dump() if _PYDANTIC_V2 else settings.dict()  # type: ignore[attr-defined]
+    data = new_settings.model_dump() if _PYDANTIC_V2 else new_settings.dict()  # type: ignore[attr-defined]
+    for key, value in data.items():
+        setattr(settings, key, value)
     _CONFIG.update(data)
     return data
 

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -308,22 +308,22 @@ def get_llm_client() -> OllamaClientProtocol:
     global client, LLM_API_BASE, VLLM_API_BASE, USE_VLLM
     current_base = cast(str, get_config("LLM_API_BASE"))
     current_vllm = cast(str | None, get_config("VLLM_API_BASE"))
+    prefer_vllm = bool(current_vllm)
 
     if current_base != LLM_API_BASE or current_vllm != VLLM_API_BASE:
         LLM_API_BASE = current_base
         VLLM_API_BASE = current_vllm
-        USE_VLLM = bool(current_vllm)
         client = None
 
-    if client is None:
-        primary = _create_vllm_client if USE_VLLM else _create_ollama_client
-        secondary = _create_ollama_client if USE_VLLM else _create_vllm_client
+    if client is None or (prefer_vllm and not USE_VLLM):
+        primary = _create_vllm_client if prefer_vllm else _create_ollama_client
+        secondary = _create_ollama_client if prefer_vllm else _create_vllm_client
 
         client, err = _retry_with_backoff(primary)
         if client is None:
             logger.error(
                 "Failed to initialize %s client: %s",
-                "vLLM" if USE_VLLM else "Ollama",
+                "vLLM" if prefer_vllm else "Ollama",
                 err,
                 exc_info=True,
             )
@@ -331,12 +331,14 @@ def get_llm_client() -> OllamaClientProtocol:
             if client is None:
                 logger.error(
                     "Failed to initialize %s client: %s",
-                    "Ollama" if USE_VLLM else "vLLM",
+                    "Ollama" if prefer_vllm else "vLLM",
                     err,
                     exc_info=True,
                 )
                 raise LLMClientInitError("Failed to initialize vLLM and Ollama clients")
-            USE_VLLM = not USE_VLLM
+            USE_VLLM = not prefer_vllm
+        else:
+            USE_VLLM = prefer_vllm
     return client
 
 

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -116,7 +116,7 @@ def save_snapshot(
 
 
 def load_snapshot(
-    step: int,
+    step: int | str | Path,
     directory: str | Path = "snapshots",
     compress: bool | None = None,
 ) -> dict[str, Any]:
@@ -131,9 +131,15 @@ def load_snapshot(
     compress = SNAPSHOT_COMPRESS if compress is None else compress
 
     path = Path(directory)
-    json_file = path / f"snapshot_{step}.json"
-    zst_file = path / f"snapshot_{step}.json.zst"
-    file_path = zst_file if compress else json_file
+    if isinstance(step, (str, Path)) and Path(step).exists():
+        file_path = Path(step)
+        compress = file_path.suffix.endswith(".zst")
+        json_file = path / file_path.with_suffix(".json").name
+        zst_file = path / file_path.with_suffix(".json.zst").name
+    else:
+        json_file = path / f"snapshot_{step}.json"
+        zst_file = path / f"snapshot_{step}.json.zst"
+        file_path = zst_file if compress else json_file
 
     if not file_path.exists() and S3_BUCKET and boto3 is not None:
         try:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -134,14 +134,21 @@ class Simulation:
 
         # Initialize world map and place agents
         self.world_map = WorldMap()
+        self._init_tasks: list[asyncio.Task[Any]] = []
         for idx, ag in enumerate(self.agents):
-            asyncio.run(self.world_map.add_agent(ag.agent_id, x=idx, y=0))
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(self.world_map.add_agent(ag.agent_id, x=idx, y=0))
+            else:
+                task = loop.create_task(self.world_map.add_agent(ag.agent_id, x=idx, y=0))
+                self._init_tasks.append(task)
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -188,9 +195,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -505,7 +512,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(


### PR DESCRIPTION
## Summary
- prefer vLLM backend when VLLM_API_BASE is set
- document VLLM_API_BASE and default port in configuration docs and `.env.example`
- reference `scripts/start_vllm.sh` in README setup
- clarify migration note about VLLM in architecture docs
- fix config validation logic
- reload ConfigSettings in place so other modules see updates
- allow `load_snapshot()` to accept file paths
- avoid `asyncio.run` errors when an event loop is active
- implement `RoleProfile.__eq__` for backward compatibility
- ensure configuration env overrides work with pydantic-settings

## Testing
- `bash scripts/lint.sh --format`
- `pytest tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_687e626c02408326b2b3391672c899a2