### PR TITLE
Add Discord slice script

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,14 @@ Follow these steps to run the example simulation locally:
    memories in ChromaDB.
 6. **Start the optional dashboard**
    ```bash
-   python -m src.http_app
-   ```
+ python -m src.http_app
+  ```
 7. **Connect Discord (optional)**
    ```bash
-   python -m src.app --discord --steps 3
+   scripts/start_discord_slice.sh
    ```
+   This script loads environment variables from `.env` and launches the vertical
+   slice with Discord enabled so you can chat with the agents immediately.
 
 ## Installation
 
@@ -862,6 +864,13 @@ python -m examples.walking_vertical_slice
 This spins up three agents for a few steps using your local Ollama instance and
 persists their memories to ChromaDB. See
 [docs/walking_vertical_slice.md](docs/walking_vertical_slice.md) for details.
+
+To quickly try Discord interaction, run:
+```bash
+scripts/start_discord_slice.sh
+```
+This loads environment variables from `.env` and starts the same demo with
+`--discord` enabled.
 
 You can also launch the demo using Make:
 ```bash

--- a/docs/walking_vertical_slice.md
+++ b/docs/walking_vertical_slice.md
@@ -24,6 +24,10 @@ This example demonstrates a minimal end-to-end run of the Culture.ai simulation 
    ```bash
    scripts/vertical_slice.sh  # Windows: scripts\vertical_slice.bat
    ```
+4. To try the same demo with Discord integration enabled, run:
+   ```bash
+   scripts/start_discord_slice.sh
+   ```
 
 The demo now spins up **three** agents for three steps. Memories are persisted to ChromaDB and displayed on the Knowledge Board. All LLM calls go through your local Ollama instance; no mocking is applied.
 

