### PR TITLE
Async world map operations

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,7 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.extensions import load_plugins
+from src.infra import config
 from src.infra.checkpoint import (
     load_checkpoint,
     restore_environment,
@@ -19,6 +20,7 @@ from src.infra.llm_client import LLMClientInitError, get_llm_client
 from src.infra.logging_config import setup_logging
 from src.infra.settings import settings
 from src.infra.warning_filters import configure_warning_filters
+from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.simulation import Simulation
 from src.utils.loop_helper import use_uvloop_if_available
@@ -145,7 +147,10 @@ def create_simulation(
         scenario=scenario,
         discord_bot=discord_bot,
     )
-    sim.knowledge_board = KnowledgeBoard()
+    if config.KNOWLEDGE_BOARD_BACKEND == "graph":
+        sim.knowledge_board = GraphKnowledgeBoard()
+    else:
+        sim.knowledge_board = KnowledgeBoard()
     sim.steps_to_run = steps
     return sim
 

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -174,7 +174,8 @@ def load_checkpoint(
         scenario=data.get("scenario", ""),
     )
     kb_entries = data.get("knowledge_board", {}).get("entries", [])
-    if config.KNOWLEDGE_BOARD_BACKEND == "graph":
+    backend = os.getenv("KNOWLEDGE_BOARD_BACKEND", config.KNOWLEDGE_BOARD_BACKEND)
+    if backend == "graph":
         board = GraphKnowledgeBoard()
         for e in kb_entries:
             board.add_entry(e["content_full"], e["agent_id"], int(e["step"]))

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -146,9 +146,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -195,9 +195,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -395,7 +395,7 @@ class Simulation:
             agent.state.mutate_genes(mutation_rate)
 
         self.agents.append(agent)
-        self.world_map.add_agent(agent.agent_id, x=len(self.agents) - 1, y=0)
+        await self.world_map.add_agent(agent.agent_id, x=len(self.agents) - 1, y=0)
         self._update_collective_metrics()
 
     async def retire_agent(self: Self, agent: "Agent") -> None:
@@ -512,9 +512,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(

--- a/tests/unit/world_map/test_concurrent_moves_multi_agents.py
+++ b/tests/unit/world_map/test_concurrent_moves_multi_agents.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import pytest
+
+from src.sim.world_map import WorldMap
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_concurrent_moves_multiple_agents() -> None:
+    m = WorldMap(width=5, height=5)
+    await m.add_agent("A", x=0, y=0)
+    await m.add_agent("B", x=0, y=1)
+
+    async def mover(agent_id: str) -> None:
+        for _ in range(50):
+            await m.move(agent_id, 1, 0)
+
+    await asyncio.gather(*(mover(a) for a in ("A", "B")))
+
+    assert m.agent_positions["A"] == (4, 0)
+    assert m.agent_positions["B"] == (4, 1)


### PR DESCRIPTION
## Summary
- await `WorldMap.add_agent` when spawning agents
- cover concurrent agent moves with a new test
- initialize knowledge board according to config
- respect env var when loading checkpoints

## Testing
- `ruff check src/app.py src/infra/checkpoint.py src/sim/simulation.py tests/unit/world_map/test_concurrent_moves_multi_agents.py`
- `mypy src/app.py src/infra/checkpoint.py src/sim/simulation.py tests/unit/world_map/test_concurrent_moves_multi_agents.py`
- `pytest tests/unit/infra/test_checkpoint.py::test_checkpoint_loads_graph_board tests/unit/world_map/test_concurrent_moves_multi_agents.py::test_concurrent_moves_multiple_agents -q`


------
https://chatgpt.com/codex/tasks/task_e_687eb441f7f48326989ae88ffdd1f2bc