### PR TITLE
Improve sim docstrings

### DIFF
--- a/examples/plugins/register_widget_example.py
+++ b/examples/plugins/register_widget_example.py
@@ -1,11 +1,13 @@
 """Example plug-in registering a custom widget with the Culture UI."""
 
+import asyncio
+
 from src.extensions import register_widget_backend
 
 
-def main() -> None:
+async def main() -> None:
     """Register a widget named ``ExampleWidget`` using the backend API."""
-    register_widget_backend(
+    await register_widget_backend(
         name="ExampleWidget",
         script_url="http://localhost:5173/example.js",
     )
@@ -13,4 +15,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - example script
-    main()
+    asyncio.run(main())

--- a/src/sim/quests/__init__.py
+++ b/src/sim/quests/__init__.py
@@ -33,7 +33,14 @@ async def _quest_loop(interval: float) -> None:
 
 
 def start_quest_generation(interval: float = 60.0) -> None:
-    """Start background quest generation."""
+    """Start periodic quest generation in the background.
+
+    Parameters
+    ----------
+    interval:
+        Number of seconds between quest generations. If ``interval`` is
+        less than or equal to zero the generator is not started.
+    """
     global _quest_task
     if interval <= 0:
         return
@@ -42,7 +49,7 @@ def start_quest_generation(interval: float = 60.0) -> None:
 
 
 async def stop_quest_generation() -> None:
-    """Stop the background quest generator."""
+    """Stop the running background quest generator task."""
     global _quest_task
     if _quest_task:
         _quest_task.cancel()
@@ -59,7 +66,23 @@ async def generate_quest(
     model: str = "mistral:latest",
     temperature: float = 0.2,
 ) -> Quest | None:
-    """Generate a quest using the LLM client and store it."""
+    """Generate a quest using the LLM client and persist it.
+
+    Parameters
+    ----------
+    prompt:
+        Natural language instruction describing the quest to create.
+    model:
+        Name of the model used to generate the quest.
+    temperature:
+        Sampling temperature for the model.
+
+    Returns
+    -------
+    Quest | None
+        The generated :class:`Quest` instance or ``None`` if generation
+        fails.
+    """
 
     result = await llm_client.async_generate_structured_output(
         prompt,
@@ -94,7 +117,11 @@ async def generate_quest(
 
 
 def get_quests() -> list[Quest]:
-    """Return the list of generated quests."""
+    """Return the list of generated quests.
+
+    Quests are loaded from the ledger if possible. If ledger access fails,
+    the in-memory list of quests is returned instead.
+    """
 
     try:
         rows = ledger.get_quests()

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -24,7 +24,27 @@ async def process_map_action(
     current_state: AgentState,
     map_action: dict[str, Any],
 ) -> None:
-    """Execute a world map action for the given agent."""
+    """Handle a map action for an agent and update the simulation state.
+
+    Supported actions include ``move``, ``gather`` and ``build``. The
+    function applies the requested action to the ``world_map`` and updates
+    the agent's ``current_state`` accordingly. A dashboard event is emitted
+    and the agent's updated state is persisted.
+
+    Parameters
+    ----------
+    sim:
+        The active :class:`~src.sim.simulation.Simulation` instance.
+    agent_index:
+        Index of the agent within ``sim.agents`` whose state should be
+        updated.
+    agent_id:
+        Unique identifier for the agent performing the action.
+    current_state:
+        The mutable state of the agent prior to applying the action.
+    map_action:
+        Dictionary describing the requested action and its parameters.
+    """
     action_type = map_action.get("action")
     details: dict[str, Any] = {}
     if action_type == "move":


### PR DESCRIPTION
## Summary
- expand docstring for `process_map_action`
- add explanatory docstrings in `sim.quests`
- fix widget example to await async function

## Testing
- `ruff check .`
- `mypy .`
- `pytest -m "unit"` *(fails: KeyboardInterrupt but shows all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_688042d189848326a47f28b1ce7b086f