### PR TITLE
Add dashboard API token middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Start the optional HTTP dashboard backend (for streaming events via SSE):
 python -m src.http_app
 ```
 
+Set `DASHBOARD_API_TOKEN` to require an access token for state-changing (POST,
+PUT, PATCH, DELETE) endpoints. Clients must include
+`Authorization: Bearer <token>` when calling those APIs.
+
 You can then consume events using any SSE-capable client. Here's a minimal
 example using `httpx`:
 

--- a/src/http_app.py
+++ b/src/http_app.py
@@ -6,16 +6,18 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 import uvicorn
-from fastapi import Request
+from fastapi import Request, Response
 
-from src.interfaces.dashboard_backend import (
-    EventSourceResponse,
-    SimulationEvent,
-    app,
-)
+from src.interfaces import dashboard_backend as db
+from src.sim.event_bus import get_event_bus
+
+db.configure_api_token(os.getenv("DASHBOARD_API_TOKEN"))
+
+EventSourceResponse = db.EventSourceResponse
+SimulationEvent = db.SimulationEvent
+app = db.app
 
 __all__ = ["app", "generate_events", "main", "parse_args"]
-from src.sim.event_bus import get_event_bus
 
 
 async def generate_events(
@@ -31,13 +33,13 @@ async def generate_events(
             event: SimulationEvent | None = await queue.get()
             if event is None:
                 break
-            yield {"event": "simulation_event", "data": event.json()}
+            yield {"event": "simulation_event", "data": event.model_dump_json()}
     finally:
         bus.unsubscribe(queue)
 
 
 @app.get("/stream/events")
-async def stream_events(request: Request) -> EventSourceResponse:
+async def stream_events(request: Request) -> Response:
     """Return an SSE stream of simulation events."""
     return EventSourceResponse(generate_events(request))
 

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -5,7 +5,7 @@ import asyncio
 # Skip self argument annotation warnings in stub classes
 import json
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
@@ -29,6 +29,14 @@ SEMANTIC_SUMMARIES_ERROR: Final[dict[str, str]] = {"error": "summary retrieval f
 
 # Default simulation context used by module-level APIs
 DEFAULT_CONTEXT = SimulationContext()
+
+API_TOKEN: str | None = None
+
+
+def configure_api_token(token: str | None) -> None:
+    """Configure the token required for state-changing requests."""
+    global API_TOKEN
+    API_TOKEN = token
 
 
 if TYPE_CHECKING:
@@ -62,8 +70,20 @@ else:  # pragma: no cover - optional runtime dependency
 
                 return dec
 
+            def middleware(self: FastAPI, *args: object, **kwargs: object) -> Callable[[Any], Any]:
+                def dec(fn: Any) -> Any:
+                    return fn
+
+                return dec
+
         class Request:  # pragma: no cover - minimal stub
-            pass
+            def __init__(
+                self: Request,
+                headers: dict[str, str] | None = None,
+                method: str = "GET",
+            ) -> None:
+                self.headers = headers or {}
+                self.method = method
 
         class Response:  # pragma: no cover - minimal stub
             def __init__(self: Response, *args: object, **kwargs: object) -> None:
@@ -199,6 +219,17 @@ class VoteRequest(BaseModel):
 
 
 app = FastAPI()
+
+
+@app.middleware("http")
+async def require_token(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    if API_TOKEN and request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+        auth = request.headers.get("Authorization")
+        if auth != f"Bearer {API_TOKEN}":
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+    return await call_next(request)
 
 
 @app.get(

--- a/tests/integration/interfaces/test_dashboard_token_middleware.py
+++ b/tests/integration/interfaces/test_dashboard_token_middleware.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+pytest.importorskip("fastapi")
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_token_required(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_API_TOKEN", "secret")
+    for mod in ["src.http_app", "src.interfaces.dashboard_backend"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    http_app = importlib.import_module("src.http_app")
+    transport = ASGITransport(app=http_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/propose", json={"proposer_id": "a1", "text": "law"})
+        assert resp.status_code == 401
+        resp = await client.post(
+            "/api/propose",
+            json={"proposer_id": "a1", "text": "law"},
+            headers={"Authorization": "Bearer secret"},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- secure state-changing routes with DASHBOARD_API_TOKEN
- configure token in http_app and document setup
- add integration test for missing token rejection

## Testing
- `pre-commit run --files README.md src/http_app.py src/interfaces/dashboard_backend.py tests/integration/interfaces/test_dashboard_token_middleware.py` (mypy skipped)
- `pytest tests/integration/interfaces/test_dashboard_token_middleware.py -m "integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_688eacfa5da483268d38f5b2d2432eb2