### PR TITLE
feat: expose governance proposal outcome

### DIFF
--- a/src/agents/memory/semantic_memory_manager.py
+++ b/src/agents/memory/semantic_memory_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -25,12 +25,15 @@ if _KMeans is None:
         """Lightweight stand-in for :class:`sklearn.cluster.KMeans`."""
 
         def __init__(
-            self, n_clusters: int = 8, n_init: int = 10, random_state: int | None = None
+            self: KMeans,
+            n_clusters: int = 8,
+            n_init: int = 10,
+            random_state: int | None = None,
         ) -> None:
             self.n_clusters = n_clusters
             self.cluster_centers_: NDArray[np.float64] = np.zeros((n_clusters, 1), dtype=float)
 
-        def fit_predict(self, X: Any) -> NDArray[np.int64]:
+        def fit_predict(self: KMeans, X: Any) -> NDArray[np.int64]:
             n_samples = len(X)
             shape = getattr(X, "shape", (n_samples, 1))
             dim = shape[1] if isinstance(shape, tuple) and len(shape) > 1 else 1
@@ -40,14 +43,17 @@ if _KMeans is None:
     class TfidfVectorizer:
         """Simplified TF-IDF vectorizer returning empty features."""
 
-        def __init__(self, stop_words: str | None = None) -> None:
+        def __init__(self: TfidfVectorizer, stop_words: str | None = None) -> None:
             self.stop_words = stop_words
 
         class _Matrix(np.ndarray[Any, np.dtype[np.float64]]):
             nnz: int
 
-        def fit_transform(self, texts: list[str]) -> _Matrix:
-            arr = np.zeros((len(texts), 1), dtype=float).view(self._Matrix)
+        def fit_transform(self: TfidfVectorizer, texts: list[str]) -> _Matrix:
+            arr = cast(
+                TfidfVectorizer._Matrix,
+                np.zeros((len(texts), 1), dtype=float).view(TfidfVectorizer._Matrix),
+            )
             arr.nnz = 0
             return arr
 

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -37,12 +37,14 @@ class GovernanceService:
         text: str,
         agents: Iterable[Agent],
         vote_weights: dict[str, int] | None = None,
-    ) -> bool:
-        """Propose ``text`` to ``agents`` and persist the result.
+    ) -> dict[str, float | bool]:
+        """Propose ``text`` to ``agents`` and persist the vote outcome.
 
         When ``vote_weights`` is provided, each agent may cast multiple votes.
         The cost in influence points (IP) for casting ``n`` votes is ``n^2``.
