### PR TITLE
Add async structured output with httpx

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -10,7 +10,7 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.memory_service import MemoryService
 from src.infra.llm_client import (
     analyze_sentiment,
-    generate_structured_output,
+    async_generate_structured_output,
 )
 from src.shared.typing import SimulationMessage
 
@@ -109,7 +109,7 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     return {"rag_summary": summary, "memory_history_list": memories}
 
 
-def generate_structured_output_from_intent(
+async def generate_structured_output_from_intent(
     intent: str,
     prompt: str,
     schema: type[AgentActionOutput],
@@ -117,7 +117,7 @@ def generate_structured_output_from_intent(
 ) -> AgentActionOutput | None:
     """Compatibility wrapper used by older tests."""
 
-    return generate_structured_output(prompt, schema, **kwargs)
+    return await async_generate_structured_output(prompt, schema, **kwargs)
 
 
 async def generate_thought_and_message_node(
@@ -160,14 +160,14 @@ async def generate_thought_and_message_node(
         action_intent = getattr(result, "chosen_action_intent", "idle")
 
     try:
-        structured = generate_structured_output_from_intent(
+        structured = await generate_structured_output_from_intent(
             action_intent,
             "prompt",
             AgentActionOutput,
             agent_state=state.get("state"),
         )
     except TypeError:
-        structured = generate_structured_output_from_intent(
+        structured = await generate_structured_output_from_intent(
             action_intent,
             "prompt",
             AgentActionOutput,

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import json
 import logging
+import sys
 import time
-from collections.abc import Iterable
+import uuid
+from collections.abc import Awaitable, Iterable
 from typing import TYPE_CHECKING, Any, Callable, ParamSpec, Protocol, TypeVar, cast
 
+import httpx
+
+from src.interfaces import metrics
 from src.shared.typing import (
     JSONDict,
     JSONValue,
@@ -62,7 +68,7 @@ from pydantic.fields import FieldInfo
 if TYPE_CHECKING:
     from src.agents.core.agent_state import AgentState
 
-from src.shared.decorator_utils import monitor_llm_call
+from src.shared.decorator_utils import llm_perf_logger, monitor_llm_call
 
 from .config import OLLAMA_REQUEST_TIMEOUT, get_config
 from .ledger import ledger
@@ -141,6 +147,121 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
         return result
 
     return wrapper
+
+
+def async_charge_du_cost(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    """Async version of :func:`charge_du_cost`."""
+
+    @functools.wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        state = cast("AgentState | None", kwargs.get("agent_state"))
+        result = await func(*args, **kwargs)
+        if state is not None:
+            try:
+                try:
+                    base_price, token_price = ledger.calculate_gas_price(state.agent_id)
+                except AttributeError:
+                    base_price = float(get_config("GAS_PRICE_PER_CALL"))
+                    token_price = float(get_config("GAS_PRICE_PER_TOKEN"))
+                tokens = 1
+                if isinstance(result, dict):
+                    usage = result.get("usage")
+                    if isinstance(usage, dict):
+                        tokens = int(usage.get("prompt_tokens", 0)) + int(
+                            usage.get("completion_tokens", 0)
+                        )
+                cost = base_price + token_price * tokens
+                if state.du < cost:
+                    logger.warning(
+                        "Insufficient DU for agent %s: cost=%s, available=%s",
+                        state.agent_id,
+                        cost,
+                        state.du,
+                    )
+                else:
+                    state.du -= cost
+                    try:
+                        ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
+                    except Exception:  # pragma: no cover - optional
+                        logger.debug("Ledger logging failed", exc_info=True)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"Failed to deduct DU cost: {e}")
+        return result
+
+    return wrapper
+
+
+def async_monitor_llm_call(
+    model_param: str = "model", context: str | None = None
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    """Async equivalent of :func:`monitor_llm_call`."""
+
+    def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            request_id = str(uuid.uuid4())[:8]
+            start_time = time.perf_counter()
+            model = kwargs.get(model_param, "unknown_model")
+            metrics_data: dict[str, Any] = {
+                "request_id": request_id,
+                "function": func.__name__,
+                "model": model,
+                "timestamp": time.time(),
+                "context": context,
+                "success": False,
+                "duration_ms": None,
+                "error_type": None,
+                "error_message": None,
+                "status_code": None,
+            }
+            try:
+                result = await func(*args, **kwargs)
+                if result is None:
+                    metrics_data["success"] = False
+                    exc_type, exc_value, _ = sys.exc_info()
+                    if exc_type and exc_value:
+                        metrics_data["error_type"] = exc_type.__name__
+                        metrics_data["error_message"] = str(exc_value)
+                        if hasattr(exc_value, "status_code"):
+                            metrics_data["status_code"] = exc_value.status_code
+                        if hasattr(exc_value, "response") and hasattr(exc_value.response, "text"):
+                            metrics_data["error_message"] = exc_value.response.text
+                    else:
+                        metrics_data["error_type"] = "UnknownError"
+                        metrics_data["error_message"] = (
+                            "Function returned None, indicating an error"
+                        )
+                else:
+                    metrics_data["success"] = True
+                    if hasattr(result, "usage"):
+                        metrics_data["prompt_tokens"] = getattr(
+                            result.usage, "prompt_tokens", None
+                        )
+                        metrics_data["completion_tokens"] = getattr(
+                            result.usage, "completion_tokens", None
+                        )
+                return result
+            except Exception as e:
+                metrics_data["success"] = False
+                metrics_data["error_type"] = type(e).__name__
+                metrics_data["error_message"] = str(e)
+                if hasattr(e, "status_code"):
+                    metrics_data["status_code"] = e.status_code
+                if hasattr(e, "response") and hasattr(e.response, "text"):
+                    metrics_data["error_message"] = e.response.text
+                raise
+            finally:
+                end_time = time.perf_counter()
+                metrics_data["duration_ms"] = round((end_time - start_time) * 1000, 2)
+                metrics.LLM_CALLS_TOTAL.inc()
+                if not metrics_data.get("success", False):
+                    metrics.LLM_ERRORS_TOTAL.inc()
+                metrics.LLM_LATENCY_MS.set(metrics_data["duration_ms"])
+                llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
+
+        return wrapper
+
+    return decorator
 
 
 class OllamaClientProtocol(Protocol):
@@ -644,9 +765,9 @@ def analyze_sentiment(
         return None  # Or 0.0 if float is always expected
 
 
-@charge_du_cost
-@monitor_llm_call(model_param="model", context="structured_output")
-def generate_structured_output(
+@async_charge_du_cost
+@async_monitor_llm_call(model_param="model", context="structured_output")
+async def async_generate_structured_output(
     prompt: str,
     response_model: type[BaseModel],
     model: str = "mistral:latest",
@@ -818,7 +939,8 @@ def generate_structured_output(
                 "stream": False,
                 "options": {"temperature": temperature, "top_p": 0.95, "num_predict": 400},
             }
-        response = requests.post(url, json=payload, timeout=timeout_value)
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, json=payload, timeout=timeout_value)
         response.raise_for_status()
         result = cast(JSONDict, response.json())
         if USE_VLLM:
@@ -847,6 +969,31 @@ def generate_structured_output(
         logger.error(f"Error in generate_structured_output: {e}")
 
         return None
+
+
+@charge_du_cost
+@monitor_llm_call(model_param="model", context="structured_output")
+def generate_structured_output(
+    prompt: str,
+    response_model: type[BaseModel],
+    model: str = "mistral:latest",
+    temperature: float = 0.2,
+    timeout: int | None = None,
+    *,
+    agent_state: Any | None = None,
+) -> BaseModel | None:
+    """Synchronous wrapper around :func:`async_generate_structured_output`."""
+
+    return asyncio.run(
+        async_generate_structured_output(
+            prompt,
+            response_model,
+            model=model,
+            temperature=temperature,
+            timeout=timeout,
+            agent_state=agent_state,
+        )
+    )
 
 
 def get_default_llm_client() -> OllamaClientProtocol:

--- a/src/sim/quests/__init__.py
+++ b/src/sim/quests/__init__.py
@@ -20,13 +20,13 @@ class Quest(BaseModel):
 
 QUESTS: list[Quest] = []
 
-_quest_task: asyncio.Task | None = None
+_quest_task: asyncio.Task[None] | None = None
 
 
 async def _quest_loop(interval: float) -> None:
     while True:
         try:
-            generate_quest("Create a new quest for the agents")
+            await generate_quest("Create a new quest for the agents")
         except Exception:  # pragma: no cover - defensive
             pass
         await asyncio.sleep(interval)
@@ -53,7 +53,7 @@ async def stop_quest_generation() -> None:
         _quest_task = None
 
 
-def generate_quest(
+async def generate_quest(
     prompt: str,
     *,
     model: str = "mistral:latest",
@@ -61,7 +61,7 @@ def generate_quest(
 ) -> Quest | None:
     """Generate a quest using the LLM client and store it."""
 
-    result = llm_client.generate_structured_output(
+    result = await llm_client.async_generate_structured_output(
         prompt,
         Quest,
         model=model,

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -825,7 +825,7 @@ class Simulation:
         await self.event_kernel.emit_environment_event(event)
 
     async def _generate_quest_event(self: Self) -> None:
-        quest = generate_quest("Create a new quest for the agents")
+        quest = await generate_quest("Create a new quest for the agents")
         if quest is None:
             return
         event = {

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -107,7 +108,7 @@ async def test_generate_thought_and_message_node(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(
         "src.agents.graphs.graph_nodes.generate_structured_output_from_intent",
-        lambda intent, prompt, schema: dummy,
+        AsyncMock(return_value=dummy),
     )
 
     out = await generate_thought_and_message_node(cast(dict[str, object], {}))
@@ -129,7 +130,9 @@ async def test_finalize_message_agent_node_variants() -> None:
         message_recipient_id="b",
         action_intent="propose",
     )
-    out2 = await finalize_message_agent_node(cast(dict[str, object], {"state": agent_state, "structured_output": dummy}))
+    out2 = await finalize_message_agent_node(
+        cast(dict[str, object], {"state": agent_state, "structured_output": dummy})
+    )
     assert out2["message_content"] == "hi"
     assert out2["is_targeted"] is True
 

--- a/tests/unit/infra/test_llm_client_async.py
+++ b/tests/unit/infra/test_llm_client_async.py
@@ -1,0 +1,60 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from src.infra import llm_client
+
+
+class DummyModel(BaseModel):
+    foo: str
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_generate_structured_output_uses_async_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+
+    async def fake_post(url: str, *args: object, **kwargs: object) -> MagicMock:
+        captured["url"] = url
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"response": json.dumps({"foo": "bar"})}
+        return resp
+
+    monkeypatch.setattr(llm_client, "USE_VLLM", False)
+    monkeypatch.setattr(
+        "src.infra.llm_client.httpx.AsyncClient.post",
+        AsyncMock(side_effect=fake_post),
+    )
+    monkeypatch.setattr(
+        "src.infra.llm_client.requests.post",
+        MagicMock(side_effect=AssertionError("sync post")),
+    )
+
+    result = await llm_client.async_generate_structured_output("prompt", DummyModel)
+
+    assert isinstance(result, DummyModel)
+    assert result.foo == "bar"
+    assert captured["url"].endswith("/api/generate")
+
+
+@pytest.mark.unit
+def test_sync_wrapper_calls_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    async_called = False
+
+    async def fake_async(*args: object, **kwargs: object) -> DummyModel:
+        nonlocal async_called
+        async_called = True
+        return DummyModel(foo="bar")
+
+    monkeypatch.setattr(llm_client, "async_generate_structured_output", fake_async)
+
+    result = llm_client.generate_structured_output("prompt", DummyModel)
+
+    assert async_called is True
+    assert isinstance(result, DummyModel)
+    assert result.foo == "bar"

--- a/tests/unit/sim/quests/test_generator.py
+++ b/tests/unit/sim/quests/test_generator.py
@@ -10,7 +10,10 @@ from tests.utils.mock_llm import MockLLM
 pytestmark = pytest.mark.unit
 
 
-def test_generate_quest_adds_to_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_generate_quest_adds_to_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     quests.QUESTS.clear()
     ledger = Ledger(tmp_path / "ledger.sqlite")
     monkeypatch.setattr(quests, "ledger", ledger)
@@ -24,7 +27,7 @@ def test_generate_quest_adds_to_list(tmp_path: Path, monkeypatch: pytest.MonkeyP
         }
     }
     with MockLLM(responses):
-        quest = quests.generate_quest("Create quest")
+        quest = await quests.generate_quest("Create quest")
     assert quest == Quest(
         id=1, title="Quest", description="Do something", progress=0, status="pending"
     )

--- a/tests/utils/mock_llm.py
+++ b/tests/utils/mock_llm.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any, Optional, cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,10 @@ def MockLLM(
         patch(
             "src.infra.llm_client.generate_structured_output",
             side_effect=mock_generate_structured_output,
+        ),
+        patch(
+            "src.infra.llm_client.async_generate_structured_output",
+            AsyncMock(side_effect=mock_generate_structured_output),
         ),
         patch("src.infra.llm_client.generate_response", side_effect=mock_generate_response),
         patch("src.infra.llm_client.client.chat", side_effect=mock_ollama_chat),


### PR DESCRIPTION
## Summary
- implement `async_generate_structured_output` using httpx.AsyncClient
- keep synchronous wrapper calling the async version
- update graph nodes and quest generation to use async structured output
- adjust simulation quest generation to await async function
- add async tests for llm_client and update existing tests

## Testing
- `mypy src/infra/llm_client.py`
- `mypy src/agents/graphs/graph_nodes.py src/sim/quests/__init__.py src/sim/simulation.py tests/unit/infra/test_llm_client_async.py`
- `python -m pytest -m "not integration and not ollama" tests/unit/infra/test_llm_client_async.py tests/unit/graphs/test_graph_nodes.py tests/unit/sim/quests/test_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68802688097883269a2f35f821db09c9