### PR TITLE
Fix memory retrieval

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -70,7 +70,6 @@ else:  # pragma: no cover - optional runtime dependency
 
 
 from src.shared.memory_store import MemoryStore
-from src.shared.pydantic_compat import _PYDANTIC_V2
 from src.shared.typing import SimulationMessage
 
 from .agent_controller import AgentController
@@ -338,9 +337,6 @@ class Agent:
         self.role_thought_generator_program = get_role_thought_generator()
         self.relationship_updater_program = get_relationship_updater()
 
-        # Track retrieved memories across turns for debugging/analysis
-        self._memory_history: list[dict[str, Any]] = []
-
         logger.info(
             f"Agent {self.agent_id} __init__: self.action_intent_selector_program is {type(self.action_intent_selector_program)}"
         )
@@ -465,35 +461,16 @@ class Agent:
         # --- End Extract Perceived Messages ---
 
         # --- Retrieve Memory History ---
-        # Start with any memories retrieved in previous turns
-        memory_history_list: list[dict[str, Any]] = list(self._memory_history)
+        # Retrieval now happens exclusively inside ``retrieve_and_summarize_memories_node``.
+        # Start with an empty list; the graph node will populate this field.
+        memory_history_list: list[dict[str, Any]] = []
 
         active_service = memory_service or getattr(self, "memory_service", None)
         if active_service is None and vector_store_manager is not None:
             active_service = MemoryService(vector_store_manager)
 
-        if active_service is not None:
-            try:
-                retrieved_memories = await active_service.retrieve_relevant_memories(
-                    self.agent_id,
-                    query="",
-                    k=5,
-                )
-                # Persist and accumulate retrieved memories for this agent
-                self._memory_history.extend(retrieved_memories)
-                memory_history_list = list(self._memory_history)
-
-            except Exception as e:  # pragma: no cover - defensive
-                logger.error(
-                    f"Agent {self.agent_id}: failed to retrieve memories: {e}",
-                    exc_info=True,
-                )
-
         # Convert the state to dictionary for compatibility with the existing graph
-        if _PYDANTIC_V2:
-            state_dict = cast(BaseModel, self._state).model_dump()
-        else:
-            state_dict = cast(BaseModel, self._state).dict()
+        state_dict = cast(BaseModel, self._state).model_dump()
 
         # Extract agent goal - handle goals which may be in different formats:
         # 1. From the AgentState goals list (which might be empty)
@@ -513,10 +490,8 @@ class Agent:
         # Prepare the input state for this turn's graph execution
         initial_turn_state: AgentTurnState = {
             "agent_id": self.agent_id,
-            "current_state": (
-                cast(BaseModel, self._state).model_dump(exclude_none=True)
-                if _PYDANTIC_V2
-                else cast(BaseModel, self._state).dict(exclude_none=True)
+            "current_state": cast(BaseModel, self._state).model_dump(
+                exclude_none=True
             ),  # Current full state
             "simulation_step": simulation_step,
             "previous_thought": self._state.last_thought,

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -38,7 +39,7 @@ def test_analyze_perception_sentiment_node(monkeypatch: pytest.MonkeyPatch) -> N
 @pytest.mark.unit
 def test_prepare_relationship_prompt_node() -> None:
     agent_state = SimpleNamespace(relationships={"b": 0.5, "c": -0.2})
-    result = prepare_relationship_prompt_node({"state": agent_state})
+    result = prepare_relationship_prompt_node(cast(dict[str, object], {"state": agent_state}))
     assert "b: 0.5" in result["prompt_modifier"]
     assert "c: -0.2" in result["prompt_modifier"]
 
@@ -47,15 +48,19 @@ def test_prepare_relationship_prompt_node() -> None:
 @pytest.mark.unit
 async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
     state = {"agent_id": "a"}
-    out = await retrieve_and_summarize_memories_node(state)
+    out = await retrieve_and_summarize_memories_node(cast(object, state))
     assert out["rag_summary"] == "(No memory retrieval)"
     assert out["memory_history_list"] == []
 
 
 class DummyService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int, int]] = []
+
     async def get_context_pipeline(
         self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2
     ) -> tuple[list[dict[str, str]], list[str]]:
+        self.calls.append((agent_id, query, k, semantic_limit))
         return [{"content": "m1"}, {"content": "m2"}], ["sem1"]
 
     def blend_with_recent_semantic(
@@ -74,13 +79,15 @@ class DummyAgent:
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_retrieve_and_summarize_memories_node_with_manager() -> None:
+    service = DummyService()
     state = {
         "agent_id": "a",
-        "memory_service": DummyService(),
+        "memory_service": service,
         "agent_instance": DummyAgent(),
         "current_role": "r",
     }
-    out = await retrieve_and_summarize_memories_node(state)
+    out = await retrieve_and_summarize_memories_node(cast(object, state))
+    assert service.calls == [("a", "", 5, 2)]
     assert out["rag_summary"] == "SUM\nsem1"
     assert out["memory_history_list"] == [{"content": "m1"}, {"content": "m2"}]
 
@@ -103,7 +110,7 @@ async def test_generate_thought_and_message_node(monkeypatch: pytest.MonkeyPatch
         lambda intent, prompt, schema: dummy,
     )
 
-    out = await generate_thought_and_message_node({})
+    out = await generate_thought_and_message_node(cast(dict[str, object], {}))
     assert out == {"structured_output": dummy}
 
 
@@ -113,7 +120,7 @@ async def test_generate_thought_and_message_node(monkeypatch: pytest.MonkeyPatch
 async def test_finalize_message_agent_node_variants() -> None:
     pytest.skip("skip in CI")
     agent_state = SimpleNamespace()
-    out = await finalize_message_agent_node({"state": agent_state})
+    out = await finalize_message_agent_node(cast(dict[str, object], {"state": agent_state}))
     assert out["message_content"] is None
     assert out["action_intent"] == "idle"
 
@@ -122,7 +129,7 @@ async def test_finalize_message_agent_node_variants() -> None:
         message_recipient_id="b",
         action_intent="propose",
     )
-    out2 = await finalize_message_agent_node({"state": agent_state, "structured_output": dummy})
+    out2 = await finalize_message_agent_node(cast(dict[str, object], {"state": agent_state, "structured_output": dummy}))
     assert out2["message_content"] == "hi"
     assert out2["is_targeted"] is True
 


### PR DESCRIPTION
## Summary
- remove duplicate memory retrieval logic from BaseAgent
- use `model_dump` for state serialization
- route graph retrieval through `MemoryService.get_context_pipeline`
- clarify retrieval comments in BaseAgent
- check memory pipeline call in `test_retrieve_and_summarize_memories_node_with_manager`

## Testing
- `ruff check tests/unit/graphs/test_graph_nodes.py`
- `mypy --config-file=pyproject.toml tests/unit/graphs/test_graph_nodes.py`
- `pytest tests/unit/graphs/test_graph_nodes.py::test_retrieve_and_summarize_memories_node_with_manager -q`
- `pytest -m "unit" -q` *(interrupt: 2 passed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687ece83051c8326a00925f4410f1ad5