### PR TITLE
Prefer vLLM client with fallback and update start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,15 @@ export VLLM_API_BASE="http://localhost:$VLLM_PORT"
 export LLM_API_BASE="$VLLM_API_BASE"   # overrides Ollama when set
 ```
 
-Requests now use vLLM instead of Ollama. See [docs/runbook.md](docs/runbook.md#start-vllm) for additional details. Run `scripts/benchmark_llm.py` to verify the endpoint.
+Requests now use vLLM instead of Ollama. See [docs/runbook.md](docs/runbook.md#start-vllm) for additional details.
+
+To compare latency between Ollama and vLLM, use the benchmarking helper:
+
+```bash
+python scripts/benchmark_llm.py "Hello" --runs 3 --model mistral:latest --vllm_base "http://localhost:$VLLM_PORT"
+```
+
+The script prints a table with average response times for each backend.
 
 5. **Run the vertical slice demo**
    ```bash

--- a/scripts/start_vllm.sh
+++ b/scripts/start_vllm.sh
@@ -10,9 +10,12 @@ if [ -f ".env" ]; then
   set +a
 fi
 
-MODEL=${VLLM_MODEL:-"mistralai/Mistral-7B-Instruct-v0.2"}
-PORT=${VLLM_PORT:-8001}
-SWAP=${VLLM_SWAP_SPACE:-16}
+MODEL=${VLLM_MODEL:-${MODEL:-"mistralai/Mistral-7B-Instruct-v0.2"}}
+PORT=${VLLM_PORT:-${PORT:-8001}}
+SWAP=${VLLM_SWAP_SPACE:-${SWAP:-16}}
+
+echo "Starting vLLM server with model '${MODEL}' on port ${PORT}" >&2
+echo "Set VLLM_API_BASE=http://localhost:${PORT} to connect" >&2
 
 python -m vllm.entrypoints.openai.api_server \
   --model "${MODEL}" \

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -277,12 +277,11 @@ class LLMClient:
     ) -> LLMChatResponse:
         if not self._client:
             raise RuntimeError("Ollama client not initialized")
