### PR TITLE
Add proposal voting API and Discord commands

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -187,6 +187,14 @@ class VotesResponse(BaseModel):
     votes: list[VoteRecord]
 
 
+class VoteRequest(BaseModel):
+    """Vote payload for manual voting."""
+
+    agent_id: str
+    text: str
+    approve: bool
+
+
 app = FastAPI()
 
 
@@ -307,6 +315,22 @@ async def api_propose(proposal: Proposal) -> Response:
             except Exception:  # pragma: no cover - defensive
                 approved = False
     return JSONResponse({"approved": approved})
+
+
+@app.post("/api/vote")
+async def api_vote(vote: VoteRequest) -> Response:
+    """Submit a manual vote for a proposal."""
+    sim = SIM_STATE.get("simulation")
+    result = False
+    if sim is not None:
+        agent = next((a for a in sim.agents if a.agent_id == vote.agent_id), None)
+        if agent is not None:
+            try:
+                allowed = await governance.vote(agent, vote.text)
+                result = bool(vote.approve and allowed)
+            except Exception:  # pragma: no cover - defensive
+                result = False
+    return JSONResponse({"vote": result})
 
 
 @app.get("/api/proposals")
@@ -531,6 +555,7 @@ __all__ = [
     "Proposal",
     "SimulationEvent",
     "VoteRecord",
+    "VoteRequest",
     "VotesResponse",
     "api_auctions",
     "api_get_laws",
@@ -539,6 +564,7 @@ __all__ = [
     "api_map",
     "api_propose_law",
     "api_token_balances",
+    "api_vote",
     "app",
     "emit_event",
     "emit_map_action_event",

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -700,3 +700,57 @@ async def slash_propose(interaction: Any, text: str) -> None:
     except Exception:
         approved = False
     await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="propose_law")
+async def slash_propose_law(interaction: Any, text: str) -> None:
+    """Propose a law using the basic endpoint."""
+    agent_id = None
+    if active_bot is not None:
+        channel = getattr(interaction, "channel", None)
+        chan_id = getattr(channel, "id", None)
+        agent_id = active_bot.channel_to_agent.get(chan_id)
+    if not agent_id:
+        await interaction.response.send_message("Unknown channel", ephemeral=True)
+        return
+    ip, du = await ledger.get_balance_async(agent_id)
+    if ip <= 0 or du <= 0:
+        await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
+        return
+    payload = {"proposer_id": agent_id, "text": text}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post("http://localhost:8000/api/propose_law", json=payload)
+            approved = resp.json().get("approved", False)
+    except Exception:
+        approved = False
+    await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="vote")
+async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
+    """Cast a manual vote on a proposal via the API."""
+    agent_id = None
+    if active_bot is not None:
+        channel = getattr(interaction, "channel", None)
+        chan_id = getattr(channel, "id", None)
+        agent_id = active_bot.channel_to_agent.get(chan_id)
+    if not agent_id:
+        await interaction.response.send_message("Unknown channel", ephemeral=True)
+        return
+    ip, du = await ledger.get_balance_async(agent_id)
+    if ip <= 0 or du <= 0:
+        await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
+        return
+    payload = {"agent_id": agent_id, "text": text, "approve": approve}
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post("http://localhost:8000/api/vote", json=payload)
+            cast = resp.json().get("vote", False)
+    except Exception:
+        cast = False
+    await interaction.response.send_message(
+        "Vote cast" if cast else "Vote rejected", ephemeral=True
+    )

