### PR TITLE
Add optional dependency checker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,7 @@ See [docs/ci_status.md](docs/ci_status.md) for tips on checking CI status with t
 ### Troubleshooting
 * **LLM connection errors** – Ensure `ollama serve` or `scripts/start_vllm.sh` is running and that `LLM_API_BASE` points to the correct URL.
 * **Missing dependencies** – Reinstall with `pip install -r requirements.txt -r requirements-dev.txt`.
+* **Check optional packages** – Run `python scripts/check_optional_deps.py` to see which optional dependencies (e.g., `chromadb`, `fastapi`, `asyncpg`) are missing before running tests.
 * **Port conflicts** – Set `VLLM_PORT` to a free port when launching the vLLM server.
 
 ## Code Quality and Type Safety

--- a/scripts/check_optional_deps.py
+++ b/scripts/check_optional_deps.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Verify presence of optional dependencies for Culture.ai.
+
+This script checks whether commonly used optional packages are installed and
+prints installation hints if any are missing. These packages enable certain
+tests and features but are not strictly required to run the project.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+OPTIONAL_DEPS = {
+    "chromadb": "pip install chromadb",
+    "fastapi": "pip install fastapi",
+    "asyncpg": "pip install asyncpg",
+}
+
+
+def have_module(name: str) -> bool:
+    """Return ``True`` if the given module can be imported."""
+    return importlib.util.find_spec(name) is not None
+
+
+def main() -> int:
+    missing = [pkg for pkg in OPTIONAL_DEPS if not have_module(pkg)]
+    if not missing:
+        print("All optional dependencies are installed.")
+        return 0
+
+    print("Missing optional packages detected:\n")
+    for pkg in missing:
+        hint = OPTIONAL_DEPS[pkg]
+        print(f"  - {pkg} -> install with: {hint}")
+
+    print("\nInstall them to enable features that rely on these packages.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- create `check_optional_deps.py` to list optional package hints
- document script in Troubleshooting section of README

## Testing
- `ruff check scripts/check_optional_deps.py`
- `black --check scripts/check_optional_deps.py`
- `mypy scripts/check_optional_deps.py`
- `python scripts/run_tests.py tests/unit/infra/test_llm_client_failure.py`

------
https://chatgpt.com/codex/tasks/task_e_6889310f3e0c8326bfaafc1d83a98366