### PR TITLE
Introduce SimulationContext for state management

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -15,6 +15,7 @@ from src.governance.law_board import law_board
 from src.governance.service import governance
 from src.infra.ledger import ledger
 from src.infra.snapshot import load_snapshot
+from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
 
 from .widget_registry import WidgetRegistry
@@ -22,6 +23,9 @@ from .widget_registry import WidgetRegistry
 SNAPSHOT_DIR = Path(__file__).resolve().parents[2] / "snapshots"
 
 logger = logging.getLogger(__name__)
+
+# Default simulation context used by module-level APIs
+DEFAULT_CONTEXT = SimulationContext()
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
@@ -86,51 +90,33 @@ else:  # pragma: no cover - optional dependency
                 self.gen = None
 
 
-# Global queue for agent messages with bounded size
-message_sse_queue: asyncio.Queue[AgentMessage] = asyncio.Queue(maxsize=1000)
+# Agent message queue stored in the simulation context
+message_sse_queue = DEFAULT_CONTEXT.message_queue
 
 
-async def enqueue_message(msg: AgentMessage) -> None:
+async def enqueue_message(msg: AgentMessage, ctx: SimulationContext = DEFAULT_CONTEXT) -> None:
     """Add a message to the SSE queue, dropping the oldest if full."""
-    if message_sse_queue.full():
+    queue = ctx.message_queue
+    if queue.full():
         try:
-            message_sse_queue.get_nowait()
+            queue.get_nowait()
         except asyncio.QueueEmpty:  # pragma: no cover - unlikely
             pass
-    await message_sse_queue.put(msg)
+    await queue.put(msg)
 
 
-# Queue for general simulation events streamed via SSE/WebSocket. Calls to
-# :func:`get_event_queue` return a queue bound to the current event loop and
-# subscribed to the global :class:`~src.sim.event_bus.EventBus` instance. The
-# same queue is returned on subsequent calls within the same loop to match the
-# previous behaviour.
-_event_queue: asyncio.Queue[SimulationEvent | None] | None = None
-_event_queue_loop: asyncio.AbstractEventLoop | None = None
+# Queue for general simulation events is managed by the context
 
 
-def get_event_queue() -> asyncio.Queue[SimulationEvent | None]:
+def get_event_queue(
+    ctx: SimulationContext = DEFAULT_CONTEXT,
+) -> asyncio.Queue[SimulationEvent | None]:
     """Return a shared event queue bound to the active loop."""
-    global _event_queue, _event_queue_loop
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:  # pragma: no cover - no running loop
-        loop = asyncio.new_event_loop()
-    if _event_queue is None or _event_queue_loop is not loop:
-        if _event_queue is not None:
-            get_event_bus().unsubscribe(_event_queue)
-        _event_queue = get_event_bus().subscribe()
-        _event_queue_loop = loop
-    return _event_queue
+    return ctx.get_event_queue()
 
 
 # Simulation control state
-SIM_STATE: dict[str, Any] = {
-    "paused": False,
-    "speed": 1.0,
-    "semantic_manager": None,
-    "simulation": None,
-}
+SIM_STATE = DEFAULT_CONTEXT.sim_state
 BREAKPOINT_TAGS: set[str] = {"violence", "nsfw"}
 
 # Registry of widgets registered by the UI or plugins
@@ -274,7 +260,7 @@ async def get_quests_api() -> Response:
 @app.get("/api/agents/{agent_id}/semantic_summaries")
 async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
     """Return recent semantic summaries for an agent."""
-    manager = SIM_STATE.get("semantic_manager")
+    manager = DEFAULT_CONTEXT.sim_state.get("semantic_manager")
     if manager is not None:
         try:
             summaries = manager.get_semantic_summaries(agent_id, limit=limit)
@@ -289,7 +275,7 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
 @app.post("/api/propose_law")
 async def api_propose_law(proposal: LawProposal) -> Response:
     """Submit a law proposal to the active simulation."""
-    sim = SIM_STATE.get("simulation")
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
     approved = False
     if sim is not None:
         try:
@@ -302,7 +288,7 @@ async def api_propose_law(proposal: LawProposal) -> Response:
 @app.post("/api/propose")
 async def api_propose(proposal: Proposal) -> Response:
     """Submit a weighted law proposal to the active simulation."""
-    sim = SIM_STATE.get("simulation")
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
     approved = False
     if sim is not None:
         proposer = next((a for a in sim.agents if a.agent_id == proposal.proposer_id), None)