--- a/tests/integration/governance/test_propose_command.py
+++ b/tests/integration/governance/test_propose_command.py
@@ -43,3 +43,35 @@ async def test_slash_propose_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
     assert DummyClient.called["url"].endswith("/api/propose")
     assert DummyClient.called["json"] == {"proposer_id": "a1", "text": "hello"}
     DummyClient.called = {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_slash_propose_law_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bot.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(bot.ledger, "get_balance_async", AsyncMock(return_value=(1.0, 1.0)))
+    monkeypatch.setattr(bot, "active_bot", SimpleNamespace(channel_to_agent={123: "a1"}))
+
+    await bot.slash_propose_law.callback(DummyInteraction(), text="hello")
+
+    assert DummyClient.called["url"].endswith("/api/propose_law")
+    assert DummyClient.called["json"] == {"proposer_id": "a1", "text": "hello"}
+    DummyClient.called = {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_slash_vote_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bot.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(bot.ledger, "get_balance_async", AsyncMock(return_value=(1.0, 1.0)))
+    monkeypatch.setattr(bot, "active_bot", SimpleNamespace(channel_to_agent={123: "a1"}))
+
+    await bot.slash_vote.callback(DummyInteraction(), text="hello", approve=True)
+
+    assert DummyClient.called["url"].endswith("/api/vote")
+    assert DummyClient.called["json"] == {
+        "agent_id": "a1",
+        "text": "hello",
+        "approve": True,
+    }
+    DummyClient.called = {}

--- a/tests/integration/governance/test_propose_law_endpoint.py
+++ b/tests/integration/governance/test_propose_law_endpoint.py
@@ -1,0 +1,95 @@
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from src.governance.law_board import LawBoard
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        pass
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_propose_law_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    gservice = importlib.import_module("src.governance.service")
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(db, "ledger", ledger)
+    monkeypatch.setattr(db, "law_board", board)
+    monkeypatch.setattr(db, "governance", gservice.governance)
+
+    async def allow(_: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow)
+
+    votes = [True, True, False]
+
+    async def fake_vote(_agent: DummyAgent, _text: str) -> bool:
+        return votes.pop(0)
+
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
+
+    from src.sim.simulation import Simulation
+
+    agents = [DummyAgent("a1"), DummyAgent("a2"), DummyAgent("a3")]
+    sim = Simulation(agents=agents)
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+
+    for a in agents:
+        ledger.log_change(a.agent_id, 5.0, 0.0, "fund")
+        a.state.ip = 5.0
+
+    resp = await db.api_propose_law(db.LawProposal(proposer_id="a1", text="law"))
+    data = json.loads(resp.body)
+    assert data["approved"] is True
+
+    proposals = ledger.get_law_proposals()
+    assert proposals[0]["approved"] is True
+    assert proposals[0]["ip_spent"] == pytest.approx(0.0)

--- a/tests/integration/governance/test_vote_endpoint.py
+++ b/tests/integration/governance/test_vote_endpoint.py
@@ -1,0 +1,87 @@
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from src.governance.law_board import LawBoard
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        pass
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {}
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_vote_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    gservice = importlib.import_module("src.governance.service")
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(db, "ledger", ledger)
+    monkeypatch.setattr(db, "law_board", board)
+    monkeypatch.setattr(db, "governance", gservice.governance)
+
+    async def allow(_: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow)
+
+    async def fake_vote(agent: DummyAgent, text: str) -> bool:
+        assert agent.agent_id == "a1"
+        assert text == "law"
+        return True
+
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
+
+    from src.sim.simulation import Simulation
+
+    agents = [DummyAgent("a1")]
+    sim = Simulation(agents=agents)
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+
+    resp = await db.api_vote(db.VoteRequest(agent_id="a1", text="law", approve=True))
+    data = json.loads(resp.body)
+    assert data["vote"] is True


### PR DESCRIPTION
## Summary
- extend dashboard API with `/api/vote` endpoint
- expose `VoteRequest` in dashboard backend
- add Discord slash commands for `propose_law` and `vote`
- cover new API and commands with integration tests

## Testing
- `ruff check tests/integration/governance/test_propose_law_endpoint.py tests/integration/governance/test_vote_endpoint.py tests/integration/governance/test_propose_command.py src/interfaces/dashboard_backend.py src/interfaces/discord_bot.py`
- `mypy src/interfaces/dashboard_backend.py src/interfaces/discord_bot.py`
- `pytest tests/integration/governance/test_propose_command.py tests/integration/governance/test_propose_law_endpoint.py tests/integration/governance/test_vote_endpoint.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_687f99634db48326b86d9fcdc303d5cd