### PR TITLE
Refine memory retrieval pipeline and add blending tests

### DIFF
--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -31,9 +31,13 @@ ActionIntentLiteral = Literal[
 
 
 class MemoryRetriever(Protocol):
-    async def aretrieve_relevant_memories(
-        self: Any, agent_id: str, query: str, k: int
-    ) -> list[dict[str, Any]]: ...
+    async def get_context_pipeline(
+        self: Any, agent_id: str, query: str, k: int, semantic_limit: int
+    ) -> tuple[list[dict[str, Any]], list[str]]: ...
+
+    def blend_with_recent_semantic(
+        self: Any, agent_id: str, episodic_summary: str, limit: int = 3
+    ) -> str: ...
 
 
 class SummaryAgent(Protocol):

--- a/tests/unit/agents/test_memory_blending.py
+++ b/tests/unit/agents/test_memory_blending.py
@@ -37,3 +37,29 @@ async def test_retrieve_and_summarize_blends_and_tracks_hit_rate():
     assert result["rag_summary"] == "blended:episodic + semantic"
     assert result["memory_history_list"] == [{"content": "e1"}]
     assert metrics.get_rag_hit_rate() == pytest.approx(2 / 7)
+
+
+class MockMemoryServiceFull:
+    async def get_context_pipeline(self, agent_id, query="", k=5, semantic_limit=2):
+        episodic = [{"content": f"e{i}"} for i in range(5)]
+        semantic = [f"s{i}" for i in range(2)]
+        return episodic, semantic
+
+    def blend_with_recent_semantic(self, agent_id, summary, limit=3):
+        return f"blended:{summary}"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_and_summarize_full_hit_rate():
+    metrics.RAG_HIT_RATE.set(0)
+    state = AgentState(agent_id="a1", name="A1")
+    turn_state = {
+        "agent_id": "a1",
+        "state": state,
+        "memory_service": MockMemoryServiceFull(),
+        "agent_instance": MockSummaryAgent(),
+    }
+    result = await retrieve_and_summarize_memories_node(turn_state)
+    assert result["rag_summary"] == "blended:episodic + semantic"
+    assert len(result["memory_history_list"]) == 5
+    assert metrics.get_rag_hit_rate() == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- Align graph memory retriever protocol with `MemoryService.get_context_pipeline`
- Track RAG hit-rate after retrieval and blend episodic with semantic context
- Add unit tests covering episodic+semantic blending and full-hit scenarios

## Testing
- `ruff check src/agents/graphs/graph_nodes.py tests/unit/agents/test_memory_blending.py`
- `pytest tests/unit/agents/test_memory_blending.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b8e0a848832685b008127d4f3f41