### PR TITLE
Add vLLM startup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,17 @@ Follow these steps to run the example simulation locally:
   ```
 
 ### Start vLLM
-Set these environment variables to customize the vLLM server:
+Launch a local vLLM server with `scripts/start_vllm.sh`. Configure it with these environment variables:
 
 ```bash
-VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" \
-VLLM_PORT=8001 \
-VLLM_SWAP_SPACE=16 \
+VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2"  # model name
+VLLM_PORT=8001                                    # port for the API
+VLLM_SWAP_SPACE=16                                # swap space in GB
 scripts/start_vllm.sh
 export VLLM_API_BASE="http://localhost:$VLLM_PORT"
-export LLM_API_BASE="$VLLM_API_BASE"
+export LLM_API_BASE="$VLLM_API_BASE"            # preferred endpoint
 ```
-Run `scripts/benchmark_llm.py` to check that the server responds before starting a simulation.
+Run `scripts/benchmark_llm.py` after the server starts to verify that requests succeed.
 
 5. **Run the vertical slice demo**
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -51,7 +51,7 @@ Install vLLM if it is not already available:
 pip install vllm
 ```
 `scripts/start_vllm.sh` launches the vLLM OpenAI-compatible API. Set these
-environment variables as needed:
+environment variables before running it:
 
 - `VLLM_MODEL` – model name to load (defaults to `mistralai/Mistral-7B-Instruct-v0.2`)
 - `VLLM_PORT` – server port (default `8001`)
@@ -65,7 +65,7 @@ export VLLM_API_BASE="http://localhost:$VLLM_PORT"
 export LLM_API_BASE="$VLLM_API_BASE"  # overrides Ollama when set
 ```
 
-Run `scripts/benchmark_llm.py` to sanity-check the server before launching a simulation.
+Run `scripts/benchmark_llm.py` after the server starts to sanity-check the endpoint.
 
 When `VLLM_API_BASE` (or `LLM_API_BASE` pointing to the same URL) is configured, the application prefers the vLLM endpoint over Ollama. Unset this variable to switch back to Ollama.
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Launch a quick demo with the UI and LLM backend.
-# Manual instructions: see README.md#start-vllm or docs/runbook.md#start-vllm.
-# After the server starts you can run scripts/benchmark_llm.py as a sanity check.
+# Manual instructions: see README.md#start-vllm or docs/runbook.md#start-vllm
+# for required environment variables. After the server starts you can run
+# scripts/benchmark_llm.py as a sanity check.
 set -euo pipefail
 
 # Load environment variables


### PR DESCRIPTION
## Summary
- document environment variables for vLLM startup
- mention `scripts/benchmark_llm.py` as a sanity check
- clarify quickstart script comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d1b1fd8ec8326ac09d5c57d6ea9af