-        if hasattr(self._client, "async_chat"):
+        async_chat = getattr(self._client, "async_chat", None)
+        if async_chat and asyncio.iscoroutinefunction(async_chat):
             return cast(
                 LLMChatResponse,
-                await cast(Any, self._client.async_chat)(
-                    model=model, messages=messages, options=options
-                ),
+                await cast(Any, async_chat)(model=model, messages=messages, options=options),
             )
         return cast(
             LLMChatResponse,
@@ -417,20 +416,7 @@ def _create_ollama_client() -> OllamaClientProtocol:
     return cast(OllamaClientProtocol, ollama.Client(host=LLM_API_BASE))
 
 
-client: OllamaClientProtocol | None
-if USE_VLLM:
-    logger.info(f"Using vLLM API base: {VLLM_API_BASE or LLM_API_BASE}")
-    client = _create_vllm_client()
-else:
-    try:
-        client = _create_ollama_client()
-        logger.info(f"Ollama client initialized for host: {LLM_API_BASE}")
-    except (APIError, RequestException) as e:
-        logger.error(
-            f"Failed to initialize Ollama client for host {LLM_API_BASE}: {e}",
-            exc_info=True,
-        )
-        client = None
+client: OllamaClientProtocol | None = None
 
 
 def get_llm_client() -> OllamaClientProtocol:
@@ -438,41 +424,32 @@ def get_llm_client() -> OllamaClientProtocol:
     global client, LLM_API_BASE, VLLM_API_BASE, USE_VLLM
     current_base = cast(str, get_config("LLM_API_BASE"))
     current_vllm = cast(str | None, get_config("VLLM_API_BASE"))
-    prefer_vllm = bool(current_vllm)
 
     if current_base != LLM_API_BASE or current_vllm != VLLM_API_BASE:
         LLM_API_BASE = current_base
         VLLM_API_BASE = current_vllm
         client = None
 
-    if client is None or (prefer_vllm and not USE_VLLM):
-        # When ``VLLM_API_BASE`` is provided prefer the vLLM client. If
-        # initialization fails, fall back to the Ollama client. When the
-        # variable is unset, keep the existing client to avoid unnecessary
-        # reinitialization during tests.
-        primary = _create_vllm_client if prefer_vllm else _create_ollama_client
-        secondary = _create_ollama_client if prefer_vllm else _create_vllm_client
-
-        client, err = _retry_with_backoff(primary)
+    if client is None:
+        client, err = _retry_with_backoff(_create_vllm_client)
         if client is None:
             logger.error(
-                "Failed to initialize %s client: %s",
-                "vLLM" if prefer_vllm else "Ollama",
+                "Failed to initialize vLLM client: %s",
                 err,
                 exc_info=True,
             )
-            client, err = _retry_with_backoff(secondary)
+            client, err = _retry_with_backoff(_create_ollama_client)
             if client is None:
                 logger.error(
-                    "Failed to initialize %s client: %s",
-                    "Ollama" if prefer_vllm else "vLLM",
+                    "Failed to initialize Ollama client: %s",
                     err,
                     exc_info=True,
                 )
                 raise LLMClientInitError("Failed to initialize vLLM and Ollama clients")
-            USE_VLLM = not prefer_vllm
+            USE_VLLM = False
         else:
-            USE_VLLM = prefer_vllm
+            logger.info(f"Using vLLM API base: {VLLM_API_BASE or LLM_API_BASE}")
+            USE_VLLM = True
     return client
 
 
@@ -954,7 +931,10 @@ async def async_generate_structured_output(
         async with httpx.AsyncClient() as client:
             response = await client.post(url, json=payload, timeout=timeout_value)
         response.raise_for_status()
-        result = cast(JSONDict, json.loads(response.text))
+        try:
+            result = cast(JSONDict, response.json())
+        except Exception:
+            result = cast(JSONDict, json.loads(response.text))
         if USE_VLLM:
             choices = cast(list[JSONDict], result.get("choices", []))
             first_choice = choices[0] if choices else {}

--- a/tests/unit/infra/test_llm_client_vllm.py
+++ b/tests/unit/infra/test_llm_client_vllm.py
@@ -13,17 +13,19 @@ from src.shared import decorator_utils
 def test_generate_text_vllm(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, str] = {}
 
+    resp_text = json.dumps(
+        {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    )
+
     async def fake_post(*args: object, **kwargs: object) -> MagicMock:
         url = args[1] if len(args) > 1 else args[0]
         captured["url"] = url
         resp = MagicMock()
         resp.raise_for_status.return_value = None
-        resp.text = json.dumps(
-            {
-                "choices": [{"message": {"content": "hi"}}],
-                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
-            }
-        )
+        resp.text = resp_text
         return resp
 
     monkeypatch.setattr(llm_client, "LLM_API_BASE", "http://ollama:1234")
@@ -53,17 +55,19 @@ def test_generate_text_vllm_env_switch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Setting ``VLLM_API_BASE`` should make the client use the vLLM endpoint."""
     captured: dict[str, str] = {}
 
+    resp_text = json.dumps(
+        {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    )
+
     async def fake_post(*args: object, **kwargs: object) -> MagicMock:
         url = args[1] if len(args) > 1 else args[0]
         captured["url"] = url
         resp = MagicMock()
         resp.raise_for_status.return_value = None
-        resp.text = json.dumps(
-            {
-                "choices": [{"message": {"content": "hi"}}],
-                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
-            }
-        )
+        resp.text = resp_text
         return resp
 
     monkeypatch.setenv("VLLM_API_BASE", "http://vllm:8002")
@@ -96,17 +100,19 @@ def test_vllm_client_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """When ``VLLM_API_BASE`` is unset, fallback to ``LLM_API_BASE``."""
     captured: dict[str, str] = {}
 
+    resp_text = json.dumps(
+        {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    )
+
     async def fake_post(*args: object, **kwargs: object) -> MagicMock:
         url = args[1] if len(args) > 1 else args[0]
         captured["url"] = url
         resp = MagicMock()
         resp.raise_for_status.return_value = None
-        resp.text = json.dumps(
-            {
-                "choices": [{"message": {"content": "hi"}}],
-                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
-            }
-        )
+        resp.text = resp_text
         return resp
 
     monkeypatch.setattr(llm_client, "LLM_API_BASE", "http://ollama:1234")


### PR DESCRIPTION
## Summary
- default to vLLM client and fall back to Ollama when unavailable
- improve `start_vllm.sh` with env var support and helpful startup messages
- document the `benchmark_llm.py` helper in README
- make structured output parsing resilient and ensure async calls only await coroutine clients
- stabilize vLLM tests by precomputing mock responses

## Testing
- `ruff check src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `black --check src/infra/llm_client.py tests/unit/infra/test_llm_client_vllm.py`
- `mypy src/infra/llm_client.py`
- `python -m pytest tests/unit/infra/test_llm_client_vllm.py::test_generate_text_vllm tests/unit/infra/test_llm_client_vllm.py::test_generate_text_vllm_env_switch tests/unit/infra/test_llm_client_vllm.py::test_vllm_client_fallback`
- `python -m pytest tests/unit/infra/test_llm_client_url.py::test_generate_structured_output_uses_base_url`
- `python -m pytest tests/unit/infra/test_llm_du_cost.py::test_du_never_negative`


------
https://chatgpt.com/codex/tasks/task_e_688f89c8b4748326bb13ea364074feca