### PR TITLE
Add map API and grid widget

### DIFF
--- a/culture-ui/src/MapGrid.test.tsx
+++ b/culture-ui/src/MapGrid.test.tsx
@@ -1,0 +1,33 @@
+import { act, render, screen } from '@testing-library/react'
+import MapGrid from './widgets/MapGrid'
+import { MockEventSource, resetMockSources } from './lib/testUtils'
+import { vi } from 'vitest'
+
+afterEach(() => {
+  resetMockSources()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('MapGrid', () => {
+  it('renders initial map and updates from events', async () => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ world_map: { width: 2, height: 2, agents: { a1: [0, 1] } } })
+      }) as unknown as Response
+    ))
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
+
+    render(<MapGrid />)
+
+    expect(await screen.findByTestId('agent-a1')).toBeInTheDocument()
+
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage('{"type":"map_change","data":{"world_map":{"width":2,"height":2,"agents":{"a1":[1,1]}}}}')
+    })
+
+    expect(await screen.findByTestId('agent-a1')).toBeInTheDocument()
+  })
+})

--- a/culture-ui/src/widgets/MapGrid.tsx
+++ b/culture-ui/src/widgets/MapGrid.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react'
+import { useEventSource } from '../lib/useEventSource'
+
+interface MapData {
+  width: number
+  height: number
+  agents?: Record<string, [number, number]>
+}
+
+interface MapEvent {
+  data?: { world_map?: MapData }
+}
+
+export default function MapGrid() {
+  const [map, setMap] = useState<MapData | null>(null)
+  const event = useEventSource<MapEvent>()
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch('/api/map')
+        const json = (await res.json()) as { world_map: MapData }
+        if (!cancelled) setMap(json.world_map)
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (event?.data?.world_map) setMap(event.data.world_map)
+  }, [event])
+
+  if (!map) return <div data-testid="map-grid" />
+
+  const cells = []
+  for (let y = 0; y < map.height; y++) {
+    for (let x = 0; x < map.width; x++) {
+      const agent = Object.entries(map.agents ?? {}).find(([, pos]) => pos[0] === x && pos[1] === y)?.[0]
+      cells.push(
+        <div
+          key={`${x}-${y}`}
+          data-testid={`cell-${x}-${y}`}
+          style={{ width: 20, height: 20, border: '1px solid black', boxSizing: 'border-box' }}
+        >
+          {agent && <span data-testid={`agent-${agent}`}>{agent}</span>}
+        </div>
+      )
+    }
+  }
+
+  return (
+    <div data-testid="map-grid" style={{ display: 'grid', gridTemplateColumns: `repeat(${map.width}, 20px)` }}>
+      {cells}
+    </div>
+  )
+}

--- a/culture-ui/src/widgets/index.ts
+++ b/culture-ui/src/widgets/index.ts
@@ -7,5 +7,6 @@ export { default as EventConsole } from './EventConsole'
 export { default as Storyboard } from './Storyboard'
 export { default as AgentTimeline } from './AgentTimeline'
 export { default as LiveMap } from './LiveMap'
+export { default as MapGrid } from './MapGrid'
 
 

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -227,11 +227,11 @@ async def stream_messages(request: Request) -> Response:
 
 
 @app.get(
-    "/api/map",
+    "/api/map/stream",
     response_class=EventSourceResponse,
     response_model=None,
 )
-async def api_map(request: Request) -> Response:
+async def stream_map(request: Request) -> Response:
     """Stream map_change events as Server-Sent Events."""
 
     bus = get_event_bus()
@@ -252,6 +252,14 @@ async def api_map(request: Request) -> Response:
 
     generator: AsyncGenerator[dict[str, Any], None] = event_generator()
     return EventSourceResponse(generator)  # type: ignore[no-any-return]
+
+
+@app.get("/api/map")
+async def api_map() -> Response:
+    """Return the latest world map state."""
+    sim = SIM_STATE.get("simulation")
+    world_map = sim.world_map.to_dict() if sim is not None else {}
+    return JSONResponse({"world_map": world_map})
 
 
 @app.get("/health")
@@ -589,9 +597,9 @@ __all__ = [
     "api_get_laws",
     "api_get_proposals",
     "api_get_votes",
+    "api_map",
     "api_memory_snapshot",
     "api_memory_snapshots",
-    "api_map",
     "api_propose_law",
     "api_token_balances",
     "api_vote",
@@ -605,4 +613,5 @@ __all__ = [
     "get_quests_api",
     "message_sse_queue",
     "register_widget",
+    "stream_map",
 ]

--- a/tests/unit/interfaces/test_dashboard_backend_map.py
+++ b/tests/unit/interfaces/test_dashboard_backend_map.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+class DummyMap:
+    def to_dict(self) -> dict[str, object]:
+        return {"width": 1, "height": 1, "agents": {"a1": [0, 0]}}
+
+
+class DummySim:
+    def __init__(self) -> None:
+        self.world_map = DummyMap()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_map_returns_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    sim = DummySim()
+    monkeypatch.setitem(db.SIM_STATE, "simulation", sim)
+    resp = await db.api_map()
+    data = json.loads(resp.body)
+    assert data["world_map"]["agents"]["a1"] == [0, 0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_map_no_sim(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.SIM_STATE, "simulation", None)
+    resp = await db.api_map()
+    data = json.loads(resp.body)
+    assert data["world_map"] == {}


### PR DESCRIPTION
## Summary
- expose current map state at `/api/map`
- stream map changes at `/api/map/stream`
- implement `MapGrid` widget in UI for displaying agent positions
- add unit tests for map endpoint and widget

## Testing
- `pytest tests/unit/interfaces/test_dashboard_backend_map.py`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6880e63b78348326a5356969f454a43e