### PR TITLE
Add minimal plugin example

### DIFF
--- a/docs/plugin_guide.md
+++ b/docs/plugin_guide.md
@@ -70,3 +70,17 @@ repository:
   and agent behavior.
 - `examples/example_plugin/static/example.js` contains the minimal widget
   script referenced by the plug-in's `setup()` function.
+- `examples/plugins/minimal_plugin` provides a tiny plug-in that registers a
+  widget and an agent behavior. Install it with:
+
+```bash
+pip install -e examples/plugins/minimal_plugin
+```
+
+Load the plug-in at startup so Culture can register the hooks:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/minimal_plugin/README.md
+++ b/examples/plugins/minimal_plugin/README.md
@@ -1,0 +1,17 @@
+# Minimal Plug-in
+
+This example package demonstrates how to register a dashboard widget and an agent behavior.
+
+Install the package in editable mode:
+
+```bash
+pip install -e examples/plugins/minimal_plugin
+```
+
+Load plug-ins so Culture discovers it:
+
+```python
+from src.extensions import load_plugins
+
+await load_plugins()
+```

--- a/examples/plugins/minimal_plugin/minimal_plugin/__init__.py
+++ b/examples/plugins/minimal_plugin/minimal_plugin/__init__.py
@@ -1,0 +1,19 @@
+"""Minimal plug-in registering a widget and agent behavior."""
+
+from typing import Any
+
+from src.extensions import PluginResult, register_agent_behavior
+
+
+def echo(agent: Any, output: dict[str, Any]) -> None:
+    """Log the agent output for demonstration."""
+    print(f"[MINIMAL_PLUGIN] {getattr(agent, 'agent_id', 'unknown')}: {output}")
+
+
+def setup() -> PluginResult:
+    """Entry point for :func:`load_plugins`."""
+    register_agent_behavior(echo)
+    return {
+        "name": "MinimalWidget",
+        "script_url": "http://localhost:5173/minimal.js",
+    }

--- a/examples/plugins/minimal_plugin/pyproject.toml
+++ b/examples/plugins/minimal_plugin/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "minimal-plugin"
+version = "0.1.0"
+description = "Minimal Culture plug-in"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.entry-points."culture.plugins"]
+minimal_plugin = "minimal_plugin:setup"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
       "@parcel/watcher",
       "@tailwindcss/oxide"
     ]
+  },
+  "culture.plugins": {
+    "minimal_plugin": "minimal_plugin:setup"
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,10 @@ preview = false
 #[tool.ruff.lint.per-file-ignores] # This line and the following are removed as they are now under [tool.ruff.per-file-ignores]
 #"src/agents/dspy_programs/*_examples.py" = ["E501"]
 #"src/agents/dspy_programs/*_summary_examples.py" = ["E501"]
-#"tests/unit/dspy_programs/test_role_specific_summary_generator.py" = ["E501"] 
+#"tests/unit/dspy_programs/test_role_specific_summary_generator.py" = ["E501"]
+
+[project]
+name = "culture"
+
+[project.entry-points."culture.plugins"]
+minimal_plugin = "minimal_plugin:setup"

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -695,7 +695,7 @@ def analyze_sentiment(
             except ValueError:
                 logger.warning(f"Invalid mock sentiment value: {val}")
                 return 0.0
-        return float(val) if isinstance(val, (int, float)) else 0.0
+        return float(val) if isinstance(val, int | float) else 0.0
 
     if not text:
         return None

--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -131,7 +131,7 @@ def load_snapshot(
     compress = SNAPSHOT_COMPRESS if compress is None else compress
 
     path = Path(directory)
-    if isinstance(step, (str, Path)) and Path(step).exists():
+    if isinstance(step, str | Path) and Path(step).exists():
         file_path = Path(step)
         compress = file_path.suffix.endswith(".zst")
         json_file = path / file_path.with_suffix(".json").name

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import TypedDict, Union
+from typing import TypedDict
 
 # Basic JSON-compatible types used throughout the codebase
-JSONValue = Union[str, int, float, bool, None, dict[str, "JSONValue"], list["JSONValue"]]
+JSONValue = str | int | float | bool | None | dict[str, "JSONValue"] | list["JSONValue"]
 
 # Simple alias for a JSON-compatible dictionary
 JSONDict = dict[str, JSONValue]


### PR DESCRIPTION
## Summary
- add new `minimal_plugin` that registers a widget and agent behavior
- document how to install and load the example plug-in
- expose the plug-in via package.json and pyproject.toml
- update helper modules to use `|` union syntax

## Testing
- `ruff check --no-fix src/ tests/`
- `black --check src/ tests/`
- `mypy src/`
- `pytest tests/unit/extensions/test_sample_plugin.py::test_sample_plugin_load -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5fa34b88832683ce46304ff93bb0