### PR TITLE
Update docs for SSE websocket fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Once the server is running, visit `http://localhost:5173/memory` to explore agen
 memories using the **Memory Explorer** page.
 Visit `/storyboard` to view the live Storyboard showing agent actions.
 
+Real-time updates are streamed from `/stream/events` using Server-Sent Events with a WebSocket fallback. See [Stream Events and WebSocket Fallback](docs/culture_ui_requirements.md#stream-events-and-websocket-fallback) for a minimal subscriber example.
 Prettier formatting is configured via `.prettierrc`. Format UI code with:
 
 ```bash

--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -122,6 +122,30 @@ The response structure is:
 ```
 
 
+### Stream Events and WebSocket Fallback
+
+The dashboard receives live updates from `/stream/events`. The preferred method uses **Server-Sent Events (SSE)**, but the UI must fall back to WebSocket when SSE isn't available.
+
+```ts
+function subscribe() {
+  const sse = new EventSource('/stream/events');
+  sse.onmessage = (ev) => {
+    const payload = JSON.parse(ev.data);
+    console.log('event', payload);
+  };
+  sse.onerror = () => {
+    sse.close();
+    const ws = new WebSocket('ws://localhost:8000/ws/events');
+    ws.onmessage = (ev) => {
+      const payload = JSON.parse(ev.data);
+      console.log('event', payload);
+    };
+  };
+}
+```
+
+This ensures live event delivery even when browsers or proxies block SSE.
+
 ## Setup
 
 Install dependencies and run the development server:


### PR DESCRIPTION
## Summary
- document stream event SSE with websocket fallback in culture UI requirements
- cross-link README to new docs section

## Testing
- `n/a` (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_688ccf08e5e083268a4562ea765a6ef3