### PR TITLE
feat: expand governance capabilities

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -39,6 +39,25 @@ export async function proposeLaw(
   return data.approved
 }
 
+export interface ProposalOutcome {
+  approved: boolean
+  yes_weight: number
+  no_weight: number
+  ip_spent: number
+}
+
+export async function submitProposal(
+  proposerId: string,
+  text: string,
+): Promise<ProposalOutcome> {
+  const res = await fetch('/api/governance/propose', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ proposer_id: proposerId, text }),
+  })
+  return (await res.json()) as ProposalOutcome
+}
+
 
 export type WidgetRegistration = WidgetInfo & Record<string, unknown>
 

--- a/culture-ui/src/pages/Proposals.tsx
+++ b/culture-ui/src/pages/Proposals.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { registerWidget } from '../lib/widgetRegistry'
+import { submitProposal } from '../lib/api'
 
 interface Proposal {
   proposer_id: string
@@ -13,27 +14,57 @@ interface Proposal {
 
 export default function Proposals() {
   const [data, setData] = useState<Proposal[]>([])
+  const [text, setText] = useState('')
+  const [proposer, setProposer] = useState('agent_1')
+  const [result, setResult] = useState<string | null>(null)
+
+  async function load() {
+    try {
+      const res = await fetch('/api/recent_proposals')
+      const json = (await res.json()) as { proposals: Proposal[] }
+      setData(json.proposals || [])
+    } catch {
+      /* ignore */
+    }
+  }
 
   useEffect(() => {
-    let cancelled = false
-    async function load() {
-      try {
-        const res = await fetch('/api/recent_proposals')
-        const json = (await res.json()) as { proposals: Proposal[] }
-        if (!cancelled) setData(json.proposals || [])
-      } catch {
-        /* ignore */
-      }
-    }
     void load()
-    return () => {
-      cancelled = true
-    }
   }, [])
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setResult(null)
+    try {
+      const outcome = await submitProposal(proposer, text)
+      setResult(outcome.approved ? 'Approved' : 'Rejected')
+      await load()
+    } catch {
+      setResult('Error')
+    }
+  }
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Recent Proposals</h1>
+      <form onSubmit={submit} className="space-y-2">
+        <input
+          placeholder="Proposal text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="border p-1 w-full"
+        />
+        <input
+          placeholder="Proposer ID"
+          value={proposer}
+          onChange={(e) => setProposer(e.target.value)}
+          className="border p-1 w-full"
+        />
+        <button type="submit" className="px-2 py-1 border rounded">
+          Submit
+        </button>
+        {result && <div data-testid="result">Result: {result}</div>}
+      </form>
       <table className="min-w-full border" data-testid="proposal-table">
         <thead>
           <tr>
@@ -42,6 +73,7 @@ export default function Proposals() {
             <th className="border px-2">Text</th>
             <th className="border px-2">Yes</th>
             <th className="border px-2">No</th>
+            <th className="border px-2">IP Spent</th>
             <th className="border px-2">Approved</th>
           </tr>
         </thead>
@@ -53,6 +85,7 @@ export default function Proposals() {
               <td className="border px-2">{p.text}</td>
               <td className="border px-2">{p.yes_weight}</td>
               <td className="border px-2">{p.no_weight}</td>
+              <td className="border px-2">{p.ip_spent}</td>
               <td className="border px-2">{p.approved ? 'Yes' : 'No'}</td>
             </tr>
           ))}

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -49,3 +49,45 @@ Returns a list of laws that have been passed and recorded on the law board.
 
 ### `GET /api/votes`
 Lists recent law proposals with their vote totals as stored in the ledger.
+
+## Example Scenarios
+
+### Simple Proposal
+1. Stake a few influence points for the proposing agent (optional):
+   ```bash
+   curl -X POST -H 'Content-Type: application/json' \
+     -d '{"agent_id": "agent_1", "amount": 5}' \
+     http://localhost:8000/api/stake_ip
+   ```
+2. Submit a proposal:
+   ```bash
+   curl -X POST -H 'Content-Type: application/json' \
+     -d '{"proposer_id": "agent_1", "text": "Allow concerts"}' \
+     http://localhost:8000/api/governance/propose
+   ```
+3. Retrieve the latest proposals and vote totals:
+   ```bash
+   curl http://localhost:8000/api/recent_proposals
+   ```
+
+### Weighted Voting
+1. Cast three "yes" votes costing nine IP:
+   ```bash
+   curl -X POST -H 'Content-Type: application/json' \
+     -d '{"agent_id": "agent_2", "text": "Allow concerts", "approve": true, "weight": 3}' \
+     http://localhost:8000/api/vote
+   ```
+2. Check the proposal record to confirm the additional weight:
+   ```bash
+   curl http://localhost:8000/api/recent_proposals
+   ```
+
+### IP Staking
+An agent can lock IP to increase quadratic voting weight:
+```bash
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"agent_id": "agent_3", "amount": 10}' \
+  http://localhost:8000/api/stake_ip
+```
+The staked amount counts toward the `sqrt(ip_balance + staked_ip)` formula used
+for default voting weight.

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -31,6 +31,54 @@ class GovernanceService:
         allowed, _ = await evaluate_with_opa(proposal)
         return allowed
 
+    async def vote_weighted(
+        self: Self,
+        agent: Agent,
+        proposal: str,
+        weight: int = 1,
+        approve: bool = True,
+    ) -> bool:
+        """Cast a weighted ``approve`` or ``reject`` vote for ``proposal``.
+
+        ``weight`` additional votes cost ``weight^2`` IP which is deducted
+        from the agent's balance via the ledger. The approval result is
+        returned only when the vote is allowed by the policy and the IP spend
+        succeeds.
+        """
+        if weight < 1:
+            weight = 1
+        allowed = await self.vote(agent, proposal)
+        if not allowed:
+            return False
+        cost = float(weight**2)
+        try:
+            await ledger.spend(agent.agent_id, ip=cost, reason="vote")
+        except Exception:
+            return False
+        return approve
+
+    async def stake_ip(self: Self, agent_id: str, amount: float) -> float:
+        """Stake ``amount`` of IP for ``agent_id`` and return total staked IP."""
+
+        def _stake() -> float:
+            ledger.stake_ip(agent_id, amount)
+            try:
+                return ledger.get_staked_ip(agent_id)
+            except Exception:
+                return 0.0
+
+        return await asyncio.to_thread(_stake)
+
+    async def submit_proposal(
+        self: Self,
+        proposer: Agent,
+        text: str,
+        agents: Iterable[Agent],
+        vote_weights: dict[str, int] | None = None,
+    ) -> dict[str, float | bool]:
+        """Convenience wrapper around :meth:`propose_law`."""
+        return await self.propose_law(proposer, text, agents, vote_weights)
+
     async def propose_law(
         self: Self,
         proposer: Agent,

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -216,6 +216,14 @@ class VoteRequest(BaseModel):
     agent_id: str
     text: str
     approve: bool
+    weight: int | None = 1
+
+
+class StakeRequest(BaseModel):
+    """Request payload for staking influence points."""
+
+    agent_id: str
+    amount: float
 
 
 app = FastAPI()
@@ -560,27 +568,6 @@ async def api_propose_law(proposal: LawProposal) -> Response:
     return JSONResponse({"approved": approved})
 
 
-@app.post("/api/propose")
-async def api_propose(proposal: Proposal) -> Response:
-    """Submit a weighted law proposal to the active simulation."""
-    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
-    approved = False
-    if sim is not None:
-        proposer = next((a for a in sim.agents if a.agent_id == proposal.proposer_id), None)
-        if proposer is not None:
-            try:
-                result = await governance.propose_law(
-                    proposer,
-                    proposal.text,
-                    sim.agents,
-                    proposal.vote_weights,
-                )
-                approved = bool(result.get("approved"))
-            except Exception:  # pragma: no cover - defensive
-                approved = False
-    return JSONResponse({"approved": approved})
-
-
 @app.post("/api/governance/propose")
 async def api_governance_propose(proposal: Proposal) -> Response:
     """Submit a proposal via the governance service and return the outcome."""
@@ -615,11 +602,22 @@ async def api_vote(vote: VoteRequest) -> Response:
         agent = next((a for a in sim.agents if a.agent_id == vote.agent_id), None)
         if agent is not None:
             try:
-                allowed = await governance.vote(agent, vote.text)
-                result = bool(vote.approve and allowed)
+                result = await governance.vote_weighted(
+                    agent, vote.text, vote.weight or 1, vote.approve
+                )
             except Exception:  # pragma: no cover - defensive
                 result = False
     return JSONResponse({"vote": result})
+
+
+@app.post("/api/stake_ip")
+async def api_stake_ip(req: StakeRequest) -> Response:
+    """Stake influence points for an agent and return the total staked."""
+    try:
+        total = await governance.stake_ip(req.agent_id, req.amount)
+    except Exception:  # pragma: no cover - defensive
+        total = 0.0
+    return JSONResponse({"staked_ip": total})
 
 
 @app.get("/api/proposals", response_model=ProposalsResponse)
@@ -887,6 +885,7 @@ __all__ = [
     "ProposalRecord",
     "ProposalsResponse",
     "SimulationEvent",
+    "StakeRequest",
     "VoteRecord",
     "VoteRequest",
     "VotesResponse",
@@ -901,6 +900,7 @@ __all__ = [
     "api_memory_snapshots",
     "api_propose_law",
     "api_recent_proposals",
+    "api_stake_ip",
     "api_token_balances",
     "api_vote",
     "app",

--- a/tests/integration/governance/test_propose_command.py
+++ b/tests/integration/governance/test_propose_command.py
@@ -44,7 +44,7 @@ async def test_slash_propose_uses_api(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await bot.slash_propose.callback(DummyInteraction(), text="hello")
 
-    assert DummyClient.called["url"].endswith("/api/propose")
+    assert DummyClient.called["url"].endswith("/api/governance/propose")
     assert DummyClient.called["json"] == {"proposer_id": "a1", "text": "hello"}
     DummyClient.called = {}
 

--- a/tests/integration/governance/test_stake_ip_endpoint.py
+++ b/tests/integration/governance/test_stake_ip_endpoint.py
@@ -1,0 +1,21 @@
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from src.infra.ledger import Ledger
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_stake_ip_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    gservice = importlib.import_module("src.governance.service")
+    monkeypatch.setattr(gservice, "ledger", ledger)
+    monkeypatch.setattr(db, "governance", gservice.governance)
+
+    resp = await db.api_stake_ip(db.StakeRequest(agent_id="a1", amount=5.0))
+    data = json.loads(resp.body)
+    assert data["staked_ip"] == pytest.approx(5.0)

--- a/tests/integration/interfaces/test_dashboard_token_middleware.py
+++ b/tests/integration/interfaces/test_dashboard_token_middleware.py
@@ -18,10 +18,13 @@ async def test_token_required(monkeypatch):
     http_app = importlib.import_module("src.http_app")
     transport = ASGITransport(app=http_app.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.post("/api/propose", json={"proposer_id": "a1", "text": "law"})
+        resp = await client.post(
+            "/api/governance/propose",
+            json={"proposer_id": "a1", "text": "law"},
+        )
         assert resp.status_code == 401
         resp = await client.post(
-            "/api/propose",
+            "/api/governance/propose",
             json={"proposer_id": "a1", "text": "law"},
             headers={"Authorization": "Bearer secret"},
         )


### PR DESCRIPTION
## Summary
- add weighted voting, IP staking, and proposal helpers to governance service
- expose governance proposal, voting, and staking endpoints in dashboard backend and UI
- document governance flows and examples
- remove redundant `/api/propose` endpoint and update integration tests to use `/api/governance/propose`

## Testing
- `ruff check src/interfaces/dashboard_backend.py tests/integration/interfaces/test_dashboard_token_middleware.py tests/integration/governance/test_propose_command.py tests/integration/governance/test_stake_ip_endpoint.py`
- `pytest -m "integration" tests/integration/interfaces/test_dashboard_token_middleware.py tests/integration/governance/test_propose_command.py tests/integration/governance/test_stake_ip_endpoint.py`
- `pnpm --filter culture-ui lint`
- `pnpm --filter culture-ui test`
- `pnpm --filter culture-ui test src/LawProposal.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6894c2a7f0b88326aec2c1cfc2eef247