### PR TITLE
feat: add memory explorer page

### DIFF
--- a/culture-ui/src/App.tsx
+++ b/culture-ui/src/App.tsx
@@ -12,7 +12,7 @@ import WorldMapPage from './pages/WorldMap'
 import LawProposalPage from './pages/LawProposal'
 import ProposalsPage from './pages/Proposals'
 import TimelineWidgetPage from './pages/TimelineWidget'
-import MemoryExplorer from './pages/MemoryExplorer'
+import MemoryExplorerPage from './pages/MemoryExplorer'
 import KpiCardPage from './pages/KpiCard'
 import StoryboardPage from './pages/Storyboard'
 import AgentTimelinePage from './pages/AgentTimeline'
@@ -35,7 +35,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/missions" element={<MissionOverview />} />
             <Route path="/agent-data" element={<AgentDataOverview />} />
-            <Route path="/memory" element={<MemoryExplorer />} />
+            <Route path="/memory" element={<MemoryExplorerPage />} />
             <Route path="/live-map" element={<LiveMapPage />} />
             <Route path="/map-state" element={<MapStatePage />} />
             <Route path="/agent-memories" element={<AgentMemoriesPage />} />

--- a/culture-ui/src/MemoryExplorer.test.tsx
+++ b/culture-ui/src/MemoryExplorer.test.tsx
@@ -1,33 +1,33 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { vi } from 'vitest'
 import App from './App'
