### PR TITLE
feat: expose agent state and memories

### DIFF
--- a/culture-ui/src/MemoryExplorer.test.tsx
+++ b/culture-ui/src/MemoryExplorer.test.tsx
@@ -9,11 +9,29 @@ vi.mock('./App.css', () => ({}))
 describe('MemoryExplorer', () => {
   let fetchMock: ReturnType<typeof vi.fn>
   beforeEach(() => {
-    fetchMock = vi.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve({ summaries: ['hello world'] }),
-      }) as unknown as Response,
-    )
+    fetchMock = vi.fn((url: string) => {
+      if (url === '/api/agents/agent-1/semantic_summaries') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ summaries: ['hello world'] }),
+        }) as unknown as Response
+      }
+      if (url === '/api/agents/agent-1/memories') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ memories: [{ content: 'm1' }] }),
+        }) as unknown as Response
+      }
+      if (url === '/api/agents/agent-2/semantic_summaries') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ summaries: ['second'] }),
+        }) as unknown as Response
+      }
+      if (url === '/api/agents/agent-2/memories') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ memories: [{ content: 'm2' }] }),
+        }) as unknown as Response
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Response
+    })
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
   })
 
@@ -30,21 +48,25 @@ describe('MemoryExplorer', () => {
     )
 
     expect(await screen.findByText('hello world')).toBeInTheDocument()
+    expect(await screen.findByText('m1')).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/agents/agent-1/semantic_summaries',
     )
-
-    fetchMock.mockResolvedValue({
-      json: () => Promise.resolve({ summaries: ['second'] }),
-    } as Response)
+    expect(fetchMock).toHaveBeenCalledWith('/api/agents/agent-1/memories')
 
     const input = screen.getByLabelText('agent-select')
     await userEvent.clear(input)
     await userEvent.type(input, 'agent-2')
 
     expect(await screen.findByText('second')).toBeInTheDocument()
+    expect(await screen.findByText('m2')).toBeInTheDocument()
     expect(
-      fetchMock.mock.calls.some((c) => c[0] === '/api/agents/agent-2/semantic_summaries'),
+      fetchMock.mock.calls.some(
+        (c) => c[0] === '/api/agents/agent-2/semantic_summaries',
+      ),
+    ).toBe(true)
+    expect(
+      fetchMock.mock.calls.some((c) => c[0] === '/api/agents/agent-2/memories'),
     ).toBe(true)
   })
 
@@ -56,8 +78,9 @@ describe('MemoryExplorer', () => {
     )
 
     expect(await screen.findByText('hello world')).toBeInTheDocument()
+    expect(await screen.findByText('m1')).toBeInTheDocument()
 
-    fetchMock.mockRejectedValueOnce(new Error('fail'))
+    fetchMock.mockImplementation(() => Promise.reject(new Error('fail')))
 
     const input = screen.getByLabelText('agent-select')
     await userEvent.clear(input)
@@ -70,8 +93,10 @@ describe('MemoryExplorer', () => {
     )
 
     expect(screen.queryByText('hello world')).toBeInTheDocument()
-    expect(
-      screen.getByTestId('summaries').textContent?.trim(),
-    ).toBe('hello world')
+    expect(screen.queryByText('m1')).toBeInTheDocument()
+    expect(screen.getByTestId('summaries').textContent?.trim()).toBe(
+      'hello world',
+    )
+    expect(screen.getByTestId('memories').textContent?.trim()).toBe('m1')
   })
 })

