### PR TITLE
Add restart test for EventBus

### DIFF
--- a/tests/unit/sim/test_event_bus.py
+++ b/tests/unit/sim/test_event_bus.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from src.interfaces.dashboard_backend import SimulationEvent
 from src.sim import event_bus
 
 pytestmark = pytest.mark.unit
@@ -27,4 +28,29 @@ def test_shutdown_allows_fresh_event_bus_in_new_loop() -> None:
     assert event_bus._event_bus_loop is loop2
     bus2.shutdown()
     loop2.close()
+    asyncio.set_event_loop(None)
+
+
+def test_shutdown_and_restart_same_loop() -> None:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    bus1 = event_bus.get_event_bus()
+    q1 = bus1.subscribe()
+    bus1.shutdown()
+    assert q1.get_nowait() is None
+    assert not bus1._queues
+
+    async def _get_bus_and_publish() -> event_bus.EventBus:
+        bus2 = event_bus.get_event_bus()
+        q2 = bus2.subscribe()
+        await bus2.publish(SimulationEvent(type="t", data={}))
+        assert await q2.get() is not None
+        return bus2
+
+    bus2 = loop.run_until_complete(_get_bus_and_publish())
+    assert bus2 is not bus1
+    assert event_bus._event_bus_loop is loop
+    assert q1.empty()
+    bus2.shutdown()
+    loop.close()
     asyncio.set_event_loop(None)


### PR DESCRIPTION
## Summary
- add a unit test ensuring EventBus can be restarted in the same loop

## Testing
- `pytest tests/unit/sim/test_event_bus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887fa7b40d083269cda8dfd9d6eeec6