@@ -322,7 +308,7 @@ async def api_propose(proposal: Proposal) -> Response:
 @app.post("/api/vote")
 async def api_vote(vote: VoteRequest) -> Response:
     """Submit a manual vote for a proposal."""
-    sim = SIM_STATE.get("simulation")
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
     result = False
     if sim is not None:
         agent = next((a for a in sim.agents if a.agent_id == vote.agent_id), None)
@@ -467,16 +453,18 @@ async def websocket_events(websocket: WebSocket) -> None:
         await websocket.close()
 
 
-async def handle_control_command(cmd: dict[str, Any]) -> dict[str, Any]:
+async def handle_control_command(
+    cmd: dict[str, Any], ctx: SimulationContext = DEFAULT_CONTEXT
+) -> dict[str, Any]:
     """Process a control command and update simulation state."""
     action = cmd.get("command")
     if action == "pause":
-        SIM_STATE["paused"] = True
+        ctx.sim_state["paused"] = True
     elif action == "resume":
-        SIM_STATE["paused"] = False
+        ctx.sim_state["paused"] = False
     elif action == "set_speed":
         try:
-            SIM_STATE["speed"] = float(cmd.get("value", 1))
+            ctx.sim_state["speed"] = float(cmd.get("value", 1))
         except (TypeError, ValueError):
             pass
     elif action == "set_breakpoints":
@@ -484,7 +472,7 @@ async def handle_control_command(cmd: dict[str, Any]) -> dict[str, Any]:
         if isinstance(tags, list):
             BREAKPOINT_TAGS.clear()
             BREAKPOINT_TAGS.update(str(t) for t in tags)
-    return {**SIM_STATE, "breakpoints": list(BREAKPOINT_TAGS)}
+    return {**ctx.sim_state, "breakpoints": list(BREAKPOINT_TAGS)}
 
 
 try:
@@ -500,7 +488,7 @@ try:
             logger.warning("Invalid control payload: %s", exc)
             return JSONResponse({"error": "invalid"})
 
-        result = await handle_control_command(command)
+        result = await handle_control_command(command, ctx=DEFAULT_CONTEXT)
         return JSONResponse(result)
 
 except AttributeError:  # pragma: no cover - stub app may lack decorators
@@ -523,7 +511,7 @@ try:
                     logger.warning("Invalid control payload via WS: %s", exc)
                     await websocket.send_text(json.dumps({"error": "invalid"}))
                     continue
-                result = await handle_control_command(cmd)
+                result = await handle_control_command(cmd, ctx=DEFAULT_CONTEXT)
                 await websocket.send_text(json.dumps(result))
         except WebSocketDisconnect:
             pass
@@ -540,7 +528,7 @@ async def emit_event(event: SimulationEvent) -> None:
     await bus.publish(event)
     tags = set(event.data.get("tags", [])) if event.data else set()
     if tags & BREAKPOINT_TAGS:
