### PR TITLE
Add example plugin docs and comments

### DIFF
--- a/docs/plugin_guide.md
+++ b/docs/plugin_guide.md
@@ -22,6 +22,10 @@ def setup() -> PluginResult:
     }
 ```
 
+For a concrete example, see the sample plug-in provided with this repository:
+`examples/example_plugin/plugin.py` registers a widget and agent behavior and
+loads `examples/example_plugin/static/example.js` as its front-end script.
+
 ## 2. Declare the entry point
 
 Expose the plug-in via `pyproject.toml` so Culture can discover it:

--- a/examples/example_plugin/plugin.py
+++ b/examples/example_plugin/plugin.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from src.extensions import PluginResult, register_agent_behavior
 
-
+# Agent-behavior callback executed after every agent action.
 def log_turn(agent: Any, output: dict[str, Any]) -> None:
     """Log each agent turn.
 
@@ -16,6 +16,7 @@ def log_turn(agent: Any, output: dict[str, Any]) -> None:
     print(f"[EXAMPLE_PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
 
 
+# Entry point discovered by ``load_plugins`` during app startup.
 def setup() -> PluginResult:
     """Register hooks with Culture and expose the ExampleWidget.
 
@@ -24,9 +25,10 @@ def setup() -> PluginResult:
     executed on each agent turn and returns metadata for the UI widget.
     """
 
+    # Register ``log_turn`` so Culture logs every agent output.
     register_agent_behavior(log_turn)
     return {
         "name": "ExampleWidget",
-        # This script is packaged with the plug-in under ``static``.
+        # UI will load this widget script from the plug-in's ``static`` directory.
         "script_url": "static/example.js",
     }


### PR DESCRIPTION
## Summary
- document example plugin in plugin guide
- clarify example plugin callback and setup with inline comments

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_688d1b209b148326afee8266a1c3de51