--- a/culture-ui/src/Storyboard.test.tsx
+++ b/culture-ui/src/Storyboard.test.tsx
@@ -17,7 +17,13 @@ describe('Storyboard widget', () => {
     const fetchSpy = vi.fn((url: string) => {
       if (url === '/api/agent_stats') {
         return Promise.resolve({
-          json: () => Promise.resolve({ agents: { a1: { mood: 0.2, retrieval_count: 3 } } }),
+          json: () =>
+            Promise.resolve({ agents: { a1: { mood: 0.2, retrieval_count: 3 } } }),
+        }) as unknown as Response
+      }
+      if (url === '/api/agents/a1/state') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ state: { ip: 5 } }),
         }) as unknown as Response
       }
       return Promise.resolve({
@@ -36,7 +42,7 @@ describe('Storyboard widget', () => {
     })
 
     expect(
-      await screen.findByText('a1: 5, 6 (mood 0.2, retrievals 3)')
+      await screen.findByText('a1: 5, 6 (mood 0.2, ip 5, retrievals 3)')
     ).toBeInTheDocument()
 
     act(() => {
@@ -46,13 +52,14 @@ describe('Storyboard widget', () => {
     expect(await screen.findByText('s1')).toBeInTheDocument()
     expect(fetchSpy).toHaveBeenCalledWith('/api/agents/a1/semantic_summaries')
     expect(fetchSpy).toHaveBeenCalledWith('/api/agent_stats')
+    expect(fetchSpy).toHaveBeenCalledWith('/api/agents/a1/state')
 
     act(() => {
       screen.getByRole('button', { name: /map/i }).click()
     })
 
     expect(
-      screen.getByText('a1: 5, 6 (mood 0.2, retrievals 3)')
+      screen.getByText('a1: 5, 6 (mood 0.2, ip 5, retrievals 3)')
     ).toBeInTheDocument()
   })
 
@@ -73,7 +80,7 @@ describe('Storyboard widget', () => {
     })
 
     expect(
-      await screen.findByText('a1: 5, 6 (mood n/a, retrievals 0)')
+      await screen.findByText('a1: 5, 6 (mood n/a, ip n/a, retrievals 0)')
     ).toBeInTheDocument()
 
     act(() => {
@@ -88,7 +95,7 @@ describe('Storyboard widget', () => {
     })
 
     expect(
-      screen.getByText('a1: 5, 6 (mood n/a, retrievals 0)')
+      screen.getByText('a1: 5, 6 (mood n/a, ip n/a, retrievals 0)')
     ).toBeInTheDocument()
   })
 

--- a/culture-ui/src/pages/MemoryExplorer.tsx
+++ b/culture-ui/src/pages/MemoryExplorer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 export default function MemoryExplorer() {
   const [agentId, setAgentId] = useState('agent-1')
   const [summaries, setSummaries] = useState<string[]>([])
+  const [memories, setMemories] = useState<string[]>([])
 
   useEffect(() => {
     let cancelled = false
@@ -13,6 +14,28 @@ export default function MemoryExplorer() {
         const res = await fetch(`/api/agents/${agentId}/semantic_summaries`)
         const json = await res.json()
         if (!cancelled) setSummaries(json.summaries || [])
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [agentId])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(`/api/agents/${agentId}/memories`)
+        const json = await res.json()
+        if (!cancelled) {
+          const items = (json.memories || []).map(
+            (m: { content?: string }) => m.content || String(m),
+          )
+          setMemories(items)
+        }
       } catch {
         /* ignore */
       }
@@ -42,6 +65,11 @@ export default function MemoryExplorer() {
       <div data-testid="summaries">
         {summaries.map((s, i) => (
           <div key={i}>{s}</div>
+        ))}
+      </div>
+      <div data-testid="memories">
+        {memories.map((m, i) => (
+          <div key={i}>{m}</div>
         ))}
       </div>
     </div>

--- a/culture-ui/src/widgets/Storyboard.tsx
+++ b/culture-ui/src/widgets/Storyboard.tsx
@@ -17,6 +17,7 @@ export default function Storyboard() {
   const [positions, setPositions] = useState<Record<string, [number, number]>>({})
   const [moods, setMoods] = useState<Record<string, number>>({})
   const [retrievals, setRetrievals] = useState<Record<string, number>>({})
+  const [agentStates, setAgentStates] = useState<Record<string, unknown>>({})
   const [heatmap, setHeatmap] = useState<Record<string, number>>({})
   const [memoryEvents, setMemoryEvents] = useState<
     Array<{ type: string; step?: number }>
@@ -34,15 +35,25 @@ export default function Storyboard() {
         }
         if (json.agents && !cancelled) {
           const counts: Record<string, number> = {}
-          for (const [id, info] of Object.entries(json.agents)) {
-            if (typeof info.retrieval_count === 'number') {
-              counts[id] = info.retrieval_count
-            }
-            if (typeof info.mood === 'number') {
-              setMoods((cur) => ({ ...cur, [id]: info.mood! }))
-            }
-          }
+          const states: Record<string, unknown> = {}
+          await Promise.all(
+            Object.entries(json.agents).map(async ([id, info]) => {
+              if (typeof info.retrieval_count === 'number') {
+                counts[id] = info.retrieval_count
+              }
+              if (typeof info.mood === 'number') {
+                setMoods((cur) => ({ ...cur, [id]: info.mood! }))
+              }
+              try {
+                const sres = await fetch(`/api/agents/${id}/state`)
+                states[id] = await sres.json()
+              } catch {
+                /* ignore */
+              }
+            }),
+          )
           setRetrievals(counts)
+          setAgentStates((cur) => ({ ...cur, ...states }))
         }
       } catch {
         /* ignore */
@@ -111,8 +122,8 @@ export default function Storyboard() {
           <ul data-testid="map-info" className="mb-2">
             {Object.entries(positions).map(([id, pos]) => (
               <li key={id}>
-                {id}: {pos[0]}, {pos[1]} (mood {moods[id] ?? 'n/a'}, retrievals{' '}
-                {retrievals[id] ?? 0})
+                {id}: {pos[0]}, {pos[1]} (mood {moods[id] ?? 'n/a'}, ip{' '}
+                {agentStates[id]?.state?.ip ?? 'n/a'}, retrievals {retrievals[id] ?? 0})
               </li>
             ))}
           </ul>

--- a/docs/memory_explorer.md
+++ b/docs/memory_explorer.md
@@ -16,6 +16,12 @@ By default the server listens on `http://localhost:8000`.
 
 With the backend running, navigate to `/memory` in your browser. When using the development server this is usually `http://localhost:5173/memory`.
 
-## 3. View semantic summaries
+## 3. View agent data
 
-Select an agent ID to load its latest semantic summaries. The UI calls `/api/agents/{agent_id}/semantic_summaries` and lists the results below the controls.
+Select an agent ID to load its latest information:
+
+- `/api/agents/{agent_id}/state` returns the agent's current state such as resource levels.
+- `/api/agents/{agent_id}/memories` returns recent raw memory entries.
+- `/api/agents/{agent_id}/semantic_summaries` provides high-level summaries.
+
+The Memory Explorer lists these results below the controls so you can inspect how an agent is evolving over time.

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -67,7 +67,8 @@ else:  # pragma: no cover - optional runtime dependency
 
         class Response:  # pragma: no cover - minimal stub
             def __init__(self: Response, *args: object, **kwargs: object) -> None:
-                pass
+                self.status_code = kwargs.get("status_code", 200)
+                self.body = kwargs.get("content", b"")
 
         class WebSocket:  # pragma: no cover - minimal stub
             pass
@@ -80,6 +81,7 @@ else:  # pragma: no cover - optional runtime dependency
                 self: JSONResponse, content: object, *args: object, **kwargs: object
             ) -> None:
                 self.body = json.dumps(content).encode("utf-8")
+                self.status_code = kwargs.get("status_code", 200)
 
 
 if TYPE_CHECKING:
@@ -347,6 +349,37 @@ async def get_semantic_summaries(agent_id: str, limit: int = 3) -> Response:
     return JSONResponse({"summaries": summaries})
 
 
+@app.get("/api/agents/{agent_id}/state")
+async def get_agent_state(agent_id: str) -> Response:
+    """Return the current state for an agent."""
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    state: dict[str, Any] | None = None
+    if sim is not None:
+        agent = next((a for a in sim.agents if a.agent_id == agent_id), None)
+        if agent is not None:
+            try:
+                state = cast(dict[str, Any], agent.state.model_dump())
+            except Exception:  # pragma: no cover - defensive
+                state = {}
+    return JSONResponse({"state": state or {}})
+
+
+@app.get("/api/agents/{agent_id}/memories")
+async def get_agent_memories(agent_id: str, limit: int = 5) -> Response:
+    """Return recent raw memories for an agent."""
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    memories: list[dict[str, Any]] = []
+    if sim is not None:
+        memory_service = getattr(sim, "memory_service", None)
+        vector_store = getattr(memory_service, "vector_store", None)
+        if vector_store is not None:
+            try:
+                memories = vector_store.retrieve_filtered_memories(agent_id, limit=limit)
+            except Exception:  # pragma: no cover - defensive
+                memories = []
+    return JSONResponse({"memories": memories})
+
+
 @app.post("/api/propose_law")
 async def api_propose_law(proposal: LawProposal) -> Response:
     """Submit a (weighted) law proposal to the active simulation."""
@@ -492,7 +525,10 @@ async def api_memory_snapshots(limit: int = 10) -> Response:
         for p in SNAPSHOT_DIR.glob("snapshot_*.json*")
         if p.stem.split("_")[1].isdigit()
     )
-    return JSONResponse({"steps": steps[-limit:]})
+    resp = JSONResponse({"steps": steps[-limit:]})
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
 
 
 @app.get("/api/memory_snapshots/{step}")
@@ -502,8 +538,14 @@ async def api_memory_snapshot(step: int) -> Response:
     try:
         data = await asyncio.to_thread(load_snapshot, step, directory=SNAPSHOT_DIR)
     except Exception:  # pragma: no cover - invalid or missing snapshot
-        return JSONResponse({"error": "not_found"}, status_code=404)
-    return JSONResponse(data)
+        resp = JSONResponse({"error": "not_found"}, status_code=404)
+        if not hasattr(resp, "status_code"):
+            resp.status_code = 404
+        return resp
+    resp = JSONResponse(data)
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
 
 
 async def register_widget(widget: dict[str, Any]) -> Response:


### PR DESCRIPTION
## Summary
- expose new dashboard endpoints for agent state and memory retrieval
- show agent state in storyboard and memories in memory explorer
- document new API routes
- ensure snapshot responses always include status codes

## Testing
- `SKIP=mypy,unit-tests pre-commit run --files src/interfaces/dashboard_backend.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5bdad2d48326ab4f7fbc2a1bf931