### PR TITLE
Add edge case tests for export_traces

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -273,6 +273,8 @@ def main() -> None:
         log_suppressed=args.log_suppressed_warnings,
     )
 
+    sim: Simulation
+    meta: dict[str, object] | None = None
     if args.replay:
         snapshot = load_snapshot(args.replay)
         sim = Simulation.from_snapshot(snapshot)
@@ -280,8 +282,6 @@ def main() -> None:
             sim.apply_event(event)
         return
 
-    sim: Simulation
-    meta: dict[str, object] | None = None
     if args.checkpoint and Path(args.checkpoint).exists():
         logging.info("Loading simulation from checkpoint %s", args.checkpoint)
         sim, meta = load_checkpoint(args.checkpoint)

--- a/tests/unit/scripts/test_export_traces.py
+++ b/tests/unit/scripts/test_export_traces.py
@@ -25,6 +25,35 @@ def test_export_traces_snapshots(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_export_traces_filter_agent(tmp_path: Path) -> None:
+    snap1 = {"step": 1, "agent_id": "a"}
+    snap1["trace_hash"] = compute_trace_hash(snap1)
+    save_snapshot(1, snap1, directory=tmp_path)
+    snap2 = {"step": 2, "agent_id": "b"}
+    snap2["trace_hash"] = compute_trace_hash(snap2)
+    save_snapshot(2, snap2, directory=tmp_path)
+    snap3 = {"step": 3, "agent_id": "a"}
+    snap3["trace_hash"] = compute_trace_hash(snap3)
+    save_snapshot(3, snap3, directory=tmp_path)
+
+    out = tmp_path / "out.jsonl"
+    ret = et.main(
+        [
+            "--snapshots",
+            str(tmp_path),
+            "-o",
+            str(out),
+            "--agent",
+            "a",
+        ]
+    )
+    assert ret == 0
+
+    lines = out.read_text().splitlines()
+    assert [json.loads(line) for line in lines] == [snap1, snap3]
+
+
+@pytest.mark.unit
 def test_export_latest(tmp_path: Path) -> None:
     snap1 = {"step": 1}
     snap1["trace_hash"] = compute_trace_hash(snap1)
@@ -38,3 +67,19 @@ def test_export_latest(tmp_path: Path) -> None:
 
     lines = out.read_text().splitlines()
     assert [json.loads(line) for line in lines] == [snap1, snap2]
+
+
+@pytest.mark.unit
+def test_export_traces_no_snapshots(tmp_path: Path) -> None:
+    out = tmp_path / "out.jsonl"
+    ret = et.main(["--snapshots", str(tmp_path), "-o", str(out)])
+    assert ret == 0
+    assert out.exists()
+    assert out.read_text() == ""
+
+
+@pytest.mark.unit
+def test_export_latest_no_snapshots(tmp_path: Path) -> None:
+    out = tmp_path / "out.jsonl"
+    with pytest.raises(FileNotFoundError):
+        et.export_latest(directory=tmp_path, output=out)


### PR DESCRIPTION
## Summary
- add tests for `scripts/export_traces.py` covering agent filtering and no snapshot cases
- fix `src/app.py` duplicate variable definition flagged by mypy

## Testing
- `bash scripts/lint.sh`
- `python scripts/run_tests.py tests/unit/scripts/test_export_traces.py`


------
https://chatgpt.com/codex/tasks/task_e_68896236a5e083269b7edf3e1a8898b0