### PR TITLE
Improve control endpoint error handling

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -442,12 +442,13 @@ try:
 
     @app.post("/control")
     async def control(request: Request) -> Response:
+        body = await request.body()
         try:
-            body = await request.body()
             command = json.loads(body)
             if not isinstance(command, dict):
-                raise ValueError
-        except Exception:
+                raise ValueError("payload must be a JSON object")
+        except (json.JSONDecodeError, ValueError, TypeError) as exc:
+            logger.warning("Invalid control payload: %s", exc)
             return JSONResponse({"error": "invalid"})
 
         result = await handle_control_command(command)
@@ -468,8 +469,9 @@ try:
                 try:
                     cmd = json.loads(data)
                     if not isinstance(cmd, dict):
-                        raise ValueError
-                except (json.JSONDecodeError, ValueError):
+                        raise ValueError("payload must be a JSON object")
+                except (json.JSONDecodeError, ValueError, TypeError) as exc:
+                    logger.warning("Invalid control payload via WS: %s", exc)
                     await websocket.send_text(json.dumps({"error": "invalid"}))
                     continue
                 result = await handle_control_command(cmd)

--- a/tests/integration/interfaces/test_invalid_control_payloads.py
+++ b/tests/integration/interfaces/test_invalid_control_payloads.py
@@ -6,13 +6,10 @@ from src.interfaces import dashboard_backend as db
 
 
 class DummyRequest:
-    def __init__(self, payload=None, exc=None):
+    def __init__(self, payload: bytes) -> None:
         self._payload = payload
-        self._exc = exc
 
-    async def json(self):
-        if self._exc is not None:
-            raise self._exc
+    async def body(self) -> bytes:
         return self._payload
 
 
@@ -41,7 +38,7 @@ class DummyWebSocket:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_control_invalid_json() -> None:
-    req = DummyRequest(exc=json.JSONDecodeError("x", "x", 0))
+    req = DummyRequest(b"{")
     resp = await db.control(req)
     assert json.loads(resp.body) == {"error": "invalid"}
 
@@ -49,7 +46,7 @@ async def test_control_invalid_json() -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_control_invalid_structure() -> None:
-    req = DummyRequest(payload=[])
+    req = DummyRequest(json.dumps([]).encode())
     resp = await db.control(req)
     assert json.loads(resp.body) == {"error": "invalid"}
 


### PR DESCRIPTION
## Summary
- handle JSON decoding errors for `/control` and `/ws/control`
- add regression tests for invalid control payloads

## Testing
- `ruff src/interfaces/dashboard_backend.py tests/integration/interfaces/test_invalid_control_payloads.py`
- `ruff format src/interfaces/dashboard_backend.py tests/integration/interfaces/test_invalid_control_payloads.py`
- `mypy src/interfaces/dashboard_backend.py tests/integration/interfaces/test_invalid_control_payloads.py`
- `pytest -q tests/integration/interfaces/test_invalid_control_payloads.py -m integration`


------
https://chatgpt.com/codex/tasks/task_e_687eb443432c8326915a684f198503e6