### PR TITLE
Add agent stats API and Storyboard updates

### DIFF
--- a/culture-ui/src/Storyboard.test.tsx
+++ b/culture-ui/src/Storyboard.test.tsx
@@ -10,15 +10,20 @@ afterEach(() => {
 })
 
 describe('Storyboard widget', () => {
-  it('shows coordinates, mood and summaries', async () => {
+  it('shows coordinates, mood, retrieval counts and summaries', async () => {
     ;(
       globalThis as unknown as { EventSource?: typeof EventSource }
     ).EventSource = MockEventSource as unknown as typeof EventSource
-    const fetchSpy = vi.fn(() =>
-      Promise.resolve({
+    const fetchSpy = vi.fn((url: string) => {
+      if (url === '/api/agent_stats') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ agents: { a1: { mood: 0.2, retrieval_count: 3 } } }),
+        }) as unknown as Response
+      }
+      return Promise.resolve({
         json: () => Promise.resolve({ summaries: ['s1'] }),
-      }) as unknown as Response,
-    )
+      }) as unknown as Response
+    })
     vi.stubGlobal('fetch', fetchSpy as unknown as typeof fetch)
 
     render(<StoryboardPage />)
@@ -30,7 +35,9 @@ describe('Storyboard widget', () => {
       )
     })
 
