### PR TITLE
Add dataset export option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,7 @@ local-slice:
 
 .PHONY: dataset
 dataset:
-	python scripts/export_traces.py --snapshots $(SNAPSHOTS) --output $(OUTPUT)
+       python - <<EOF
+from scripts.export_traces import export_latest
+export_latest(directory="$(SNAPSHOTS)", output="$(OUTPUT)")
+EOF

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -98,6 +98,10 @@ output paths if needed:
 ```bash
 make dataset SNAPSHOTS=snapshots OUTPUT=data/traces.jsonl
 ```
+The `make dataset` target uses this helper to export the most recent snapshots.
+
+Run the simulation with `--export-dataset <file>` to automatically write a
+dataset from the latest snapshots when the run finishes.
 
 ### Creating a JSONL Dataset
 Generate a dataset from saved snapshots using `export_traces.py`. This example

--- a/scripts/export_traces.py
+++ b/scripts/export_traces.py
@@ -14,6 +14,30 @@ from src.infra import event_log
 from src.infra.snapshot import load_snapshot
 
 
+def export_latest(directory: str | Path = "snapshots", output: str | Path = "data/traces.jsonl") -> Path:
+    """Write a dataset from the newest snapshots in ``directory``.
+
+    The snapshots are sorted by step number and all available files are exported
+    to ``output`` in JSON Lines format.
+    """
+
+    path = Path(directory)
+    files = sorted(path.glob("snapshot_*.json*"), key=lambda p: int(p.stem.split("_")[1]))
+    if not files:
+        raise FileNotFoundError(f"No snapshots found in {directory}")
+
+    out_path = Path(output)
+    with out_path.open("w", encoding="utf-8") as out:
+        for file in files:
+            step = int(file.stem.split("_")[1])
+            compress = file.suffix == ".zst"
+            snap = load_snapshot(step, directory=directory, compress=compress)
+            out.write(json.dumps(snap))
+            out.write("\n")
+
+    return out_path
+
+
 def iter_snapshots(directory: str | Path) -> Iterable[dict[str, Any]]:
     """Yield snapshots from ``directory`` in step order."""
     path = Path(directory)

--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from scripts.export_traces import export_latest
 from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
@@ -233,6 +234,12 @@ def parse_args() -> argparse.Namespace:
         default="agent_1",
         help="Agent ID submitting the proposal.",
     )
+    parser.add_argument(
+        "--export-dataset",
+        type=str,
+        metavar="PATH",
+        help="Write a JSONL dataset from the latest snapshots after the run.",
+    )
     return parser.parse_args()
 
 
@@ -292,6 +299,9 @@ def main() -> None:
 
     if args.checkpoint:
         save_checkpoint(sim, args.checkpoint)
+
+    if args.export_dataset:
+        export_latest(output=args.export_dataset)
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_export_traces.py
+++ b/tests/unit/scripts/test_export_traces.py
@@ -22,3 +22,19 @@ def test_export_traces_snapshots(tmp_path: Path) -> None:
 
     lines = out.read_text().splitlines()
     assert [json.loads(line) for line in lines] == [snap1, snap2]
+
+
+@pytest.mark.unit
+def test_export_latest(tmp_path: Path) -> None:
+    snap1 = {"step": 1}
+    snap1["trace_hash"] = compute_trace_hash(snap1)
+    save_snapshot(1, snap1, directory=tmp_path)
+    snap2 = {"step": 2}
+    snap2["trace_hash"] = compute_trace_hash(snap2)
+    save_snapshot(2, snap2, directory=tmp_path)
+
+    out = tmp_path / "out.jsonl"
+    et.export_latest(directory=tmp_path, output=out)
+
+    lines = out.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == [snap1, snap2]

--- a/tests/unit/test_app_cli.py
+++ b/tests/unit/test_app_cli.py
@@ -122,3 +122,31 @@ def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
         ((app.load_plugins.return_value,), {}),
         ((dummy_sim.async_run.return_value,), {}),
     ]
+
+
+def test_main_exports_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", "--export-dataset", "out.jsonl"],
+    )
+
+    dummy_sim = SimpleNamespace(async_run=MagicMock(return_value="coro"))
+
+    create_sim = MagicMock(return_value=dummy_sim)
+    monkeypatch.setattr(app, "create_simulation", create_sim)
+    run_mock = MagicMock()
+    monkeypatch.setattr(app.asyncio, "run", run_mock)
+    monkeypatch.setattr(app, "load_plugins", MagicMock())
+
+    monkeypatch.setattr(app, "load_checkpoint", MagicMock(return_value=(dummy_sim, None)))
+    monkeypatch.setattr(app, "save_checkpoint", MagicMock())
+    monkeypatch.setattr(app, "restore_rng_state", MagicMock())
+    monkeypatch.setattr(app, "restore_environment", MagicMock())
+
+    export_mock = MagicMock()
+    monkeypatch.setattr(app, "export_latest", export_mock)
+
+    app.main()
+
+    export_mock.assert_called_once_with(output="out.jsonl")


### PR DESCRIPTION
## Summary
- add `export_latest` helper to `export_traces.py`
- support `--export-dataset` in the simulation CLI
- update Makefile dataset target
- document dataset export option
- test dataset export logic

## Testing
- `bash scripts/lint.sh`
- `pytest -k "export_latest or export_dataset" -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a41d02c48326ac872480d6b0b7bc