### PR TITLE
Add custom map action hook

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -12,6 +12,7 @@ Culture exposes a small API for plug-in authors:
 | -------- | ----------- |
 | `register_widget_backend(name, script_url, backend_url="http://localhost:8000")` | Register a widget with the backend so the dashboard can load it. |
 | `register_agent_behavior(func)` | Register a callback executed after each agent turn. |
+| `register_map_action(name, handler)` | Register a custom world map action handler. |
 | `load_plugins(group="culture.plugins", *, backend_url="http://localhost:8000")` | Load plug-ins declared under the given entry point group. |
 
 Two protocol classes define the expected signatures:
@@ -66,6 +67,25 @@ register_agent_behavior(log_turn)
 Each callback receives the agent instance and the dictionary returned from
 `Agent.run_turn`. Multiple behaviors can be registered and will be invoked in the
 order added.
+
+## Map Action Hooks
+
+Custom world map actions let plug-ins modify the simulation when an agent issues
+an unknown action. Use `register_map_action` to associate a handler with an
+action name:
+
+```python
+from src.extensions import register_map_action
+
+def dance_action(sim, idx, agent_id, state, action):
+    state.has_danced = True
+    return {"result": "danced"}
+
+register_map_action("dance", dance_action)
+```
+
+When an agent outputs `{"action": "dance"}` the handler is invoked and its
+returned dictionary is included in the emitted map event.
 
 ## Loading Plug-ins via Entry Points
 

--- a/src/extensions/__init__.py
+++ b/src/extensions/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable
 from importlib import metadata
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 import httpx
 from typing_extensions import Self
@@ -15,10 +15,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "BEHAVIOR_REGISTRY",
+    "MAP_ACTION_REGISTRY",
     "AgentBehavior",
     "Plugin",
     "load_plugins",
     "register_agent_behavior",
+    "register_map_action",
     "register_widget_backend",
 ]
 