-    expect(await screen.findByText('a1: 5, 6 (mood 0.2)')).toBeInTheDocument()
+    expect(
+      await screen.findByText('a1: 5, 6 (mood 0.2, retrievals 3)')
+    ).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button', { name: /summaries/i }).click()
@@ -38,12 +45,15 @@ describe('Storyboard widget', () => {
 
     expect(await screen.findByText('s1')).toBeInTheDocument()
     expect(fetchSpy).toHaveBeenCalledWith('/api/agents/a1/semantic_summaries')
+    expect(fetchSpy).toHaveBeenCalledWith('/api/agent_stats')
 
     act(() => {
       screen.getByRole('button', { name: /map/i }).click()
     })
 
-    expect(screen.getByText('a1: 5, 6 (mood 0.2)')).toBeInTheDocument()
+    expect(
+      screen.getByText('a1: 5, 6 (mood 0.2, retrievals 3)')
+    ).toBeInTheDocument()
   })
 
   it('handles fetch errors gracefully', async () => {
@@ -62,7 +72,9 @@ describe('Storyboard widget', () => {
       )
     })
 
-    expect(await screen.findByText('a1: 5, 6 (mood n/a)')).toBeInTheDocument()
+    expect(
+      await screen.findByText('a1: 5, 6 (mood n/a, retrievals 0)')
+    ).toBeInTheDocument()
 
     act(() => {
       screen.getByRole('button', { name: /summaries/i }).click()
@@ -75,13 +87,23 @@ describe('Storyboard widget', () => {
       screen.getByRole('button', { name: /map/i }).click()
     })
 
-    expect(screen.getByText('a1: 5, 6 (mood n/a)')).toBeInTheDocument()
+    expect(
+      screen.getByText('a1: 5, 6 (mood n/a, retrievals 0)')
+    ).toBeInTheDocument()
   })
 
   it('renders heatmap and memory events', async () => {
     ;(
       globalThis as unknown as { EventSource?: typeof EventSource }
     ).EventSource = MockEventSource as unknown as typeof EventSource
+
+    vi.stubGlobal(
+      'fetch',
+      (() =>
+        Promise.resolve({
+          json: () => Promise.resolve({ agents: {} }),
+        })) as unknown as typeof fetch,
+    )
 
     render(<StoryboardPage />)
 

--- a/culture-ui/src/widgets/Storyboard.tsx
+++ b/culture-ui/src/widgets/Storyboard.tsx
@@ -16,12 +16,43 @@ export default function Storyboard() {
   const event = useEventSource<SnapshotEvent>()
   const [positions, setPositions] = useState<Record<string, [number, number]>>({})
   const [moods, setMoods] = useState<Record<string, number>>({})
+  const [retrievals, setRetrievals] = useState<Record<string, number>>({})
   const [heatmap, setHeatmap] = useState<Record<string, number>>({})
   const [memoryEvents, setMemoryEvents] = useState<
     Array<{ type: string; step?: number }>
   >([])
   const [tab, setTab] = useState<'map' | 'summaries'>('map')
   const [summaries, setSummaries] = useState<string[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch('/api/agent_stats')
+        const json = (await res.json()) as {
+          agents?: Record<string, { mood?: number; retrieval_count?: number }>
+        }
+        if (json.agents && !cancelled) {
+          const counts: Record<string, number> = {}
+          for (const [id, info] of Object.entries(json.agents)) {
+            if (typeof info.retrieval_count === 'number') {
+              counts[id] = info.retrieval_count
+            }
+            if (typeof info.mood === 'number') {
+              setMoods((cur) => ({ ...cur, [id]: info.mood! }))
+            }
+          }
+          setRetrievals(counts)
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [event])
 
   const agentId = Object.keys(positions)[0] || Object.keys(moods)[0] || 'agent-1'
 
@@ -80,7 +111,8 @@ export default function Storyboard() {
           <ul data-testid="map-info" className="mb-2">
             {Object.entries(positions).map(([id, pos]) => (
               <li key={id}>
-                {id}: {pos[0]}, {pos[1]} (mood {moods[id] ?? 'n/a'})
+                {id}: {pos[0]}, {pos[1]} (mood {moods[id] ?? 'n/a'}, retrievals{' '}
+                {retrievals[id] ?? 0})
               </li>
             ))}
           </ul>

--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -106,6 +106,22 @@ await registerWidgetBackend({
 The backend exposes REST endpoints for listing available memory snapshot steps and retrieving snapshot data.
 Use `GET /api/memory_snapshots` to list the latest steps and `GET /api/memory_snapshots/{step}` to fetch a specific snapshot.
 
+### Agent Stats API
+
+The Storyboard widget displays the current mood and memory retrieval count for each agent.
+These values are retrieved from a new endpoint:
+
+```http
+GET /api/agent_stats
+```
+
+The response structure is:
+
+```json
+{ "agents": { "agent-1": { "mood": 0.2, "retrieval_count": 42 } } }
+```
+
+
 ## Setup
 
 Install dependencies and run the development server:

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -264,6 +264,46 @@ async def api_map() -> Response:
     return JSONResponse({"world_map": world_map, "agents": agents})
 
 
+@app.get("/api/agent_stats")
+async def api_agent_stats() -> Response:
+    """Return retrieval counts and mood for each agent."""
+    sim = SIM_STATE.get("simulation")
+    stats: dict[str, dict[str, Any]] = {}
+    retrieval_counts: dict[str, int] = {}
+    if sim is not None:
+        store = getattr(getattr(sim, "memory_service", None), "vector_store", None)
+
+        if store is not None:
+
+            def _load() -> dict[str, int]:
+                counts: dict[str, int] = {}
+                try:
+                    results = store.collection.get(include=["metadatas"])
+                    metadatas = results.get("metadatas") or []
+                    for meta in metadatas:
+                        if not meta:
+                            continue
+                        agent_id = meta.get("agent_id")
+                        if agent_id is None:
+                            continue
+                        counts[agent_id] = counts.get(agent_id, 0) + int(
+                            meta.get("retrieval_count", 0)
+                        )
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception("Failed to gather retrieval stats")
+                return counts
+
+            retrieval_counts = await asyncio.to_thread(_load)
+
+        for ag in sim.agents:
+            mood = getattr(ag.state, "mood_value", None)
+            stats[ag.agent_id] = {
+                "mood": mood,
+                "retrieval_count": retrieval_counts.get(ag.agent_id, 0),
+            }
+    return JSONResponse({"agents": stats})
+
+
 @app.get("/health")
 async def health() -> Response:
     return JSONResponse({"status": "ok"})
@@ -607,6 +647,7 @@ __all__ = [
     "api_get_proposals",
     "api_get_votes",
     "api_map",
+    "api_agent_stats",
     "api_memory_snapshot",
     "api_memory_snapshots",
     "api_propose_law",


### PR DESCRIPTION
## Summary
- extend Storyboard widget to show retrieval counts for each agent
- expose `/api/agent_stats` endpoint from dashboard backend
- document the new endpoint in Culture UI requirements
- type cleanup for Storyboard stats

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_6882ea1c5b288326aeda68e6bcb2770f