### PR TITLE
Add snapshot replay support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,21 +10,29 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.extensions import load_plugins
-from src.infra import config
+from src.infra import config, event_log
 from src.infra.checkpoint import (
     load_checkpoint,
-    restore_environment,
-    restore_rng_state,
     save_checkpoint,
+)
+from src.infra.checkpoint import (
+    restore_environment as _restore_environment,
+)
+from src.infra.checkpoint import (
+    restore_rng_state as _restore_rng_state,
 )
 from src.infra.llm_client import LLMClientInitError, get_llm_client
 from src.infra.logging_config import setup_logging
 from src.infra.settings import settings
+from src.infra.snapshot import load_snapshot
 from src.infra.warning_filters import configure_warning_filters
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.simulation import Simulation
 from src.utils.loop_helper import use_uvloop_if_available
+
+restore_rng_state = _restore_rng_state
+restore_environment = _restore_environment
 
 
 def _simple_yaml(path: Path) -> dict[str, object]:
@@ -218,10 +226,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--replay",
-        action="store_true",
-        help=(
-            "Restore RNG and environment state from the checkpoint to reproduce agent decisions"
-        ),
+        type=str,
+        metavar="SNAPSHOT",
+        help="Replay a previous run from the given snapshot using the event log.",
     )
     parser.add_argument(
         "--proposal",
@@ -266,11 +273,18 @@ def main() -> None:
         log_suppressed=args.log_suppressed_warnings,
     )
 
+    if args.replay:
+        snapshot = load_snapshot(args.replay)
+        sim = Simulation.from_snapshot(snapshot)
+        for event in event_log.stream_events(after_step=sim.current_step):
+            sim.apply_event(event)
+        return
+
     sim: Simulation
     meta: dict[str, object] | None = None
     if args.checkpoint and Path(args.checkpoint).exists():
         logging.info("Loading simulation from checkpoint %s", args.checkpoint)
-        sim, meta = load_checkpoint(args.checkpoint, replay=args.replay)
+        sim, meta = load_checkpoint(args.checkpoint)
         sim.steps_to_run = args.steps
     else:
         sim = create_simulation(
@@ -285,12 +299,6 @@ def main() -> None:
             semantic_user=args.semantic_user,
             semantic_password=args.semantic_password,
         )
-
-    if args.replay and meta:
-        if meta.get("rng_state") is not None:
-            restore_rng_state(meta["rng_state"])
-        if meta.get("environment") is not None:
-            restore_environment(meta["environment"])
 
     if args.proposal:
         asyncio.run(sim.forward_proposal(args.proposer_id, args.proposal))

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -6,6 +6,7 @@ import random
 import threading
 import time
 from collections.abc import Awaitable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from pydantic import ValidationError
@@ -996,6 +997,58 @@ class Simulation:
                         f" event {expected_hash} != file {snapshot.get('trace_hash')}"
                     )
                 self._last_trace_hash = snapshot.get("trace_hash", "")
