### PR TITLE
Add Prometheus and OTEL docs

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -7,11 +7,41 @@ This guide explains how to configure basic monitoring for Culture.ai using Grafa
 - A running Prometheus instance collecting metrics from Culture.ai services
 - Grafana installed and able to connect to Prometheus
 
-## 2. Import the Dashboard
+## 2. Running Prometheus Locally
+
+Create a file named `prometheus.yml` with the following contents:
+
+```yaml
+global:
+  scrape_interval: 10s
+scrape_configs:
+  - job_name: "culture"
+    static_configs:
+      - targets: ["host.docker.internal:8000"]
+```
+
+Start Prometheus with Docker:
+
+```bash
+docker run -d -p 9090:9090 \
+  -v $(pwd)/prometheus.yml:/etc/prometheus/prometheus.yml \
+  prom/prometheus
+```
+
+Visit [http://localhost:9090](http://localhost:9090) to confirm metrics are being scraped.
+
+## 3. Import the Dashboard
 
 1. Open Grafana and navigate to **Dashboards > Import**.
 2. Upload `docs/grafana_dashboard.json` from this repository.
 3. Select your Prometheus data source when prompted and click **Import**.
+4. Or import via the API:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d @docs/grafana_dashboard.json \
+    http://admin:admin@localhost:3000/api/dashboards/db
+```
 
 The imported dashboard includes panels for CPU usage, Knowledge Board size, active agent count, and the LLM query rate (QPS).
 
@@ -19,9 +49,9 @@ Additional Prometheus metrics include:
 
 - `llm_errors_total` – counts failed LLM calls captured by the monitoring decorator.
 
-## 3. Running Grafana Locally
+## 4. Running Grafana Locally
 
-If you want to run Grafana locally for quick testing, you can use Docker:
+If you want to run Grafana locally for quick testing, you can use Docker. The default login is `admin`/`admin`:
 
 ```bash
 docker run -d -p 3000:3000 grafana/grafana
@@ -29,11 +59,17 @@ docker run -d -p 3000:3000 grafana/grafana
 
 Once running, access Grafana at [http://localhost:3000](http://localhost:3000) and follow the import steps above.
 
-## 4. OpenTelemetry Logs
+## 5. OpenTelemetry Logs
 
 Culture.ai can export structured logs via the OpenTelemetry OTLP exporter. The exporter
-sends logs to `localhost:4318/v1/logs` by default. Set `OTEL_EXPORTER_ENDPOINT` to
-override this URL, and set `ENABLE_OTEL=1` in your `.env` file to activate the exporter.
+sends logs to `localhost:4318/v1/logs` by default. Copy `.env.example` to `.env` and
+set the following variables to enable exporting:
+
+```env
+ENABLE_OTEL=1
+OTEL_EXPORTER_ENDPOINT=http://localhost:4318/v1/logs
+```
+Adjust the endpoint if your collector runs elsewhere.
 
 To receive these logs locally, run an OTLP-compatible collector such as the
 [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/):
@@ -44,7 +80,7 @@ otelcol --config=your_config.yaml
 
 You should then see logs arriving on port `4318`.
 
-## 5. Debugging SQLite Locks
+## 6. Debugging SQLite Locks
 
 If you encounter database lock errors during development, enable SQLite debug mode:
 
@@ -54,7 +90,7 @@ export DEBUG_SQLITE=1
 
 This sets the database to WAL mode and increases the busy timeout to help diagnose locking issues.
 
-## 6. Policy Engine (OPA)
+## 7. Policy Engine (OPA)
 
 Culture.ai can optionally send outgoing messages through an [Open Policy Agent](https://www.openpolicyagent.org/) service for additional filtering. Set the `OPA_URL` environment variable to point at your OPA policy endpoint (for example `http://localhost:8181/v1/data/discord/allow`). The endpoint should return JSON in the form:
 
@@ -66,7 +102,7 @@ Culture.ai can optionally send outgoing messages through an [Open Policy Agent](
 
 If `allow` is `false`, the message will be blocked. If `content` is returned, it will replace the original text before sending.
 
-## 7. Redpanda Event Log
+## 8. Redpanda Event Log
 
 Culture.ai can stream all simulation events to a Redpanda broker for later replay and analysis.
 Follow [docs/redpanda_setup.md](redpanda_setup.md) to install Redpanda locally and start it with Docker Compose.
@@ -79,7 +115,7 @@ REDPANDA_BROKER=localhost:9092
 
 Events will be written to the `culture-events` topic. You can inspect them with the `rpk` CLI or any Kafka-compatible consumer.
 
-## 8. Metrics Reference
+## 9. Metrics Reference
 
 Prometheus metrics exported by the simulation include:
 


### PR DESCRIPTION
## Summary
- document how to run Prometheus
- add API-based Grafana dashboard import instructions
- clarify how to enable OpenTelemetry log export

## Testing
- `pre-commit` *(skipped: docs only)*

------
https://chatgpt.com/codex/tasks/task_e_688976ca29e08326a5fc9e1ca5847095