@@ -27,7 +29,7 @@ __all__ = [
 class AgentBehavior(Protocol):
     """Callable invoked after each agent turn."""
 
-    def __call__(self, agent: Any, output: dict[str, Any]) -> None: ...
+    def __call__(self: Self, agent: Any, output: dict[str, Any]) -> None: ...
 
 
 PluginResult = dict[str, str] | None
@@ -37,7 +39,7 @@ PluginResult = dict[str, str] | None
 class Plugin(Protocol):
     """Callable loaded via entry points."""
 
-    def __call__(self) -> PluginResult | Awaitable[PluginResult]: ...
+    def __call__(self: Self) -> PluginResult | Awaitable[PluginResult]: ...
 
 
 class BehaviorRegistry:
@@ -57,10 +59,66 @@ class BehaviorRegistry:
 BEHAVIOR_REGISTRY = BehaviorRegistry()
 
 
+@runtime_checkable
+class MapActionHandler(Protocol):
+    """Callable that processes a custom map action."""
+
+    def __call__(
+        self: Self,
+        sim: Any,
+        agent_index: int,
+        agent_id: str,
+        current_state: Any,
+        map_action: dict[str, Any],
+    ) -> Awaitable[dict[str, Any] | None] | dict[str, Any] | None: ...
+
+
+class MapActionRegistry:
+    """Registry for custom world map actions."""
+
+    def __init__(self: Self) -> None:
+        self._actions: dict[str, MapActionHandler] = {}
+
+    def register(self: Self, name: str, handler: MapActionHandler) -> None:
+        self._actions[name] = handler
+
+    async def run(
+        self: Self,
+        name: str,
+        sim: Any,
+        agent_index: int,
+        agent_id: str,
+        current_state: Any,
+        map_action: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        func = self._actions.get(name)
+        if func is None:
+            return None
+        result: Awaitable[dict[str, Any] | None] | dict[str, Any] | None = func(
+            sim,
+            agent_index,
+            agent_id,
+            current_state,
+            map_action,
+        )
+        if asyncio.iscoroutine(result):
+            return cast(dict[str, Any] | None, await result)
+        return cast(dict[str, Any] | None, result)
+
+
+MAP_ACTION_REGISTRY = MapActionRegistry()
+
+
 def register_agent_behavior(func: AgentBehavior) -> None:
     """Register a callback executed after each agent turn."""
 
     BEHAVIOR_REGISTRY.register(func)
+
+
+def register_map_action(name: str, handler: MapActionHandler) -> None:
+    """Register a custom world map action handler."""
+
+    MAP_ACTION_REGISTRY.register(name, handler)
 
 
 async def register_widget_backend(

--- a/src/sim/world_map_actions.py
+++ b/src/sim/world_map_actions.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from src.extensions import MAP_ACTION_REGISTRY
 from src.infra import config
 from src.infra.ledger import log_reward, run_auction
 from src.interfaces.dashboard_backend import emit_map_change_event
@@ -123,6 +124,18 @@ async def process_map_action(
                 )
         else:
             details = {}
+    else:
+        custom = await MAP_ACTION_REGISTRY.run(
+            action_type,
+            sim,
+            agent_index,
+            agent_id,
+            current_state,
+            map_action,
+        )
+        if custom is None:
+            return
+        details = custom or {}
 
     map_event_data = {
         "type": "map_action",

--- a/tests/unit/extensions/test_map_action_plugin.py
+++ b/tests/unit/extensions/test_map_action_plugin.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import types
+from importlib import metadata
+
+import pytest
+
+from src.extensions import MAP_ACTION_REGISTRY, load_plugins
+from src.sim.world_map_actions import process_map_action
+
+
+class DummyEntryPoints(list[object]):
+    def select(self, group: str | None = None) -> list[object]:
+        return self if group == "culture.plugins" else []
+
+
+calls: list[tuple[int, str, dict[str, object]]] = []
+
+
+def custom_action(sim: object, idx: int, aid: str, state: object, action: dict[str, object]):
+    calls.append((idx, aid, action))
+    return {"handled": True}
+
+
+def plugin_setup() -> None:
+    from src.extensions import register_map_action
+
+    register_map_action("dance", custom_action)
+
+
+class DummyEventKernel:
+    def __init__(self) -> None:
+        self.events: list[dict[str, object]] = []
+
+    async def schedule_immediate(self, cb, *, vector) -> None:
+        await cb()
+
+    async def emit_environment_event(self, event: dict[str, object]) -> None:
+        self.events.append(event)
+
+
+class DummySimulation:
+    def __init__(self) -> None:
+        self.world_map = types.SimpleNamespace(to_dict=lambda: {})
+        self.vector = types.SimpleNamespace(to_dict=lambda: {})
+        self.event_kernel = DummyEventKernel()
+        self.current_step = 0
+        self.discord_bot = None
+        self.agents = [types.SimpleNamespace(update_state=lambda s: None)]
+
+
+async def noop(*args: object, **kwargs: object) -> None:  # pragma: no cover - helper
+    pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_custom_map_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    MAP_ACTION_REGISTRY._actions.clear()
+    ep = types.SimpleNamespace(load=lambda: plugin_setup, name="dance_plugin")
+    monkeypatch.setattr(metadata, "entry_points", lambda: DummyEntryPoints([ep]))
+    monkeypatch.setattr("src.sim.world_map_actions.emit_map_change_event", noop)
+
+    await load_plugins()
+
+    assert "dance" in MAP_ACTION_REGISTRY._actions
+
+    sim = DummySimulation()
+    state = types.SimpleNamespace()
+    await process_map_action(sim, 0, "agent", state, {"action": "dance"})
+
+    assert calls == [(0, "agent", {"action": "dance"})]
+    assert sim.event_kernel.events == [
+        {
+            "type": "map_action",
+            "agent_id": "agent",
+            "step": 0,
+            "action": "dance",
+            "handled": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- expose register_map_action in extensions
- use custom map action handlers in process_map_action
- document map action hooks in plugins guide
- add unit tests for a sample map action plug-in

## Testing
- `pytest -m 'not integration and not ollama' tests/unit/extensions/test_map_action_plugin.py -q`
- `ruff check src/extensions/__init__.py src/sim/world_map_actions.py tests/unit/extensions/test_map_action_plugin.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c9401ed48326ac37c8c6f1395064