### PR TITLE
Fix mypy strict errors and cleanup

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -48,7 +48,7 @@ def load_scenario(value: str) -> tuple[str, int | None, int | None]:
     path = Path(value)
     if path.is_file():
         try:  # Try full YAML parsing if PyYAML is available
-            import yaml  # type: ignore
+            import yaml
 
             content = yaml.safe_load(path.read_text())
         except Exception:  # pragma: no cover - fallback

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -6,8 +6,6 @@ import importlib
 import logging
 from typing import Any
 
-from src.shared.pydantic_compat import _PYDANTIC_V2
-
 from .settings import ConfigSettings, settings
 
 logger = logging.getLogger(__name__)
@@ -240,12 +238,12 @@ def load_config(*, validate_required: bool = True) -> dict[str, Any]:
     global settings, _CONFIG
     new_settings = ConfigSettings()
     if validate_required:
-        raw_data = new_settings.model_dump() if _PYDANTIC_V2 else new_settings.dict()
+        raw_data = new_settings.model_dump()
         missing = [k for k in REQUIRED_CONFIG_KEYS if not raw_data.get(k)]
         if missing:
             raise RuntimeError("Missing mandatory configuration keys: " + ", ".join(missing))
     data: dict[str, Any]
-    data = new_settings.model_dump() if _PYDANTIC_V2 else new_settings.dict()  # type: ignore[attr-defined]
+    data = new_settings.model_dump()
     for key, value in data.items():
         setattr(settings, key, value)
     _CONFIG.update(data)
@@ -255,7 +253,7 @@ def load_config(*, validate_required: bool = True) -> dict[str, Any]:
 def get_config(key: str | None = None) -> Any:
     """Return a configuration value from :class:`ConfigSettings`."""
     if key is None:
-        return settings.model_dump() if _PYDANTIC_V2 else settings.dict()
+        return settings.model_dump()
     if key in _CONFIG and str(_CONFIG.get(key, "")).strip() != "":
         return _CONFIG[key]
     if hasattr(settings, key):

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -7,7 +7,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Final
+from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
 from pydantic import BaseModel
 
@@ -223,7 +223,7 @@ async def stream_messages(request: Request) -> Response:
                 yield {"event": "error", "data": json.dumps({"error": str(e)})}
 
     generator: AsyncGenerator[dict[str, Any], None] = event_generator()
