### PR TITLE
Handle missing defaults in Simulation config

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -303,14 +303,16 @@ class Simulation:
             ip_cost = float(
                 config.get_config("IP_COST_BROADCAST_MESSAGE")
                 or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                or 0.0
             )
             du_cost = float(
                 config.get_config("DU_COST_BROADCAST_ACTION")
                 or config.get_config("DU_COST_PER_ACTION")
+                or 0.0
             )
         else:
-            ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE"))
-            du_cost = float(config.get_config("DU_COST_PER_ACTION"))
+            ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
+            du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
 
         if state.ip < ip_cost or state.du < du_cost:
             logger.info(
@@ -407,7 +409,7 @@ class Simulation:
     ) -> None:
         """Add a new agent to the simulation, inheriting genes with mutation."""
         if mutation_rate is None:
-            mutation_rate = float(config.get_config("GENE_MUTATION_RATE"))
+            mutation_rate = float(config.get_config("GENE_MUTATION_RATE") or 0.0)
 
         agent.state.ip += inheritance
 

--- a/tests/unit/sim/test_human_command_costs.py
+++ b/tests/unit/sim/test_human_command_costs.py
@@ -1,0 +1,106 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from src.infra import config
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyState:
+    def __init__(self, ip: float = 2.0, du: float = 2.0) -> None:
+        self.ip = ip
+        self.du = du
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+        self.genes = {}
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str, ip: float = 2.0, du: float = 2.0) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState(ip, du)
+        from src.infra.ledger import ledger as _ledger
+
+        _ledger.log_change(agent_id, ip, du, "init")
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:  # pragma: no cover - simple accessor
+        return self._state
+
+    def update_state(self, state: DummyState) -> None:  # pragma: no cover - unused
+        self._state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:  # pragma: no cover - unused
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_handle_human_command_missing_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+
+    dashboard_stub = types.ModuleType("src.interfaces.dashboard_backend")
+
+    class _SimulationEvent:  # pragma: no cover - simple placeholder
+        pass
+
+    def _emit_event(event: _SimulationEvent) -> None:  # pragma: no cover - placeholder
+        return None
+
+    def _emit_map_action_event(*args: object, **kwargs: object) -> None:  # pragma: no cover
+        return None
+
+    dashboard_stub.SimulationEvent = _SimulationEvent
+    dashboard_stub.emit_event = _emit_event
+    dashboard_stub.emit_map_action_event = _emit_map_action_event
+    dashboard_stub.get_event_queue = lambda: asyncio.Queue()
+    monkeypatch.setitem(sys.modules, "src.interfaces.dashboard_backend", dashboard_stub)
+
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    for key in [
+        "IP_COST_SEND_DIRECT_MESSAGE",
+        "IP_COST_BROADCAST_MESSAGE",
+        "DU_COST_PER_ACTION",
+        "DU_COST_BROADCAST_ACTION",
+    ]:
+        monkeypatch.setitem(config._CONFIG, key, None)
+
+    await sim._handle_human_command("hello")
+    await sim._handle_human_command("/broadcast hi")
+
+    assert agent.state.ip == pytest.approx(2.0)
+    assert agent.state.du == pytest.approx(2.0)
+    async with sim._msg_lock:
+        assert len(sim.pending_messages_for_next_round) == 2
+    sim.close()


### PR DESCRIPTION
## Summary
- guard float-based config lookups with `or 0.0` in simulation
- add regression test ensuring human commands work when costs are unset

## Testing
- `bash scripts/lint.sh`
- `pytest tests/unit/sim/test_human_command_costs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eba9ef2d88326b6ca7e46d06fdf7e