### PR TITLE
Add ledger helpers and simplify world map actions

### DIFF
--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -666,7 +666,30 @@ class Ledger:
 
 ledger = Ledger()
 
+
+def run_auction(item: str, agent_id: str, amount: float) -> None:
+    """Safely run an auction for ``item`` with a single bid from ``agent_id``."""
+    if amount <= 0:
+        return
+    try:  # pragma: no cover - optional
+        aid = ledger.open_auction(item)
+        ledger.place_bid(aid, agent_id, amount)
+        ledger.resolve_auction(aid)
+    except Exception:  # pragma: no cover - optional
+        logging.getLogger(__name__).debug("Ledger auction failed", exc_info=True)
+
+
+def log_reward(agent_id: str, delta_ip: float, delta_du: float, reason: str) -> None:
+    """Safely log a reward or penalty to the ledger."""
+    try:  # pragma: no cover - optional
+        ledger.log_change(agent_id, delta_ip, delta_du, reason)
+    except Exception:  # pragma: no cover - optional
+        logging.getLogger(__name__).debug("Ledger logging failed", exc_info=True)
+
+
 __all__ = [
     "Ledger",
     "ledger",
+    "log_reward",
+    "run_auction",
 ]

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from src.infra import config
+from src.infra.ledger import log_reward, run_auction
 from src.interfaces.dashboard_backend import emit_map_change_event
 from src.sim.world_map import ResourceToken, StructureType
 
