### PR TITLE
feat: enforce DU budgets and track LLM costs

### DIFF
--- a/scripts/start_vllm.sh
+++ b/scripts/start_vllm.sh
@@ -13,11 +13,16 @@ fi
 MODEL=${VLLM_MODEL:-${MODEL:-"mistralai/Mistral-7B-Instruct-v0.2"}}
 PORT=${VLLM_PORT:-${PORT:-8001}}
 SWAP=${VLLM_SWAP_SPACE:-${SWAP:-16}}
+GPUS=${VLLM_GPUS:-${GPUS:-0}}
+TP_SIZE=${VLLM_TENSOR_PARALLEL_SIZE:-${TP_SIZE:-1}}
+GPU_UTIL=${VLLM_GPU_MEMORY_UTILIZATION:-${GPU_UTIL:-0.9}}
 
-echo "Starting vLLM server with model '${MODEL}' on port ${PORT}" >&2
+echo "Starting vLLM server with model '${MODEL}' on port ${PORT} using GPUs ${GPUS}" >&2
 echo "Set VLLM_API_BASE=http://localhost:${PORT} to connect" >&2
 
-python -m vllm.entrypoints.openai.api_server \
+CUDA_VISIBLE_DEVICES=${GPUS} python -m vllm.entrypoints.openai.api_server \
   --model "${MODEL}" \
   --port "${PORT}" \
-  --swap-space "${SWAP}"
+  --swap-space "${SWAP}" \
+  --tensor-parallel-size "${TP_SIZE}" \
+  --gpu-memory-utilization "${GPU_UTIL}"

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -104,19 +104,28 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                if state.du < cost:
+                # Enforce DU budget via the simulation resource manager
+                try:
+                    from src.sim.resource_manager import get_resource_manager
+
+                    get_resource_manager().charge_du(state.agent_id, cost)
+                except Exception as exc:
                     logger.warning(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
-                    except Exception:  # pragma: no cover - optional
-                        logger.debug("Ledger logging failed", exc_info=True)
+                    raise
+                state.du -= cost
+                # Update cost metrics
+                if tokens > 0:
+                    du_per_1k = cost / (tokens / 1000)
+                    metrics.LLM_DU_PER_1K_TOKENS.set(du_per_1k)
+                try:
+                    ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
+                except Exception:  # pragma: no cover - optional
+                    logger.debug("Ledger logging failed", exc_info=True)
 
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
@@ -147,19 +156,26 @@ def async_charge_du_cost(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitab
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                if state.du < cost:
+                try:
+                    from src.sim.resource_manager import get_resource_manager
+
+                    get_resource_manager().charge_du(state.agent_id, cost)
+                except Exception as exc:
                     logger.warning(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
                         cost,
                         state.du,
                     )
-                else:
-                    state.du -= cost
-                    try:
-                        ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
-                    except Exception:  # pragma: no cover - optional
-                        logger.debug("Ledger logging failed", exc_info=True)
+                    raise
+                state.du -= cost
+                if tokens > 0:
+                    du_per_1k = cost / (tokens / 1000)
+                    metrics.LLM_DU_PER_1K_TOKENS.set(du_per_1k)
+                try:
+                    ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
+                except Exception:  # pragma: no cover - optional
+                    logger.debug("Ledger logging failed", exc_info=True)
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug(f"Failed to deduct DU cost: {e}")
         return result
@@ -204,9 +220,9 @@ def async_monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data["error_message"] = (
-                            "Function returned None, indicating an error"
-                        )
+                        metrics_data[
+                            "error_message"
+                        ] = "Function returned None, indicating an error"
                 else:
                     metrics_data["success"] = True
                     if hasattr(result, "usage"):
@@ -248,7 +264,8 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse: ...
+    ) -> LLMChatResponse:
+        ...
 
 
 class LLMClientConfig(BaseModel):
@@ -410,6 +427,20 @@ def _create_vllm_client() -> OllamaClientProtocol:
                 "usage": cast(JSONDict, data.get("usage", {})),
             }
 
+        async def async_chat_batch(
+            self: _Client,
+            batch: Iterable[tuple[str, list[LLMMessage], dict[str, Any] | None]],
+        ) -> list[LLMChatResponse]:
+            """Send multiple chat requests concurrently for continuous batching."""
+
+            async def _one(
+                req: tuple[str, list[LLMMessage], dict[str, Any] | None],
+            ) -> LLMChatResponse:
+                model, messages, opts = req
+                return await self.async_chat(model=model, messages=messages, options=opts)
+
+            return await asyncio.gather(*[_one(r) for r in batch])
+
         def chat(
             self: _Client,
             model: str,
@@ -417,6 +448,12 @@ def _create_vllm_client() -> OllamaClientProtocol:
             options: dict[str, Any] | None = None,
         ) -> LLMChatResponse:
             return asyncio.run(self.async_chat(model=model, messages=messages, options=options))
