### PR TITLE
Add sample plugin and tests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -169,3 +169,20 @@ from src.extensions import load_plugins
 
 await load_plugins()
 ```
+
+## Installing the Sample Plug-in
+
+For a minimal demonstration look at `examples/plugins/sample_plugin`. Install it
+in editable mode:
+
+```bash
+pip install -e examples/plugins/sample_plugin
+```
+
+Load the plug-in at startup so Culture can register its hooks:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/sample_plugin/README.md
+++ b/examples/plugins/sample_plugin/README.md
@@ -1,0 +1,19 @@
+# Sample Culture Plug-in
+
+This minimal package demonstrates how a third-party plug-in can extend Culture.
+It registers a simple agent behavior and directly registers a UI widget using
+`register_widget_backend`.
+
+Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/sample_plugin
+```
+
+Then load the plug-in at application startup:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/sample_plugin/pyproject.toml
+++ b/examples/plugins/sample_plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sample-plugin"
+version = "0.1.0"
+description = "Sample Culture plug-in"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.entry-points."culture.plugins"]
+sample_plugin = "sample_plugin:setup"

--- a/examples/plugins/sample_plugin/sample_plugin/__init__.py
+++ b/examples/plugins/sample_plugin/sample_plugin/__init__.py
@@ -1,0 +1,20 @@
+"""Sample plug-in demonstrating Culture's extension hooks."""
+
+from typing import Any
+
+from src.extensions import register_agent_behavior, register_widget_backend
+
+
+def log_turn(agent: Any, output: dict[str, Any]) -> None:
+    """Log the agent's output."""
+    print(f"[SAMPLE_PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
+
+
+def setup() -> None:
+    """Entry point for :func:`load_plugins`."""
+    register_agent_behavior(log_turn)
+    # Demonstrate direct widget registration instead of returning a dict
+    return register_widget_backend(
+        name="SampleWidget",
+        script_url="http://localhost:5173/sample.js",
+    )

--- a/tests/unit/extensions/test_sample_plugin.py
+++ b/tests/unit/extensions/test_sample_plugin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import types
+from importlib import metadata
+
+import pytest
+
+from examples.plugins.sample_plugin import sample_plugin
+from src.extensions import BEHAVIOR_REGISTRY, load_plugins
+
+
+class DummyEntryPoints(list[object]):
+    def select(self, group: str | None = None) -> list[object]:
+        return self if group == "culture.plugins" else []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sample_plugin_load(monkeypatch: pytest.MonkeyPatch) -> None:
+    BEHAVIOR_REGISTRY._behaviors.clear()
+    widgets: list[tuple[str, str, str]] = []
+
+    async def register_widget_backend(
+        name: str, script_url: str, backend_url: str = "http://localhost:8000"
+    ) -> None:
+        widgets.append((name, script_url, backend_url))
+
+    ep = types.SimpleNamespace(load=lambda: sample_plugin.setup, name="sample_plugin")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.extensions.register_widget_backend", register_widget_backend)
+
+    await load_plugins(backend_url="http://backend")
+
+    assert sample_plugin.log_turn in BEHAVIOR_REGISTRY._behaviors
+    assert widgets == [("SampleWidget", "http://localhost:5173/sample.js", "http://backend")]


### PR DESCRIPTION
## Summary
- provide a minimal plug-in package under `examples/plugins/`
- document installation steps for the new package
- test that `load_plugins()` executes the sample plug-in

## Testing
- `SKIP=unit-tests pre-commit run --files docs/plugins.md examples/plugins/sample_plugin/README.md examples/plugins/sample_plugin/pyproject.toml examples/plugins/sample_plugin/sample_plugin/__init__.py tests/unit/extensions/test_sample_plugin.py`
- `pytest -k "" -m "not integration and not ollama"`

------
https://chatgpt.com/codex/tasks/task_e_6880e63c265483269a47c0ddef1a177f