### PR TITLE
Add optional scikit-learn checks for memory tests

### DIFF
--- a/tests/integration/agents/test_multilayer_retriever_simulation.py
+++ b/tests/integration/agents/test_multilayer_retriever_simulation.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip("sklearn")
+
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager

--- a/tests/integration/memory/test_multilayer_retriever.py
+++ b/tests/integration/memory/test_multilayer_retriever.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("sklearn")
 pytest.importorskip("chromadb")
 
 from src.agents.memory.memory_service import MemoryService

--- a/tests/integration/memory/test_semantic_group_retrieval.py
+++ b/tests/integration/memory/test_semantic_group_retrieval.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("sklearn")
 pytest.importorskip("chromadb")
 
 from src.agents.memory.memory_service import MemoryService

--- a/tests/integration/memory/test_semantic_recent_summaries.py
+++ b/tests/integration/memory/test_semantic_recent_summaries.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("sklearn")
 pytest.importorskip("chromadb")
 
 from src.agents.memory.memory_service import MemoryService

--- a/tests/integration/memory/test_semantic_update_on_retrieval.py
+++ b/tests/integration/memory/test_semantic_update_on_retrieval.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("sklearn")
 pytest.importorskip("chromadb")
 
 from src.agents.memory.memory_service import MemoryService

--- a/tests/unit/memory/test_memory_tracking_manager.py
+++ b/tests/unit/memory/test_memory_tracking_manager.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
+
+pytest.importorskip("sklearn")
 from typing_extensions import Self
 
 from src.agents.memory.memory_tracking_manager import MemoryTrackingManager

--- a/tests/unit/memory/test_multi_layer_retriever.py
+++ b/tests/unit/memory/test_multi_layer_retriever.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import pytest
 
+pytest.importorskip("sklearn")
+
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager

--- a/tests/unit/memory/test_semantic_memory_manager.py
+++ b/tests/unit/memory/test_semantic_memory_manager.py
@@ -2,6 +2,8 @@ import asyncio
 
 import pytest
 
+pytest.importorskip("sklearn")
+
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from tests.utils.dummy_chromadb import setup_dummy_chromadb


### PR DESCRIPTION
## Summary
- skip memory tests when scikit-learn isn't available

## Testing
- `bash scripts/lint.sh`
- `pytest tests/unit/memory/test_semantic_memory_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688bda563960832696382f88a4ccc4cb