### PR TITLE
Add proposals API and UI page

### DIFF
--- a/culture-ui/README.md
+++ b/culture-ui/README.md
@@ -81,6 +81,7 @@ The UI includes pages for monitoring active missions and reviewing agent data:
 
 - **Mission Overview** – shows current missions with status and progress for each agent.
 - **Agent Data Overview** – lists observations, messages and other data gathered by agents.
+- **Proposals** – view recent law proposals and vote results (navigate to `/proposals`).
 
 Screenshots will be added to this README as these pages mature.
 

--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -10,6 +10,7 @@ import AgentMemoriesPage from './pages/AgentMemories'
 import NetworkWebPage from './pages/NetworkWeb'
 import WorldMapPage from './pages/WorldMap'
 import LawProposalPage from './pages/LawProposal'
+import ProposalsPage from './pages/Proposals'
 import TimelineWidgetPage from './pages/TimelineWidget'
 import MemoryExplorer from './pages/MemoryExplorer'
 import KpiCardPage from './pages/KpiCard'
@@ -43,6 +44,7 @@ export default function App() {
             <Route path="/timeline" element={<TimelineWidgetPage />} />
             <Route path="/agent-timeline" element={<AgentTimelinePage />} />
             <Route path="/propose-law" element={<LawProposalPage />} />
+            <Route path="/proposals" element={<ProposalsPage />} />
             <Route path="/kpi-card" element={<KpiCardPage />} />
             <Route path="/storyboard" element={<StoryboardPage />} />
             <Route path="/balances" element={<TokenBalancesPage />} />

--- a/culture-ui/src/components/Sidebar.tsx
+++ b/culture-ui/src/components/Sidebar.tsx
@@ -58,6 +58,11 @@ export default function Sidebar() {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/proposals" className={linkClass}>
+            Proposals
+          </NavLink>
+        </li>
+        <li>
           <NavLink to="/memory" className={linkClass}>
             Memory Explorer
           </NavLink>

--- a/culture-ui/src/pages/Proposals.tsx
+++ b/culture-ui/src/pages/Proposals.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+import { registerWidget } from '../lib/widgetRegistry'
+
+interface Proposal {
+  proposer_id: string
+  text: string
+  approved: boolean
+  yes_weight: number
+  no_weight: number
+  ip_spent: number
+  ts: string
+}
+
+export default function Proposals() {
+  const [data, setData] = useState<Proposal[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch('/api/recent_proposals')
+        const json = (await res.json()) as { proposals: Proposal[] }
+        if (!cancelled) setData(json.proposals || [])
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Recent Proposals</h1>
+      <table className="min-w-full border" data-testid="proposal-table">
+        <thead>
+          <tr>
+            <th className="border px-2">Time</th>
+            <th className="border px-2">Proposer</th>
+            <th className="border px-2">Text</th>
+            <th className="border px-2">Yes</th>
+            <th className="border px-2">No</th>
+            <th className="border px-2">Approved</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((p, idx) => (
+            <tr key={idx}>
+              <td className="border px-2">{new Date(p.ts).toLocaleString()}</td>
+              <td className="border px-2">{p.proposer_id}</td>
+              <td className="border px-2">{p.text}</td>
+              <td className="border px-2">{p.yes_weight}</td>
+              <td className="border px-2">{p.no_weight}</td>
+              <td className="border px-2">{p.approved ? 'Yes' : 'No'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+registerWidget('Proposals', Proposals)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -413,6 +413,13 @@ async def api_get_proposals(limit: int = 10) -> Response:
     return JSONResponse({"proposals": proposals})
 
 
+@app.get("/api/recent_proposals", response_model=ProposalsResponse)
+async def api_recent_proposals(limit: int = 5) -> Response:
+    """Return the most recent law proposals."""
+    proposals = governance.get_proposals(limit)
+    return JSONResponse({"proposals": proposals})
+
+
 @app.get("/api/laws", response_model=LawsResponse)
 async def api_get_laws() -> Response:
     """Return passed laws from the law board."""
@@ -667,6 +674,7 @@ __all__ = [
     "api_memory_snapshot",
     "api_memory_snapshots",
     "api_propose_law",
+    "api_recent_proposals",
     "api_token_balances",
     "api_vote",
     "app",


### PR DESCRIPTION
## Summary
- expose `/api/recent_proposals` endpoint
- display recent proposals in a new UI page
- link proposals page in the sidebar and routes
- document the page in the Culture UI README
- fix `__all__` ordering after lint

## Testing
- `ruff check src/interfaces/dashboard_backend.py`
- `mypy src/interfaces/dashboard_backend.py`
- `pytest tests/unit/core/test_agent_controller.py::test_select_intent_uses_dspy -q`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_6889191e4a8083269a1504f38a89adc0