### PR TITLE
Refactor graph memory calls to use MemoryService

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -79,12 +79,7 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
     service = cast(MemoryService | None, state.get("memory_service"))
     if service is None:
-        vector = cast(MemoryRetriever | None, state.get("vector_store_manager"))
-        semantic = cast(Any, state.get("semantic_manager"))
-        if vector or semantic:
-            service = MemoryService(cast(Any, vector), cast(Any, semantic))
-        else:
-            service = None
+        return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
     if not service or not agent:

--- a/tests/integration/memory/test_multilayer_retriever.py
+++ b/tests/integration/memory/test_multilayer_retriever.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("chromadb")
 
-from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
@@ -20,19 +20,22 @@ async def test_multilayer_retrieval_combines_layers(chroma_test_dir: Path) -> No
     )
     driver = DummyDriver()
     semantic = SemanticMemoryManager(vector, driver)
-    retriever = MultiLayerRetriever(vector, semantic)
+    service = MemoryService(vector, semantic)
 
     vector.add_memory("agent", 1, "thought", "cat", memory_type="raw")
     vector.add_memory("agent", 2, "thought", "dog", memory_type="raw")
 
-    await retriever.retrieve_and_update_semantic("agent", k=2)
+    await service.retrieve_episodic_and_update_semantic("agent", k=2)
 
     vector.add_memory("agent", 3, "thought", "bird", memory_type="raw")
     semantic.group_memories_by_topic("agent", num_topics=2)
 
     episodic_only = await vector.aretrieve_relevant_memories("agent", "cat", k=5)
-    combined = await retriever.retrieve("agent", "cat", k=5)
-    assert len(combined) >= len(episodic_only)
+    episodic, semantic_res = await service.get_context_pipeline(
+        "agent", query="cat", k=5, semantic_limit=5
+    )
+    combined_len = len(episodic) + len(semantic_res)
+    assert combined_len >= len(episodic_only)
 
 
 @pytest.mark.integration
@@ -45,13 +48,13 @@ async def test_blend_with_recent_semantic(chroma_test_dir: Path) -> None:
     )
     driver = DummyDriver()
     semantic = SemanticMemoryManager(vector, driver)
-    retriever = MultiLayerRetriever(vector, semantic)
+    service = MemoryService(vector, semantic)
 
     vector.add_memory("agent", 1, "thought", "cat", memory_type="raw")
     vector.add_memory("agent", 2, "thought", "dog", memory_type="raw")
 
-    await retriever.run_semantic_job("agent")
+    await service.run_semantic_job("agent")
 
-    blended = retriever.blend_with_recent_semantic("agent", "bird", limit=1)
+    blended = service.blend_with_recent_semantic("agent", "bird", limit=1)
     assert "bird" in blended
     assert "cat" in blended or "dog" in blended

--- a/tests/integration/memory/test_semantic_group_retrieval.py
+++ b/tests/integration/memory/test_semantic_group_retrieval.py
@@ -5,6 +5,7 @@ import pytest
 
 pytest.importorskip("chromadb")
 
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 
@@ -21,6 +22,7 @@ class TestSemanticGroupingRetrieval(unittest.TestCase):
     def setUp(self):
         self.vector_store = ChromaVectorStoreManager(persist_directory=self.chroma_test_dir)
         self.manager = SemanticMemoryManager(self.vector_store, driver=None)
+        self.service = MemoryService(self.vector_store, self.manager)
         self.agent_id = "semantic_agent"
         for i in range(5):
             self.vector_store.add_memory(
@@ -50,7 +52,7 @@ class TestSemanticGroupingRetrieval(unittest.TestCase):
         assert len(groups) == 2
         assert sum(len(v) for v in groups.values()) == 10
 
-        cat_res = self.manager.retrieve_context(self.agent_id, "sleepy cat", k=5)
-        dog_res = self.manager.retrieve_context(self.agent_id, "walk with dog", k=5)
+        cat_res = self.service.retrieve_semantic_context(self.agent_id, "sleepy cat", k=5)
+        dog_res = self.service.retrieve_semantic_context(self.agent_id, "walk with dog", k=5)
         assert cat_res
         assert dog_res

--- a/tests/integration/memory/test_semantic_recent_summaries.py
+++ b/tests/integration/memory/test_semantic_recent_summaries.py
@@ -4,6 +4,7 @@ import pytest
 
 pytest.importorskip("chromadb")
 
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
@@ -20,6 +21,7 @@ async def test_nightly_job_and_retrieval(chroma_test_dir: Path) -> None:
     )
     driver = DummyDriver()
     manager = SemanticMemoryManager(vector, driver)
+    service = MemoryService(vector, manager)
 
     vector.add_memory("agent", 1, "thought", "first")
     vector.add_memory("agent", 2, "thought", "second")
@@ -27,7 +29,7 @@ async def test_nightly_job_and_retrieval(chroma_test_dir: Path) -> None:
     await manager.run_nightly_job("agent")
 
     assert driver.store[0]["agent"] == "agent"
-    recent = manager.get_recent_summaries("agent", limit=1)
+    recent = service.get_recent_semantic_summaries("agent", limit=1)
     assert recent == ["first\nsecond"]
-    blended = manager.blend_episodic_and_semantic("agent", "third", limit=1)
+    blended = service.blend_with_recent_semantic("agent", "third", limit=1)
     assert "third" in blended and "first" in blended


### PR DESCRIPTION
## Summary
- drop direct vector/semantic access in `retrieve_and_summarize_memories_node`
- adapt memory integration tests to use `MemoryService`

## Testing
- `ruff check src/agents/graphs/graph_nodes.py tests/integration/memory/test_multilayer_retriever.py tests/integration/memory/test_semantic_recent_summaries.py tests/integration/memory/test_semantic_group_retrieval.py`
- `ruff format src/agents/graphs/graph_nodes.py tests/integration/memory/test_multilayer_retriever.py tests/integration/memory/test_semantic_recent_summaries.py tests/integration/memory/test_semantic_group_retrieval.py`
- `pytest tests/integration/memory/test_semantic_recent_summaries.py::test_nightly_job_and_retrieval -q -m integration`
- `pytest tests/integration/memory/test_multilayer_retriever.py::test_blend_with_recent_semantic -q -m integration`
- `pytest tests/integration/memory/test_semantic_group_retrieval.py::TestSemanticGroupingRetrieval::test_grouping_and_retrieval -q -m integration`


------
https://chatgpt.com/codex/tasks/task_e_6880303571c88326938cc39081ab0c68