### PR TITLE
test: reload summary on agent change

### DIFF
--- a/culture-ui/README.md
+++ b/culture-ui/README.md
@@ -67,6 +67,16 @@ pnpm --filter culture-ui build
 pnpm --filter culture-ui test:e2e
 ```
 
+Run the entire Playwright suite or target a single file:
+
+```bash
+# all tests
+pnpm --filter culture-ui test:e2e
+
+# specific test
+pnpm --filter culture-ui test:e2e tests/memory-explorer.pw.ts
+```
+
 Use `pnpm` to execute tests so that the bundled Playwright version matches the
 installed `@playwright/test` dependency. Running `npx playwright` may install a
 different version and cause failures.

--- a/culture-ui/tests/memory-explorer.pw.ts
+++ b/culture-ui/tests/memory-explorer.pw.ts
@@ -12,8 +12,22 @@ test.beforeEach(async ({ page }) => {
   })
 })
 
-test('memory explorer loads', async ({ page }) => {
+test('memory explorer reloads summaries when agent changes', async ({ page }) => {
   await page.goto('/memory')
+  const summaries = page.getByTestId('summaries')
   await expect(page.getByRole('heading', { name: 'Memory Explorer' })).toBeVisible()
-  await expect(page.getByText('test summary')).toBeVisible()
+  await expect(summaries).toContainText('test summary')
+
+  await page.route('/api/agents/agent-2/semantic_summaries', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ summaries: ['new summary'] }),
+    })
+  })
+
+  await page.getByLabel('agent-select').fill('agent-2')
+
+  await expect(summaries).toContainText('new summary')
+  await expect(summaries).not.toContainText('test summary')
 })


### PR DESCRIPTION
## Summary
- extend Memory Explorer test to ensure summaries refresh after selecting a different agent
- document how to run the Playwright suite in the UI README

## Testing
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui build`
- `pnpm --filter culture-ui test:e2e tests/memory-explorer.pw.ts`


------
https://chatgpt.com/codex/tasks/task_e_688e2b8031b88326a695f285267816a5