### PR TITLE
Add mypy coverage for sim modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,15 @@ module = [
 ]
 ignore_errors = true
 
+[[tool.mypy.overrides]]
+module = [
+    "src.sim.quests",
+    "src.sim.world_map_actions",
+    "src.sim.event_bus",
+    "src.sim.event_kernel",
+    "src.sim.version_vector",
+]
+
 [tool.ruff.format]
 preview = false
 


### PR DESCRIPTION
## Summary
- ensure mypy checks for quests and world_map helper modules
- update pyproject configuration

## Testing
- `mypy src/sim/world_map_actions.py src/sim/quests/__init__.py src/sim/event_bus.py src/sim/event_kernel.py src/sim/version_vector.py --ignore-missing-imports --no-site-packages --follow-imports=skip`
- `pytest tests/integration/sim/test_world_map_actions.py::test_move_action_updates_position_and_ledger -q`

------
https://chatgpt.com/codex/tasks/task_e_687f996adbfc832690251ff5751d484c