### PR TITLE
Add Discord control and moderation commands with OPA rate limiting

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -159,6 +159,19 @@ class MemoryService:
             l2_min_age_days,
         )
 
+    def reset_agent(self: Self, agent_id: str) -> None:
+        """Remove all memory entries for the given agent."""
+        if self.vector_store and hasattr(self.vector_store, "delete_agent_memories"):
+            try:
+                self.vector_store.delete_agent_memories(agent_id)
+            except Exception:
+                pass
+        if self.semantic_manager and hasattr(self.semantic_manager, "delete_agent"):
+            try:
+                self.semantic_manager.delete_agent(agent_id)
+            except Exception:
+                pass
+
     def consolidate_long_term(self: Self, agent_id: str, start_step: int, end_step: int) -> None:
         if not self.level3_manager:
             return None

--- a/src/agents/memory/vector_store.py
+++ b/src/agents/memory/vector_store.py
@@ -276,6 +276,13 @@ class ChromaVectorStoreManager(MemoryStore):
             logger.error("Error pruning documents: %s", exc)
         return pruned
 
+    def delete_agent_memories(self: Self, agent_id: str) -> None:
+        """Remove all memories associated with the given agent."""
+        try:
+            self.collection.delete(where={"agent_id": {"$eq": agent_id}})
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to delete memories for agent %s: %s", agent_id, exc)
+
     def add_memory(
         self: Self,
         agent_id: str,

--- a/src/app.py
+++ b/src/app.py
@@ -26,6 +26,8 @@ from src.infra.logging_config import setup_logging
 from src.infra.settings import settings
 from src.infra.snapshot import load_snapshot
 from src.infra.warning_filters import configure_warning_filters
+from src.interfaces.dashboard_backend import DEFAULT_CONTEXT, SimulationEvent
+from src.sim.context import SimulationContext
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.simulation import Simulation
@@ -33,6 +35,34 @@ from src.utils.loop_helper import use_uvloop_if_available
 
 restore_rng_state = _restore_rng_state
 restore_environment = _restore_environment
+
+
+async def start_simulation(ctx: SimulationContext | None = None) -> None:
+    """Enqueue a control command to start the simulation."""
+    context = ctx or DEFAULT_CONTEXT
+    await context.get_event_queue().put(
+        SimulationEvent(type="control", data={"command": "start"})
+    )
+
+
+async def stop_simulation(ctx: SimulationContext | None = None) -> None:
+    """Enqueue a control command to stop the simulation."""
+    context = ctx or DEFAULT_CONTEXT
+    await context.get_event_queue().put(
+        SimulationEvent(type="control", data={"command": "stop"})
+    )
+
+
+async def spawn_agent_command(
+    agent_id: str, ctx: SimulationContext | None = None
+) -> None:
+    """Request spawning of a new agent via the event queue."""
+    context = ctx or DEFAULT_CONTEXT
+    await context.get_event_queue().put(
+        SimulationEvent(
+            type="control", data={"command": "spawn", "agent_id": agent_id}
+        )
+    )
 
 
 def _simple_yaml(path: Path) -> dict[str, object]:
@@ -80,13 +110,9 @@ def load_scenario(value: str) -> tuple[str, int | None, int | None]:
 
 use_uvloop_if_available()
 
-try:
-    from src.interfaces.discord_bot import SimulationDiscordBot
-
-    simulation_discord_bot_class: Optional[type[SimulationDiscordBot]] = SimulationDiscordBot
-except ImportError:  # pragma: no cover - optional dependency
-    logging.warning("Discord bot module not found, running without Discord integration.")
-    simulation_discord_bot_class = None
+# Discord bot integration is imported lazily to avoid circular imports when
+# ``src.interfaces.discord_bot`` references functions from this module.
+simulation_discord_bot_class: Optional[type[object]] = None
 
 DEFAULT_SCENARIO = "Agents collaborate to design a specification for a communication protocol."
 
@@ -112,20 +138,34 @@ def create_simulation(
         sys.exit(1)
 
     discord_bot = None
-    if use_discord and simulation_discord_bot_class:
-        bot_token_raw = str(settings.DISCORD_BOT_TOKEN)
-        channel_id = settings.DISCORD_CHANNEL_ID
-        if bot_token_raw and channel_id:
-            tokens = [tok.strip() for tok in bot_token_raw.split(",") if tok.strip()]
-            bot = asyncio.run(
-                simulation_discord_bot_class.create(
-                    tokens if len(tokens) > 1 else tokens[0], int(channel_id)
+    if use_discord:
+        global simulation_discord_bot_class
+        if simulation_discord_bot_class is None:
+            try:
+                from src.interfaces import discord_moderation  # noqa: F401
+                from src.interfaces.discord_bot import SimulationDiscordBot
+
+                simulation_discord_bot_class = SimulationDiscordBot
+            except ImportError:  # pragma: no cover - optional dependency
+                logging.warning(
+                    "Discord bot module not found, running without Discord integration."
                 )
-            )
-            if bot.is_ready:
-                discord_bot = bot
-            else:
-                logging.warning("Discord bot not ready, running without integration.")
+        if simulation_discord_bot_class:
+            bot_token_raw = str(settings.DISCORD_BOT_TOKEN)
+            channel_id = settings.DISCORD_CHANNEL_ID
+            if bot_token_raw and channel_id:
+                tokens = [tok.strip() for tok in bot_token_raw.split(",") if tok.strip()]
+                bot = asyncio.run(
+                    simulation_discord_bot_class.create(
+                        tokens if len(tokens) > 1 else tokens[0], int(channel_id)
+                    )
+                )
+                if bot.is_ready:
+                    discord_bot = bot
+                else:
+                    logging.warning(
+                        "Discord bot not ready, running without integration."
+                    )
 
     agents = [Agent(agent_id=f"agent_{i + 1}", name=f"Agent_{i + 1}") for i in range(num_agents)]
 

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -763,6 +763,41 @@ async def slash_resume(interaction: Any) -> None:
     await interaction.response.send_message("resume", ephemeral=True)
 
 
+@bot.tree.command(name="start")
+async def slash_start(interaction: Any) -> None:
+    """Start the simulation via a control command."""
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(type="control", data={"command": "start"})
+    )
+    await interaction.response.send_message("start", ephemeral=True)
+
+
+@bot.tree.command(name="stop")
+async def slash_stop(interaction: Any) -> None:
+    """Stop the simulation via a control command."""
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(type="control", data={"command": "stop"})
+    )
+    await interaction.response.send_message("stop", ephemeral=True)
+
+
+@bot.tree.command(name="spawn")
+async def slash_spawn(interaction: Any, agent_id: str) -> None:
+    """Spawn a new agent in the simulation."""
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(
+            type="control", data={"command": "spawn", "agent_id": agent_id}
+        )
+    )
+    await interaction.response.send_message(f"spawn {agent_id}", ephemeral=True)
+
+
 @bot.tree.command(name="set_speed")
 async def slash_set_speed(interaction: Any, value: float) -> None:
     """Adjust the simulation speed via a control command."""

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -1,0 +1,72 @@
+"""Discord moderation commands with OPA-based rate limiting."""
+
+from typing import Any
+
+from src.interfaces.dashboard_backend import (
+    DEFAULT_CONTEXT,
+    SimulationEvent,
+)
+from src.interfaces.discord_bot import bot, get_active_bot
+from src.utils.policy import evaluate_with_opa
+
+
+async def _rate_limit(user: Any, action: str) -> bool:
+    """Use OPA to determine if the action is allowed for the user."""
+    user_id = str(getattr(user, "id", ""))
+    allow, _ = await evaluate_with_opa(f"{user_id}:{action}")
+    return allow
+
+
+@bot.tree.command(name="mute")
+async def slash_mute(interaction: Any, agent_id: str) -> None:
+    """Mute an agent in the simulation."""
+    if not await _rate_limit(getattr(interaction, "user", None), "mute"):
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(
+            type="moderation", data={"command": "mute", "agent_id": agent_id}
+        )
+    )
+    await interaction.response.send_message("muted", ephemeral=True)
+
+
+@bot.tree.command(name="reset_memory")
+async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
+    """Reset the memory of an agent."""
+    if not await _rate_limit(getattr(interaction, "user", None), "reset_memory"):
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(
+            type="moderation", data={"command": "reset_memory", "agent_id": agent_id}
+        )
+    )
+    await interaction.response.send_message("memory reset", ephemeral=True)
+
+
+@bot.tree.command(name="penalty")
+async def slash_penalty(
+    interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0
+) -> None:
+    """Apply an IP/DU penalty to an agent."""
+    if not await _rate_limit(getattr(interaction, "user", None), "penalty"):
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    await ctx.get_event_queue().put(
+        SimulationEvent(
+            type="moderation",
+            data={"command": "penalty", "agent_id": agent_id, "ip": ip, "du": du},
+        )
+    )
+    await interaction.response.send_message("penalty applied", ephemeral=True)
+
+
+__all__ = ["slash_mute", "slash_penalty", "slash_reset_memory"]
+

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -104,6 +104,7 @@ class Simulation:
         self.paused: bool = False
         self.speed: float = 1.0
         self.agent_initial_token_budget = int(config.get_config("AGENT_TOKEN_BUDGET"))
