### PR TITLE
Add Markdown link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run Black Formatter Check
         run: black --check .
 
+      - name: Check Markdown links
+        run: python scripts/check_markdown_links.py
+
   changes:
     runs-on: ubuntu-latest
     needs: lint-and-check-newlines

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Check Markdown files for broken relative links."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+LINK_RE = re.compile(r"\[(?:[^\]]+)\]\(([^)]+)\)")
+EXCLUDE_DIRS = {".git", "node_modules", "dspy_ai-2.6.27.dist-info"}
+
+
+def is_relative(link: str) -> bool:
+    """Return True if the link is relative."""
+    if link.startswith(("http://", "https://", "mailto:", "#", "/")):
+        return False
+    return True
+
+
+def check_file(md_file: Path) -> list[str]:
+    broken: list[str] = []
+    try:
+        text = md_file.read_text(encoding="utf-8")
+    except Exception as e:  # pragma: no cover - reading errors
+        print(f"Failed to read {md_file}: {e}", file=sys.stderr)
+        return broken
+
+    for match in LINK_RE.finditer(text):
+        link = match.group(1).split("#", 1)[0].split("?", 1)[0]
+        if not link or not is_relative(link):
+            continue
+        target = (md_file.parent / link).resolve()
+        if not target.exists():
+            broken.append(f"{md_file}:{link}")
+    return broken
+
+
+def main() -> int:
+    broken_links: list[str] = []
+    for md_file in ROOT.rglob("*.md"):
+        if any(part in EXCLUDE_DIRS for part in md_file.parts):
+            continue
+        broken_links.extend(check_file(md_file))
+
+    if broken_links:
+        print("Broken markdown links detected:", file=sys.stderr)
+        for item in broken_links:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print("No broken markdown links found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -24,6 +24,9 @@ SNAPSHOT_DIR = Path(__file__).resolve().parents[2] / "snapshots"
 
 logger = logging.getLogger(__name__)
 
+# JSON response body for semantic summary retrieval errors
+SEMANTIC_SUMMARIES_ERROR: Final[dict[str, str]] = {"error": "summary retrieval failed"}
+
 # Default simulation context used by module-level APIs
 DEFAULT_CONTEXT = SimulationContext()
 


### PR DESCRIPTION
## Summary
- add `check_markdown_links.py` to verify relative markdown links exist
- run the new checker in the CI lint job
- define `SEMANTIC_SUMMARIES_ERROR` constant to fix lint failures

## Testing
- `bash scripts/lint.sh`
- `pytest tests/unit/interfaces/test_dashboard_semantic_summaries.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68817b738a948326b07e2874f4162f58