### PR TITLE
Update plugin guide

### DIFF
--- a/docs/plugin_guide.md
+++ b/docs/plugin_guide.md
@@ -33,7 +33,7 @@ my_plugin = "my_plugin:setup"
 
 ## 3. Install and load the plug-in
 
-Install the package in editable mode and call `load_plugins()` at startup:
+Install the package in editable mode and call `load_plugins(backend_url="http://localhost:8000")` at startup so Culture can register the widget with the running UI server:
 
 ```bash
 pip install -e path/to/my_plugin
@@ -42,10 +42,10 @@ pip install -e path/to/my_plugin
 ```python
 from src.extensions import load_plugins
 
-await load_plugins()
+await load_plugins(backend_url="http://localhost:8000")
 ```
 
-Culture will execute the `setup` function and register any declared widgets or behaviors. See [plugins.md](plugins.md) for a more detailed reference.
+Culture will execute the `setup` function and register any declared widgets or behaviors with the UI. After installing the plug-in, reload your Culture server so the new entry point is picked up. See [plugins.md](plugins.md) for a more detailed reference.
 
 ## 4. Scaffold a plug-in automatically
 
@@ -57,4 +57,4 @@ python scripts/create_plugin.py my_plugin
 
 This creates a new `my_plugin` directory containing a ready-to-install package
 with entry-point metadata. Install it in editable mode and load it as shown
-above.
+above, then reload your Culture server to activate the plug-in.


### PR DESCRIPTION
## Summary
- document `load_plugins(backend_url="http://localhost:8000")`
- mention installing in editable mode and reloading the server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68843453dc9483269f16381c4a7f2165