### PR TITLE
Use context pipeline and track RAG hit rate

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -12,6 +12,7 @@ from src.infra.llm_client import (
     analyze_sentiment,
     async_generate_structured_output,
 )
+from src.interfaces import metrics
 from src.shared.typing import SimulationMessage
 
 from .basic_agent_types import AgentActionOutput, AgentTurnState
@@ -85,8 +86,13 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     if not service or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
 
+    k = 5
+    semantic_limit = 2
     memories, semantic = await service.get_context_pipeline(
-        state["agent_id"], query="", k=5, semantic_limit=2
+        state["agent_id"], query="", k=k, semantic_limit=semantic_limit
+    )
+    metrics.RAG_HIT_RATE.set(
+        (len(memories) + len(semantic)) / (k + semantic_limit) if (k + semantic_limit) else 0
     )
     memories_content = [m.get("content", "") for m in memories] + list(semantic)
 

--- a/tests/unit/agents/test_memory_blending.py
+++ b/tests/unit/agents/test_memory_blending.py
@@ -1,0 +1,39 @@
+import pytest
+
+from src.agents.core.agent_state import AgentState
+from src.agents.graphs.graph_nodes import retrieve_and_summarize_memories_node
+from src.interfaces import metrics
+
+pytestmark = pytest.mark.unit
+
+
+class MockMemoryService:
+    async def get_context_pipeline(self, agent_id, query="", k=5, semantic_limit=2):
+        return ([{"content": "e1"}], ["s1"])
+
+    def blend_with_recent_semantic(self, agent_id, summary, limit=3):
+        return f"blended:{summary}"
+
+
+class MockSummaryAgent:
+    async def async_generate_l1_summary(self, role_prompt, memories, context):
+        class R:
+            summary = "episodic + semantic"
+
+        return R()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_and_summarize_blends_and_tracks_hit_rate():
+    metrics.RAG_HIT_RATE.set(0)
+    state = AgentState(agent_id="a1", name="A1")
+    turn_state = {
+        "agent_id": "a1",
+        "state": state,
+        "memory_service": MockMemoryService(),
+        "agent_instance": MockSummaryAgent(),
+    }
+    result = await retrieve_and_summarize_memories_node(turn_state)
+    assert result["rag_summary"] == "blended:episodic + semantic"
+    assert result["memory_history_list"] == [{"content": "e1"}]
+    assert metrics.get_rag_hit_rate() == pytest.approx(2 / 7)


### PR DESCRIPTION
## Summary
- call `MemoryService.get_context_pipeline` in graph nodes to get episodic and semantic context and track RAG hit rate
- test semantic and episodic blending along with RAG hit rate recording

## Testing
- `ruff check src/agents/graphs/graph_nodes.py tests/unit/agents/test_memory_blending.py`
- `pytest tests/unit/agents/test_memory_blending.py`


------
https://chatgpt.com/codex/tasks/task_e_68915bac93a48326955a23f888f92fce