### PR TITLE
Add dataset export runbook instructions

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -120,3 +120,17 @@ python scripts/export_traces.py --snapshots snapshots/ --output data/traces.json
 ```
 
 Each line of `data/traces.jsonl` contains a single JSON object.
+
+### Dataset Export
+Follow these steps to manually export a dataset using `scripts/export_traces.py`:
+1. Decide which source to use:
+   - `--snapshots <DIR>` reads snapshots from a directory.
+   - `--events <FILE>` loads a saved event log.
+   - `--redpanda` pulls events from a running Redpanda broker.
+2. Choose an output path with `-o`/`--output`.
+3. Optionally filter the results with `--agent`, `--start-step`, or `--end-step`.
+4. Run the script. For example:
+
+   ```bash
+   python scripts/export_traces.py --snapshots snapshots/ --output data/traces.jsonl
+   ```


### PR DESCRIPTION
## Summary
- document manual dataset export steps in the runbook

## Testing
- `n/a` (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68896236e6888326a430ffbde48aca2c