@@ -38,30 +39,18 @@ async def process_map_action(
             details = {"position": pos}
             start_ip = current_state.ip
             if config.MAP_MOVE_DU_COST > 0:
-                try:
-                    from src.infra.ledger import ledger
-
-                    aid = ledger.open_auction("move")
-                    ledger.place_bid(aid, agent_id, config.MAP_MOVE_DU_COST)
-                    ledger.resolve_auction(aid)
-                except Exception:  # pragma: no cover - optional
-                    logger.debug("Ledger auction failed", exc_info=True)
+                run_auction("move", agent_id, config.MAP_MOVE_DU_COST)
                 current_state.du -= config.MAP_MOVE_DU_COST
             start_du = current_state.du
             current_state.ip -= config.MAP_MOVE_IP_COST
             current_state.ip += config.MAP_MOVE_IP_REWARD
             current_state.du += config.MAP_MOVE_DU_REWARD
-            try:
-                from src.infra.ledger import ledger
-
-                ledger.log_change(
-                    agent_id,
-                    current_state.ip - start_ip,
-                    current_state.du - start_du,
-                    "move",
-                )
-            except Exception:  # pragma: no cover - optional
-                logger.debug("Ledger logging failed", exc_info=True)
+            log_reward(
+                agent_id,
+                current_state.ip - start_ip,
+                current_state.du - start_du,
+                "move",
+            )
     elif action_type == "gather":
         res = map_action.get("resource")
         success = False
@@ -75,30 +64,18 @@ async def process_map_action(
             if success:
                 start_ip = current_state.ip
                 if config.MAP_GATHER_DU_COST > 0:
-                    try:
-                        from src.infra.ledger import ledger
-
-                        aid = ledger.open_auction("gather")
-                        ledger.place_bid(aid, agent_id, config.MAP_GATHER_DU_COST)
-                        ledger.resolve_auction(aid)
-                    except Exception:  # pragma: no cover - optional
-                        logger.debug("Ledger auction failed", exc_info=True)
+                    run_auction("gather", agent_id, config.MAP_GATHER_DU_COST)
                     current_state.du -= config.MAP_GATHER_DU_COST
                 start_du = current_state.du
                 current_state.ip -= config.MAP_GATHER_IP_COST
                 current_state.ip += config.MAP_GATHER_IP_REWARD
                 current_state.du += config.MAP_GATHER_DU_REWARD
-                try:
-                    from src.infra.ledger import ledger
-
-                    ledger.log_change(
-                        agent_id,
-                        current_state.ip - start_ip,
-                        current_state.du - start_du,
-                        "gather",
-                    )
-                except Exception:  # pragma: no cover - optional
-                    logger.debug("Ledger logging failed", exc_info=True)
+                log_reward(
+                    agent_id,
+                    current_state.ip - start_ip,
+                    current_state.du - start_du,
+                    "gather",
+                )
     elif action_type == "build":
         struct = map_action.get("structure")
         success = False
@@ -112,30 +89,18 @@ async def process_map_action(
             if success:
                 start_ip = current_state.ip
                 if config.MAP_BUILD_DU_COST > 0:
-                    try:
-                        from src.infra.ledger import ledger
-
-                        aid = ledger.open_auction("build")
-                        ledger.place_bid(aid, agent_id, config.MAP_BUILD_DU_COST)
-                        ledger.resolve_auction(aid)
-                    except Exception:  # pragma: no cover - optional
-                        logger.debug("Ledger auction failed", exc_info=True)
+                    run_auction("build", agent_id, config.MAP_BUILD_DU_COST)
                     current_state.du -= config.MAP_BUILD_DU_COST
                 start_du = current_state.du
                 current_state.ip -= config.MAP_BUILD_IP_COST
                 current_state.ip += config.MAP_BUILD_IP_REWARD
                 current_state.du += config.MAP_BUILD_DU_REWARD
-                try:
-                    from src.infra.ledger import ledger
-
-                    ledger.log_change(
-                        agent_id,
-                        current_state.ip - start_ip,
-                        current_state.du - start_du,
-                        "build",
-                    )
-                except Exception:  # pragma: no cover - optional
-                    logger.debug("Ledger logging failed", exc_info=True)
+                log_reward(
+                    agent_id,
+                    current_state.ip - start_ip,
+                    current_state.du - start_du,
+                    "build",
+                )
         else:
             details = {}
 

--- a/tests/integration/sim/test_world_map_actions.py
+++ b/tests/integration/sim/test_world_map_actions.py
@@ -13,6 +13,7 @@ class DummyNeo4j:
 
 sys.modules.setdefault("neo4j", DummyNeo4j())
 
+from src.infra import config
 from src.infra.ledger import Ledger
 from src.sim.simulation import Simulation
 from src.sim.world_map import ResourceToken, StructureType
@@ -68,6 +69,27 @@ async def test_move_action_updates_position_and_ledger(
     assert sim_obj.world_map.agent_positions[agent.agent_id] == (1, 0)
     rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
     assert rows == [("move",)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_move_action_with_du_cost_triggers_auction(
+    sim: tuple[Simulation, Ledger, DummyAgent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sim_obj, ledger, agent = sim
+    monkeypatch.setattr(config, "MAP_MOVE_DU_COST", 1.0)
+
+    await process_map_action(
+        sim_obj,
+        0,
+        agent.agent_id,
+        agent.state,
+        {"action": "move", "dx": 1, "dy": 0},
+    )
+
+    rows = ledger.conn.execute("SELECT reason FROM transactions").fetchall()
+    assert rows == [("stake",), ("move",)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `run_auction` and `log_reward` helper functions to `src/infra/ledger.py`
- refactor world map actions to use the helpers
- extend integration tests to validate auction cost handling

## Testing
- `ruff format src/infra/ledger.py src/sim/world_map_actions.py tests/integration/sim/test_world_map_actions.py`
- `ruff check src/infra/ledger.py src/sim/world_map_actions.py tests/integration/sim/test_world_map_actions.py`
- `black --check src/infra/ledger.py src/sim/world_map_actions.py tests/integration/sim/test_world_map_actions.py`
- `pytest tests/integration/sim/test_world_map_actions.py -m integration -q`


------
https://chatgpt.com/codex/tasks/task_e_688030361bf48326ab67f729731c8824