+
+        def chat_batch(
+            self: _Client,
+            batch: Iterable[tuple[str, list[LLMMessage], dict[str, Any] | None]],
+        ) -> list[LLMChatResponse]:
+            return asyncio.run(self.async_chat_batch(batch))
 
         def chat_sync(
             self: _Client,

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -15,6 +15,7 @@ from src.governance.law_board import law_board
 from src.governance.service import governance
 from src.infra.ledger import ledger
 from src.infra.snapshot import load_snapshot
+from src.interfaces import metrics
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
 
@@ -668,6 +669,17 @@ async def api_token_balances() -> Response:
 
     agents = await asyncio.to_thread(_load)
     return JSONResponse({"agents": agents})
+
+
+@app.get("/api/cost_metrics")
+async def api_cost_metrics() -> Response:
+    """Return DU cost and latency metrics for dashboards."""
+
+    data = {
+        "du_per_1k_tokens": metrics.get_du_per_1k_tokens(),
+        "llm_latency_p95_ms": metrics.get_llm_latency_p95(),
+    }
+    return JSONResponse(data)
 
 
 @app.get("/api/auctions")

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -41,6 +41,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 # Expose metrics for LLM calls and knowledge board state
 LLM_LATENCY_MS = Gauge("llm_latency_ms", "Latency of last LLM call in milliseconds")
+LLM_LATENCY_P95_MS = Gauge(
+    "llm_latency_p95_ms", "95th percentile latency of recent LLM calls in milliseconds"
+)
 LLM_CALLS_TOTAL = Counter("llm_calls_total", "Total number of LLM calls")
 LLM_ERRORS_TOTAL = Counter("llm_errors_total", "Total number of failed LLM calls")
 KNOWLEDGE_BOARD_SIZE = Gauge(
@@ -69,6 +72,7 @@ HUMAN_MESSAGES_TOTAL = Counter(
 # Gas price metrics updated by ``Ledger.calculate_gas_price``
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
+LLM_DU_PER_1K_TOKENS = Gauge("llm_du_per_1k_tokens", "DU cost per 1k tokens for the last LLM call")
 
 # Start the metrics HTTP server when this module is imported
 try:
@@ -80,6 +84,11 @@ except Exception:  # pragma: no cover - best effort if port is in use
 def get_llm_latency() -> float:
     """Return the last recorded LLM latency in milliseconds."""
     return float(LLM_LATENCY_MS._value.get())
+
+
+def get_llm_latency_p95() -> float:
+    """Return the 95th percentile LLM latency in milliseconds."""
+    return float(LLM_LATENCY_P95_MS._value.get())
 
 
 def get_kb_size() -> int:
@@ -95,6 +104,11 @@ def get_gas_price_per_call() -> float:
 def get_gas_price_per_token() -> float:
     """Return the latest gas price charged per generated token."""
     return float(GAS_PRICE_PER_TOKEN._value.get())
+
+
+def get_du_per_1k_tokens() -> float:
+    """Return the DU cost per 1k tokens for the last call."""
+    return float(LLM_DU_PER_1K_TOKENS._value.get())
 
 
 def get_memory_retrievals() -> int:
@@ -123,18 +137,22 @@ __all__ = [
     "HUMAN_MESSAGES_TOTAL",
     "KNOWLEDGE_BOARD_SIZE",
     "LLM_CALLS_TOTAL",
+    "LLM_DU_PER_1K_TOKENS",
     "LLM_ERRORS_TOTAL",
     "LLM_LATENCY_MS",
+    "LLM_LATENCY_P95_MS",
     "MEMORY_RETRIEVALS_TOTAL",
     "MEMORY_RETRIEVAL_ERRORS_TOTAL",
     "RAG_HIT_RATE",
     "Counter",
     "Gauge",
+    "get_du_per_1k_tokens",
     "get_gas_price_per_call",
     "get_gas_price_per_token",
     "get_human_messages",
     "get_kb_size",
     "get_llm_latency",
+    "get_llm_latency_p95",
     "get_memory_retrieval_errors",
     "get_memory_retrievals",
     "get_rag_hit_rate",

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -3,6 +3,7 @@ import json
 import sys
 import time
 import uuid
+from collections import deque
 from typing import Any, Callable, Optional, ParamSpec, TypeVar
 
 from src.interfaces import metrics
@@ -13,6 +14,8 @@ llm_perf_logger = get_logger("llm_performance")
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+_LATENCY_SAMPLES: "deque[float]" = deque(maxlen=100)
 
 
 def monitor_llm_call(
@@ -65,9 +68,9 @@ def monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data["error_message"] = (
-                            "Function returned None, indicating an error"
-                        )
+                        metrics_data[
+                            "error_message"
+                        ] = "Function returned None, indicating an error"
                 else:
                     metrics_data["success"] = True
                     if result is not None and hasattr(result, "usage"):
@@ -93,6 +96,11 @@ def monitor_llm_call(
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
                 metrics.LLM_LATENCY_MS.set(metrics_data["duration_ms"])
+                _LATENCY_SAMPLES.append(metrics_data["duration_ms"])
+                if _LATENCY_SAMPLES:
+                    ordered = sorted(_LATENCY_SAMPLES)
+                    idx = int(0.95 * (len(ordered) - 1))
+                    metrics.LLM_LATENCY_P95_MS.set(ordered[idx])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
             return result
 

--- a/src/sim/resource_manager.py
+++ b/src/sim/resource_manager.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class HasResources(Protocol):
+    ip: float
+    du: float
+
+
+class ResourceManager:
+    """Manage per-tick caps and per-agent DU budgets."""
+
+    def __init__(self, max_ip_per_tick: float, max_du_per_tick: float) -> None:
+        self.max_ip_per_tick = float(max_ip_per_tick)
+        self.max_du_per_tick = float(max_du_per_tick)
+        self._du_budgets: dict[str, float] = {}
+
+    def cap_tick(self, *, ip_start: float, du_start: float, obj: HasResources) -> None:
+        """Clamp the object's IP and DU gains for the current tick."""
+        ip_gain = obj.ip - ip_start
+        if ip_gain > self.max_ip_per_tick:
+            obj.ip = ip_start + self.max_ip_per_tick
+        du_gain = obj.du - du_start
+        if du_gain > self.max_du_per_tick:
+            obj.du = du_start + self.max_du_per_tick
+
+    def set_du_budget(self, agent_id: str, budget: float) -> None:
+        self._du_budgets[agent_id] = float(budget)
+
+    def charge_du(self, agent_id: str, amount: float) -> None:
+        remaining = self._du_budgets.get(agent_id, 0.0)
+        if amount > remaining:
+            raise RuntimeError(f"Agent {agent_id} exceeded DU budget")
+        self._du_budgets[agent_id] = remaining - amount
+
+    def get_du_budget(self, agent_id: str) -> float:
+        return float(self._du_budgets.get(agent_id, 0.0))
+
+
+_resource_manager: ResourceManager | None = None
+
+
+def get_resource_manager() -> ResourceManager:
+    """Return a singleton instance of :class:`ResourceManager`."""
+    global _resource_manager
+    if _resource_manager is None:
+        from src.infra.config import get_config
+
+        _resource_manager = ResourceManager(
+            float(get_config("MAX_IP_PER_TICK")), float(get_config("MAX_DU_PER_TICK"))
+        )
+    return _resource_manager

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 from pydantic import ValidationError
 from typing_extensions import Self
 
-from src.agents.core import ResourceManager
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentActionIntent
 from src.agents.memory.memory_service import MemoryService
@@ -35,10 +34,11 @@ from src.interfaces.dashboard_backend import (
     emit_event,
 )
 from src.shared.typing import SimulationMessage
+from src.sim.event_kernel import EventKernel
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
-from src.sim.kernel import DiscreteEventKernel
 from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.quests import generate_quest
+from src.sim.resource_manager import get_resource_manager
 from src.sim.version_vector import VersionVector
 from src.sim.world_map import WorldMap
 
@@ -97,9 +97,9 @@ class Simulation:
         self.last_completed_agent_index: int | None = None
         self.steps_to_run: int = 0  # Number of steps to run, set externally
         self.total_turns_executed = 0
-        self.resource_manager = ResourceManager(config.MAX_IP_PER_TICK, config.MAX_DU_PER_TICK)
+        self.resource_manager = get_resource_manager()
         self.simulation_complete = False
-        self.event_kernel = DiscreteEventKernel()
+        self.event_kernel = EventKernel()
         self.vector = VersionVector()
         self.paused: bool = False
         self.speed: float = 1.0
@@ -209,6 +209,7 @@ class Simulation:
             for agent in self.agents:
                 logger.info(f"  - {agent.get_id()}")
                 self.event_kernel.set_budget(agent.get_id(), self.agent_initial_token_budget)
+                self.resource_manager.set_du_budget(agent.get_id(), agent.state.du)
 
             # Initialize collective metrics based on starting agent states
             self._update_collective_metrics()
@@ -572,7 +573,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -587,9 +590,9 @@ class Simulation:
         async with self._msg_lock:
             perception_data["perceived_messages"] = list(self.messages_to_perceive_this_round)
         if self.knowledge_board:
-            perception_data["knowledge_board_content"] = (
-                self.knowledge_board.get_recent_entries_for_prompt()
-            )
+            perception_data[
+                "knowledge_board_content"
+            ] = self.knowledge_board.get_recent_entries_for_prompt()
 
         agent_output = await agent.run_turn(
             simulation_step=self.current_step,


### PR DESCRIPTION
## Summary
- add GPU and tensor parallel options to `start_vllm.sh`
- enforce per-agent DU budgets and add continuous batching support in LLM client
- expose cost metrics and endpoint for dashboards

## Testing
- `bash scripts/lint.sh`
- `python -m pytest tests/unit/interfaces/test_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_689541c61ca483268c34bdda7bf020b8