### PR TITLE
Prefer vLLM backend with Ollama fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Ollama. See [docs/runbook.md](docs/runbook.md#start-vllm) for additional details
 To compare latency and throughput between vLLM and Ollama, use the benchmarking helper:
 
 ```bash
-python scripts/benchmark_llm.py "Hello" --runs 3 --model mistral:latest --vllm_base "http://localhost:$VLLM_PORT"
+python scripts/benchmark_llm.py "Hello" --runs 3 --model mistral:latest --vllm_base "http://localhost:$VLLM_PORT" --output results.json
 ```
 
 Example results:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -74,6 +74,8 @@ Run `scripts/benchmark_llm.py` after the server starts to compare vLLM and Ollam
 | vLLM    | 0.25            | 4.00               |
 | Ollama  | 1.20            | 0.83               |
 
+Add `--output results.json` to persist the results for later analysis.
+
 Results will vary depending on hardware and models.
 
 When `VLLM_API_BASE` (or `LLM_API_BASE` pointing to the same URL) is configured, the application prefers the vLLM endpoint over Ollama. Unset this variable to switch back to Ollama.

--- a/scripts/benchmark_llm.py
+++ b/scripts/benchmark_llm.py
@@ -12,7 +12,8 @@ from typing import Callable
 # Add project root so we can import llm_client directly when executed from scripts/
 sys.path.append(str(os.path.dirname(os.path.dirname(__file__))))
 
-from src.infra import config as infra_config, llm_client
+from src.infra import config as infra_config
+from src.infra import llm_client
 
 
 def parse_args() -> argparse.Namespace:
@@ -28,6 +29,12 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default=os.environ.get("VLLM_API_BASE", "http://localhost:8000"),
         help="Base URL of the vLLM server",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional path to write benchmark results as JSON",
     )
     return parser.parse_args()
 
@@ -45,7 +52,7 @@ def time_calls(func: Callable[[], None], runs: int) -> list[float]:
     return times
 
 
-def benchmark(prompt: str, model: str, runs: int, vllm_base: str) -> None:
+def benchmark(prompt: str, model: str, runs: int, vllm_base: str, output: str | None) -> None:
     # Benchmark vLLM first
     os.environ["VLLM_API_BASE"] = vllm_base
     infra_config.load_config(validate_required=False)
@@ -86,19 +93,27 @@ def benchmark(prompt: str, model: str, runs: int, vllm_base: str) -> None:
     def throughput(values: list[float]) -> float:
         return runs / sum(values)
 
+    results = {
+        "vllm": {"avg_latency": avg(vllm_times), "throughput": throughput(vllm_times)},
+        "ollama": {"avg_latency": avg(ollama_times), "throughput": throughput(ollama_times)},
+    }
+
     print("| Backend | Avg latency (s) | Throughput (req/s) |")
     print("|---------|----------------:|--------------------:|")
-    print(
-        f"| vLLM | {avg(vllm_times):.2f} | {throughput(vllm_times):.2f} |"
-    )
-    print(
-        f"| Ollama | {avg(ollama_times):.2f} | {throughput(ollama_times):.2f} |"
-    )
+    print(f"| vLLM | {results['vllm']['avg_latency']:.2f} | {results['vllm']['throughput']:.2f} |")
+    print(f"| Ollama | {results['ollama']['avg_latency']:.2f} | {results['ollama']['throughput']:.2f} |")
+
+    if output:
+        import json
+
+        with open(output, "w", encoding="utf-8") as fh:
+            json.dump(results, fh, indent=2)
+        print(f"Results written to {output}")
 
 
 def main() -> None:
     args = parse_args()
-    benchmark(args.prompt, args.model, args.runs, args.vllm_base)
+    benchmark(args.prompt, args.model, args.runs, args.vllm_base, args.output)
 
 
 if __name__ == "__main__":

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -509,7 +509,10 @@ def generate_text(
     agent_state: Any | None = None,
 ) -> str | None:
     """
-    Generates text using the specified Ollama model.
+    Generates text using the configured LLM backend.
+
+    vLLM is preferred when available; the function falls back to Ollama if
+    the vLLM client cannot be initialized.
 
     Args:
         prompt (str): The prompt to send to the model.
@@ -789,7 +792,7 @@ async def async_generate_structured_output(
     Args:
         prompt (str): Instruction prompt for the LLM
         response_model (Type[T]): The Pydantic model to parse the response into
-        model (str): The Ollama model to use
+        model (str): The model to use for generation
         temperature (float): The temperature for generation
         timeout (int | None): Request timeout in seconds. Defaults to the
             `OLLAMA_REQUEST_TIMEOUT` config value.
@@ -889,9 +892,19 @@ async def async_generate_structured_output(
         except (ValidationError, json.JSONDecodeError, TypeError) as e:
             logger.error(f"Error generating mock structured output: {e}")
             return None
+
     # Ensure response_model is a subclass of BaseModel for type safety
     if not issubclass(response_model, BaseModel):
         raise TypeError("response_model must be a subclass of BaseModel")
+
+    # Initialize the appropriate LLM client (prefers vLLM, falls back to Ollama)
+    global client, USE_VLLM
+    if client is None and USE_VLLM:
+        try:
+            get_llm_client()
+        except LLMClientInitError as exc:
+            logger.error(f"LLM client unavailable: {exc}")
+            USE_VLLM = False
     if hasattr(response_model, "model_json_schema"):
         schema_json = json.dumps(response_model.model_json_schema(), indent=2)
     else:
@@ -965,7 +978,7 @@ async def async_generate_structured_output(
             response_text = str(result.get("response", ""))
         logger.debug(f"FULL RAW LLM RESPONSE: {response_text}")
         try:
-            logger.debug(f"Received potential JSON response from Ollama: {response_text}")
+            logger.debug(f"Received potential JSON response from LLM: {response_text}")
             if response_model:
                 json_data: JSONDict = json.loads(str(response_text))
                 parsed_output: BaseModel = response_model(**json_data)
@@ -975,7 +988,7 @@ async def async_generate_structured_output(
                 # Defensive: fallback for non-model response, cast to BaseModel | None
                 return cast(BaseModel | None, json.loads(str(response_text)))
         except (json.JSONDecodeError, ValidationError) as e:
-            logger.warning(f"Failed to parse JSON from Ollama response: {e}")
+            logger.warning(f"Failed to parse JSON from LLM response: {e}")
             logger.warning(f"Raw response: {response_text}")
             return None
     except (RequestException, APIError) as e:


### PR DESCRIPTION
## Summary
- prefer vLLM client and fallback to Ollama in async structured output generation
- add JSON output and throughput reporting to benchmark script
- document vLLM setup and benchmarking in runbook and README

## Testing
- `ruff check scripts/benchmark_llm.py src/infra/llm_client.py`
- `python -m pytest tests -k llm_client`


------
https://chatgpt.com/codex/tasks/task_e_6894b8e179d883269447a867fa27348c