### PR TITLE
Add memory widget plugin example

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -206,3 +206,21 @@ from src.extensions import load_plugins
 
 await load_plugins()
 ```
+
+## Installing the Memory Widget Plug-in
+
+The `examples/plugins/memory_widget` package registers a widget named
+`MemoryWidget` that displays recent semantic summaries. Its script is served from
+`https://localhost:5173/memory_widget.js`. Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/memory_widget
+```
+
+Load the plug-in so Culture can register the widget:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/memory_widget/README.md
+++ b/examples/plugins/memory_widget/README.md
@@ -1,0 +1,17 @@
+# Memory Widget Plug-in
+
+This example package registers a widget that displays recent semantic summaries for an agent. The widget's script is served from `https://localhost:5173/memory_widget.js`.
+
+Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/memory_widget
+```
+
+Load the plug-in so Culture can register the widget:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/memory_widget/memory_widget/__init__.py
+++ b/examples/plugins/memory_widget/memory_widget/__init__.py
@@ -1,0 +1,11 @@
+"""Widget showing recent semantic summaries."""
+
+from src.extensions import PluginResult
+
+
+def setup() -> PluginResult:
+    """Register the MemoryWidget."""
+    return {
+        "name": "MemoryWidget",
+        "script_url": "https://localhost:5173/memory_widget.js",
+    }

--- a/examples/plugins/memory_widget/pyproject.toml
+++ b/examples/plugins/memory_widget/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "memory-widget"
+version = "0.1.0"
+description = "Culture plug-in providing a memory widget"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.entry-points."culture.plugins"]
+memory_widget = "memory_widget:setup"


### PR DESCRIPTION
## Summary
- add minimal `memory_widget` plug-in package under `examples/plugins`
- implement setup() returning widget info
- document installation of the memory widget plug-in
- update docs describing script URL

## Testing
- `ruff check examples/plugins/memory_widget/memory_widget/__init__.py`
- `pytest tests/unit/scripts/test_export_traces.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6887947993c88326ace6aa249991efae