+
+    @classmethod
+    def from_snapshot(cls: type[Self], snapshot: dict[str, Any]) -> Self:
+        """Create a ``Simulation`` instance from a snapshot dictionary."""
+        agents_data = snapshot.get("agents", [])
+        agents = [Agent(agent_id=a.get("agent_id", str(i))) for i, a in enumerate(agents_data)]
+        sim = cls(agents=agents, scenario="")
+        sim.current_step = int(snapshot.get("step", 0))
+        sim.collective_ip = float(snapshot.get("collective_ip", 0.0))
+        sim.collective_du = float(snapshot.get("collective_du", 0.0))
+        sim._last_trace_hash = snapshot.get("trace_hash", "")
+
+        for a_data in agents_data:
+            aid = a_data.get("agent_id")
+            for ag in sim.agents:
+                if ag.agent_id == aid:
+                    ag.state.ip = float(a_data.get("ip", 0.0))
+                    ag.state.du = float(a_data.get("du", 0.0))
+                    ag.state.mood_level = float(a_data.get("mood", 0.0))
+                    break
+
+        kb = snapshot.get("knowledge_board", {})
+        for entry in kb.get("entries", []):
+            sim.knowledge_board.add_entry(
+                entry.get("content_full", ""),
+                entry.get("agent_id", "unknown"),
+                int(entry.get("step", 0)),
+                kb.get("vector"),
+            )
+        if isinstance(kb.get("vector"), dict):
+            sim.knowledge_board.vector.clock.update(kb["vector"])
+
+        wm = snapshot.get("world_map", {})
+        if wm:
+            sim.world_map.width = int(wm.get("width", sim.world_map.width))
+            sim.world_map.height = int(wm.get("height", sim.world_map.height))
+            agents_pos = {k: tuple(v) for k, v in wm.get("agents", {}).items()}
+            sim.world_map.agent_positions = agents_pos
+            if isinstance(wm.get("vector"), dict):
+                sim.world_map.vector.clock.update(wm["vector"])
+        return sim
+
+    @classmethod
+    def replay_from_snapshot(cls: type[Self], snapshot_path: str | Path) -> Self:
+        """Load a snapshot and replay events from the event log."""
+        snap = load_snapshot(snapshot_path)
+        sim = cls.from_snapshot(snap)
+        from src.infra import event_log
+
+        for event in event_log.stream_events(after_step=sim.current_step):
+            sim.apply_event(event)
+        return sim
 
     async def run_turns_concurrent(self: Self, agents: list["Agent"]) -> list[dict[str, Any]]:
         """Run a batch of agent turns concurrently.

--- a/tests/integration/sim/test_snapshot_replay.py
+++ b/tests/integration/sim/test_snapshot_replay.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from src.infra import event_log
+from src.sim.simulation import Simulation
+
+
+class DummyProducer:
+    def __init__(self, store: list[bytes]):
+        self.store = store
+
+    def produce(self, _topic: str, payload: bytes) -> None:
+        self.store.append(payload)
+
+    def poll(self, _timeout: float) -> None:  # pragma: no cover - no-op
+        return None
+
+
+class DummyConsumer:
+    def __init__(self, _conf: dict[str, object], store: list[bytes]):
+        self.store = store
+        self.index = 0
+
+    def subscribe(self, _topics: list[str]) -> None:  # pragma: no cover - no-op
+        pass
+
+    def poll(self, _timeout: float):
+        if self.index >= len(self.store):
+            return None
+        payload = self.store[self.index]
+        self.index += 1
+
+        class Message:
+            def __init__(self, value: bytes) -> None:
+                self._value = value
+
+            def error(self) -> None:
+                return None
+
+            def value(self) -> bytes:
+                return self._value
+
+        return Message(payload)
+
+    def close(self) -> None:  # pragma: no cover - no-op
+        pass
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    short_term_memory: ClassVar[list[object]] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict[str, float]] = {}
+    role: str = "dummy"
+    steps_in_current_role: int = 0
+    mood_level: float = 0.0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:  # pragma: no cover - stub
+        pass
+
+
+class MoveAgent:
+    def __init__(self, agent_id: str = "agent") -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+        self._added = False
+
+    def get_id(self) -> str:  # pragma: no cover - used by scheduler
+        return self.agent_id
+
+    def update_state(self, new_state: DummyState) -> None:  # pragma: no cover - simple
+        self.state = new_state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict[str, object] | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict[str, object]:
+        if not self._added and knowledge_board is not None:
+            knowledge_board.add_entry("hello", self.agent_id, simulation_step)
+            self._added = True
+        return {"map_action": {"action": "move", "dx": 1, "dy": 0}}
+
+
+async def _run_simulation(tmp_path: Path) -> tuple[Simulation, Path]:
+    agent = MoveAgent()
+    sim = Simulation([agent])
+
+    for step in range(2):
+        await sim.run_step()
+
+    snap_path = tmp_path / "snapshot_2.json"
+    return sim, snap_path
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_replay_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENABLE_REDPANDA", "1")
+    monkeypatch.setenv("SNAPSHOT_INTERVAL_STEPS", "1")
+
+    store: list[bytes] = []
+    monkeypatch.setattr(event_log, "KafkaProducer", lambda conf: DummyProducer(store))
+    monkeypatch.setattr(event_log, "KafkaConsumer", lambda conf: DummyConsumer(conf, store))
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+
+    def _save(step: int, data: dict, directory: Path = tmp_path) -> None:
+        from src.infra.snapshot import save_snapshot as real_save
+
+        real_save(step, data, directory)
+
+    monkeypatch.setattr("src.sim.simulation.save_snapshot", _save)
+    monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda step: None)
+
+    sim, snap_path = await _run_simulation(tmp_path)
+
+    replay = Simulation.replay_from_snapshot(snap_path)
+
+    assert replay.world_map.agent_positions == sim.world_map.agent_positions
+    assert replay.knowledge_board.get_full_entries() == sim.knowledge_board.get_full_entries()


### PR DESCRIPTION
## Summary
- implement replay from snapshots via event log
- update CLI to accept `--replay` with a snapshot path
- expose helper methods in `Simulation` for snapshot replay
- test snapshot replay restores world map positions and knowledge board

## Testing
- `ruff check src/app.py tests/integration/sim/test_snapshot_replay.py`
- `black src/app.py src/sim/simulation.py tests/integration/sim/test_snapshot_replay.py`
- `pytest tests/unit/app/test_plugin_loading.py::test_main_invokes_load_plugins tests/integration/sim/test_snapshot_replay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889378ff1c88326a285df34d66f58da