### PR TITLE
Handle summary error response

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -7,7 +7,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Final
 
 from pydantic import BaseModel
 
@@ -22,6 +22,9 @@ from .widget_registry import WidgetRegistry
 SNAPSHOT_DIR = Path(__file__).resolve().parents[2] / "snapshots"
 
 logger = logging.getLogger(__name__)
+
+# JSON response body for semantic summary retrieval errors
+SEMANTIC_SUMMARIES_ERROR: Final[dict[str, str]] = {"error": "summary retrieval failed"}
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
@@ -280,7 +283,7 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
             summaries = manager.get_semantic_summaries(agent_id, limit=limit)
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Failed to get semantic summaries for %s", agent_id, exc_info=exc)
-            return JSONResponse({"error": "summary retrieval failed"}, status_code=500)
+            return JSONResponse(SEMANTIC_SUMMARIES_ERROR, status_code=500)
     else:
         summaries = []
     return JSONResponse({"summaries": summaries})

--- a/tests/unit/interfaces/test_dashboard_semantic_summaries.py
+++ b/tests/unit/interfaces/test_dashboard_semantic_summaries.py
@@ -18,6 +18,12 @@ class DummyManager:
         return self.summaries[:limit]
 
 
+class DummyResponse:
+    def __init__(self, content: object, status_code: int = 200, **_: object) -> None:
+        self.body = json.dumps(content).encode("utf-8")
+        self.status_code = status_code
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_semantic_summaries_with_manager(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -48,4 +54,15 @@ async def test_get_semantic_summaries_error(monkeypatch: pytest.MonkeyPatch) -> 
 
     resp = await db.get_semantic_summaries("agent")
     data = json.loads(resp.body)
-    assert data["error"] == "summary retrieval failed"
+    assert data == db.SEMANTIC_SUMMARIES_ERROR
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_semantic_summaries_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = DummyManager(raise_exc=True)
+    monkeypatch.setitem(db.SIM_STATE, "semantic_manager", manager)
+    monkeypatch.setattr(db, "JSONResponse", DummyResponse)
+
+    resp = await db.get_semantic_summaries("agent")
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- ensure semantic summary failures return HTTP 500
- test that failed summary retrieval sets status code to 500
- mark semantic summaries error constant as `Final`

## Testing
- `SKIP=pydantic-v2-compat,unit-tests pre-commit run --files src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_semantic_summaries.py`
- `pytest -q tests/unit/interfaces/test_dashboard_semantic_summaries.py`


------
https://chatgpt.com/codex/tasks/task_e_6880d37f3f448326ab3c4d55f4fe3ddb