### PR TITLE
feat: gate Discord interactions by ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,14 @@ Proposes a new law and triggers an on-chain vote.
 ```
 Casts a yes/no vote on the given proposal.
 
+#### Usage and Gating Rules
+
+- Chat in a specific agent's channel to become associated with that agent.
+- Each message consumes Influence Points (IP) and Decision Units (DU) from the
+  mapped agent according to the simulation's ledger settings.
+- Messages are rejected with an "Insufficient IP/DU" notice if the ledger shows
+  the agent lacks the required resources.
+
 See `/status` and `/stats` for ephemeral information about agent resources and
 latency.
 

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -121,6 +121,9 @@ class SimulationDiscordBot:
         self.channel_map: dict[str, int] = channel_map or {}
         self.channel_to_agent: dict[int, str] = {v: k for k, v in self.channel_map.items()}
         self.user_channels: dict[str, int] = {}
+        self.user_agents: dict[str, str] = {}
+        self.last_agent_id: str | None = None
+        self.last_channel_id: int | None = None
         self.is_ready = False
         self.context = context
         self.context.sim_state["discord_bot"] = self
@@ -201,8 +204,40 @@ class SimulationDiscordBot:
                 if user_id and channel_id:
                     self.user_channels[str(user_id)] = channel_id
                 recipient = self.channel_to_agent.get(channel_id)
+                if user_id:
+                    if recipient:
+                        self.user_agents[str(user_id)] = recipient
+                    agent_id = self.user_agents.get(str(user_id))
+                else:
+                    agent_id = None
+                if not agent_id:
+                    if hasattr(channel, "send"):
+                        await channel.send("Unknown agent mapping")
+                    return
+                broadcast = content.startswith("/broadcast ")
+                if broadcast:
+                    ip_cost = float(
+                        config.get_config("IP_COST_BROADCAST_MESSAGE")
+                        or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                        or 0.0
+                    )
+                    du_cost = float(
+                        config.get_config("DU_COST_BROADCAST_ACTION")
+                        or config.get_config("DU_COST_PER_ACTION")
+                        or 0.0
+                    )
+                else:
+                    ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
+                    du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
+                ip_bal, du_bal = await ledger.get_balance_async(agent_id)
+                if ip_bal < ip_cost or du_bal < du_cost:
+                    if hasattr(channel, "send"):
+                        await channel.send("Insufficient IP/DU")
+                    return
+                self.last_agent_id = agent_id
+                self.last_channel_id = channel_id
                 evt_type = "direct_message" if recipient else "broadcast"
-                data = {"author": str(getattr(message, "author", "")), "content": content}
+                data = {"author": agent_id, "content": content}
                 if recipient:
                     data["recipient_id"] = recipient
                 await self.event_queue.put(SimulationEvent(type=evt_type, data=data))

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -147,9 +147,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -196,9 +196,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -297,7 +297,12 @@ class Simulation:
             broadcast = True
             text = text[len("/broadcast ") :].strip()
 
-        target = self.agents[self.current_agent_index]
+        agent_id = None
+        if self.discord_bot and self.discord_bot.last_agent_id:
+            agent_id = self.discord_bot.last_agent_id
+        target = next((a for a in self.agents if a.agent_id == agent_id), None)
+        if target is None:
+            target = self.agents[self.current_agent_index]
         state = target.state
         if broadcast:
             ip_cost = float(
@@ -320,6 +325,12 @@ class Simulation:
                 "broadcast" if broadcast else "command",
                 target.agent_id,
             )
+            if self.discord_bot:
+                await self.discord_bot.send_simulation_update(
+                    "Insufficient IP/DU",
+                    agent_id=target.agent_id,
+                    target_channel_id=self.discord_bot.last_channel_id,
+                )
             return
 
         state.ip -= ip_cost
@@ -555,7 +566,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -108,8 +109,12 @@ async def test_multi_token_message_forwarding() -> None:
     with (
         patch("src.interfaces.discord_bot.discord.Client", Client),
         patch("src.interfaces.dashboard_backend.get_event_queue", lambda: q_events),
+        patch(
+            "src.interfaces.discord_bot.ledger.get_balance_async",
+            AsyncMock(return_value=(1.0, 1.0)),
+        ),
     ):
-        bot = await SimulationDiscordBot.create(tokens, 999, context=ctx)
+        bot = await SimulationDiscordBot.create(tokens, 999, channel_map={"A": 999}, context=ctx)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
 
@@ -118,7 +123,8 @@ async def test_multi_token_message_forwarding() -> None:
             on_msg = bot.clients[token]._events["on_message"]
             msg = MagicMock()
             msg.content = f"hello-{token}"
-            msg.author = f"user_{token}"
+            msg.author = SimpleNamespace(id=f"user_{token}")
+            msg.channel = SimpleNamespace(id=999, send=AsyncMock())
             await on_msg(msg)
             stored = await q_events.get()
             assert (stored.data or {}).get("content") == f"hello-{token}"
@@ -163,9 +169,15 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
             lambda: q_events,
         ),
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
+        patch(
+            "src.interfaces.discord_bot.ledger.get_balance_async",
+            AsyncMock(return_value=(1.0, 1.0)),
+        ),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
+        bot = await SimulationDiscordBot.create(
+            "token", 123, channel_map={"A": 123}, context=SimulationContext()
+        )
         assert "on_message" in bot.client._events
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
@@ -173,7 +185,8 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()
         msg.content = "hello"
-        msg.author = "user1"
+        msg.author = SimpleNamespace(id="user1")
+        msg.channel = SimpleNamespace(id=123, send=AsyncMock())
         await on_msg(msg)
         stored = await q_events.get()
         assert stored.type == "broadcast"
@@ -199,14 +212,21 @@ async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -
     ctx._event_queue = q_events
     ctx._event_queue_loop = asyncio.get_event_loop()
     ctx.message_queue = q_msgs
-    with patch("src.interfaces.discord_bot.discord.Client", Client):
-        bot = await SimulationDiscordBot.create("token", 456, context=ctx)
+    with (
+        patch("src.interfaces.discord_bot.discord.Client", Client),
+        patch(
+            "src.interfaces.discord_bot.ledger.get_balance_async",
+            AsyncMock(return_value=(1.0, 1.0)),
+        ),
+    ):
+        bot = await SimulationDiscordBot.create("token", 456, channel_map={"A": 456}, context=ctx)
         tasks = bot.run_bot()
         await asyncio.gather(*tasks[:-1])
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()
         msg.content = "hello world"
-        msg.author = "userA"
+        msg.author = SimpleNamespace(id="userA")
+        msg.channel = SimpleNamespace(id=456, send=AsyncMock())
         await on_msg(msg)
         event = await q_events.get()
         agent_state = {"messages": []}

--- a/tests/integration/simulation/test_discord_bot_integration.py
+++ b/tests/integration/simulation/test_discord_bot_integration.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -101,7 +101,9 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         patch.object(Simulation, "_handle_human_command", wrapped),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
-        bot = await SimulationDiscordBot.create("token", 1, context=SimulationContext())
+        bot = await SimulationDiscordBot.create(
+            "token", 1, channel_map={"A": 1}, context=SimulationContext()
+        )
         agent = DummyAgent("A")
         sim = Simulation([agent], discord_bot=bot)
 
@@ -111,7 +113,8 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         on_msg = bot.client._events["on_message"]
         msg = MagicMock()
         msg.content = "hello"
-        msg.author = "user1"
+        msg.author = SimpleNamespace(id="user1")
+        msg.channel = SimpleNamespace(id=1, send=AsyncMock())
         await on_msg(msg)
         await asyncio.sleep(0.05)
 


### PR DESCRIPTION
## Summary
- map Discord users to agents and check ledger IP/DU balances before forwarding messages
- send IP/DU insufficiency notices back to the originating Discord channel
- document Discord usage and gating rules

## Testing
- `ruff check src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_bot.py tests/integration/simulation/test_discord_bot_integration.py`
- `black --check src/interfaces/discord_bot.py src/sim/simulation.py tests/integration/interfaces/test_discord_bot.py tests/integration/simulation/test_discord_bot_integration.py`
- `mypy src/interfaces/discord_bot.py src/sim/simulation.py --ignore-missing-imports`
- `pytest tests/unit/sim/test_human_command.py tests/unit/sim/test_human_command_costs.py tests/integration/interfaces/test_discord_bot.py tests/integration/simulation/test_discord_bot_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68915075065c832690db106eb45b861a