### PR TITLE
Add hybrid memory retriever with recall metrics

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -43,6 +43,27 @@ class MemoryService:
             agent_id, step, event_type, content, memory_type, metadata
         )
 
+    def store_post_turn_memory(
+        self: Self,
+        agent_id: str,
+        step: int,
+        event_type: str,
+        content: str,
+        *,
+        write: bool,
+        memory_type: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Apply post-turn write/no-write policy.
+
+        When ``write`` is ``False`` the memory is skipped and an empty string is
+        returned. Otherwise the memory is stored using :meth:`add_memory`.
+        """
+
+        if not write:
+            return ""
+        return self.add_memory(agent_id, step, event_type, content, memory_type, metadata)
+
     async def retrieve_relevant_memories(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:

--- a/src/langgraph/__init__.py
+++ b/src/langgraph/__init__.py
@@ -1,5 +1,6 @@
 """Stub langgraph package for tests."""
 
 from .graph import END, START
+from .retriever import RetrieverNode
 
-__all__ = ["END", "START"]
+__all__ = ["END", "START", "RetrieverNode"]

--- a/src/langgraph/retriever.py
+++ b/src/langgraph/retriever.py
@@ -1,0 +1,37 @@
+"""LangGraph node for hybrid episodic-semantic retrieval."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import Self
+
+
+class RetrieverNode:
+    """Retrieve memories and enforce a per-turn token cap.
+
+    This node delegates retrieval to a ``MemoryService`` which mixes episodic
+    and semantic memories. Retrieved results are truncated so that the total
+    number of whitespace-separated tokens does not exceed ``token_cap``.
+    """
+
+    def __init__(self: Self, memory_service: Any, k: int = 5, token_cap: int = 1000) -> None:
+        self.memory_service = memory_service
+        self.k = k
+        self.token_cap = token_cap
+
+    async def __call__(self: Self, state: dict[str, Any]) -> dict[str, Any]:
+        """Retrieve relevant memories for the given state."""
+        agent_id = str(state.get("agent_id", ""))
+        query = str(state.get("query", ""))
+        memories = await self.memory_service.retrieve_relevant_memories(agent_id, query, self.k)
+        limited: list[dict[str, Any]] = []
+        tokens = 0
+        for mem in memories:
+            text = mem.get("content", "")
+            tokens += len(text.split())
+            if tokens > self.token_cap:
+                break
+            limited.append(mem)
+        state["memories"] = limited
+        return state

--- a/src/utils/retrieval_metrics.py
+++ b/src/utils/retrieval_metrics.py
@@ -1,0 +1,24 @@
+"""Utilities for evaluating retrieval quality and performance."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Awaitable, Callable, Sequence
+
+
+def precision_at_k(retrieved_ids: Sequence[str], relevant_ids: set[str], k: int) -> float:
+    """Return precision at ``k`` for retrieved versus relevant IDs."""
+    if k <= 0:
+        return 0.0
+    top_k = retrieved_ids[:k]
+    if not top_k:
+        return 0.0
+    hits = sum(1 for _id in top_k if _id in relevant_ids)
+    return hits / float(min(k, len(top_k)))
+
+
+async def time_call(coro: Callable[[], Awaitable[Sequence[Any]]]) -> tuple[Sequence[Any], float]:
+    """Execute ``coro`` and return its result and runtime in seconds."""
+    start = time.perf_counter()
+    result = await coro()
+    return result, time.perf_counter() - start

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.utils.retrieval_metrics import precision_at_k, time_call
+
+
+@pytest.fixture
+def recall_benchmark():
+    """Return helper to measure precision@k and latency for a retrieval coroutine."""
+
+    async def _bench(retrieval_coro, relevant_ids, k):
+        results, latency = await time_call(retrieval_coro)
+        ids = [m.get("id") for m in results]
+        metrics = {
+            "p_at_k": precision_at_k(ids, set(relevant_ids), k),
+            "latency": latency,
+        }
+        return metrics
+
+    return _bench

--- a/tests/integration/memory/test_recall_benchmark.py
+++ b/tests/integration/memory/test_recall_benchmark.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("chromadb")
+
+from src.agents.memory.memory_service import MemoryService
+from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+from tests.unit.memory.test_semantic_memory_manager import DummyDriver
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+async def test_recall_benchmark(recall_benchmark, chroma_test_dir: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir,
+        embedding_function=lambda t: [[1.0 if "cat" in x else 0.0] for x in t],
+    )
+    driver = DummyDriver()
+    semantic = SemanticMemoryManager(vector, driver)
+    service = MemoryService(vector, semantic)
+
+    cat_id = vector.add_memory("agent", 1, "thought", "cat", memory_type="raw")
+    await service.run_semantic_job("agent")
+
+    async def retrieval():
+        return await service.retrieve_relevant_memories("agent", "cat", k=1)
+
+    metrics = await recall_benchmark(retrieval, {cat_id}, 1)
+    assert 0.0 <= metrics["p_at_k"] <= 1.0
+    assert metrics["latency"] >= 0.0

--- a/tests/unit/memory/test_post_turn_policy.py
+++ b/tests/unit/memory/test_post_turn_policy.py
@@ -1,0 +1,26 @@
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("chromadb")
+
+from pathlib import Path  # noqa: E402
+
+from src.agents.memory.memory_service import MemoryService  # noqa: E402
+from src.agents.memory.vector_store import ChromaVectorStoreManager  # noqa: E402
+
+
+@pytest.mark.unit
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+def test_post_turn_write_policy(chroma_test_dir: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir,
+        embedding_function=lambda t: [[0.0] for _ in t],
+    )
+    service = MemoryService(vector)
+
+    mem_id = service.store_post_turn_memory("agent", 1, "thought", "hello", write=True)
+    assert mem_id
+
+    no_mem = service.store_post_turn_memory("agent", 2, "thought", "skip", write=False)
+    assert no_mem == ""


### PR DESCRIPTION
## Summary
- introduce LangGraph `RetrieverNode` blending episodic and semantic memories with per-turn token cap
- expose retrieval metrics utilities and recall benchmark fixture
- add post-turn memory write policy and accompanying tests

## Testing
- `SKIP=unit-tests pre-commit run --files src/utils/retrieval_metrics.py src/langgraph/retriever.py src/langgraph/__init__.py src/agents/memory/memory_service.py tests/integration/memory/conftest.py tests/integration/memory/test_recall_benchmark.py tests/unit/memory/test_post_turn_policy.py`
- `pytest tests/unit/memory/test_post_turn_policy.py tests/integration/memory/test_recall_benchmark.py -m "unit or integration"`

------
https://chatgpt.com/codex/tasks/task_e_689541c5350c8326a496737e6e98ee41