### PR TITLE
Add governance slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,16 @@ Adjusts the simulation tick speed.
 ```
 Creates a new entry on the shared Knowledge Board.
 
+```text
+/propose_law Agents must document major decisions
+```
+Proposes a new law and triggers an on-chain vote.
+
+```text
+/vote "Agents must document major decisions" true
+```
+Casts a yes/no vote on the given proposal.
+
 See `/status` and `/stats` for ephemeral information about agent resources and
 latency.
 

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -14,9 +14,10 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 from typing_extensions import Self
 
+from src.governance.service import governance
 from src.infra import config
 from src.infra.ledger import ledger
-from src.interfaces import metrics
+from src.interfaces import dashboard_backend, metrics
 from src.interfaces.dashboard_backend import (
     AgentMessage,
     SimulationEvent,
@@ -746,7 +747,7 @@ async def slash_propose(interaction: Any, text: str) -> None:
 @typing.no_type_check
 @bot.tree.command(name="propose_law")
 async def slash_propose_law(interaction: Any, text: str) -> None:
-    """Propose a law using the basic endpoint."""
+    """Propose a law using the governance service."""
     agent_id = None
     if active_bot is not None:
         channel = getattr(interaction, "channel", None)
@@ -759,11 +760,16 @@ async def slash_propose_law(interaction: Any, text: str) -> None:
     if ip <= 0 or du <= 0:
         await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
         return
-    payload = {"proposer_id": agent_id, "text": text}
+    sim = dashboard_backend.SIM_STATE.get("simulation")
+    if sim is None:
+        await interaction.response.send_message("Simulation inactive", ephemeral=True)
+        return
+    proposer = next((a for a in sim.agents if a.agent_id == agent_id), None)
+    if proposer is None:
+        await interaction.response.send_message("Unknown agent", ephemeral=True)
+        return
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post("http://localhost:8000/api/propose_law", json=payload)
-            approved = resp.json().get("approved", False)
+        approved = await governance.propose_law(proposer, text, sim.agents)
     except Exception:
         approved = False
     await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
@@ -772,7 +778,7 @@ async def slash_propose_law(interaction: Any, text: str) -> None:
 @typing.no_type_check
 @bot.tree.command(name="vote")
 async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
-    """Cast a manual vote on a proposal via the API."""
+    """Cast a manual vote on a proposal via the governance service."""
     agent_id = None
     if active_bot is not None:
         channel = getattr(interaction, "channel", None)
@@ -785,11 +791,17 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
     if ip <= 0 or du <= 0:
         await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
         return
-    payload = {"agent_id": agent_id, "text": text, "approve": approve}
+    sim = dashboard_backend.SIM_STATE.get("simulation")
+    if sim is None:
+        await interaction.response.send_message("Simulation inactive", ephemeral=True)
+        return
+    agent = next((a for a in sim.agents if a.agent_id == agent_id), None)
+    if agent is None:
+        await interaction.response.send_message("Unknown agent", ephemeral=True)
+        return
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post("http://localhost:8000/api/vote", json=payload)
-            cast = resp.json().get("vote", False)
+        allowed = await governance.vote(agent, text)
+        cast = bool(approve and allowed)
     except Exception:
         cast = False
     await interaction.response.send_message(

--- a/tests/integration/governance/test_propose_command.py
+++ b/tests/integration/governance/test_propose_command.py
@@ -47,31 +47,62 @@ async def test_slash_propose_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_slash_propose_law_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bot.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+async def test_slash_propose_law_uses_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict | None = None
+
+    async def fake_propose(
+        proposer: object, text: str, agents: list[object], vote_weights: object | None = None
+    ) -> bool:
+        nonlocal called
+        called = {
+            "proposer": getattr(proposer, "agent_id", None),
+            "text": text,
+            "agents": [getattr(a, "agent_id", None) for a in agents],
+            "vote_weights": vote_weights,
+        }
+        return True
+
     monkeypatch.setattr(bot.ledger, "get_balance_async", AsyncMock(return_value=(1.0, 1.0)))
     monkeypatch.setattr(bot, "active_bot", SimpleNamespace(channel_to_agent={123: "a1"}))
+    monkeypatch.setitem(
+        bot.dashboard_backend.SIM_STATE,
+        "simulation",
+        SimpleNamespace(agents=[SimpleNamespace(agent_id="a1"), SimpleNamespace(agent_id="a2")]),
+    )
+    monkeypatch.setattr(bot.governance, "propose_law", fake_propose)
 
     await bot.slash_propose_law.callback(DummyInteraction(), text="hello")
 
-    assert DummyClient.called["url"].endswith("/api/propose_law")
-    assert DummyClient.called["json"] == {"proposer_id": "a1", "text": "hello"}
-    DummyClient.called = {}
+    assert called == {
+        "proposer": "a1",
+        "text": "hello",
+        "agents": ["a1", "a2"],
+        "vote_weights": None,
+    }
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_slash_vote_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(bot.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+async def test_slash_vote_uses_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict | None = None
+
+    async def fake_vote(agent: object, text: str) -> bool:
+        nonlocal called
+        called = {
+            "agent": getattr(agent, "agent_id", None),
+            "text": text,
+        }
+        return True
+
     monkeypatch.setattr(bot.ledger, "get_balance_async", AsyncMock(return_value=(1.0, 1.0)))
     monkeypatch.setattr(bot, "active_bot", SimpleNamespace(channel_to_agent={123: "a1"}))
+    monkeypatch.setitem(
+        bot.dashboard_backend.SIM_STATE,
+        "simulation",
+        SimpleNamespace(agents=[SimpleNamespace(agent_id="a1")]),
+    )
+    monkeypatch.setattr(bot.governance, "vote", fake_vote)
 
     await bot.slash_vote.callback(DummyInteraction(), text="hello", approve=True)
 
-    assert DummyClient.called["url"].endswith("/api/vote")
-    assert DummyClient.called["json"] == {
-        "agent_id": "a1",
-        "text": "hello",
-        "approve": True,
-    }
-    DummyClient.called = {}
+    assert called == {"agent": "a1", "text": "hello"}


### PR DESCRIPTION
## Summary
- expose governance service in Discord bot
- teach propose_law and vote slash commands to call the service
- document `/propose_law` and `/vote` usage
- update governance integration tests

## Testing
- `mypy src/interfaces/discord_bot.py`
- `ruff check src/interfaces/discord_bot.py tests/integration/governance/test_propose_command.py`
- `python scripts/run_tests.py -k test_propose_command.py -m integration`

------
https://chatgpt.com/codex/tasks/task_e_688042cc82f08326a695e943adb11fc5