-        SIM_STATE["paused"] = True
+        DEFAULT_CONTEXT.sim_state["paused"] = True
         await bus.publish(
             SimulationEvent(
                 type="breakpoint_hit",
@@ -573,6 +561,7 @@ async def emit_map_change_event(world_map: dict[str, Any]) -> None:
 
 
 __all__ = [
+    "DEFAULT_CONTEXT",
     "WIDGET_REGISTRY",
     "EventSourceResponse",
     "LawProposal",
@@ -586,9 +575,9 @@ __all__ = [
     "api_get_laws",
     "api_get_proposals",
     "api_get_votes",
+    "api_map",
     "api_memory_snapshot",
     "api_memory_snapshots",
-    "api_map",
     "api_propose_law",
     "api_token_balances",
     "api_vote",

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -7,6 +7,7 @@ IP/DU cost for the currently active agent.
 """
 
 import asyncio
+import json
 import logging
 import typing
 from typing import TYPE_CHECKING, Any, Optional
@@ -19,15 +20,12 @@ from src.infra import config
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend, metrics
 from src.interfaces.dashboard_backend import (
+    DEFAULT_CONTEXT,
     AgentMessage,
     SimulationEvent,
-    message_sse_queue,
 )
-from src.sim.event_bus import get_event_bus
+from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
-
-# Backwards compatibility for tests expecting a module-level queue
-event_queue = get_event_bus().subscribe()
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     import discord
@@ -68,6 +66,7 @@ class SimulationDiscordBot:
         ) = None,
         *,
         channel_map: dict[str, int] | None = None,
+        context: SimulationContext | None = None,
     ) -> Self:
         """Asynchronously construct a ``SimulationDiscordBot`` instance."""
         tokens: list[str] = []
@@ -89,7 +88,14 @@ class SimulationDiscordBot:
         if not tokens:
             raise RuntimeError("No Discord bot tokens provided")
 
-        return cls(tokens, channel_id, token_lookup=token_lookup, channel_map=channel_map)
+        ctx = context or DEFAULT_CONTEXT
+        return cls(
+            tokens,
+            channel_id,
+            token_lookup=token_lookup,
+            channel_map=channel_map,
+            context=ctx,
+        )
 
     def __init__(
         self: Self,
@@ -100,6 +106,7 @@ class SimulationDiscordBot:
         ) = None,
         *,
         channel_map: dict[str, int] | None = None,
+        context: SimulationContext = DEFAULT_CONTEXT,
     ) -> None:
         """
         Initialize the Discord bot with token and target channel.
@@ -117,6 +124,7 @@ class SimulationDiscordBot:
         self.channel_to_agent: dict[int, str] = {v: k for k, v in self.channel_map.items()}
         self.user_channels: dict[str, int] = {}
         self.is_ready = False
+        self.context = context
         global active_bot
         active_bot = self
         if token_lookup is None:
@@ -139,8 +147,8 @@ class SimulationDiscordBot:
             token: discord.Client(intents=intents) for token in self.bot_tokens
         }
         self.client = self.clients[self.bot_tokens[0]]
-        self.event_queue = get_event_bus().subscribe()
-        self.message_queue = message_sse_queue
+        self.event_queue = self.context.get_event_queue()
+        self.message_queue = self.context.message_queue
         self._forward_task: asyncio.Task[Any] | None = None
         self._client_tasks: list[asyncio.Task[Any]] = []
 
@@ -672,7 +680,8 @@ async def slash_stats(interaction: Any) -> None:
 @bot.tree.command(name="pause")
 async def slash_pause(interaction: Any) -> None:
     """Pause the simulation via a control command."""
-    await event_queue.put(SimulationEvent(type="control", data={"command": "pause"}))
+    ctx = active_bot.context if active_bot is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(SimulationEvent(type="control", data={"command": "pause"}))
     await interaction.response.send_message("pause", ephemeral=True)
 
 
@@ -680,7 +689,8 @@ async def slash_pause(interaction: Any) -> None:
 @bot.tree.command(name="resume")
 async def slash_resume(interaction: Any) -> None:
     """Resume the simulation via a control command."""
-    await event_queue.put(SimulationEvent(type="control", data={"command": "resume"}))
+    ctx = active_bot.context if active_bot is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(SimulationEvent(type="control", data={"command": "resume"}))
     await interaction.response.send_message("resume", ephemeral=True)
 
 
@@ -688,7 +698,8 @@ async def slash_resume(interaction: Any) -> None:
 @bot.tree.command(name="set_speed")
 async def slash_set_speed(interaction: Any, value: float) -> None:
     """Adjust the simulation speed via a control command."""
-    await event_queue.put(
+    ctx = active_bot.context if active_bot is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
         SimulationEvent(type="control", data={"command": "set_speed", "value": value})
     )
     await interaction.response.send_message(f"speed {value}", ephemeral=True)
@@ -705,7 +716,8 @@ async def slash_speed(interaction: Any, value: float) -> None:
 @bot.tree.command(name="kb")
 async def slash_kb(interaction: Any, text: str) -> None:
     """Post an entry to the Knowledge Board."""
-    await event_queue.put(
+    ctx = active_bot.context if active_bot is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
         SimulationEvent(
             type="control",
             data={
@@ -738,7 +750,8 @@ async def slash_propose(interaction: Any, text: str) -> None:
     try:
         async with httpx.AsyncClient() as client:
             resp = await client.post("http://localhost:8000/api/propose", json=payload)
-            approved = resp.json().get("approved", False)
+            data = json.loads(resp.text)
+            approved = data.get("approved", False)
     except Exception:
         approved = False
     await interaction.response.send_message("Approved" if approved else "Rejected", ephemeral=True)
@@ -760,7 +773,7 @@ async def slash_propose_law(interaction: Any, text: str) -> None:
     if ip <= 0 or du <= 0:
         await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
         return
-    sim = dashboard_backend.SIM_STATE.get("simulation")
+    sim = dashboard_backend.DEFAULT_CONTEXT.sim_state.get("simulation")
     if sim is None:
         await interaction.response.send_message("Simulation inactive", ephemeral=True)
         return
@@ -791,7 +804,7 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
     if ip <= 0 or du <= 0:
         await interaction.response.send_message("Insufficient IP/DU", ephemeral=True)
         return
-    sim = dashboard_backend.SIM_STATE.get("simulation")
+    sim = dashboard_backend.DEFAULT_CONTEXT.sim_state.get("simulation")
     if sim is None:
         await interaction.response.send_message("Simulation inactive", ephemeral=True)
         return

--- a/src/sim/context.py
+++ b/src/sim/context.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from .event_bus import get_event_bus
+
+
+@dataclass
+class SimulationContext:
+    """Container for cross-module simulation state."""
+
+    sim_state: dict[str, Any] = field(
+        default_factory=lambda: {
+            "paused": False,
+            "speed": 1.0,
+            "semantic_manager": None,
+            "simulation": None,
+        }
+    )
+    message_queue: asyncio.Queue[Any] = field(default_factory=lambda: asyncio.Queue(maxsize=1000))
+    _event_queue: asyncio.Queue[Any] | None = field(default=None, init=False)
+    _event_queue_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
+
+    def get_event_queue(self: SimulationContext) -> asyncio.Queue[Any]:
+        """Return an event queue bound to the current loop."""
+        bus = get_event_bus()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+        if self._event_queue is None or self._event_queue_loop is not loop:
+            if self._event_queue is not None:
+                bus.unsubscribe(self._event_queue)
+            self._event_queue = bus.subscribe()
+            self._event_queue_loop = loop
+        return self._event_queue

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -9,6 +9,7 @@ pytest.importorskip("discord")
 from src.interfaces import metrics
 from src.interfaces.dashboard_backend import AgentMessage, SimulationEvent
 from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
+from src.sim.context import SimulationContext
 
 sent_by_token: list[str] = []
 
@@ -52,7 +53,7 @@ class DummyDiscordClient:
 @pytest.fixture
 async def simulation_bot() -> SimulationDiscordBot:
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient):
-        bot = await SimulationDiscordBot.create("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
     return bot
 
 
@@ -77,7 +78,9 @@ async def test_multi_token_start_and_send() -> None:
             AsyncMock(side_effect=lambda content: (True, content)),
         ),
     ):
-        bot = await SimulationDiscordBot.create(tokens, 123, token_lookup=lookup)
+        bot = await SimulationDiscordBot.create(
+            tokens, 123, token_lookup=lookup, context=SimulationContext()
+        )
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         await bot.send_simulation_update(content="hi", agent_id="agent_b")
@@ -98,12 +101,15 @@ async def test_multi_token_message_forwarding() -> None:
 
     tokens = ["tok1", "tok2"]
 
+    ctx = SimulationContext()
+    ctx._event_queue = q_events
+    ctx._event_queue_loop = asyncio.get_event_loop()
+    ctx.message_queue = q_msgs
     with (
         patch("src.interfaces.discord_bot.discord.Client", Client),
         patch("src.interfaces.dashboard_backend.get_event_queue", lambda: q_events),
-        patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
     ):
-        bot = await SimulationDiscordBot.create(tokens, 999)
+        bot = await SimulationDiscordBot.create(tokens, 999, context=ctx)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
 
@@ -159,7 +165,7 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = await SimulationDiscordBot.create("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
         assert "on_message" in bot.client._events
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
@@ -189,18 +195,12 @@ async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -
     class Client(DummyDiscordClient):
         pass
 
-    with (
-        patch("src.interfaces.discord_bot.discord.Client", Client),
-        patch(
-            "src.interfaces.discord_bot.event_queue",
-            q_events,
-        ),
-        patch(
-            "src.interfaces.discord_bot.message_sse_queue",
-            q_msgs,
-        ),
-    ):
-        bot = await SimulationDiscordBot.create("token", 456)
+    ctx = SimulationContext()
+    ctx._event_queue = q_events
+    ctx._event_queue_loop = asyncio.get_event_loop()
+    ctx.message_queue = q_msgs
+    with patch("src.interfaces.discord_bot.discord.Client", Client):
+        bot = await SimulationDiscordBot.create("token", 456, context=ctx)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         on_msg = bot.client._events["on_message"]

--- a/tests/integration/simulation/test_discord_bot_integration.py
+++ b/tests/integration/simulation/test_discord_bot_integration.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.interfaces import dashboard_backend as db
 from src.interfaces.discord_bot import SimulationDiscordBot
+from src.sim.context import SimulationContext
 from src.sim.simulation import Simulation
 
 
@@ -100,7 +101,7 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         patch.object(Simulation, "_handle_human_command", wrapped),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = await SimulationDiscordBot.create("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1, context=SimulationContext())
         agent = DummyAgent("A")
         sim = Simulation([agent], discord_bot=bot)
 

--- a/tests/integration/simulation/test_discord_message_flow.py
+++ b/tests/integration/simulation/test_discord_message_flow.py
@@ -16,6 +16,7 @@ sys.modules.setdefault("weaviate.classes", types.ModuleType("weaviate.classes"))
 from src.agents.core.agent_state import AgentActionIntent
 from src.interfaces import dashboard_backend as db
 from src.sim import simulation as sim_module
+from src.sim.context import SimulationContext
 
 
 class DummyAgentState:
@@ -62,9 +63,10 @@ class DummyAgent:
 @pytest.mark.asyncio
 async def test_discord_message_triggers_agent_reply(monkeypatch: pytest.MonkeyPatch) -> None:
     q_events: asyncio.Queue[db.SimulationEvent | None] = asyncio.Queue()
-
-    monkeypatch.setattr(sim_module, "event_queue", q_events)
-    monkeypatch.setattr(db, "event_queue", q_events)
+    ctx = SimulationContext()
+    ctx._event_queue = q_events
+    ctx._event_queue_loop = asyncio.get_event_loop()
+    monkeypatch.setattr(db, "DEFAULT_CONTEXT", ctx)
 
     agent = DummyAgent("A")
     sim = sim_module.Simulation([agent])

--- a/tests/unit/interfaces/test_discord_errors.py
+++ b/tests/unit/interfaces/test_discord_errors.py
@@ -5,6 +5,7 @@ import pytest
 
 from src.infra import config
 from src.interfaces.discord_bot import SimulationDiscordBot
+from src.sim.context import SimulationContext
 
 
 class DummyChannel:
@@ -35,7 +36,7 @@ async def test_send_simulation_update_logs_error(monkeypatch: pytest.MonkeyPatch
             DummyException,
         ),
     ):
-        bot = await SimulationDiscordBot.create("token", 999)
+        bot = await SimulationDiscordBot.create("token", 999, context=SimulationContext())
         bot.is_ready = True
         error_called = asyncio.Event()
 
@@ -72,7 +73,7 @@ async def test_run_bot_retries_on_start_failure(monkeypatch: pytest.MonkeyPatch)
         patch("src.interfaces.discord_bot.discord.DiscordException", DummyException),
         patch("asyncio.sleep", sleep_mock),
     ):
-        bot = await SimulationDiscordBot.create("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         await bot.stop_bot()
@@ -104,7 +105,7 @@ async def test_stop_bot_cancels_pending_tasks(monkeypatch: pytest.MonkeyPatch) -
         patch("src.interfaces.discord_bot.discord.Client", HangingClient),
         patch("src.interfaces.discord_bot.discord.DiscordException", DummyException),
     ):
-        bot = await SimulationDiscordBot.create("token", 123)
+        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
         bot.message_queue = asyncio.Queue()
         tasks = bot.run_bot()
         await asyncio.sleep(0)

--- a/tests/unit/interfaces/test_discord_policy.py
+++ b/tests/unit/interfaces/test_discord_policy.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.infra import config
 from src.interfaces.discord_bot import SimulationDiscordBot
+from src.sim.context import SimulationContext
 
 
 class DummyChannel:
@@ -37,7 +38,7 @@ async def test_opa_blocks_message(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.discord.Thread", DummyChannel),
         patch("src.interfaces.discord_bot.discord.DiscordException", Exception),
     ):
-        bot = await SimulationDiscordBot.create("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1, context=SimulationContext())
         bot.is_ready = True
         channel = DummyChannel()
         bot.client.get_channel = MagicMock(return_value=channel)
@@ -63,7 +64,7 @@ async def test_opa_modifies_message(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.discord_bot.discord.Thread", DummyChannel),
         patch("src.interfaces.discord_bot.discord.DiscordException", Exception),
     ):
-        bot = await SimulationDiscordBot.create("token", 1)
+        bot = await SimulationDiscordBot.create("token", 1, context=SimulationContext())
         bot.is_ready = True
         channel = DummyChannel()
         bot.client.get_channel = MagicMock(return_value=channel)


### PR DESCRIPTION
## Summary
- create `SimulationContext` to hold simulation state and queues
- refactor dashboard backend and Discord bot to use the context
- update tests to construct and pass the context

## Testing
- `pytest tests/unit/interfaces/test_discord_errors.py tests/unit/interfaces/test_discord_policy.py tests/integration/interfaces/test_discord_bot.py tests/integration/simulation/test_discord_bot_integration.py tests/integration/simulation/test_discord_message_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e367b70c8326b381eb0f690de246