### PR TITLE
Add example plugin docs

### DIFF
--- a/docs/plugin_guide.md
+++ b/docs/plugin_guide.md
@@ -58,3 +58,11 @@ python scripts/create_plugin.py my_plugin
 This creates a new `my_plugin` directory containing a ready-to-install package
 with entry-point metadata. Install it in editable mode and load it as shown
 above, then reload your Culture server to activate the plug-in.
+
+For a complete demonstration, see the sample files included with the
+repository:
+
+- `examples/example_plugin/plugin.py` shows a plug-in that registers a widget
+  and agent behavior.
+- `examples/example_plugin/static/example.js` contains the minimal widget
+  script referenced by the plug-in's `setup()` function.

--- a/examples/example_plugin/plugin.py
+++ b/examples/example_plugin/plugin.py
@@ -1,0 +1,32 @@
+"""Example Culture plug-in demonstrating widget and agent hooks."""
+
+from typing import Any
+
+from src.extensions import PluginResult, register_agent_behavior
+
+
+def log_turn(agent: Any, output: dict[str, Any]) -> None:
+    """Log each agent turn.
+
+    This function is registered as an agent-behavior callback via
+    :func:`register_agent_behavior`. Culture will invoke it after every
+    agent action, providing the agent instance and the emitted output.
+    """
+
+    print(f"[EXAMPLE_PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
+
+
+def setup() -> PluginResult:
+    """Register hooks with Culture and expose the ExampleWidget.
+
+    The :func:`load_plugins` helper calls this entry point during
+    application startup. It registers ``log_turn`` so the callback is
+    executed on each agent turn and returns metadata for the UI widget.
+    """
+
+    register_agent_behavior(log_turn)
+    return {
+        "name": "ExampleWidget",
+        # This script is packaged with the plug-in under ``static``.
+        "script_url": "static/example.js",
+    }

--- a/examples/example_plugin/static/example.js
+++ b/examples/example_plugin/static/example.js
@@ -1,0 +1,2 @@
+// Minimal widget script used by ExampleWidget
+console.log('ExampleWidget loaded');


### PR DESCRIPTION
## Summary
- document example plugin hooks and widget script
- add a minimal ExampleWidget script
- mention example files in the plugin guide

## Testing
- `ruff check examples/example_plugin/plugin.py`
- `black examples/example_plugin/plugin.py`
- `mypy examples/example_plugin/plugin.py`
- `pytest tests/unit/extensions/test_example_plugin.py::test_example_plugin_load -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdb8a20288326ab205e3e99c9e146