### PR TITLE
Add arc summary retrieval test

### DIFF
--- a/tests/unit/memory/test_level3_summary_manager.py
+++ b/tests/unit/memory/test_level3_summary_manager.py
@@ -27,3 +27,19 @@ def test_l3_consolidation_and_retrieval(tmp_path) -> None:
 
     retrieved = service.get_long_term_summaries("agent", limit=1)
     assert retrieved == [summary]
+
+
+@pytest.mark.unit
+def test_get_summaries_returns_arc(tmp_path):
+    vector = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path), embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    l3 = Level3SummaryManager(vector)
+
+    vector.add_memory("agent", 1, "thought", "c1", memory_type="chapter_summary")
+    vector.add_memory("agent", 2, "thought", "c2", memory_type="chapter_summary")
+
+    l3.consolidate_summaries("agent", 1, 2)
+
+    summaries = l3.get_summaries("agent")
+    assert any("c1" in s and "c2" in s for s in summaries)


### PR DESCRIPTION
## Summary
- extend unit tests for Level3SummaryManager
- verify arc summaries are returned after consolidation

## Testing
- `python scripts/run_tests.py tests/unit/memory/test_level3_summary_manager.py`
- `ruff check tests/unit/memory/test_level3_summary_manager.py`
- `ruff format tests/unit/memory/test_level3_summary_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68896bc4393c8326b99c98058977b6d9