### PR TITLE
Add integration tests for weighted voting edge cases

### DIFF
--- a/tests/integration/governance/test_weighted_vote.py
+++ b/tests/integration/governance/test_weighted_vote.py
@@ -102,3 +102,104 @@ async def test_weighted_vote_records_spend(
     assert proposals[0]["ip_spent"] == pytest.approx(5.0)
     assert proposals[0]["yes_weight"] == pytest.approx(2.0)
     assert proposals[0]["no_weight"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_weighted_vote_overdraw(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    ledger._hooks = [ledger._db_hook]  # keep DB hook only for thread safety
+    orig_spend = ledger.spend
+    lock = asyncio.Lock()
+
+    async def locked_spend(*args, **kwargs):
+        async with lock:
+            return await orig_spend(*args, **kwargs)
+
+    monkeypatch.setattr(ledger, "spend", locked_spend)
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    gservice = importlib.import_module("src.governance.service")
+    voting_mod = importlib.import_module("src.governance.voting")
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(voting_mod, "governance", gservice.governance)
+
+    async def allow(_: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow)
+
+    vote_order = [True, False]
+
+    async def fake_vote(_agent: DummyAgent, _text: str) -> bool:
+        return vote_order.pop(0)
+
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
+
+    # each agent has less IP than their weight squared
+    await ledger.reward("a1", ip=3.0, reason="fund")
+    await ledger.reward("a2", ip=1.0, reason="fund")
+
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+    weights = {"a1": 3, "a2": 1}
+
+    approved = await gservice.governance.propose_law(
+        agents[0], "law", agents, vote_weights=weights
+    )
+    assert approved is True
+
+    # IP cannot go negative, so both balances hit zero
+    assert ledger.get_balance("a1")[0] == pytest.approx(0.0)
+    assert ledger.get_balance("a2")[0] == pytest.approx(0.0)
+
+    proposals = ledger.get_law_proposals()
+    # only the available IP is deducted and persisted
+    assert proposals[0]["ip_spent"] == pytest.approx(4.0)
+    assert proposals[0]["yes_weight"] == pytest.approx(3.0)
+    assert proposals[0]["no_weight"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_quadratic_weighting(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    board = LawBoard(tmp_path / "laws.sqlite")
+
+    gservice = importlib.import_module("src.governance.service")
+    voting_mod = importlib.import_module("src.governance.voting")
+    monkeypatch.setattr(gservice, "law_board", board)
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(voting_mod, "governance", gservice.governance)
+
+    async def allow(_: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(gservice, "evaluate_with_opa", allow)
+
+    vote_order = [True, False]
+
+    async def fake_vote(_agent: DummyAgent, _text: str) -> bool:
+        return vote_order.pop(0)
+
+    monkeypatch.setattr(gservice.governance, "vote", fake_vote)
+
+    # quadratic weights derived from agent state + ledger balance
+    await ledger.reward("a1", ip=16.0, reason="fund")
+    await ledger.reward("a2", ip=1.0, reason="fund")
+
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+    agents[0].state.ip = 16.0
+    agents[1].state.ip = 1.0
+
+    approved = await gservice.governance.propose_law(agents[0], "law", agents)
+    assert approved is True
+
+    # no IP is spent when vote_weights is None
+    assert ledger.get_balance("a1")[0] == pytest.approx(16.0)
+    assert ledger.get_balance("a2")[0] == pytest.approx(1.0)
+
+    proposals = ledger.get_law_proposals()
+    assert proposals[0]["ip_spent"] == pytest.approx(0.0)
+    assert proposals[0]["yes_weight"] == pytest.approx(4.0)
+    assert proposals[0]["no_weight"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- test overspending with weighted votes exceeding IP balances
- ensure ledger records the IP spent
- cover quadratic weighting path when vote_weights is not provided

## Testing
- `ruff check tests/integration/governance/test_weighted_vote.py`
- `black tests/integration/governance/test_weighted_vote.py --check`
- `pytest tests/integration/governance/test_weighted_vote.py -m integration -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b4c48d08326af0331cae3be930f