### PR TITLE
Update runbook with dataset export steps

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -98,3 +98,13 @@ output paths if needed:
 ```bash
 make dataset SNAPSHOTS=snapshots OUTPUT=data/traces.jsonl
 ```
+
+### Creating a JSONL Dataset
+Generate a dataset from saved snapshots using `export_traces.py`. This example
+writes the output to `data/traces.jsonl`:
+
+```bash
+python scripts/export_traces.py --snapshots snapshots/ --output data/traces.jsonl
+```
+
+Each line of `data/traces.jsonl` contains a single JSON object.


### PR DESCRIPTION
## Summary
- document how to produce a JSONL dataset from saved snapshots
- clarify that `export_traces.py` writes to `data/traces.jsonl`

## Testing
- `pre-commit run --files docs/runbook.md`

------
https://chatgpt.com/codex/tasks/task_e_68817b72fa3c8326a23831e4c1d9710f