### PR TITLE
Add vLLM startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Setup](#installation)
 - [Windows / WSL2 Setup Checklist](docs/windows_setup.md#quick-setup-checklist)
 - [Running Tests](#running-tests)
+- [Start vLLM](#start-vllm)
 - [culture-ui Frontend](#culture-ui-frontend)
 - [Extensions and Plug-ins](#extensions-and-plug-ins)
 - [Roadmap](#roadmap)
@@ -177,6 +178,20 @@ Follow these steps to run the example simulation locally:
   scripts/start_vllm.sh
   export LLM_API_BASE="http://localhost:$VLLM_PORT"
   ```
+
+### Start vLLM
+Set these environment variables to customize the vLLM server:
+
+```bash
+VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" \
+VLLM_PORT=8001 \
+VLLM_SWAP_SPACE=16 \
+scripts/start_vllm.sh
+export VLLM_API_BASE="http://localhost:$VLLM_PORT"
+export LLM_API_BASE="$VLLM_API_BASE"
+```
+Run `scripts/benchmark_llm.py` to check that the server responds before starting a simulation.
+
 5. **Run the vertical slice demo**
    ```bash
    make local-slice

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -45,7 +45,7 @@ This runbook outlines routine operations for working with Culture.ai.
    zstd -d snapshot_100.json.zst -o snapshot_100.json
    ```
 
-## Starting the vLLM Server
+## Start vLLM
 Install vLLM if it is not already available:
 ```bash
 pip install vllm
@@ -65,9 +65,9 @@ export VLLM_API_BASE="http://localhost:$VLLM_PORT"
 export LLM_API_BASE="$VLLM_API_BASE"  # overrides Ollama when set
 ```
 
-When `VLLM_API_BASE` (or `LLM_API_BASE` pointing to the same URL) is configured,
-the application prefers the vLLM endpoint over Ollama. Unset this variable to
-switch back to Ollama.
+Run `scripts/benchmark_llm.py` to sanity-check the server before launching a simulation.
+
+When `VLLM_API_BASE` (or `LLM_API_BASE` pointing to the same URL) is configured, the application prefers the vLLM endpoint over Ollama. Unset this variable to switch back to Ollama.
 
 ## Running Tests
 Run the full suite with coverage:

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Launch a quick demo with the UI and LLM backend.
+# Manual instructions: see README.md#start-vllm or docs/runbook.md#start-vllm.
+# After the server starts you can run scripts/benchmark_llm.py as a sanity check.
 set -euo pipefail
 
 # Load environment variables


### PR DESCRIPTION
## Summary
- document how to start a vLLM server
- add a small `Start vLLM` section in the runbook
- mention benchmark script in quickstart

## Testing
- No tests run since only documentation and comment changes were made

------
https://chatgpt.com/codex/tasks/task_e_688cdb8955288326b35b82ecbbbcb92f