### PR TITLE
Add plugin quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ UI requirements are summarized in [docs/culture_ui_requirements.md](docs/culture
 ## Extensions and Plug-ins
 
 Culture exposes simple hooks for registering dashboard widgets and agent behaviors.
-See [docs/plugins.md](docs/plugins.md) for details.
+See [docs/plugins.md](docs/plugins.md) for details. The plug-in quickstart is in [docs/plugin_guide.md](docs/plugin_guide.md).
 
 ## Project Structure
 

--- a/docs/plugin_guide.md
+++ b/docs/plugin_guide.md
@@ -1,0 +1,48 @@
+# Plug-in Quickstart Guide
+
+This guide explains how to implement and register a Culture plug-in using the `culture.plugins` entry point.
+
+## 1. Create the plug-in code
+
+Define a function that registers any widgets or agent behaviors and return optional widget information.
+
+```python
+# my_plugin/__init__.py
+from typing import Any
+from src.extensions import PluginResult, register_agent_behavior
+
+def log_turn(agent: Any, output: dict[str, Any]) -> None:
+    print(f"[MY_PLUGIN] {output}")
+
+def setup() -> PluginResult:
+    register_agent_behavior(log_turn)
+    return {
+        "name": "MyWidget",
+        "script_url": "http://localhost:5173/my_widget.js",
+    }
+```
+
+## 2. Declare the entry point
+
+Expose the plug-in via `pyproject.toml` so Culture can discover it:
+
+```toml
+[project.entry-points."culture.plugins"]
+my_plugin = "my_plugin:setup"
+```
+
+## 3. Install and load the plug-in
+
+Install the package in editable mode and call `load_plugins()` at startup:
+
+```bash
+pip install -e path/to/my_plugin
+```
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```
+
+Culture will execute the `setup` function and register any declared widgets or behaviors. See [plugins.md](plugins.md) for a more detailed reference.

--- a/examples/example_plugin/README.md
+++ b/examples/example_plugin/README.md
@@ -4,6 +4,8 @@ This example package shows how a third-party distribution can extend Culture.
 It registers a simple agent behavior and a UI widget using the
 `culture.plugins` entry point.
 
+For a step-by-step guide, see [../../docs/plugin_guide.md](../../docs/plugin_guide.md).
+
 Install the package in editable mode:
 
 ```bash


### PR DESCRIPTION
## Summary
- add docs/plugin_guide.md with instructions for implementing and registering plugins via `culture.plugins`
- link new guide from the main README and the example plugin README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688168f53e1083268666e8abbb54c758