+        self.muted_agents: set[str] = set()
         # Add other simulation-wide state if needed (e.g., environment properties)
         # self.environment_state = {}
 
@@ -386,6 +387,21 @@ class Simulation:
             self.paused = True
         elif action == "resume":
             self.paused = False
+        elif action == "start":
+            self.paused = False
+        elif action == "stop":
+            self.simulation_complete = True
+            await self.stop_event_listener()
+        elif action == "spawn":
+            agent_id = cmd.get("agent_id")
+            if agent_id:
+                try:
+                    from src.agents.core.base_agent import Agent
+
+                    new_agent = Agent(agent_id=str(agent_id), name=str(agent_id))
+                    await self.spawn_agent(new_agent)
+                except Exception:
+                    logger.error("Failed to spawn agent %s", agent_id, exc_info=True)
         elif action == "set_speed":
             try:
                 self.speed = float(cmd.get("value", 1))
@@ -415,6 +431,25 @@ class Simulation:
                         )
                     )
                     _ = task
+
+    async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
+        """Process moderation actions like muting or penalties."""
+        action = cmd.get("command")
+        agent_id = cmd.get("agent_id")
+        if action == "mute" and agent_id:
+            self.muted_agents.add(str(agent_id))
+        elif action == "reset_memory" and agent_id:
+            try:
+                self.memory_service.reset_agent(str(agent_id))
+            except Exception:
+                logger.error("Failed to reset memory for %s", agent_id, exc_info=True)
+        elif action == "penalty" and agent_id:
+            ip = float(cmd.get("ip", 0))
+            du = float(cmd.get("du", 0))
+            try:
+                ledger.log_change(str(agent_id), -abs(ip), -abs(du), "moderation_penalty")
+            except Exception:
+                logger.error("Failed to apply penalty to %s", agent_id, exc_info=True)
 
     async def spawn_agent(
         self: Self,
@@ -538,6 +573,9 @@ class Simulation:
         self.current_step += 1
         agent = self.agents[agent_index]
         agent_id = agent.agent_id
+        if agent_id in self.muted_agents:
+            self.current_agent_index = (agent_index + 1) % len(self.agents)
+            return
         self.vector.increment(agent_id)
         current_agent_state = agent.state
 
@@ -893,7 +931,12 @@ class Simulation:
         if evt.type == "control":
             await self.handle_control_command(evt.data)
             return
+        if evt.type == "moderation":
+            await self.handle_moderation_command(evt.data)
+            return
         sender = str(evt.data.get("author", "external"))
+        if sender in self.muted_agents:
+            return
         content = str(evt.data.get("content", ""))
         recipient = evt.data.get("recipient_id") if evt.type == "direct_message" else None
         msg: SimulationMessage = {


### PR DESCRIPTION
## Summary
- support `/start`, `/stop`, and `/spawn` control commands in Discord
- expose moderation commands with OPA-based rate limiting
- add simulation APIs for muting agents, resetting memory, and applying IP/DU penalties

## Testing
- `ruff check src/agents/memory/memory_service.py src/agents/memory/vector_store.py src/app.py src/interfaces/discord_bot.py src/interfaces/discord_moderation.py src/sim/simulation.py`
- `pytest tests/unit/interfaces/test_discord_bot.py tests/integration/interfaces/test_discord_control_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_689541c487ac8326a037f8915bb7cbf9