### PR TITLE
Add RAG hit rate metric

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -101,9 +101,15 @@ class MemoryService:
         """Return episodic, semantic, and optionally long-term summaries."""
         episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
         semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
+        hits = len(episodic) + len(semantic)
+        total = k + semantic_limit
         if long_term_limit:
             long_term = self.get_long_term_summaries(agent_id, long_term_limit)
+            hits += len(long_term)
+            total += long_term_limit
+            metrics.RAG_HIT_RATE.set(hits / total if total else 0)
             return episodic, semantic, long_term
+        metrics.RAG_HIT_RATE.set(hits / total if total else 0)
         return episodic, semantic
 
     async def run_semantic_job(

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -57,6 +57,9 @@ MEMORY_RETRIEVAL_ERRORS_TOTAL = Counter(
     "Total number of failed memory retrievals",
 )
 
+# Retrieval Augmented Generation (RAG) metrics
+RAG_HIT_RATE = Gauge("rag_hit_rate", "Hit rate for RAG memory retrieval")
+
 # Gas price metrics updated by ``Ledger.calculate_gas_price``
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
@@ -98,6 +101,11 @@ def get_memory_retrieval_errors() -> int:
     return int(MEMORY_RETRIEVAL_ERRORS_TOTAL._value.get())
 
 
+def get_rag_hit_rate() -> float:
+    """Return the current RAG hit rate."""
+    return float(RAG_HIT_RATE._value.get())
+
+
 __all__ = [
     "GAS_PRICE_PER_CALL",
     "GAS_PRICE_PER_TOKEN",
@@ -107,6 +115,7 @@ __all__ = [
     "LLM_LATENCY_MS",
     "MEMORY_RETRIEVALS_TOTAL",
     "MEMORY_RETRIEVAL_ERRORS_TOTAL",
+    "RAG_HIT_RATE",
     "Counter",
     "Gauge",
     "get_gas_price_per_call",
@@ -115,5 +124,6 @@ __all__ = [
     "get_llm_latency",
     "get_memory_retrieval_errors",
     "get_memory_retrievals",
+    "get_rag_hit_rate",
     "start_http_server",
 ]

--- a/tests/unit/memory/test_rag_hit_rate.py
+++ b/tests/unit/memory/test_rag_hit_rate.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.agents.memory.memory_service import MemoryService
+from src.interfaces import metrics
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_rag_hit_rate_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MemoryService()
+
+    async def fake_episodic(agent_id: str, query: str, k: int) -> list[dict[str, int]]:
+        return [{"id": 1}, {"id": 2}]
+
+    def fake_semantic(agent_id: str, limit: int) -> list[str]:
+        return ["s1"]
+
+    monkeypatch.setattr(service, "retrieve_episodic_and_update_semantic", fake_episodic)
+    monkeypatch.setattr(service, "get_recent_semantic_summaries", fake_semantic)
+    metrics.RAG_HIT_RATE.set(0)
+
+    await service.get_context_pipeline("agent", "query", k=5, semantic_limit=3)
+
+    assert metrics.get_rag_hit_rate() == pytest.approx(3 / 8)


### PR DESCRIPTION
## Summary
- add RAG_HIT_RATE gauge with accessor
- track RAG retrieval hit rate in MemoryService
- test that RAG_HIT_RATE updates after context pipeline retrieval

## Testing
- `ruff check src/interfaces/metrics.py src/agents/memory/memory_service.py tests/unit/memory/test_rag_hit_rate.py`
- `pytest tests/unit/memory/test_rag_hit_rate.py tests/unit/memory/test_multi_layer_retriever.py::test_service_metrics_increment -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8ad561048326a23b4da043ba117a