+import { MockEventSource, resetMockSources } from './lib/testUtils'
 
 vi.mock('./App.css', () => ({}))
 
 describe('MemoryExplorer', () => {
   let fetchMock: ReturnType<typeof vi.fn>
   beforeEach(() => {
+    resetMockSources()
+    ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
+      MockEventSource as unknown as typeof EventSource
     fetchMock = vi.fn((url: string) => {
-      if (url === '/api/agents/agent-1/semantic_summaries') {
+      if (url === '/api/map') {
         return Promise.resolve({
-          json: () => Promise.resolve({ summaries: ['hello world'] }),
+          json: () =>
+            Promise.resolve({ agents: { 'agent-1': {}, 'agent-2': {} } }),
         }) as unknown as Response
       }
-      if (url === '/api/agents/agent-1/memories') {
+      if (url === '/api/memory/agent-1') {
         return Promise.resolve({
-          json: () => Promise.resolve({ memories: [{ content: 'm1' }] }),
+          json: () => Promise.resolve({ semantic: ['s1'], episodic: ['e1'] }),
         }) as unknown as Response
       }
-      if (url === '/api/agents/agent-2/semantic_summaries') {
+      if (url === '/api/memory/agent-2') {
         return Promise.resolve({
-          json: () => Promise.resolve({ summaries: ['second'] }),
-        }) as unknown as Response
-      }
-      if (url === '/api/agents/agent-2/memories') {
-        return Promise.resolve({
-          json: () => Promise.resolve({ memories: [{ content: 'm2' }] }),
+          json: () => Promise.resolve({ semantic: ['s2'], episodic: ['e2'] }),
         }) as unknown as Response
       }
       return Promise.resolve({ json: () => Promise.resolve({}) }) as Response
@@ -36,67 +36,34 @@ describe('MemoryExplorer', () => {
   })
 
   afterEach(() => {
+    resetMockSources()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
-  it('fetches summaries for selected agent', async () => {
+  it('loads map, memories, and streams messages', async () => {
     render(
       <MemoryRouter initialEntries={["/memory"]}>
         <App />
       </MemoryRouter>,
     )
 
-    expect(await screen.findByText('hello world')).toBeInTheDocument()
-    expect(await screen.findByText('m1')).toBeInTheDocument()
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/api/agents/agent-1/semantic_summaries',
-    )
-    expect(fetchMock).toHaveBeenCalledWith('/api/agents/agent-1/memories')
+    expect(fetchMock).toHaveBeenCalledWith('/api/map')
+    expect(await screen.findByText('s1')).toBeInTheDocument()
+    expect(await screen.findByText('e1')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/api/memory/agent-1')
 
-    const input = screen.getByLabelText('agent-select')
-    await userEvent.clear(input)
-    await userEvent.type(input, 'agent-2')
+    const es = MockEventSource.instances[0]
+    act(() => {
+      es.emitMessage('{"agent_id":"agent-1","content":"hello"}')
+    })
+    expect(await screen.findByText('hello')).toBeInTheDocument()
 
-    expect(await screen.findByText('second')).toBeInTheDocument()
-    expect(await screen.findByText('m2')).toBeInTheDocument()
-    expect(
-      fetchMock.mock.calls.some(
-        (c) => c[0] === '/api/agents/agent-2/semantic_summaries',
-      ),
-    ).toBe(true)
-    expect(
-      fetchMock.mock.calls.some((c) => c[0] === '/api/agents/agent-2/memories'),
-    ).toBe(true)
-  })
-
-  it('keeps previous summaries when fetch fails', async () => {
-    render(
-      <MemoryRouter initialEntries={["/memory"]}>
-        <App />
-      </MemoryRouter>,
-    )
-
-    expect(await screen.findByText('hello world')).toBeInTheDocument()
-    expect(await screen.findByText('m1')).toBeInTheDocument()
-
-    fetchMock.mockImplementation(() => Promise.reject(new Error('fail')))
-
-    const input = screen.getByLabelText('agent-select')
-    await userEvent.clear(input)
-    await userEvent.type(input, 'agent-2')
-
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledWith(
-        '/api/agents/agent-2/semantic_summaries',
-      ),
-    )
-
-    expect(screen.queryByText('hello world')).toBeInTheDocument()
-    expect(screen.queryByText('m1')).toBeInTheDocument()
-    expect(screen.getByTestId('summaries').textContent?.trim()).toBe(
-      'hello world',
-    )
-    expect(screen.getByTestId('memories').textContent?.trim()).toBe('m1')
+    const select = screen.getByLabelText('agent-select')
+    await userEvent.selectOptions(select, 'agent-2')
+    expect(fetchMock).toHaveBeenCalledWith('/api/memory/agent-2')
+    expect(await screen.findByText('s2')).toBeInTheDocument()
+    expect(await screen.findByText('e2')).toBeInTheDocument()
   })
 })
+

--- a/culture-ui/src/pages/MemoryExplorer.tsx
+++ b/culture-ui/src/pages/MemoryExplorer.tsx
@@ -1,19 +1,60 @@
-import EventConsole from '../widgets/EventConsole'
-import BreakpointList from '../widgets/BreakpointList'
 import { useEffect, useState } from 'react'
 
-export default function MemoryExplorer() {
-  const [agentId, setAgentId] = useState('agent-1')
-  const [summaries, setSummaries] = useState<string[]>([])
-  const [memories, setMemories] = useState<string[]>([])
+interface AgentInfo {
+  mood?: number
+  summary?: string
+}
+
+interface MessagePayload {
+  agent_id?: string
+  content?: string
+}
+
+export default function MemoryExplorerPage() {
+  const [agents, setAgents] = useState<string[]>([])
+  const [agentId, setAgentId] = useState('')
+  const [semantic, setSemantic] = useState<string[]>([])
+  const [episodic, setEpisodic] = useState<string[]>([])
+  const [messages, setMessages] = useState<string[]>([])
 
   useEffect(() => {
     let cancelled = false
     async function load() {
       try {
-        const res = await fetch(`/api/agents/${agentId}/semantic_summaries`)
-        const json = await res.json()
-        if (!cancelled) setSummaries(json.summaries || [])
+        const res = await fetch('/api/map')
+        const json = (await res.json()) as {
+          agents?: Record<string, AgentInfo>
+        }
+        if (cancelled) return
+        const ids = Object.keys(json.agents || {})
+        setAgents(ids)
+        if (ids.length) setAgentId(ids[0])
+      } catch {
+        /* ignore */
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!agentId) return
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch(`/api/memory/${agentId}`)
+        const json = (await res.json()) as {
+          semantic?: string[]
+          episodic?: Array<{ content?: string } | string>
+        }
+        if (cancelled) return
+        setSemantic(json.semantic || [])
+        const eps = (json.episodic || []).map((m) =>
+          typeof m === 'string' ? m : m.content || String(m),
+        )
+        setEpisodic(eps)
       } catch {
         /* ignore */
       }
@@ -25,50 +66,51 @@ export default function MemoryExplorer() {
   }, [agentId])
 
   useEffect(() => {
-    let cancelled = false
-    async function load() {
+    if (!agentId) return
+    const es = new EventSource('/stream/messages')
+    es.onmessage = (ev) => {
       try {
-        const res = await fetch(`/api/agents/${agentId}/memories`)
-        const json = await res.json()
-        if (!cancelled) {
-          const items = (json.memories || []).map(
-            (m: { content?: string }) => m.content || String(m),
-          )
-          setMemories(items)
+        const msg = JSON.parse(ev.data) as MessagePayload
+        if (!msg.agent_id || msg.agent_id === agentId) {
+          setMessages((cur) => [...cur, msg.content || String(ev.data)])
         }
       } catch {
-        /* ignore */
+        setMessages((cur) => [...cur, String(ev.data)])
       }
     }
-    void load()
-    return () => {
-      cancelled = true
-    }
+    return () => es.close()
   }, [agentId])
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Memory Explorer</h1>
       <label className="block">
-        Agent ID:
-        <input
+        Agent:
+        <select
           aria-label="agent-select"
           value={agentId}
           onChange={(e) => setAgentId(e.target.value)}
           className="border p-1 ml-2"
-        />
+        >
+          {agents.map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
       </label>
-      <div className="grid gap-4 grid-cols-2">
-        <BreakpointList />
-        <EventConsole />
-      </div>
       <div data-testid="summaries">
-        {summaries.map((s, i) => (
+        {semantic.map((s, i) => (
           <div key={i}>{s}</div>
         ))}
       </div>
       <div data-testid="memories">
-        {memories.map((m, i) => (
+        {episodic.map((m, i) => (
+          <div key={i}>{m}</div>
+        ))}
+      </div>
+      <div data-testid="messages">
+        {messages.map((m, i) => (
           <div key={i}>{m}</div>
         ))}
       </div>

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -411,6 +411,32 @@ async def get_agent_memories(agent_id: str, limit: int = 5) -> Response:
     return JSONResponse({"memories": memories})
 
 
+@app.get("/api/memory/{agent_id}")
+async def api_memory(agent_id: str, limit: int = 5) -> Response:
+    """Return semantic and episodic memories for an agent."""
+    semantic: list[str] = []
+    episodic: list[dict[str, Any]] = []
+
+    manager = DEFAULT_CONTEXT.sim_state.get("semantic_manager")
+    if manager is not None:
+        try:
+            semantic = manager.get_semantic_summaries(agent_id, limit=limit)
+        except Exception:  # pragma: no cover - defensive
+            semantic = []
+
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    if sim is not None:
+        memory_service = getattr(sim, "memory_service", None)
+        vector_store = getattr(memory_service, "vector_store", None)
+        if vector_store is not None:
+            try:
+                episodic = vector_store.retrieve_filtered_memories(agent_id, limit=limit)
+            except Exception:  # pragma: no cover - defensive
+                episodic = []
+
+    return JSONResponse({"semantic": semantic, "episodic": episodic})
+
+
 @app.post("/api/propose_law")
 async def api_propose_law(proposal: LawProposal) -> Response:
     """Submit a (weighted) law proposal to the active simulation."""
@@ -744,6 +770,7 @@ __all__ = [
     "api_get_proposals",
     "api_get_votes",
     "api_map",
+    "api_memory",
     "api_memory_snapshot",
     "api_memory_snapshots",
     "api_propose_law",

--- a/tests/unit/interfaces/test_dashboard_memory_endpoint.py
+++ b/tests/unit/interfaces/test_dashboard_memory_endpoint.py
@@ -1,0 +1,34 @@
+import json
+import pytest
+from src.interfaces import dashboard_backend as db
+
+
+class DummyVectorStore:
+    def retrieve_filtered_memories(self, agent_id: str, limit: int = 5):
+        return [{"content": "m1"}][:limit]
+
+
+class DummyMemoryService:
+    def __init__(self) -> None:
+        self.vector_store = DummyVectorStore()
+
+
+class DummySim:
+    def __init__(self) -> None:
+        self.memory_service = DummyMemoryService()
+
+
+class DummyManager:
+    def get_semantic_summaries(self, agent_id: str, limit: int = 5):
+        return ["s1"][:limit]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "semantic_manager", DummyManager())
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "simulation", DummySim())
+
+    resp = await db.api_memory("agent", limit=1)
+    data = json.loads(resp.body)
+    assert data == {"semantic": ["s1"], "episodic": [{"content": "m1"}]}


### PR DESCRIPTION
## Summary
- add Memory Explorer page consuming `/api/map` and `/stream/messages`
- expose `/api/memory/{agent_id}` endpoint for combined semantic and episodic memories
- wire Memory Explorer route in app

## Testing
- `pre-commit run ruff --files src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_memory_endpoint.py`
- `pre-commit run ruff-format --files src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_memory_endpoint.py`
- `pytest tests/unit/interfaces/test_dashboard_memory_endpoint.py -q`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_688f89c77310832690c77de121b111b4