### PR TITLE
feat: add agent streaming endpoints and dashboard UI

### DIFF
--- a/culture-ui/src/components/AgentEmotions.tsx
+++ b/culture-ui/src/components/AgentEmotions.tsx
@@ -1,0 +1,18 @@
+import { useAgentStream } from '../lib/useAgentStream'
+
+export default function AgentEmotions() {
+  const agents = useAgentStream()?.agents ?? []
+
+  return (
+    <div>
+      <h2 className="font-bold">Agent Emotions</h2>
+      <ul>
+        {agents.map((ag) => (
+          <li key={ag.agent_id}>
+            {ag.agent_id}: {ag.mood ?? 'n/a'}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/culture-ui/src/components/AgentMemories.tsx
+++ b/culture-ui/src/components/AgentMemories.tsx
@@ -1,0 +1,21 @@
+import { useAgentStream } from '../lib/useAgentStream'
+
+export default function AgentMemories() {
+  const agents = useAgentStream()?.agents ?? []
+
+  return (
+    <div>
+      <h2 className="font-bold">Top Memories</h2>
+      {agents.map((ag) => (
+        <div key={ag.agent_id} className="mb-2">
+          <h3 className="font-semibold">{ag.agent_id}</h3>
+          <ul className="list-disc ml-4">
+            {(ag.memories ?? []).map((m, i) => (
+              <li key={i}>{m}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/culture-ui/src/components/AgentPositions.tsx
+++ b/culture-ui/src/components/AgentPositions.tsx
@@ -1,0 +1,24 @@
+import { useAgentStream } from '../lib/useAgentStream'
+
+export default function AgentPositions() {
+  const data = useAgentStream()
+  const agents = data?.agents ?? []
+
+  return (
+    <div>
+      <h2 className="font-bold">Agent Positions</h2>
+      <ul>
+        {agents.map((ag) => {
+          const state = ag.state as Record<string, unknown> | undefined
+          const pos = state?.position as { x: number; y: number } | undefined
+          const text = pos ? `${pos.x}, ${pos.y}` : 'unknown'
+          return (
+            <li key={ag.agent_id}>
+              {ag.agent_id}: {text}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/culture-ui/src/lib/useAgentStream.ts
+++ b/culture-ui/src/lib/useAgentStream.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+export interface AgentData {
+  agent_id: string
+  state?: Record<string, unknown>
+  mood?: number | null
+  memories?: string[]
+}
+
+interface AgentStreamPayload {
+  agents: AgentData[]
+}
+
+export function useAgentStream() {
+  const [data, setData] = useState<AgentStreamPayload | null>(null)
+
+  useEffect(() => {
+    const es = new EventSource('/stream/agents')
+    es.onmessage = (ev) => {
+      try {
+        setData(JSON.parse(ev.data) as AgentStreamPayload)
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return () => es.close()
+  }, [])
+
+  return data
+}

--- a/culture-ui/src/pages/Home.tsx
+++ b/culture-ui/src/pages/Home.tsx
@@ -1,10 +1,16 @@
 import { registerWidget } from '../lib/widgetRegistry'
+import AgentPositions from '../components/AgentPositions'
+import AgentEmotions from '../components/AgentEmotions'
+import AgentMemories from '../components/AgentMemories'
 
 export default function Home() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Welcome to Culture UI</h1>
       <p className="mt-2">Select a page from the sidebar.</p>
+      <AgentPositions />
+      <AgentEmotions />
+      <AgentMemories />
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "lint": "pre-commit run -a"
+    "lint": "pre-commit run -a",
+    "dashboard": "uvicorn src.interfaces.dashboard_backend:app --reload"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -294,6 +294,95 @@ async def stream_map(request: Request) -> Response:
     return cast(Response, EventSourceResponse(generator))
 
 
+@app.get(
+    "/stream/agents",
+    response_class=EventSourceResponse,
+    response_model=None,
+)
+async def stream_agents(request: Request) -> Response:
+    """Stream agent state, mood, and top memories."""
+
+    async def event_generator() -> AsyncGenerator[dict[str, Any], None]:
+        while True:
+            if await request.is_disconnected():
+                break
+            sim = SIM_STATE.get("simulation")
+            agents: list[dict[str, Any]] = []
+            if sim is not None:
+                memory_service = getattr(sim, "memory_service", None)
+                for ag in sim.agents:
+                    try:
+                        state = cast(dict[str, Any], ag.state.model_dump())
+                    except Exception:  # pragma: no cover - defensive
+                        state = {}
+                    mood = getattr(ag.state, "mood_value", None)
+                    memories: list[str] = []
+                    if memory_service is not None:
+                        try:
+                            memories = memory_service.get_recent_semantic_summaries(
+                                ag.agent_id, limit=3
+                            )
+                        except Exception:  # pragma: no cover - defensive
+                            memories = []
+                    agents.append(
+                        {
+                            "agent_id": ag.agent_id,
+                            "state": state,
+                            "mood": mood,
+                            "memories": memories,
+                        }
+                    )
+            yield {"data": json.dumps({"agents": agents})}
+            await asyncio.sleep(1)
+
+    generator: AsyncGenerator[dict[str, Any], None] = event_generator()
+    return cast(Response, EventSourceResponse(generator))
+
+
+try:
+
+    @app.websocket("/ws/agents")
+    async def ws_agents(websocket: WebSocket) -> None:
+        await websocket.accept()
+        try:
+            while True:
+                sim = SIM_STATE.get("simulation")
+                agents: list[dict[str, Any]] = []
+                if sim is not None:
+                    memory_service = getattr(sim, "memory_service", None)
+                    for ag in sim.agents:
+                        try:
+                            state = cast(dict[str, Any], ag.state.model_dump())
+                        except Exception:  # pragma: no cover - defensive
+                            state = {}
+                        mood = getattr(ag.state, "mood_value", None)
+                        memories: list[str] = []
+                        if memory_service is not None:
+                            try:
+                                memories = memory_service.get_recent_semantic_summaries(
+                                    ag.agent_id, limit=3
+                                )
+                            except Exception:  # pragma: no cover - defensive
+                                memories = []
+                        agents.append(
+                            {
+                                "agent_id": ag.agent_id,
+                                "state": state,
+                                "mood": mood,
+                                "memories": memories,
+                            }
+                        )
+                await websocket.send_text(json.dumps({"agents": agents}))
+                await asyncio.sleep(1)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            await websocket.close()
+
+except AttributeError:  # pragma: no cover - stub app may lack decorators
+    pass
+
+
 @app.get("/api/map")
 async def api_map() -> Response:
     """Return the latest world map state with agent mood and summaries."""
@@ -824,5 +913,6 @@ __all__ = [
     "get_quests_api",
     "message_sse_queue",
     "register_widget",
+    "stream_agents",
     "stream_map",
 ]


### PR DESCRIPTION
## Summary
- stream agent updates over SSE or websockets
- expose agent positions, emotions and memories on the dashboard
- add dashboard launch script

## Testing
- `SKIP=unit-tests pre-commit run --files src/interfaces/dashboard_backend.py package.json culture-ui/src/pages/Home.tsx culture-ui/src/components/AgentEmotions.tsx culture-ui/src/components/AgentMemories.tsx culture-ui/src/components/AgentPositions.tsx culture-ui/src/lib/useAgentStream.ts`
- `pytest tests/unit/interfaces/test_dashboard_backend_map.py`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test AgentDataOverview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68915075ef108326a04368f0c0139762