### PR TITLE
Add vLLM server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,11 +822,17 @@ Metrics include `llm_latency_ms`, `llm_calls_total`, `knowledge_board_size`, and
 check the latest values with the `!stats` Discord command.
 
 For routine operations and troubleshooting, see [docs/runbook.md](docs/runbook.md).
-When running against a local vLLM server, set `LLM_API_BASE` to its base URL.
+When running against a local vLLM server, set `VLLM_API_BASE` or `LLM_API_BASE` to its base URL.
 
 ### Starting the vLLM Server
 `scripts/start_vllm.sh` launches the vLLM OpenAI-compatible API with sensible defaults.
-Run it from the project root, optionally overriding the model or port:
+Set the following environment variables to customize the launch:
+
+- `VLLM_MODEL` – Hugging Face model name (defaults to `mistralai/Mistral-7B-Instruct-v0.2`)
+- `VLLM_PORT` – port for the server (default `8001`)
+- `VLLM_SWAP_SPACE` – swap space in GB (default `16`)
+
+Run the script from the project root, overriding values as needed:
 
 ```bash
 VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 scripts/start_vllm.sh
@@ -835,7 +841,8 @@ VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 scripts/start_vll
 After the server is running, point the application to it:
 
 ```bash
-export LLM_API_BASE="http://localhost:$VLLM_PORT"
+export VLLM_API_BASE="http://localhost:$VLLM_PORT"
+export LLM_API_BASE="$VLLM_API_BASE"  # overrides Ollama when set
 ```
 
 ### Walking Vertical Slice

--- a/culture_ai_overview.md
+++ b/culture_ai_overview.md
@@ -33,6 +33,11 @@ Create a dynamic environment where AI agents can evolve, develop unique personal
 - Python 3.11+
 - DSPy, Ollama, Weaviate, Docker, Pytest, Ruff & MyPy
 
+Culture can also leverage vLLM for local model serving. See
+[README.md](README.md#starting-the-vllm-server) and
+[docs/runbook.md](docs/runbook.md#starting-the-vllm-server) for instructions on
+launching `scripts/start_vllm.sh` and switching from Ollama.
+
 ### Current Focus (Mid-May 2025)
 - Refining agent architecture and state
 - Developing/testing DSPy programs for cognition

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,16 +12,8 @@ This runbook outlines routine operations for working with Culture.ai.
    ```bash
    ollama pull mistral:latest
    ```
-   Alternatively, start a vLLM server with swap space enabled to avoid
-   out-of-memory errors when running many agents. The helper script
-   `start_vllm.sh` launches the server and you can point the application to it:
-   ```bash
-   # Optionally override the model or port used by vLLM (defaults to port 8001)
-   VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 \
-   scripts/start_vllm.sh
-   export VLLM_API_BASE="http://localhost:$VLLM_PORT"
-   # When set, the application uses the vLLM OpenAI-compatible endpoint
-   ```
+   To use vLLM instead, follow the
+   [Starting the vLLM Server](#starting-the-vllm-server) section below.
 4. (Optional) Start the vector store:
    ```bash
    docker compose up -d
@@ -49,6 +41,25 @@ This runbook outlines routine operations for working with Culture.ai.
    ```bash
    zstd -d snapshot_100.json.zst -o snapshot_100.json
    ```
+
+## Starting the vLLM Server
+`scripts/start_vllm.sh` launches the vLLM OpenAI-compatible API. Set these
+environment variables as needed:
+
+- `VLLM_MODEL` – model name to load (defaults to `mistralai/Mistral-7B-Instruct-v0.2`)
+- `VLLM_PORT` – server port (default `8001`)
+- `VLLM_SWAP_SPACE` – swap space in GB (default `16`)
+
+Example:
+
+```bash
+VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 scripts/start_vllm.sh
+export VLLM_API_BASE="http://localhost:$VLLM_PORT"
+export LLM_API_BASE="$VLLM_API_BASE"  # overrides Ollama when set
+```
+
+When `VLLM_API_BASE` is configured, the application prefers the vLLM endpoint over
+Ollama.
 
 ## Running Tests
 Run the full suite with coverage:


### PR DESCRIPTION
## Summary
- document how to launch `scripts/start_vllm.sh`
- add dedicated section in the runbook
- mention environment variables to switch from Ollama to vLLM
- reference these docs from the development overview

## Testing
- No tests run due to documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_688161cfd0408326851ed16ff32f2962