### PR TITLE
Add Discord reply support and new slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ your channel.
 Sends a broadcast message to all agents.
 
 ```text
+/pause
+```
+Pauses the simulation.
+
+```text
+/resume
+```
+Resumes the simulation.
+
+```text
+/speed 2.0
+```
+Adjusts the simulation tick speed.
+
+```text
 /kb Add multi-agent architecture diagram to the KB
 ```
 Creates a new entry on the shared Knowledge Board.

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -114,6 +114,7 @@ class SimulationDiscordBot:
         self.channel_id = channel_id
         self.channel_map: dict[str, int] = channel_map or {}
         self.channel_to_agent: dict[int, str] = {v: k for k, v in self.channel_map.items()}
+        self.user_channels: dict[str, int] = {}
         self.is_ready = False
         global active_bot
         active_bot = self
@@ -179,7 +180,12 @@ class SimulationDiscordBot:
                 if getattr(message, "author", None) == client.user:
                     return
                 content = getattr(message, "content", "")
-                channel_id = getattr(getattr(message, "channel", None), "id", None)
+                channel = getattr(message, "channel", None)
+                channel_id = getattr(channel, "id", None)
+                user = getattr(message, "author", None)
+                user_id = getattr(user, "id", None)
+                if user_id and channel_id:
+                    self.user_channels[str(user_id)] = channel_id
                 recipient = self.channel_to_agent.get(channel_id)
                 evt_type = "direct_message" if recipient else "broadcast"
                 data = {"author": str(getattr(message, "author", "")), "content": content}
@@ -202,13 +208,16 @@ class SimulationDiscordBot:
         content: Optional[str] = None,
         embed: Optional[Any] = None,
         agent_id: Optional[str] = None,
+        *,
+        target_channel_id: Optional[int] = None,
     ) -> Optional[bool]:
         """
-        Send a simulation update message to the configured Discord channel.
+        Send a simulation update message to Discord.
 
         Args:
             content (Optional[str]): The text message content to send
             embed (Optional[Any]): The embed object to send
+            target_channel_id (Optional[int]): Explicit channel to send to
 
         Returns:
             bool: True if message was sent successfully, False otherwise
@@ -226,10 +235,10 @@ class SimulationDiscordBot:
                 return False
         try:
             client = await self._select_client(agent_id)
-            target_channel_id = self.channel_map.get(agent_id, self.channel_id)
-            channel = client.get_channel(target_channel_id)
+            chan_id = target_channel_id or self.channel_map.get(agent_id, self.channel_id)
+            channel = client.get_channel(chan_id)
             if not channel:
-                logger.warning(f"Could not find Discord channel with ID: {target_channel_id}")
+                logger.warning(f"Could not find Discord channel with ID: {chan_id}")
                 return False
             if embed:
                 if hasattr(channel, "send"):
@@ -495,7 +504,15 @@ class SimulationDiscordBot:
         try:
             while True:
                 msg: AgentMessage = await self.message_queue.get()
-                await self.send_simulation_update(content=msg.content, agent_id=msg.agent_id)
+                channel_override = None
+                recipient = msg.recipient_id
+                if recipient and recipient in self.user_channels:
+                    channel_override = self.user_channels[recipient]
+                await self.send_simulation_update(
+                    content=msg.content,
+                    agent_id=msg.agent_id,
+                    target_channel_id=channel_override,
+                )
         except asyncio.CancelledError:  # pragma: no cover - task cancelled on stop
             pass
 
@@ -674,6 +691,30 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
         SimulationEvent(type="control", data={"command": "set_speed", "value": value})
     )
     await interaction.response.send_message(f"speed {value}", ephemeral=True)
+
+
+@typing.no_type_check
+@bot.tree.command(name="speed")
+async def slash_speed(interaction: Any, value: float) -> None:
+    """Alias for ``set_speed``."""
+    await slash_set_speed.callback(interaction, value=value)
+
+
+@typing.no_type_check
+@bot.tree.command(name="kb")
+async def slash_kb(interaction: Any, text: str) -> None:
+    """Post an entry to the Knowledge Board."""
+    await event_queue.put(
+        SimulationEvent(
+            type="control",
+            data={
+                "command": "post_kb",
+                "text": text,
+                "author": str(getattr(interaction, "user", "human")),
+            },
+        )
+    )
+    await interaction.response.send_message("KB entry created", ephemeral=True)
 
 
 @typing.no_type_check

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -356,6 +356,30 @@ class Simulation:
                 self.speed = float(cmd.get("value", 1))
             except (TypeError, ValueError):
                 pass
+        elif action == "post_kb":
+            text = cmd.get("text")
+            author = cmd.get("author", "human")
+            if text and self.knowledge_board:
+                async with self.knowledge_board.lock:
+                    self.knowledge_board.add_entry(
+                        text,
+                        str(author),
+                        self.current_step,
+                        self.vector.to_dict(),
+                    )
+                if self.discord_bot:
+                    embed = self.discord_bot.create_knowledge_board_embed(
+                        str(author),
+                        text,
+                        self.current_step,
+                    )
+                    task = asyncio.create_task(
+                        self.discord_bot.send_simulation_update(
+                            embed=embed,
+                            agent_id=str(author),
+                        )
+                    )
+                    _ = task
 
     async def spawn_agent(
         self: Self,


### PR DESCRIPTION
## Summary
- extend `SimulationDiscordBot` to remember user channels for replies
- allow sending simulation updates to a specific channel
- forward agent messages to the original user channel when possible
- provide `/speed` alias and `/kb` command for Knowledge Board posts
- handle `post_kb` control action in the simulation
- document Discord control commands

## Testing
- `pytest -m "unit" tests/unit/interfaces/test_discord_bot.py::test_embed_creators`
- `ruff check src/interfaces/discord_bot.py src/sim/simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_687f9961a38c8326877d67dc39d2b622