### PR TITLE
Track human message metrics

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -193,6 +193,7 @@ class SimulationDiscordBot:
                 if not allowed:
                     logger.debug("Message blocked by OPA policy")
                     return
+                metrics.HUMAN_MESSAGES_TOTAL.inc()
                 channel = getattr(message, "channel", None)
                 channel_id = getattr(channel, "id", None)
                 user = getattr(message, "author", None)

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -60,6 +60,12 @@ MEMORY_RETRIEVAL_ERRORS_TOTAL = Counter(
 # Retrieval Augmented Generation (RAG) metrics
 RAG_HIT_RATE = Gauge("rag_hit_rate", "Hit rate for RAG memory retrieval")
 
+# Human interaction metrics
+HUMAN_MESSAGES_TOTAL = Counter(
+    "human_messages_total",
+    "Total number of human messages received",
+)
+
 # Gas price metrics updated by ``Ledger.calculate_gas_price``
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
@@ -106,9 +112,15 @@ def get_rag_hit_rate() -> float:
     return float(RAG_HIT_RATE._value.get())
 
 
+def get_human_messages() -> int:
+    """Return the total human messages received."""
+    return int(HUMAN_MESSAGES_TOTAL._value.get())
+
+
 __all__ = [
     "GAS_PRICE_PER_CALL",
     "GAS_PRICE_PER_TOKEN",
+    "HUMAN_MESSAGES_TOTAL",
     "KNOWLEDGE_BOARD_SIZE",
     "LLM_CALLS_TOTAL",
     "LLM_ERRORS_TOTAL",
@@ -120,6 +132,7 @@ __all__ = [
     "Gauge",
     "get_gas_price_per_call",
     "get_gas_price_per_token",
+    "get_human_messages",
     "get_kb_size",
     "get_llm_latency",
     "get_memory_retrieval_errors",

--- a/tests/unit/interfaces/test_discord_human_messages.py
+++ b/tests/unit/interfaces/test_discord_human_messages.py
@@ -1,0 +1,78 @@
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs) -> None:
+        self.user = SimpleNamespace(id="bot")
+
+    def event(self, func):
+        setattr(self, func.__name__, func)
+        return func
+
+
+class DummyBot:
+    def __init__(self, *args, **kwargs) -> None:
+        self.tree = SimpleNamespace(command=lambda *a, **k: (lambda f: f))
+
+    def command(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def reload_module(monkeypatch: pytest.MonkeyPatch):
+    dummy_commands = SimpleNamespace(Bot=DummyBot)
+    dummy_discord = SimpleNamespace(
+        Intents=SimpleNamespace(default=lambda: SimpleNamespace(message_content=True)),
+        Client=DummyClient,
+        Embed=object,
+        TextChannel=object,
+        Thread=object,
+        DiscordException=Exception,
+        Color=SimpleNamespace(blue=lambda: None),
+    )
+    monkeypatch.setitem(sys.modules, "discord", dummy_discord)
+    monkeypatch.setitem(sys.modules, "discord.ext", SimpleNamespace(commands=dummy_commands))
+    monkeypatch.setitem(sys.modules, "discord.ext.commands", dummy_commands)
+    module = importlib.reload(importlib.import_module("src.interfaces.discord_bot"))
+    return module
+
+
+@pytest.fixture()
+def discord_module(monkeypatch: pytest.MonkeyPatch):
+    module = reload_module(monkeypatch)
+    yield module
+    importlib.reload(module)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_human_messages_counter_increments(discord_module, monkeypatch):
+    monkeypatch.setattr(discord_module, "allow_message", lambda _: True)
+
+    async def dummy_eval(content):
+        return True, content
+
+    monkeypatch.setattr(discord_module, "evaluate_with_opa", dummy_eval)
+
+    from src.interfaces import metrics
+    from src.sim.context import SimulationContext
+
+    bot = discord_module.SimulationDiscordBot("token", 123, context=SimulationContext())
+
+    message = SimpleNamespace(
+        content="hello",
+        author=SimpleNamespace(id="user"),
+        channel=SimpleNamespace(id=999),
+    )
+
+    before = metrics.HUMAN_MESSAGES_TOTAL._value.get()
+    await bot.client.on_message(message)
+    after = metrics.HUMAN_MESSAGES_TOTAL._value.get()
+
+    assert after == before + 1


### PR DESCRIPTION
## Summary
- add `HUMAN_MESSAGES_TOTAL` metric and accessor
- increment counter in `SimulationDiscordBot.on_message`
- test counter increments on received message

## Testing
- `ruff check src/interfaces/metrics.py src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_human_messages.py`
- `pytest tests/unit/interfaces/test_discord_human_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb11f76d483268cddfaa09781a264