### PR TITLE
Add Memory Explorer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ A Husky pre-commit hook runs `pnpm lint` and `pnpm type-check` automatically.
 
 See [culture-ui/README.md](culture-ui/README.md) for additional details.
 UI requirements are summarized in [docs/culture_ui_requirements.md](docs/culture_ui_requirements.md).
+Steps for launching the Memory Explorer are in [docs/memory_explorer.md](docs/memory_explorer.md).
 
 ## Extensions and Plug-ins
 

--- a/docs/memory_explorer.md
+++ b/docs/memory_explorer.md
@@ -1,0 +1,21 @@
+# Memory Explorer
+
+This guide explains how to inspect an agent's semantic summaries using the Memory Explorer page.
+
+## 1. Start the dashboard backend
+
+Launch the HTTP service so the UI can fetch data:
+
+```bash
+python -m src.http_app
+```
+
+By default the server listens on `http://localhost:8000`.
+
+## 2. Open the Memory Explorer page
+
+With the backend running, navigate to `/memory` in your browser. When using the development server this is usually `http://localhost:5173/memory`.
+
+## 3. View semantic summaries
+
+Select an agent ID to load its latest semantic summaries. The UI calls `/api/agents/{agent_id}/semantic_summaries` and lists the results below the controls.


### PR DESCRIPTION
## Summary
- document how to launch the dashboard backend and browse semantic summaries
- link the new doc from the culture-ui section of the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a86610f808326988c1d4388ccbbdc