### PR TITLE
Add memory retrieval metrics counters

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -45,7 +45,14 @@ curl -X POST -H "Content-Type: application/json" \
 
 The imported dashboard includes panels for CPU usage, Knowledge Board size, active agent count, and the LLM query rate (QPS).
 
-To monitor memory retrievals, add a new panel in Grafana using the `memory_retrievals_total` and `memory_retrieval_errors_total` counters. For example, graph `rate(memory_retrievals_total[1m])` to see retrieval throughput.
+### Memory Retrieval Metrics
+
+Two counters track memory lookup activity:
+
+- `memory_retrievals_total` – counts successful memory lookups.
+- `memory_retrieval_errors_total` – counts memory retrieval failures.
+
+Add a new panel in Grafana using these counters. For example, graph `rate(memory_retrievals_total[1m])` to view retrieval throughput.
 
 Additional Prometheus metrics include:
 

--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -74,7 +74,13 @@ class MemoryService:
     async def retrieve_episodic_and_update_semantic(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
-        return await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
+        try:
+            result = await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return result
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     def blend_with_recent_semantic(
         self: Self, agent_id: str, episodic_summary: str, limit: int = 3

--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -71,8 +71,15 @@ class MultiLayerRetriever:
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         if not self.semantic_manager:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
             return []
-        return self.semantic_manager.get_recent_summaries(agent_id, limit)
+        try:
+            result = self.semantic_manager.get_recent_summaries(agent_id, limit)
+            metrics.MEMORY_RETRIEVALS_TOTAL.inc()
+            return result
+        except Exception:
+            metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
+            raise
 
     def blend_with_recent_semantic(
         self: Self, agent_id: str, episodic_summary: str, limit: int = 3

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -88,6 +88,16 @@ def get_gas_price_per_token() -> float:
     return float(GAS_PRICE_PER_TOKEN._value.get())
 
 
+def get_memory_retrievals() -> int:
+    """Return the total successful memory retrievals."""
+    return int(MEMORY_RETRIEVALS_TOTAL._value.get())
+
+
+def get_memory_retrieval_errors() -> int:
+    """Return the total failed memory retrievals."""
+    return int(MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get())
+
+
 __all__ = [
     "GAS_PRICE_PER_CALL",
     "GAS_PRICE_PER_TOKEN",
@@ -103,5 +113,7 @@ __all__ = [
     "get_gas_price_per_token",
     "get_kb_size",
     "get_llm_latency",
+    "get_memory_retrieval_errors",
+    "get_memory_retrievals",
     "start_http_server",
 ]

--- a/tests/unit/memory/test_multi_layer_retriever.py
+++ b/tests/unit/memory/test_multi_layer_retriever.py
@@ -3,14 +3,14 @@ from typing import Any
 
 import pytest
 
-from src.interfaces import metrics
-
-pytest.importorskip("sklearn")
-
+from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.interfaces import metrics
 from tests.utils.dummy_chromadb import setup_dummy_chromadb
+
+pytest.importorskip("sklearn")
 
 pytestmark = pytest.mark.unit
 
@@ -92,15 +92,42 @@ async def test_metrics_increment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
         return []
 
     monkeypatch.setattr(vector, "aretrieve_relevant_memories", fake_success)
-    before = metrics.MEMORY_RETRIEVALS_TOTAL._value.get()
+    before = metrics.get_memory_retrievals()
     await retriever.retrieve("agent", "q")
-    assert metrics.MEMORY_RETRIEVALS_TOTAL._value.get() == before + 1
+    assert metrics.get_memory_retrievals() == before + 1
 
     async def fake_fail(agent_id: str, query: str, k: int) -> list[dict[str, Any]]:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(vector, "aretrieve_relevant_memories", fake_fail)
-    err_before = metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get()
+    err_before = metrics.get_memory_retrieval_errors()
     with pytest.raises(RuntimeError):
         await retriever.retrieve("agent", "q")
-    assert metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get() == err_before + 1
+    assert metrics.get_memory_retrieval_errors() == err_before + 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_service_metrics_increment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=str(tmp_path), embedding_function=lambda t: [[0.0] for _ in t]
+    )
+    semantic = SemanticMemoryManager(vector, driver=None)
+    service = MemoryService(vector_store=vector, semantic_manager=semantic)
+
+    async def fake_success(agent_id: str, query: str, k: int) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(service.retriever, "retrieve_and_update_semantic", fake_success)
+    before = metrics.get_memory_retrievals()
+    await service.retrieve_episodic_and_update_semantic("agent", "q")
+    assert metrics.get_memory_retrievals() == before + 1
+
+    async def fake_fail(agent_id: str, query: str, k: int) -> list[dict[str, Any]]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service.retriever, "retrieve_and_update_semantic", fake_fail)
+    err_before = metrics.get_memory_retrieval_errors()
+    with pytest.raises(RuntimeError):
+        await service.retrieve_episodic_and_update_semantic("agent", "q")
+    assert metrics.get_memory_retrieval_errors() == err_before + 1


### PR DESCRIPTION
## Summary
- track memory retrievals in `MemoryService` and `MultiLayerRetriever`
- expose helper functions for the counters in `metrics`
- document new metrics in `observability.md`
- test counter increments for service and retriever

## Testing
- `ruff check tests/unit/memory/test_multi_layer_retriever.py src/agents/memory/memory_service.py src/agents/memory/multi_layer_retriever.py src/interfaces/metrics.py`
- `mypy src/agents/memory/memory_service.py src/agents/memory/multi_layer_retriever.py src/interfaces/metrics.py tests/unit/memory/test_multi_layer_retriever.py`
- `pytest tests/unit/memory/test_multi_layer_retriever.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0c642e808326a85b6fc3081f8150