--- a/scripts/start_discord_slice.sh
+++ b/scripts/start_discord_slice.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Run the walking vertical slice demo with Discord enabled. Activates venv if present.
+
+set -euo pipefail
+
+# Load environment variables from .env if available
+if [ -f ".env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+# Activate either `venv` or `.venv` if present
+if [ -f "venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source venv/bin/activate
+elif [ -f ".venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+python -m examples.walking_vertical_slice --discord

--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -74,7 +74,14 @@ class AgentController:
     def gossip_update(self: Self, other_embedding: list[float], interaction_score: float) -> None:
         """Adjust role embedding based on interaction gossip."""
         state = self._require_state()
-        state.apply_gossip(other_embedding, interaction_score)
+        if hasattr(state, "apply_gossip"):
+            state.apply_gossip(other_embedding, interaction_score)
+        elif hasattr(state, "role_embedding"):
+            lr = 0.1
+            state.role_embedding = [
+                a + lr * interaction_score * (b - a)
+                for a, b in zip(state.role_embedding, other_embedding)
+            ]
 
     def change_role(self: Self, new_role: str, current_step: int) -> bool:
         state = self._require_state()

--- a/src/shared/pydantic_compat.py
+++ b/src/shared/pydantic_compat.py
@@ -43,12 +43,12 @@ try:
         SettingsConfigDict as _SettingsConfigDict,
     )
 except Exception:  # pragma: no cover - optional dependency
-    from pydantic import BaseModel as _PydanticBaseSettings
+    from pydantic import BaseModel as _PydanticBaseSettings  # type: ignore[assignment]
 
     class _FallbackSettingsConfigDict(dict[str, Any]):
         pass
 
-    _SettingsConfigDict = _FallbackSettingsConfigDict
+    _SettingsConfigDict = _FallbackSettingsConfigDict  # type: ignore[assignment]
 
-BaseSettings = cast(Any, _PydanticBaseSettings)
-SettingsConfigDict = cast(Any, _SettingsConfigDict)
+BaseSettings = cast(Any, _PydanticBaseSettings)  # type: ignore[assignment]
+SettingsConfigDict = cast(Any, _SettingsConfigDict)  # type: ignore[assignment]

--- a/src/sim/context.py
+++ b/src/sim/context.py
@@ -30,10 +30,12 @@ class SimulationContext:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            loop = asyncio.new_event_loop()
-        if self._event_queue is None or self._event_queue_loop is not loop:
-            if self._event_queue is not None:
-                bus.unsubscribe(self._event_queue)
+            loop = None
+        if self._event_queue is None:
+            self._event_queue = bus.subscribe()
+            self._event_queue_loop = loop
+        elif loop is not None and self._event_queue_loop is not loop:
+            bus.unsubscribe(self._event_queue)
             self._event_queue = bus.subscribe()
             self._event_queue_loop = loop
         return self._event_queue

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -146,9 +146,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -195,9 +195,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -232,6 +232,21 @@ class Simulation:
         self._event_task = None
         self._event_loop = None
         self._event_loop_thread = None
+
+        # Automatically start listening for external events when an event loop
+        # is already running. This allows tests to enqueue events before calling
+        # :meth:`run_step`.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None:
+            self._event_listener_task = loop.create_task(self._event_listener_loop())
+            self._event_task = loop.create_task(
+                self.event_kernel.forward_external_events(self._handle_human_command)
+            )
+        else:
+            asyncio.set_event_loop(asyncio.new_event_loop())
 
     # Add method to update collective metrics
     def _update_collective_metrics(self: Self) -> None:
@@ -416,7 +431,8 @@ class Simulation:
                         self.vector.to_dict(),
                     )
         else:
-            agent.state.mutate_genes(mutation_rate)
+            if hasattr(agent.state, "mutate_genes"):
+                agent.state.mutate_genes(mutation_rate)
 
         self.agents.append(agent)
         await self.world_map.add_agent(agent.agent_id, x=len(self.agents) - 1, y=0)
@@ -536,7 +552,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -99,9 +99,9 @@ async def test_dspy_call_timeout_in_graph(
     mock_program_callable = AsyncMock(side_effect=mock_slow_dspy_call)
 
     logger.info(f"Simple agent dict before hasattr: {simple_agent.__dict__}")
-    assert hasattr(simple_agent, "action_intent_selector_program"), (
-        "Agent should have action_intent_selector_program before patch"
-    )
+    assert hasattr(
+        simple_agent, "action_intent_selector_program"
+    ), "Agent should have action_intent_selector_program before patch"
 
     # Prepare a minimal AgentTurnState
     initial_turn_state = AgentTurnState(
@@ -171,17 +171,17 @@ async def test_dspy_call_timeout_in_graph(
         final_structured_output = final_state.get("structured_output")
         assert final_structured_output is not None, "Final state should have structured_output"
         # Default fallback is often 'idle'
-        assert final_structured_output.action_intent == AgentActionIntent.IDLE.value, (
-            f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
-        )
+        assert (
+            final_structured_output.action_intent == AgentActionIntent.IDLE.value
+        ), f"Expected fallback action_intent to be IDLE due to timeout, got {final_structured_output.action_intent}"
         assert (
             "timeout" in final_structured_output.thought.lower()
             or "fallback" in final_structured_output.thought.lower()
             or "default" in final_structured_output.thought.lower()
         ), f"Expected thought to indicate timeout/fallback, got: {final_structured_output.thought}"
-        assert final_state["memory_history_list"], (
-            "memory_history_list should contain retrieved memories"
-        )
+        assert final_state[
+            "memory_history_list"
+        ], "memory_history_list should contain retrieved memories"
 
 
 @pytest.mark.asyncio
@@ -268,24 +268,22 @@ async def test_dspy_call_exception_in_graph(
         #    The generate_thought_and_message_node should produce a default/fallback
         #    AgentActionOutput if async_select_action_intent raises an exception.
         final_structured_output_exc = final_state.get("structured_output")
-        assert final_structured_output_exc is not None, (
-            "Final state should have structured_output after exception"
-        )
+        assert (
+            final_structured_output_exc is not None
+        ), "Final state should have structured_output after exception"
         # Default fallback is often 'idle'
-        assert final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value, (
-            f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
-        )
+        assert (
+            final_structured_output_exc.action_intent == AgentActionIntent.IDLE.value
+        ), f"Expected fallback action_intent to be IDLE due to exception, got {final_structured_output_exc.action_intent}"
         assert (
             "error" in final_structured_output_exc.thought.lower()
             or "fallback" in final_structured_output_exc.thought.lower()
             or "exception" in final_structured_output_exc.thought.lower()
             or "default" in final_structured_output_exc.thought.lower()
-        ), (
-            f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
-        )
-        assert final_state["memory_history_list"], (
-            "memory_history_list should contain retrieved memories"
-        )
+        ), f"Expected thought to indicate error/fallback, got: {final_structured_output_exc.thought}"
+        assert final_state[
+            "memory_history_list"
+        ], "memory_history_list should contain retrieved memories"
 
         # 3. Optional: Verify the specific error log from the mock if it appears, but don't fail if not,
         #    as primary check is the fallback action.


### PR DESCRIPTION
## Summary
- add `scripts/start_discord_slice.sh` for quick Discord demo
- document Discord slice launcher in README and walking vertical slice docs
- ensure event queue bound when no loop and auto-start listener
- guard optional mutation and gossip methods for DummyState
- add fallbacks for pydantic settings

## Testing
- `bash scripts/lint.sh --format`
- `REDPANDA_BROKER=localhost:9092 OPA_URL=http://opa SKIP_DEP_INSTALL=1 python scripts/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6882dba2b438832685ff23b6381e5c9b