### PR TITLE
Add event log chaining, replay controls, and OTel spans

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from opentelemetry import trace
 from typing_extensions import Self
 
 from src.interfaces import metrics
@@ -12,6 +13,8 @@ from .level3_summary_manager import Level3SummaryManager
 from .multi_layer_retriever import MultiLayerRetriever
 from .semantic_memory_manager import SemanticMemoryManager
 from .vector_store import ChromaVectorStoreManager
+
+tracer = trace.get_tracer(__name__)
 
 
 class MemoryService:
@@ -39,15 +42,17 @@ class MemoryService:
     ) -> str:
         if not self.vector_store:
             return ""
-        return self.vector_store.add_memory(
-            agent_id, step, event_type, content, memory_type, metadata
-        )
+        with tracer.start_as_current_span("memory.add_memory"):
+            return self.vector_store.add_memory(
+                agent_id, step, event_type, content, memory_type, metadata
+            )
 
     async def retrieve_relevant_memories(
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
         try:
-            result = await self.retriever.retrieve(agent_id, query, k)
+            with tracer.start_as_current_span("memory.retrieve_relevant"):
+                result = await self.retriever.retrieve(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
         except Exception:
@@ -61,7 +66,8 @@ class MemoryService:
             metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
             return []
         try:
-            result = self.semantic_manager.retrieve_context(agent_id, query, k)
+            with tracer.start_as_current_span("memory.retrieve_semantic"):
+                result = self.semantic_manager.retrieve_context(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
         except Exception:
@@ -75,7 +81,8 @@ class MemoryService:
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
         try:
-            result = await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
+            with tracer.start_as_current_span("memory.retrieve_and_update_semantic"):
+                result = await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
         except Exception:
@@ -99,18 +106,19 @@ class MemoryService:
         tuple[list[dict[str, Any]], list[str]] | tuple[list[dict[str, Any]], list[str], list[str]]
     ):
         """Return episodic, semantic, and optionally long-term summaries."""
-        episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
-        semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
-        hits = len(episodic) + len(semantic)
-        total = k + semantic_limit
-        if long_term_limit:
-            long_term = self.get_long_term_summaries(agent_id, long_term_limit)
-            hits += len(long_term)
-            total += long_term_limit
+        with tracer.start_as_current_span("memory.get_context_pipeline"):
+            episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
+            semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
+            hits = len(episodic) + len(semantic)
+            total = k + semantic_limit
+            if long_term_limit:
+                long_term = self.get_long_term_summaries(agent_id, long_term_limit)
+                hits += len(long_term)
+                total += long_term_limit
+                metrics.RAG_HIT_RATE.set(hits / total if total else 0)
+                return episodic, semantic, long_term
             metrics.RAG_HIT_RATE.set(hits / total if total else 0)
-            return episodic, semantic, long_term
-        metrics.RAG_HIT_RATE.set(hits / total if total else 0)
-        return episodic, semantic
+            return episodic, semantic
 
     async def run_semantic_job(
         self: Self,

--- a/src/app.py
+++ b/src/app.py
@@ -10,7 +10,7 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.extensions import load_plugins
-from src.infra import config, event_log
+from src.infra import config
 from src.infra.checkpoint import (
     load_checkpoint,
     save_checkpoint,
@@ -24,7 +24,6 @@ from src.infra.checkpoint import (
 from src.infra.llm_client import LLMClientInitError, get_llm_client
 from src.infra.logging_config import setup_logging
 from src.infra.settings import settings
-from src.infra.snapshot import load_snapshot
 from src.infra.warning_filters import configure_warning_filters
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import KnowledgeBoard
@@ -231,6 +230,16 @@ def parse_args() -> argparse.Namespace:
         help="Replay a previous run from the given snapshot using the event log.",
     )
     parser.add_argument(
+        "--replay-start",
+        type=int,
+        help="Start tick for event log replay.",
+    )
+    parser.add_argument(
+        "--replay-end",
+        type=int,
+        help="End tick for event log replay.",
+    )
+    parser.add_argument(
         "--proposal",
         type=str,
         help="Submit a law proposal before running the simulation.",
@@ -276,10 +285,11 @@ def main() -> None:
     sim: Simulation
     meta: dict[str, object] | None = None
     if args.replay:
-        snapshot = load_snapshot(args.replay)
-        sim = Simulation.from_snapshot(snapshot)
-        for event in event_log.stream_events(after_step=sim.current_step):
-            sim.apply_event(event)
+        sim = Simulation.replay_from_snapshot(
+            args.replay,
+            start_step=args.replay_start,
+            end_step=args.replay_end,
+        )
         return
 
     if args.checkpoint and Path(args.checkpoint).exists():

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -20,6 +20,7 @@ _broker = os.getenv("REDPANDA_BROKER", "localhost:9092")
 _topic = os.getenv("REDPANDA_TOPIC", "culture.events")
 
 _producer: Any | None = None
+_last_hash: str | None = None
 
 _consumer_conf = {
     "bootstrap.servers": _broker,
@@ -37,10 +38,20 @@ def _get_producer() -> Any:
 
 def log_event(event: dict[str, Any]) -> dict[str, Any]:
     """Send an event dictionary to Redpanda and return it with ``trace_hash``."""
+
+    global _last_hash
+
     if "trace_hash" in event:
         event = {**event}
         event.pop("trace_hash", None)
+    from src.infra.checkpoint import capture_rng_state
+
+    event = {**event, "rng_state": capture_rng_state()}
+    if _last_hash is not None:
+        event["prev_hash"] = _last_hash
     event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
+    _last_hash = event_with_hash["trace_hash"]
+
     if os.getenv("ENABLE_REDPANDA", "0") != "1":
         return event_with_hash
     try:

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, ParamSpec, Protocol, TypeVar, c
 
 import httpx
 from httpx import HTTPError, TimeoutException
+from opentelemetry import trace
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
 
@@ -31,6 +32,8 @@ from src.shared.typing import (
 
 from .config import OLLAMA_REQUEST_TIMEOUT, get_config
 from .ledger import ledger
+
+tracer = trace.get_tracer(__name__)
 
 try:
     import ollama
@@ -523,54 +526,55 @@ def generate_text(
     Returns:
         str | None: The generated text, or None if an error occurred.
     """
-    if is_mock_mode_enabled():
-        # Even in mock mode, allow a monkeypatched side_effect to run for failure tests.
-        if client and hasattr(client, "chat") and hasattr(client.chat, "side_effect"):
-            if client.chat.side_effect:
-                try:
-                    return client.chat(model=model, messages=[{"role": "user", "content": prompt}])
-                except _RequestException:
-                    return None  # Ensure side_effect exceptions are caught and handled.
+    with tracer.start_as_current_span("llm.generate_text"):
+        if is_mock_mode_enabled():
+            # Even in mock mode, allow a monkeypatched side_effect to run for failure tests.
+            if client and hasattr(client, "chat") and hasattr(client.chat, "side_effect"):
+                if client.chat.side_effect:
+                    try:
+                        return client.chat(model=model, messages=[{"role": "user", "content": prompt}])
+                    except _RequestException:
+                        return None  # Ensure side_effect exceptions are caught and handled.
 
-        mock_response = _MOCK_RESPONSES.get("text_generation", _MOCK_RESPONSES["default"])
-        # Simulate the structure of the real response to get the content
-        return {"message": {"content": mock_response}}["message"]["content"]
+            mock_response = _MOCK_RESPONSES.get("text_generation", _MOCK_RESPONSES["default"])
+            # Simulate the structure of the real response to get the content
+            return {"message": {"content": mock_response}}["message"]["content"]
 
-    def call() -> LLMChatResponse:
-        """Invoke the LLM using ``LLMClient`` so the method can be monkeypatched
-        in tests.
+        def call() -> LLMChatResponse:
+            """Invoke the LLM using ``LLMClient`` so the method can be monkeypatched
+            in tests.
 
-        Previous implementations called ``get_llm_client`` directly which
-        returned the underlying Ollama client.  Tests expecting to patch
-        ``LLMClient.chat`` would therefore bypass the patch and attempt a real
-        network request.  Instantiating ``LLMClient`` here preserves the public
-        API while allowing unit tests to mock ``LLMClient.chat`` easily.
-        """
+            Previous implementations called ``get_llm_client`` directly which
+            returned the underlying Ollama client.  Tests expecting to patch
+            ``LLMClient.chat`` would therefore bypass the patch and attempt a real
+            network request.  Instantiating ``LLMClient`` here preserves the public
+            API while allowing unit tests to mock ``LLMClient.chat`` easily.
+            """
 
-        wrapper = LLMClient(LLMClientConfig())
-        messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
-        return wrapper.chat_sync(
-            model=model,
-            messages=messages,
-            options={"temperature": temperature},
-        )
+            wrapper = LLMClient(LLMClientConfig())
+            messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
+            return wrapper.chat_sync(
+                model=model,
+                messages=messages,
+                options={"temperature": temperature},
+            )
 
-    try:
-        response, error = _retry_with_backoff(call)
-    except LLMClientInitError as exc:
-        logger.error(f"Failed to initialize LLM client: {exc}")
-        return None
+        try:
+            response, error = _retry_with_backoff(call)
+        except LLMClientInitError as exc:
+            logger.error(f"Failed to initialize LLM client: {exc}")
+            return None
 
-    if error:
-        logger.error(f"Failed to generate text after retries: {error}")
-        return None
-    if isinstance(response, dict) and "message" in response and "content" in response["message"]:
-        generated_text = response["message"]["content"]
-        logger.debug(f"Received response from Ollama: {generated_text}")
-        return str(generated_text).strip()
-    else:
-        logger.error(f"Unexpected response structure from Ollama: {response}")
-        return None
+        if error:
+            logger.error(f"Failed to generate text after retries: {error}")
+            return None
+        if isinstance(response, dict) and "message" in response and "content" in response["message"]:
+            generated_text = response["message"]["content"]
+            logger.debug(f"Received response from Ollama: {generated_text}")
+            return str(generated_text).strip()
+        else:
+            logger.error(f"Unexpected response structure from Ollama: {response}")
+            return None
 
 
 @charge_du_cost
@@ -642,11 +646,12 @@ def summarize_memory_context(
         )
 
         chat_messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
-        response = ollama_client.chat_sync(
-            model=model,
-            messages=chat_messages,
-            options={"temperature": temperature},
-        )
+        with tracer.start_as_current_span("llm.summarize_memory_context"):
+            response = ollama_client.chat_sync(
+                model=model,
+                messages=chat_messages,
+                options={"temperature": temperature},
+            )
 
         # Extract the summary text from the response
         if (
@@ -1009,17 +1014,17 @@ def generate_structured_output(
     agent_state: Any | None = None,
 ) -> BaseModel | None:
     """Synchronous wrapper around :func:`async_generate_structured_output`."""
-
-    return asyncio.run(
-        async_generate_structured_output(
-            prompt,
-            response_model,
-            model=model,
-            temperature=temperature,
-            timeout=timeout,
-            agent_state=agent_state,
+    with tracer.start_as_current_span("llm.generate_structured_output"):
+        return asyncio.run(
+            async_generate_structured_output(
+                prompt,
+                response_model,
+                model=model,
+                temperature=temperature,
+                timeout=timeout,
+                agent_state=agent_state,
+            )
         )
-    )
 
 
 def get_default_llm_client() -> OllamaClientProtocol:

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -14,6 +14,7 @@ from collections.abc import Awaitable
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import httpx
+from opentelemetry import trace
 from typing_extensions import Self
 
 from src.infra import config
@@ -45,6 +46,7 @@ else:  # pragma: no cover - runtime import with fallback
         commands = MagicMock()
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 message_sse_queue = dashboard_message_queue
 
@@ -203,61 +205,62 @@ class SimulationDiscordBot:
 
             @client.event
             async def on_message(message: Any, client: Any = client) -> None:
-                if getattr(message, "author", None) == client.user:
-                    return
-                content = getattr(message, "content", "")
-                if not allow_message(content):
-                    logger.debug("Message blocked by policy")
-                    return
-                allowed, content = await evaluate_with_opa(content)
-                if not allowed:
-                    logger.debug("Message blocked by OPA policy")
-                    return
-                metrics.HUMAN_MESSAGES_TOTAL.inc()
-                channel = getattr(message, "channel", None)
-                channel_id = getattr(channel, "id", None)
-                user = getattr(message, "author", None)
-                user_id = getattr(user, "id", None)
-                if user_id and channel_id:
-                    self.user_channels[str(user_id)] = channel_id
-                    self.last_user_id = str(user_id)
-                recipient = self.channel_to_agent.get(channel_id)
-                agent_id = None
-                if user_id:
-                    agent_id = self.user_agents.get(str(user_id))
-                    if agent_id is None and recipient:
-                        agent_id = recipient
-                        self.user_agents[str(user_id)] = agent_id
-                if not agent_id:
-                    if hasattr(channel, "send"):
-                        send = getattr(channel, "send")
-                        if asyncio.iscoroutinefunction(send):
-                            await send("Unknown agent mapping")
-                        else:
-                            send("Unknown agent mapping")
-                    return
-                ip_cost = float(
-                    config.get_config("IP_COST_BROADCAST_MESSAGE")
-                    or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                    or 0.0
-                )
-                du_cost = float(
-                    config.get_config("DU_COST_BROADCAST_ACTION")
-                    or config.get_config("DU_COST_PER_ACTION")
-                    or 0.0
-                )
-                ip_bal, du_bal = await ledger.get_balance_async(agent_id)
-                if ip_bal < ip_cost or du_bal < du_cost:
-                    if hasattr(channel, "send"):
-                        await channel.send("Insufficient IP/DU")
-                    return
-                self.last_agent_id = agent_id
-                self.last_channel_id = channel_id
-                evt_type = "broadcast"
-                data = {"author": agent_id, "content": content}
-                if recipient:
-                    data["recipient_id"] = recipient
-                await self.event_queue.put(SimulationEvent(type=evt_type, data=data))
+                with tracer.start_as_current_span("discord.on_message"):
+                    if getattr(message, "author", None) == client.user:
+                        return
+                    content = getattr(message, "content", "")
+                    if not allow_message(content):
+                        logger.debug("Message blocked by policy")
+                        return
+                    allowed, content = await evaluate_with_opa(content)
+                    if not allowed:
+                        logger.debug("Message blocked by OPA policy")
+                        return
+                    metrics.HUMAN_MESSAGES_TOTAL.inc()
+                    channel = getattr(message, "channel", None)
+                    channel_id = getattr(channel, "id", None)
+                    user = getattr(message, "author", None)
+                    user_id = getattr(user, "id", None)
+                    if user_id and channel_id:
+                        self.user_channels[str(user_id)] = channel_id
+                        self.last_user_id = str(user_id)
+                    recipient = self.channel_to_agent.get(channel_id)
+                    agent_id = None
+                    if user_id:
+                        agent_id = self.user_agents.get(str(user_id))
+                        if agent_id is None and recipient:
+                            agent_id = recipient
+                            self.user_agents[str(user_id)] = agent_id
+                    if not agent_id:
+                        if hasattr(channel, "send"):
+                            send = getattr(channel, "send")
+                            if asyncio.iscoroutinefunction(send):
+                                await send("Unknown agent mapping")
+                            else:
+                                send("Unknown agent mapping")
+                        return
+                    ip_cost = float(
+                        config.get_config("IP_COST_BROADCAST_MESSAGE")
+                        or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                        or 0.0
+                    )
+                    du_cost = float(
+                        config.get_config("DU_COST_BROADCAST_ACTION")
+                        or config.get_config("DU_COST_PER_ACTION")
+                        or 0.0
+                    )
+                    ip_bal, du_bal = await ledger.get_balance_async(agent_id)
+                    if ip_bal < ip_cost or du_bal < du_cost:
+                        if hasattr(channel, "send"):
+                            await channel.send("Insufficient IP/DU")
+                        return
+                    self.last_agent_id = agent_id
+                    self.last_channel_id = channel_id
+                    evt_type = "broadcast"
+                    data = {"author": agent_id, "content": content}
+                    if recipient:
+                        data["recipient_id"] = recipient
+                    await self.event_queue.put(SimulationEvent(type=evt_type, data=data))
 
     async def _select_client(self: Self, agent_id: Optional[str]) -> Any:
         """Return the Discord client for the given agent."""
@@ -290,69 +293,70 @@ class SimulationDiscordBot:
         Returns:
             bool: True if message was sent successfully, False otherwise
         """
-        if not self.is_ready:
-            logger.warning("Discord bot not ready yet, message not sent")
-            return False
-        if not allow_message(content):
-            logger.debug("Message blocked by policy")
-            return False
-        if content is not None and agent_id is None:
-            allowed, content = await evaluate_with_opa(content)
-            if not allowed:
-                logger.debug("Message blocked by OPA policy")
+        with tracer.start_as_current_span("discord.send_simulation_update"):
+            if not self.is_ready:
+                logger.warning("Discord bot not ready yet, message not sent")
                 return False
-        try:
-            client = await self._select_client(agent_id)
-            chan_id = target_channel_id
-            if chan_id is None and recipient:
-                chan_id = self.user_channels.get(recipient)
-            if chan_id is None:
-                chan_id = self.channel_map.get(agent_id, self.channel_id)
-            channel = client.get_channel(chan_id)
-            if not channel:
-                logger.warning(f"Could not find Discord channel with ID: {chan_id}")
+            if not allow_message(content):
+                logger.debug("Message blocked by policy")
                 return False
-            if embed:
-                if hasattr(channel, "send"):
-                    await channel.send(embed=embed)
-                    logger.debug("Sent Discord embed update")
-                    return True
-                else:
-                    if channel is not None:
-                        chan_id = getattr(channel, "id", "unknown")
-                        logger.warning(
-                            f"Attempted to send embed to channel {chan_id} "
-                            f"of type {type(channel).__name__}, which does not support .send()"
-                        )
-                    else:
-                        logger.warning("Attempted to send embed to a None channel.")
+            if content is not None and agent_id is None:
+                allowed, content = await evaluate_with_opa(content)
+                if not allowed:
+                    logger.debug("Message blocked by OPA policy")
                     return False
-            elif content:
-                if len(content) > 1990:
-                    content = content[:1990] + "..."
-                if hasattr(channel, "send"):
-                    await channel.send(content)
-                    logger.debug(f"Sent Discord text update: {content[:50]}...")
-                    return True
-                else:
-                    if channel is not None:
-                        chan_id = getattr(channel, "id", "unknown")
-                        logger.warning(
-                            f"Attempted to send text to channel {chan_id} "
-                            f"of type {type(channel).__name__}, which does not support .send()"
-                        )
-                    else:
-                        logger.warning("Attempted to send text to a None channel.")
+            try:
+                client = await self._select_client(agent_id)
+                chan_id = target_channel_id
+                if chan_id is None and recipient:
+                    chan_id = self.user_channels.get(recipient)
+                if chan_id is None:
+                    chan_id = self.channel_map.get(agent_id, self.channel_id)
+                channel = client.get_channel(chan_id)
+                if not channel:
+                    logger.warning(f"Could not find Discord channel with ID: {chan_id}")
                     return False
-            else:
-                logger.warning("send_simulation_update called with no content or embed")
+                if embed:
+                    if hasattr(channel, "send"):
+                        await channel.send(embed=embed)
+                        logger.debug("Sent Discord embed update")
+                        return True
+                    else:
+                        if channel is not None:
+                            chan_id = getattr(channel, "id", "unknown")
+                            logger.warning(
+                                f"Attempted to send embed to channel {chan_id} "
+                                f"of type {type(channel).__name__}, which does not support .send()"
+                            )
+                        else:
+                            logger.warning("Attempted to send embed to a None channel.")
+                        return False
+                elif content:
+                    if len(content) > 1990:
+                        content = content[:1990] + "..."
+                    if hasattr(channel, "send"):
+                        await channel.send(content)
+                        logger.debug(f"Sent Discord text update: {content[:50]}...")
+                        return True
+                    else:
+                        if channel is not None:
+                            chan_id = getattr(channel, "id", "unknown")
+                            logger.warning(
+                                f"Attempted to send text to channel {chan_id} "
+                                f"of type {type(channel).__name__}, which does not support .send()"
+                            )
+                        else:
+                            logger.warning("Attempted to send text to a None channel.")
+                        return False
+                else:
+                    logger.warning("send_simulation_update called with no content or embed")
+                    return False
+            except (discord.DiscordException, OSError) as e:
+                logger.error(f"Discord API/network error sending message: {e}", exc_info=True)
                 return False
-        except (discord.DiscordException, OSError) as e:
-            logger.error(f"Discord API/network error sending message: {e}", exc_info=True)
-            return False
-        except (RuntimeError, ValueError, TypeError) as e:
-            logger.error(f"Unexpected error sending Discord message: {e}", exc_info=True)
-            return False
+            except (RuntimeError, ValueError, TypeError) as e:
+                logger.error(f"Unexpected error sending Discord message: {e}", exc_info=True)
+                return False
 
     def create_step_start_embed(self: Self, step: int) -> Any:
         """Creates an embed for simulation step start"""

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -1056,13 +1056,28 @@ class Simulation:
         return sim
 
     @classmethod
-    def replay_from_snapshot(cls: type[Self], snapshot_path: str | Path) -> Self:
+    def replay_from_snapshot(
+        cls: type[Self],
+        snapshot_path: str | Path,
+        *,
+        start_step: int | None = None,
+        end_step: int | None = None,
+    ) -> Self:
         """Load a snapshot and replay events from the event log."""
         snap = load_snapshot(snapshot_path)
         sim = cls.from_snapshot(snap)
         from src.infra import event_log
 
-        for event in event_log.stream_events(after_step=sim.current_step):
+        after_step = sim.current_step
+        if start_step is not None:
+            after_step = max(after_step, start_step - 1)
+
+        for event in event_log.stream_events(after_step=after_step):
+            step = int(event.get("step", 0))
+            if start_step is not None and step < start_step:
+                continue
+            if end_step is not None and step > end_step:
+                break
             sim.apply_event(event)
         return sim
 


### PR DESCRIPTION
## Summary
- chain event log entries with previous hashes and RNG state for append-only replay
- add CLI flags and simulation support to replay event ranges
- trace LLM, memory, and Discord operations with OpenTelemetry

## Testing
- `ruff check src/infra/event_log/__init__.py src/app.py src/sim/simulation.py src/infra/llm_client.py src/agents/memory/memory_service.py src/interfaces/discord_bot.py`
- `pytest` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689541c3517c83269da5a39d2a6587f6