### PR TITLE
Unify SimulationEvent usage

### DIFF
--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -7,21 +7,8 @@ import pytest
 
 pytest.importorskip("discord")
 from src.interfaces import metrics
+from src.interfaces.dashboard_backend import AgentMessage, SimulationEvent
 from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
-
-
-class SimulationEvent:
-    def __init__(self, type: str, data: dict[str, object] | None = None) -> None:
-        self.type = type
-        self.data = data
-
-
-class AgentMessage:
-    def __init__(self, agent_id: str, content: str, step: int) -> None:
-        self.agent_id = agent_id
-        self.content = content
-        self.step = step
-
 
 sent_by_token: list[str] = []
 


### PR DESCRIPTION
## Summary
- rely on the shared SimulationEvent dataclass in discord bot tests

## Testing
- `ruff check .`
- `ruff format tests/integration/interfaces/test_discord_bot.py`
- `black --check tests/integration/interfaces/test_discord_bot.py`
- `SKIP_DEP_INSTALL=1 python scripts/run_tests.py -k test_dummy -m "not integration"`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_687ece83d7c8832682b06b0cf08f2c59