### PR TITLE
Route Discord replies to user channels

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -224,6 +224,7 @@ class SimulationDiscordBot:
         agent_id: Optional[str] = None,
         *,
         target_channel_id: Optional[int] = None,
+        recipient: Optional[str] = None,
     ) -> Optional[bool]:
         """
         Send a simulation update message to Discord.
@@ -232,6 +233,7 @@ class SimulationDiscordBot:
             content (Optional[str]): The text message content to send
             embed (Optional[Any]): The embed object to send
             target_channel_id (Optional[int]): Explicit channel to send to
+            recipient (Optional[str]): User ID to reply to
 
         Returns:
             bool: True if message was sent successfully, False otherwise
@@ -249,7 +251,11 @@ class SimulationDiscordBot:
                 return False
         try:
             client = await self._select_client(agent_id)
-            chan_id = target_channel_id or self.channel_map.get(agent_id, self.channel_id)
+            chan_id = target_channel_id
+            if chan_id is None and recipient:
+                chan_id = self.user_channels.get(recipient)
+            if chan_id is None:
+                chan_id = self.channel_map.get(agent_id, self.channel_id)
             channel = client.get_channel(chan_id)
             if not channel:
                 logger.warning(f"Could not find Discord channel with ID: {chan_id}")
@@ -518,14 +524,10 @@ class SimulationDiscordBot:
         try:
             while True:
                 msg: AgentMessage = await self.message_queue.get()
-                channel_override = None
-                recipient = msg.recipient_id
-                if recipient and recipient in self.user_channels:
-                    channel_override = self.user_channels[recipient]
                 await self.send_simulation_update(
                     content=msg.content,
                     agent_id=msg.agent_id,
-                    target_channel_id=channel_override,
+                    recipient=msg.recipient_id,
                 )
         except asyncio.CancelledError:  # pragma: no cover - task cancelled on stop
             pass

--- a/tests/integration/interfaces/test_discord_message_flow.py
+++ b/tests/integration/interfaces/test_discord_message_flow.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -133,3 +133,80 @@ async def test_event_queue_kb_post(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 
     sim.close()
     await queue.put(None)
+
+
+@pytest.mark.integration
+@pytest.mark.anyio("asyncio")
+async def test_user_channel_reply(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.interfaces.discord_bot import SimulationDiscordBot
+    from src.sim.context import SimulationContext
+
+    class RecordingChannel:
+        def __init__(self, cid: int) -> None:
+            self.id = cid
+            self.sent: list[object] = []
+
+        async def send(self, *args: object, **kwargs: object) -> None:
+            if args:
+                self.sent.append(args[0])
+            elif "embed" in kwargs:
+                self.sent.append(kwargs["embed"])
+            else:
+                self.sent.append(None)
+
+    class RecordingClient(DummyDiscordClient):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)
+            self._events: dict[str, object] = {}
+            self.channels: dict[int, RecordingChannel] = {}
+
+            def _event(func: object) -> object:
+                if hasattr(func, "__name__"):
+                    self._events[func.__name__] = func
+                return func
+
+            self.event = _event
+
+        def get_channel(self, channel_id: int) -> RecordingChannel:
+            channel = self.channels.setdefault(channel_id, RecordingChannel(channel_id))
+            return channel
+
+    q_events: asyncio.Queue[db.SimulationEvent] = asyncio.Queue()
+    q_msgs: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
+    ctx = SimulationContext()
+    ctx._event_queue = q_events
+    ctx._event_queue_loop = asyncio.get_event_loop()
+    ctx.message_queue = q_msgs
+
+    with (
+        patch("src.interfaces.discord_bot.discord.Client", RecordingClient),
+        patch(
+            "src.interfaces.discord_bot.evaluate_with_opa",
+            AsyncMock(side_effect=lambda c: (True, c)),
+        ),
+    ):
+        bot = await SimulationDiscordBot.create("token", 999, context=ctx)
+        tasks = bot.run_bot()
+        await asyncio.gather(*tasks[:-1])
+
+        on_msg = bot.client._events["on_message"]
+        msg = MagicMock()
+        msg.content = "hi"
+        msg.author = MagicMock()
+        msg.author.id = 42
+        msg.channel = MagicMock()
+        msg.channel.id = 111
+        await on_msg(msg)
+
+        await q_msgs.put(
+            db.AgentMessage(agent_id="agent1", content="hello", step=0, recipient_id="42")
+        )
+        await asyncio.sleep(0)
+
+        assert 111 in bot.client.channels
+        channel = bot.client.channels[111]
+        assert channel.sent and channel.sent[0] == "hello"
+
+        assert 999 not in bot.client.channels
+
+        await bot.stop_bot()


### PR DESCRIPTION
## Summary
- route simulation updates to a user's Discord channel when replying
- track user to channel mapping on incoming messages
- test that replies use stored user-channel map

## Testing
- `ruff check src/interfaces/discord_bot.py tests/integration/interfaces/test_discord_message_flow.py`
- `pytest tests/integration/interfaces/test_discord_message_flow.py -m "integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_688eba9e9d908326b6d91aea401a3fb1