### PR TITLE
Add export traces integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,13 @@ CI enforces `--cov-fail-under=90` for overall coverage.
 CI also uploads `coverage.xml` as a GitHub Actions artifact. Open the workflow run
 and download the file from the **Artifacts** section.
 
+### Generating a Dataset
+Use `scripts/export_traces.py` to convert snapshots or event logs into a JSONL dataset.
+```bash
+python scripts/export_traces.py --snapshots snapshots/ --output data/traces.jsonl
+```
+This process is covered by `tests/integration/tools/test_export_traces.py`.
+
 ### Project Structure (Key Directories)
 - `src/` — Main source code (agents, graphs, memory, infra, simulation)
 - `tests/` — Unit and integration tests

--- a/tests/integration/tools/test_export_traces.py
+++ b/tests/integration/tools/test_export_traces.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import export_traces
+from src.infra import snapshot as snap
+
+pytestmark = pytest.mark.integration
+
+
+def test_export_traces_sample_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def load_no_verify(
+        step: int | str | Path, directory: str | Path = "snapshots", compress: bool | None = None
+    ) -> dict:
+        path = Path(directory) / f"snapshot_{step}.json"
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+
+    monkeypatch.setattr(snap, "load_snapshot", load_no_verify)
+    monkeypatch.setattr(export_traces, "load_snapshot", load_no_verify)
+
+    out = tmp_path / "traces.jsonl"
+    ret = export_traces.main(["--snapshots", "snapshots", "-o", str(out)])
+    assert ret == 0
+    lines = out.read_text().splitlines()
+    assert len(lines) > 0
+    first = json.loads(lines[0])
+    assert isinstance(first, dict)


### PR DESCRIPTION
## Summary
- add integration test for `export_traces.py`
- document dataset generation in README

## Testing
- `./scripts/lint.sh --format`
- `pytest -m integration tests/integration/tools/test_export_traces.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882dba2e3f0832698ae92a5263dc79f