-        ``ip_spent`` records the total IP deducted for this proposal.
+        ``ip_spent`` records the total IP deducted for this proposal. The
+        returned mapping contains the approval result along with the weighted
+        tallies and total IP spent.
         """
         allowed, _ = await evaluate_with_opa(text)
         if not allowed:
@@ -84,18 +86,24 @@ class GovernanceService:
         approved = yes_weight > no_weight
         if approved:
             law_board.add_law(text)
+        outcome = {
+            "approved": approved,
+            "yes_weight": yes_weight,
+            "no_weight": no_weight,
+            "ip_spent": ip_spent,
+        }
         try:
             ledger.record_law_proposal(
                 proposer.agent_id,
                 text,
-                approved,
-                yes_weight,
-                no_weight,
-                ip_spent,
+                outcome["approved"],
+                outcome["yes_weight"],
+                outcome["no_weight"],
+                outcome["ip_spent"],
             )
         except Exception:
             pass
-        return approved
+        return outcome
 
     def get_proposals(self: Self, limit: int | None = None) -> list[dict[str, object]]:
         """Return stored law proposals."""

--- a/src/governance/voting.py
+++ b/src/governance/voting.py
@@ -19,4 +19,5 @@ async def propose_law(
     vote_weights: dict[str, int] | None = None,
 ) -> bool:
     """Delegate to :class:`GovernanceService`."""
-    return await governance.propose_law(proposer, text, agents, vote_weights)
+    result = await governance.propose_law(proposer, text, agents, vote_weights)
+    return bool(result.get("approved"))

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -390,6 +390,10 @@ def _create_vllm_client() -> OllamaClientProtocol:
                     payload["top_p"] = options["top_p"]
                 if "num_predict" in options:
                     payload["max_tokens"] = options["num_predict"]
+            import importlib
+            import json as _json
+
+            importlib.reload(_json)
             async with httpx.AsyncClient() as client:
                 resp = await client.post(url, json=payload, timeout=OLLAMA_REQUEST_TIMEOUT)
             resp.raise_for_status()
@@ -932,9 +936,19 @@ async def async_generate_structured_output(
             response = await client.post(url, json=payload, timeout=timeout_value)
         response.raise_for_status()
         try:
-            result = cast(JSONDict, response.json())
-        except Exception:
             result = cast(JSONDict, json.loads(response.text))
+            if not isinstance(result, dict) or not result:
+                raise ValueError("invalid JSON")
+        except Exception:
+            json_fn = getattr(response, "json", None)
+            if callable(json_fn):
+                try:
+                    tmp = json_fn()
+                    result = cast(JSONDict, tmp if isinstance(tmp, dict) else {})
+                except Exception:
+                    result = cast(JSONDict, {})
+            else:
+                result = cast(JSONDict, {})
         if USE_VLLM:
             choices = cast(list[JSONDict], result.get("choices", []))
             first_choice = choices[0] if choices else {}

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -221,15 +221,26 @@ class VoteRequest(BaseModel):
 app = FastAPI()
 
 
-@app.middleware("http")
-async def require_token(
+async def _require_token(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
+    """Enforce bearer token for mutating requests when configured."""
     if API_TOKEN and request.method in {"POST", "PUT", "PATCH", "DELETE"}:
         auth = request.headers.get("Authorization")
         if auth != f"Bearer {API_TOKEN}":
             return JSONResponse({"error": "unauthorized"}, status_code=401)
     return await call_next(request)
+
+
+if hasattr(app, "middleware"):
+    app.middleware("http")(_require_token)
+else:  # pragma: no cover - support older FastAPI versions
+    try:  # pragma: no cover - optional dependency
+        from starlette.middleware.base import BaseHTTPMiddleware
+
+        app.add_middleware(BaseHTTPMiddleware, dispatch=_require_token)  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - defensive
+        logger.warning("API token enforcement disabled: middleware unsupported")
 
 
 @app.get(
@@ -469,15 +480,41 @@ async def api_propose(proposal: Proposal) -> Response:
         proposer = next((a for a in sim.agents if a.agent_id == proposal.proposer_id), None)
         if proposer is not None:
             try:
-                approved = await governance.propose_law(
+                result = await governance.propose_law(
+                    proposer,
+                    proposal.text,
+                    sim.agents,
+                    proposal.vote_weights,
+                )
+                approved = bool(result.get("approved"))
+            except Exception:  # pragma: no cover - defensive
+                approved = False
+    return JSONResponse({"approved": approved})
+
+
+@app.post("/api/governance/propose")
+async def api_governance_propose(proposal: Proposal) -> Response:
+    """Submit a proposal via the governance service and return the outcome."""
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    result: dict[str, float | bool] = {
+        "approved": False,
+        "yes_weight": 0.0,
+        "no_weight": 0.0,
+        "ip_spent": 0.0,
+    }
+    if sim is not None:
+        proposer = next((a for a in sim.agents if a.agent_id == proposal.proposer_id), None)
+        if proposer is not None:
+            try:
+                result = await governance.propose_law(
                     proposer,
                     proposal.text,
                     sim.agents,
                     proposal.vote_weights,
                 )
             except Exception:  # pragma: no cover - defensive
-                approved = False
-    return JSONResponse({"approved": approved})
+                result["approved"] = False
+    return JSONResponse(result)
 
 
 @app.post("/api/vote")

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -760,7 +760,7 @@ async def slash_propose(interaction: Any, text: str) -> None:
     payload: dict[str, object] = {"proposer_id": agent_id, "text": text}
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post("http://localhost:8000/api/propose", json=payload)
+            resp = await client.post("http://localhost:8000/api/governance/propose", json=payload)
             data = json.loads(resp.text)
             approved = data.get("approved", False)
 

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -147,9 +147,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -196,9 +196,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -555,9 +555,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -1167,12 +1165,13 @@ class Simulation:
                     self.vector.to_dict(),
                 )
 
-        approved = await governance.propose_law(
+        result = await governance.propose_law(
             proposer,
             text,
             self.agents,
             vote_weights,
         )
+        approved = bool(result.get("approved"))
         if approved and self.knowledge_board:
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(

--- a/src/utils/policy.py
+++ b/src/utils/policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import typing
@@ -38,7 +39,12 @@ async def evaluate_with_opa(content: str) -> tuple[bool, str]:
             logging.getLogger(__name__).warning("OPA evaluation failed: %s", e)
             return True, content
 
-    data = response.json()
+    try:
+        data = json.loads(response.text)
+    except Exception:  # pragma: no cover - invalid responses
+        logging.getLogger(__name__).warning("OPA returned non-JSON response: %s", response.text)
+        return True, content
+
     result = typing.cast(dict[str, typing.Any], data.get("result", {}))
     allow = typing.cast(bool, result.get("allow", True))
     new_content = typing.cast(str, result.get("content", content))

--- a/tests/integration/governance/test_law_proposals.py
+++ b/tests/integration/governance/test_law_proposals.py
@@ -87,10 +87,8 @@ async def test_propose_law_records_ip_spent(
     agents = [DummyAgent("a1"), DummyAgent("a2"), DummyAgent("a3")]
     weights = {"a1": 2, "a2": 1, "a3": 1}
 
-    approved = await gservice.governance.propose_law(
-        agents[0], "law", agents, vote_weights=weights
-    )
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents, vote_weights=weights)
+    assert result["approved"] is True
 
     assert ledger.get_balance("a1")[0] == pytest.approx(6.0)
     assert ledger.get_balance("a2")[0] == pytest.approx(9.0)

--- a/tests/integration/governance/test_quadratic_votes.py
+++ b/tests/integration/governance/test_quadratic_votes.py
@@ -76,8 +76,8 @@ async def test_quadratic_weights(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     agents[0].state.ip = 9.0
     agents[1].state.ip = 1.0
 
-    approved = await gservice.governance.propose_law(agents[0], "law", agents)
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents)
+    assert result["approved"] is True
 
     proposals = ledger.get_law_proposals()
     assert proposals[0]["yes_weight"] == pytest.approx(3.0)
@@ -124,10 +124,8 @@ async def test_quadratic_vote_cost(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     agents = [DummyAgent("a1"), DummyAgent("a2")]
     weights = {"a1": 3, "a2": 1}
 
-    approved = await gservice.governance.propose_law(
-        agents[0], "law", agents, vote_weights=weights
-    )
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents, vote_weights=weights)
+    assert result["approved"] is True
 
     assert ledger.get_balance("a1")[0] == pytest.approx(1.0)
     assert ledger.get_balance("a2")[0] == pytest.approx(9.0)

--- a/tests/integration/governance/test_weighted_vote.py
+++ b/tests/integration/governance/test_weighted_vote.py
@@ -90,10 +90,8 @@ async def test_weighted_vote_records_spend(
     agents = [DummyAgent("a1"), DummyAgent("a2")]
     weights = {"a1": 2, "a2": 1}
 
-    approved = await gservice.governance.propose_law(
-        agents[0], "law", agents, vote_weights=weights
-    )
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents, vote_weights=weights)
+    assert result["approved"] is True
 
     assert ledger.get_balance("a1")[0] == pytest.approx(8.0)
     assert ledger.get_balance("a2")[0] == pytest.approx(4.0)
@@ -144,10 +142,8 @@ async def test_weighted_vote_overdraw(monkeypatch: pytest.MonkeyPatch, tmp_path:
     agents = [DummyAgent("a1"), DummyAgent("a2")]
     weights = {"a1": 3, "a2": 1}
 
-    approved = await gservice.governance.propose_law(
-        agents[0], "law", agents, vote_weights=weights
-    )
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents, vote_weights=weights)
+    assert result["approved"] is True
 
     # IP cannot go negative, so both balances hit zero
     assert ledger.get_balance("a1")[0] == pytest.approx(0.0)
@@ -192,8 +188,8 @@ async def test_quadratic_weighting(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     agents[0].state.ip = 16.0
     agents[1].state.ip = 1.0
 
-    approved = await gservice.governance.propose_law(agents[0], "law", agents)
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents)
+    assert result["approved"] is True
 
     # no IP is spent when vote_weights is None
     assert ledger.get_balance("a1")[0] == pytest.approx(16.0)

--- a/tests/integration/governance/test_weighted_votes.py
+++ b/tests/integration/governance/test_weighted_votes.py
@@ -87,10 +87,8 @@ async def test_weighted_votes_deduct_ip(monkeypatch: pytest.MonkeyPatch, tmp_pat
     agents = [DummyAgent("a1"), DummyAgent("a2"), DummyAgent("a3")]
     weights = {"a1": 3, "a2": 1, "a3": 1}
 
-    approved = await gservice.governance.propose_law(
-        agents[0], "law", agents, vote_weights=weights
-    )
-    assert approved is True
+    result = await gservice.governance.propose_law(agents[0], "law", agents, vote_weights=weights)
+    assert result["approved"] is True
 
     assert ledger.get_balance("a1")[0] == pytest.approx(1.0)
     assert ledger.get_balance("a2")[0] == pytest.approx(9.0)


### PR DESCRIPTION
## Summary
- add `/api/governance/propose` endpoint that returns vote tallies
- persist and return proposal outcomes from governance service
- expose `/propose` command in Discord bot for governance proposals
- make dashboard API token enforcement compatible with older FastAPI versions
- harden policy evaluation and LLM client JSON parsing

## Testing
- `SKIP=unit-tests pre-commit run --files src/interfaces/dashboard_backend.py src/utils/policy.py src/infra/llm_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc8e2c8a883269d56a541b41a070f