### PR TITLE
Add metrics for memory retrievals

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,9 +45,13 @@ curl -X POST -H "Content-Type: application/json" \
 
 The imported dashboard includes panels for CPU usage, Knowledge Board size, active agent count, and the LLM query rate (QPS).
 
+To monitor memory retrievals, add a new panel in Grafana using the `memory_retrievals_total` and `memory_retrieval_errors_total` counters. For example, graph `rate(memory_retrievals_total[1m])` to see retrieval throughput.
+
 Additional Prometheus metrics include:
 
 - `llm_errors_total` – counts failed LLM calls captured by the monitoring decorator.
+- `memory_retrievals_total` – counts successful memory lookups.
+- `memory_retrieval_errors_total` – counts memory retrieval failures.
 
 ## 4. Running Grafana Locally
 
@@ -125,4 +129,6 @@ Prometheus metrics exported by the simulation include:
 - `llm_errors_total` – failed LLM calls
 - `knowledge_board_size` – total Knowledge Board entries
 - `event_bus_queue_size` – number of queues subscribed to the event bus
+- `memory_retrievals_total` – successful memory retrievals
+- `memory_retrieval_errors_total` – failed memory retrievals
 

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from typing_extensions import Self
 
+from src.interfaces import metrics
+
 from .level3_summary_manager import Level3SummaryManager
 from .multi_layer_retriever import MultiLayerRetriever
 from .semantic_memory_manager import SemanticMemoryManager
@@ -44,14 +46,27 @@ class MemoryService:
     async def retrieve_relevant_memories(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        return await self.retriever.retrieve(agent_id, query, k)
+        try:
+            result = await self.retriever.retrieve(agent_id, query, k)
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return result
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     def retrieve_semantic_context(
         self: Self, agent_id: str, query: str, k: int = 5
     ) -> list[dict[str, Any]]:
         if not self.semantic_manager:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
             return []
-        return self.semantic_manager.retrieve_context(agent_id, query, k)
+        try:
+            result = self.semantic_manager.retrieve_context(agent_id, query, k)
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return result
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         return self.retriever.get_recent_semantic_summaries(agent_id, limit)

--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from typing_extensions import Self
 
+from src.interfaces import metrics
+
 from .semantic_memory_manager import SemanticMemoryManager
 from .vector_store import ChromaVectorStoreManager
 
@@ -24,36 +26,48 @@ class MultiLayerRetriever:
     async def retrieve(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        episodic: list[dict[str, Any]] = []
-        if self.vector_store:
-            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+        try:
+            episodic: list[dict[str, Any]] = []
+            if self.vector_store:
+                episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
 
-        semantic: list[dict[str, Any]] = []
-        if self.semantic_manager:
-            import asyncio
+            semantic: list[dict[str, Any]] = []
+            if self.semantic_manager:
+                import asyncio
 
-            semantic = await asyncio.to_thread(
-                self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
-            )
+                semantic = await asyncio.to_thread(
+                    self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
+                )
 
-        combined = episodic + semantic
-        combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
-        return combined[:k]
+            combined = episodic + semantic
+            combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return combined[:k]
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     async def retrieve_and_update_semantic(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        episodic = []
-        if self.vector_store:
-            episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
-        if self.semantic_manager:
-            try:
-                await self.semantic_manager.run_nightly_job(agent_id, episodic)
-            except Exception:  # pragma: no cover - defensive
-                import logging
+        try:
+            episodic = []
+            if self.vector_store:
+                episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+            if self.semantic_manager:
+                try:
+                    await self.semantic_manager.run_nightly_job(agent_id, episodic)
+                except Exception:  # pragma: no cover - defensive
+                    import logging
 
-                logging.getLogger(__name__).error("Semantic consolidation failed", exc_info=True)
-        return episodic
+                    logging.getLogger(__name__).error(
+                        "Semantic consolidation failed", exc_info=True
+                    )
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return episodic
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         if not self.semantic_manager:

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -47,6 +47,16 @@ KNOWLEDGE_BOARD_SIZE = Gauge(
     "knowledge_board_size", "Number of entries currently on the Knowledge Board"
 )
 
+# Memory retrieval metrics
+MEMORY_RETRIEVALS_TOTAL = Counter(
+    "memory_retrievals_total",
+    "Total number of successful memory retrievals",
+)
+MEMORY_RETRIEVAL_ERRORS_TOTAL = Counter(
+    "memory_retrieval_errors_total",
+    "Total number of failed memory retrievals",
+)
+
 # Gas price metrics updated by ``Ledger.calculate_gas_price``
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
@@ -85,6 +95,8 @@ __all__ = [
     "LLM_CALLS_TOTAL",
     "LLM_ERRORS_TOTAL",
     "LLM_LATENCY_MS",
+    "MEMORY_RETRIEVALS_TOTAL",
+    "MEMORY_RETRIEVAL_ERRORS_TOTAL",
     "Counter",
     "Gauge",
     "get_gas_price_per_call",

--- a/tests/unit/memory/test_multi_layer_retriever.py
+++ b/tests/unit/memory/test_multi_layer_retriever.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import pytest
 
+from src.interfaces import metrics
+
 pytest.importorskip("sklearn")
 
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
@@ -75,3 +77,30 @@ async def test_retrieve_and_update_calls_semantic_job(
 
     assert results == episodic
     assert calls == [("agent", episodic)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_metrics_increment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path), embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    semantic = SemanticMemoryManager(vector, driver=None)
+    retriever = MultiLayerRetriever(vector, semantic)
+
+    async def fake_success(agent_id: str, query: str, k: int) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(vector, "aretrieve_relevant_memories", fake_success)
+    before = metrics.MEMORY_RETRIEVALS_TOTAL._value.get()
+    await retriever.retrieve("agent", "q")
+    assert metrics.MEMORY_RETRIEVALS_TOTAL._value.get() == before + 1
+
+    async def fake_fail(agent_id: str, query: str, k: int) -> list[dict[str, Any]]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(vector, "aretrieve_relevant_memories", fake_fail)
+    err_before = metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get()
+    with pytest.raises(RuntimeError):
+        await retriever.retrieve("agent", "q")
+    assert metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get() == err_before + 1


### PR DESCRIPTION
## Summary
- track successful and failed memory retrievals
- expose metrics via the metrics interface
- document how to monitor memory retrievals in Grafana
- test that retrieval counters increment

## Testing
- `bash scripts/lint.sh > /tmp/lint.log && tail -n 20 /tmp/lint.log`
- `python -m pytest tests/unit/memory/test_multi_layer_retriever.py::test_metrics_increment -q > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_688cc921b9a0832699b867c6b4332185