### PR TITLE
feat: add dashboard UI script

### DIFF
--- a/culture-ui/src/setupTests.ts
+++ b/culture-ui/src/setupTests.ts
@@ -8,5 +8,20 @@ class ResizeObserver {
 
 ;(global as typeof global & { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = ResizeObserver
 
+// Provide a minimal EventSource implementation for tests
+class MockEventSource {
+  constructor(url: string) {
+    void url
+  }
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+}
+
+;(globalThis as typeof globalThis & { EventSource?: typeof EventSource }).EventSource =
+  MockEventSource as unknown as typeof EventSource
+
 import { vi } from 'vitest'
 vi.mock('flexlayout-react/style/light.css', () => ({}))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "lint": "pre-commit run -a",
-    "dashboard": "uvicorn src.interfaces.dashboard_backend:app --reload"
+    "dashboard": "uvicorn src.interfaces.dashboard_backend:app --reload",
+    "dashboard:ui": "pnpm --filter culture-ui dev"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary
- add script to launch dashboard UI via pnpm
- mock EventSource in culture-ui tests so App renders in tests

## Testing
- `pre-commit run --files culture-ui/src/setupTests.ts`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`


------
https://chatgpt.com/codex/tasks/task_e_6894a804b87c83269a1761ae3fff8968