### PR TITLE
Add SSE integration and export traces tests

### DIFF
--- a/tests/integration/interfaces/test_stream_multiple_sse.py
+++ b/tests/integration/interfaces/test_stream_multiple_sse.py
@@ -1,0 +1,78 @@
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+
+import pytest
+
+pytest.importorskip("fastapi")
+import fastapi
+
+if not hasattr(fastapi.FastAPI(), "__call__"):
+    pytest.skip("FastAPI ASGI app not available", allow_module_level=True)
+
+import pytest
+
+from src import http_app
+from src.interfaces import dashboard_backend as db
+from src.sim import event_bus
+
+
+class SimpleESR:
+    def __init__(self, gen: AsyncGenerator[dict[str, str], None]) -> None:
+        self.gen = gen
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_events_multiple_sse(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(http_app, "EventSourceResponse", SimpleESR)
+    bus = event_bus.EventBus()
+    monkeypatch.setattr(event_bus, "get_event_bus", lambda: bus)
+
+    async def publish() -> None:
+        await bus.publish(db.SimulationEvent(type="one", data={"step": 1}))
+        await bus.publish(db.SimulationEvent(type="two", data={"step": 2}))
+        bus.shutdown()
+
+    publisher = asyncio.create_task(publish())
+    resp = await http_app.stream_events(DummyRequest())
+
+    events = []
+    for _ in range(2):
+        evt = await resp.gen.__anext__()
+        events.append(evt)
+
+    await publisher
+
+    assert [e["event"] for e in events] == ["simulation_event", "simulation_event"]
+    data = [json.loads(e["data"]) for e in events]
+    assert [d["step"] for d in data] == [1, 2]
+
+
+class DummyRequest:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def is_disconnected(self) -> bool:
+        self.calls += 1
+        return self.calls > 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stream_messages_multiple_sse(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db, "EventSourceResponse", SimpleESR)
+    queue: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
+    monkeypatch.setattr(db, "message_sse_queue", queue)
+
+    msg1 = db.AgentMessage(agent_id="a", content="one", step=1)
+    msg2 = db.AgentMessage(agent_id="b", content="two", step=2)
+    await db.enqueue_message(msg1)
+    await db.enqueue_message(msg2)
+
+    resp = await db.stream_messages(DummyRequest())
+
+    events = [await resp.gen.__anext__() for _ in range(2)]
+
+    contents = [json.loads(e["data"])["content"] for e in events]
+    assert contents == ["one", "two"]

--- a/tests/unit/scripts/test_export_traces.py
+++ b/tests/unit/scripts/test_export_traces.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import export_traces as et
+from src.infra.snapshot import compute_trace_hash, save_snapshot
+
+
+@pytest.mark.unit
+def test_export_traces_snapshots(tmp_path: Path) -> None:
+    snap1 = {"step": 1}
+    snap1["trace_hash"] = compute_trace_hash(snap1)
+    save_snapshot(1, snap1, directory=tmp_path)
+    snap2 = {"step": 2}
+    snap2["trace_hash"] = compute_trace_hash(snap2)
+    save_snapshot(2, snap2, directory=tmp_path)
+
+    out = tmp_path / "out.jsonl"
+    ret = et.main(["--snapshots", str(tmp_path), "-o", str(out)])
+    assert ret == 0
+
+    lines = out.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == [snap1, snap2]


### PR DESCRIPTION
## Summary
- add integration tests to verify SSE output for events/messages
- add unit test for `export_traces.py`

## Testing
- `ruff check tests/integration/interfaces/test_stream_multiple_sse.py tests/unit/scripts/test_export_traces.py`
- `mypy tests/integration/interfaces/test_stream_multiple_sse.py tests/unit/scripts/test_export_traces.py`
- `SKIP_DEP_INSTALL=1 python -m pytest -c pytest.ini tests/unit/scripts/test_export_traces.py tests/integration/interfaces/test_stream_multiple_sse.py -m "not dspy" -q`

------
https://chatgpt.com/codex/tasks/task_e_688042d0600083269a2e5078d800db80