### PR TITLE
Add dataset export filters and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ ACTIVATE := .venv/bin/activate
 VERTICAL_SLICE := ./scripts/vertical_slice.sh
 endif
 
+SNAPSHOTS ?= snapshots
+OUTPUT ?= data/traces.jsonl
+
 .PHONY: local-slice
 local-slice:
 	@if [ -f "$(ACTIVATE)" ]; then \
@@ -21,4 +24,8 @@ local-slice:
 	        touch .venv/.deps_installed; \
 	    fi; \
 	fi; \
-	$(VERTICAL_SLICE)
+        $(VERTICAL_SLICE)
+
+.PHONY: dataset
+dataset:
+	python scripts/export_traces.py --snapshots $(SNAPSHOTS) --output $(OUTPUT)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -75,3 +75,15 @@ ENABLE_REDPANDA=1 python scripts/export_traces.py --redpanda -o traces.jsonl
 ```
 
 Each line in the output file is a JSON object representing a snapshot or event.
+
+The script accepts optional filters:
+
+- `--agent` – only include events with a matching `agent_id`
+- `--start-step`/`--end-step` – restrict the step range
+
+You can also generate a dataset with `make dataset`, overriding the input and
+output paths if needed:
+
+```bash
+make dataset SNAPSHOTS=snapshots OUTPUT=data/traces.jsonl
+```

--- a/scripts/export_traces.py
+++ b/scripts/export_traces.py
@@ -48,6 +48,9 @@ def main(argv: list[str] | None = None) -> int:
     src_group.add_argument("--events", help="JSON file containing event log")
     src_group.add_argument("--redpanda", action="store_true", help="Fetch events from Redpanda")
     parser.add_argument("-o", "--output", help="Output JSONL file (default: stdout)")
+    parser.add_argument("--agent", help="Only include events for this agent_id")
+    parser.add_argument("--start-step", type=int, help="First step to include (inclusive)")
+    parser.add_argument("--end-step", type=int, help="Last step to include (inclusive)")
     args = parser.parse_args(argv)
 
     if args.snapshots:
@@ -59,6 +62,14 @@ def main(argv: list[str] | None = None) -> int:
 
     out = open(args.output, "w", encoding="utf-8") if args.output else sys.stdout
     for item in iterator:
+        step = item.get("step")
+        if step is not None:
+            if args.start_step is not None and step < args.start_step:
+                continue
+            if args.end_step is not None and step > args.end_step:
+                continue
+        if args.agent and item.get("agent_id") != args.agent:
+            continue
         out.write(json.dumps(item))
         out.write("\n")
     if args.output:

--- a/tests/unit/scripts/test_export_traces.py
+++ b/tests/unit/scripts/test_export_traces.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import export_traces
+from src.infra.snapshot import compute_trace_hash, save_snapshot
+
+pytestmark = pytest.mark.unit
+
+
+def _make_snapshot(step: int, agent_id: str, directory: Path) -> None:
+    data = {"step": step, "agent_id": agent_id, "value": step}
+    data["trace_hash"] = compute_trace_hash(data)
+    save_snapshot(step, data, directory=directory)
+
+
+def test_export_traces_jsonl(tmp_path: Path) -> None:
+    snap_dir = tmp_path / "snaps"
+    snap_dir.mkdir()
+    _make_snapshot(1, "a1", snap_dir)
+    _make_snapshot(2, "a1", snap_dir)
+
+    out = tmp_path / "out.jsonl"
+    export_traces.main([
+        "--snapshots",
+        str(snap_dir),
+        "--agent",
+        "a1",
+        "--start-step",
+        "2",
+        "-o",
+        str(out),
+    ])
+
+    lines = out.read_text().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["step"] == 2
+    assert record["agent_id"] == "a1"


### PR DESCRIPTION
## Summary
- expand `export_traces.py` with agent and step filters
- add `dataset` Makefile target for dataset generation
- document dataset workflow in runbook
- test exported JSONL output

## Testing
- `ruff check scripts/export_traces.py tests/unit/scripts/test_export_traces.py`
- `mypy scripts/export_traces.py`
- `mypy tests/unit/scripts/test_export_traces.py`
- `python scripts/run_tests.py -k test_export_traces`

------
https://chatgpt.com/codex/tasks/task_e_688042cdcb088326978b5030c8305470