### PR TITLE
Add memory snapshot API tests

### DIFF
--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -76,3 +76,20 @@ def get_gas_price_per_call() -> float:
 def get_gas_price_per_token() -> float:
     """Return the latest gas price charged per generated token."""
     return float(GAS_PRICE_PER_TOKEN._value.get())
+
+
+__all__ = [
+    "GAS_PRICE_PER_CALL",
+    "GAS_PRICE_PER_TOKEN",
+    "KNOWLEDGE_BOARD_SIZE",
+    "LLM_CALLS_TOTAL",
+    "LLM_ERRORS_TOTAL",
+    "LLM_LATENCY_MS",
+    "Counter",
+    "Gauge",
+    "get_gas_price_per_call",
+    "get_gas_price_per_token",
+    "get_kb_size",
+    "get_llm_latency",
+    "start_http_server",
+]

--- a/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
+++ b/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.infra.snapshot import compute_trace_hash, save_snapshot
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_memory_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # create several snapshot files
+    steps = [1, 2, 3]
+    for step in steps:
+        data = {"step": step}
+        data["trace_hash"] = compute_trace_hash(data)
+        save_snapshot(step, data, directory=tmp_path)
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+
+    resp = await db.api_memory_snapshots(limit=2)
+    assert json.loads(resp.body) == {"steps": steps[-2:]}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_memory_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {"step": 5}
+    data["trace_hash"] = compute_trace_hash(data)
+    save_snapshot(5, data, directory=tmp_path)
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+
+    resp = await db.api_memory_snapshot(5)
+    assert json.loads(resp.body) == data
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_memory_snapshot_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+
+    resp = await db.api_memory_snapshot(42)
+    assert resp.status_code == 404
+    assert json.loads(resp.body) == {"error": "not_found"}


### PR DESCRIPTION
## Summary
- test dashboard memory snapshot endpoints
- export Gauge via __all__ in metrics

## Testing
- `bash scripts/lint.sh`
- `pytest -c pytest.ini tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_688ad22d45948326858fb7f5649da428