### PR TITLE
Add resource_plugin example

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -278,3 +278,19 @@ from src.extensions import load_plugins
 
 await load_plugins()
 ```
+
+## Installing the Resource Plug-in
+
+The `examples/plugins/resource_plugin` package registers a custom map action `gather_crystal` that lets agents collect crystals from the world map. Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/resource_plugin
+```
+
+Load the plug-in so Culture can register the action:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/resource_plugin/README.md
+++ b/examples/plugins/resource_plugin/README.md
@@ -1,0 +1,17 @@
+# Resource Plug-in
+
+This example package registers a custom map action `gather_crystal` that lets agents collect crystals from the world map.
+
+Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/resource_plugin
+```
+
+Load the plug-in so Culture can register the action:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/resource_plugin/pyproject.toml
+++ b/examples/plugins/resource_plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "resource-plugin"
+version = "0.1.0"
+description = "Culture plug-in providing a crystal gathering map action"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.entry-points."culture.plugins"]
+resource_plugin = "resource_plugin:setup"

--- a/examples/plugins/resource_plugin/resource_plugin/__init__.py
+++ b/examples/plugins/resource_plugin/resource_plugin/__init__.py
@@ -1,0 +1,58 @@
+"""Plug-in adding a custom crystal gathering action."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.extensions import PluginResult, register_map_action
+from src.infra import config
+from src.infra.ledger import log_reward, run_auction
+
+
+async def gather_crystal(
+    sim: Any,
+    agent_index: int,
+    agent_id: str,
+    state: Any,
+    action: dict[str, Any],
+) -> dict[str, Any]:
+    """Gather a crystal from the agent's current position."""
+    pos = sim.world_map.agent_positions.get(agent_id)
+    success = False
+    if pos is not None:
+        cell = sim.world_map.resources.get(pos)
+        if cell and cell.get("crystal", 0) > 0:
+            cell["crystal"] -= 1
+            if cell["crystal"] == 0:
+                del cell["crystal"]
+            bag = sim.world_map.agent_resources.setdefault(agent_id, {})
+            bag["crystal"] = bag.get("crystal", 0) + 1
+            try:
+                from src.infra.ledger import ledger
+
+                ledger.add_tokens(agent_id, "crystal", 1)
+            except Exception:  # pragma: no cover - optional
+                pass
+            sim.world_map.vector.increment(agent_id)
+            success = True
+            start_ip = state.ip
+            if config.MAP_GATHER_DU_COST > 0:
+                run_auction("gather_crystal", agent_id, config.MAP_GATHER_DU_COST)
+                state.du -= config.MAP_GATHER_DU_COST
+            start_du = state.du
+            state.ip -= config.MAP_GATHER_IP_COST
+            state.ip += config.MAP_GATHER_IP_REWARD
+            state.du += config.MAP_GATHER_DU_REWARD
+            log_reward(
+                agent_id,
+                state.ip - start_ip,
+                state.du - start_du,
+                "gather_crystal",
+            )
+    return {"resource": "crystal", "success": success}
+
+
+def setup() -> PluginResult:
+    """Entry point for :func:`load_plugins`."""
+    register_map_action("gather_crystal", gather_crystal)
+    return None


### PR DESCRIPTION
## Summary
- add resource_plugin example package
- implement `gather_crystal` map action
- document how to install and load the plug-in

## Testing
- `ruff check examples/plugins/resource_plugin/resource_plugin/__init__.py`
- `ruff format examples/plugins/resource_plugin/resource_plugin/__init__.py`
- `pytest -m "not integration and not ollama" tests/test_pytest_sanity.py`


------
https://chatgpt.com/codex/tasks/task_e_688ac59961f4832682a79cfc16178273