### PR TITLE
Add stream events subsection and cross-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Once the server is running, visit `http://localhost:5173/memory` to explore agen
 memories using the **Memory Explorer** page.
 Visit `/storyboard` to view the live Storyboard showing agent actions.
 
-Real-time updates are streamed from `/stream/events` using Server-Sent Events with a WebSocket fallback. See [Stream Events and WebSocket Fallback](docs/culture_ui_requirements.md#stream-events-and-websocket-fallback) for a minimal subscriber example.
+Real-time updates are streamed from `/stream/events` using Server-Sent Events with a WebSocket fallback. See [Stream Events and WebSocket Fallback](docs/culture_ui_requirements.md#streamevents-and-websocket-fallback) for a minimal subscriber example.
 Prettier formatting is configured via `.prettierrc`. Format UI code with:
 
 ```bash

--- a/docs/culture_ui_requirements.md
+++ b/docs/culture_ui_requirements.md
@@ -122,7 +122,7 @@ The response structure is:
 ```
 
 
-### Stream Events and WebSocket Fallback
+### `/stream/events` and WebSocket Fallback
 
 The dashboard receives live updates from `/stream/events`. The preferred method uses **Server-Sent Events (SSE)**, but the UI must fall back to WebSocket when SSE isn't available.
 


### PR DESCRIPTION
## Summary
- rename WebSocket fallback section in culture_ui_requirements
- update README link to the new heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d0c6502948326902a71b798edb6cc