-    return EventSourceResponse(generator)  # type: ignore[no-any-return]
+    return cast(Response, EventSourceResponse(generator))
 
 
 @app.get(
@@ -251,7 +251,7 @@ async def api_map(request: Request) -> Response:
             bus.unsubscribe(queue)
 
     generator: AsyncGenerator[dict[str, Any], None] = event_generator()
-    return EventSourceResponse(generator)  # type: ignore[no-any-return]
+    return cast(Response, EventSourceResponse(generator))
 
 
 @app.get("/health")

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -7,9 +7,10 @@ IP/DU cost for the currently active agent.
 """
 
 import asyncio
+import json
 import logging
 import typing
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, cast
 
 import httpx
 from typing_extensions import Self
@@ -147,7 +148,7 @@ class SimulationDiscordBot:
         # Set up event handlers for all clients
         for _token, client in self.clients.items():
 
-            @client.event  # type: ignore[misc]
+            @client.event
             async def on_ready(client: Any = client) -> None:
                 """Event handler that fires when the bot connects to Discord."""
                 self.is_ready = True
@@ -176,7 +177,7 @@ class SimulationDiscordBot:
                 else:
                     logger.warning(f"Could not find Discord channel with ID: {self.channel_id}")
 
-            @client.event  # type: ignore[misc]
+            @client.event
             async def on_message(message: Any, client: Any = client) -> None:
                 if getattr(message, "author", None) == client.user:
                     return
@@ -616,14 +617,12 @@ def get_kb_size() -> int:
     return metrics.get_kb_size()
 
 
-@typing.no_type_check
 @bot.command(name="say")
 async def say(ctx: Any, *, message: str) -> None:
     """Echo a user-provided message for smoke testing."""
     await ctx.send(f"Simulated message received: {message}")
 
 
-@typing.no_type_check
 @bot.command(name="stats")
 async def stats(ctx: Any) -> None:
     """Return basic runtime statistics."""
@@ -631,7 +630,6 @@ async def stats(ctx: Any) -> None:
     await ctx.send(stats_text)
 
 
-@typing.no_type_check
 @bot.tree.command(name="status")
 async def slash_status(interaction: Any) -> None:
     """Return IP/DU balance for the mapped agent."""
@@ -650,7 +648,6 @@ async def slash_status(interaction: Any) -> None:
         await interaction.response.send_message("Unknown channel", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="stats")
 async def slash_stats(interaction: Any) -> None:
     """Return runtime metrics if the agent has resources."""
@@ -668,7 +665,6 @@ async def slash_stats(interaction: Any) -> None:
     await interaction.response.send_message(stats_text, ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="pause")
 async def slash_pause(interaction: Any) -> None:
     """Pause the simulation via a control command."""
@@ -676,7 +672,6 @@ async def slash_pause(interaction: Any) -> None:
     await interaction.response.send_message("pause", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="resume")
 async def slash_resume(interaction: Any) -> None:
     """Resume the simulation via a control command."""
@@ -684,7 +679,6 @@ async def slash_resume(interaction: Any) -> None:
     await interaction.response.send_message("resume", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="set_speed")
 async def slash_set_speed(interaction: Any, value: float) -> None:
     """Adjust the simulation speed via a control command."""
@@ -694,14 +688,13 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
     await interaction.response.send_message(f"speed {value}", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="speed")
 async def slash_speed(interaction: Any, value: float) -> None:
     """Alias for ``set_speed``."""
-    await slash_set_speed.callback(interaction, value=value)
+    callback = cast(Callable[[Any, float], Awaitable[None]], slash_set_speed.callback)
+    await callback(interaction, value)
 
 
-@typing.no_type_check
 @bot.tree.command(name="kb")
 async def slash_kb(interaction: Any, text: str) -> None:
     """Post an entry to the Knowledge Board."""
@@ -718,7 +711,6 @@ async def slash_kb(interaction: Any, text: str) -> None:
     await interaction.response.send_message("KB entry created", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="propose")
 async def slash_propose(interaction: Any, text: str) -> None:
     """Propose a law via the dashboard API."""
@@ -738,13 +730,13 @@ async def slash_propose(interaction: Any, text: str) -> None:
     try:
         async with httpx.AsyncClient() as client:
             resp = await client.post("http://localhost:8000/api/propose", json=payload)
-            approved = resp.json().get("approved", False)
+            content = resp.text
+            approved = json.loads(content).get("approved", False)
     except Exception:
         approved = False
     await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="propose_law")
 async def slash_propose_law(interaction: Any, text: str) -> None:
     """Propose a law using the governance service."""
@@ -775,7 +767,6 @@ async def slash_propose_law(interaction: Any, text: str) -> None:
     await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
 
 
-@typing.no_type_check
 @bot.tree.command(name="vote")
 async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
     """Cast a manual vote on a proposal via the governance service."""

--- a/src/shared/pydantic_compat.py
+++ b/src/shared/pydantic_compat.py
@@ -43,12 +43,12 @@ try:
         SettingsConfigDict as _SettingsConfigDict,
     )
 except Exception:  # pragma: no cover - optional dependency
-    from pydantic import BaseModel as _PydanticBaseSettings  # type: ignore[assignment]
+    from pydantic import BaseModel as _PydanticBaseSettings
 
     class _FallbackSettingsConfigDict(dict[str, Any]):
         pass
 
-    _SettingsConfigDict = _FallbackSettingsConfigDict  # type: ignore[assignment]
+    _SettingsConfigDict = _FallbackSettingsConfigDict
 
 BaseSettings = cast(Any, _PydanticBaseSettings)
 SettingsConfigDict = cast(Any, _SettingsConfigDict)

--- a/src/sim/quests/__init__.py
+++ b/src/sim/quests/__init__.py
@@ -99,7 +99,7 @@ async def generate_quest(
     else:
         # Defensive: unexpected return type
         try:
-            quest = Quest.model_validate(result)  # type: ignore[arg-type]
+            quest = Quest.model_validate(result)
         except Exception:
             return None
     QUESTS.append(quest)


### PR DESCRIPTION
## Summary
- remove stray type: ignores
- clean up some Pydantic compatibility helpers
- add missing imports and json parsing in discord bot
- type cast dashboard event responses
- prefer `model_dump` for config

## Testing
- `SKIP=unit-tests pre-commit run --files src/shared/pydantic_compat.py src/infra/config.py src/interfaces/discord_bot.py src/interfaces/dashboard_backend.py src/sim/quests/__init__.py src/app.py`
- `pytest -m "not integration and not ollama"`

------
https://chatgpt.com/codex/tasks/task_e_6880e63e5b2083268a13460248600531