### PR TITLE
Add planning scenario with evaluation hooks and trace plotting

### DIFF
--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -1,0 +1,32 @@
+# Planning Project Scenario
+
+This scenario guides a small group through a structured planning process.
+
+## Setup
+
+1. Run the simulation using the scenario file:
+   ```bash
+   python src/app.py --scenario scenarios/planning_project.yaml
+   ```
+2. Export trace data after the run:
+   ```bash
+   python scripts/export_traces.py --snapshots snapshots --output data/traces.jsonl
+   ```
+3. Generate evaluation plots:
+   ```bash
+   python tools/export_traces.py data/traces.jsonl --outdir plots
+   ```
+
+## Scripted Beats
+
+1. **Proposal** – the planner presents a project idea.
+2. **Critique** – the critic challenges and refines the plan.
+3. **Vote** – participants decide whether to proceed.
+4. **Deliverable** – the worker produces the agreed output.
+
+## Metrics
+
+- **Coalitions formed**: number of projects with more than one member.
+- **Sentiment curves**: average agent mood over time.
+
+The resulting plots appear in the `plots/` directory.

--- a/scenarios/planning_project.yaml
+++ b/scenarios/planning_project.yaml
@@ -1,0 +1,16 @@
+description: Collaborative project planning with proposal, critique, vote, and deliverable phases
+steps: 40
+agents:
+  - role: planner
+    goal: propose a project plan for the group
+  - role: critic
+    goal: analyze and critique the proposal
+  - role: voter
+    goal: evaluate options and vote on the proposal
+  - role: worker
+    goal: produce the final deliverable after approval
+beats:
+  - proposal
+  - critique
+  - vote
+  - deliverable

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -159,6 +159,11 @@ class Simulation:
         self.collective_du: float = 0.0
         logger.info("Simulation initialized with collective IP/DU tracking.")
 
+        # --- NEW: Evaluation hooks and metrics ---
+        self.evaluation_hooks: list[Callable[[Self, list[Any]], dict[str, Any] | None]] = []
+        self.metrics: list[dict[str, Any]] = []
+        self.add_evaluation_hook(self._collect_metrics)
+
         # --- Initialize memory service ---
         if memory_service is None:
             memory_service = MemoryService(vector_store_manager, semantic_manager)
@@ -980,6 +985,24 @@ class Simulation:
                 pass
             self._event_task = None
 
+    def add_evaluation_hook(
+        self: Self, hook: Callable[[Self, list[Any]], dict[str, Any] | None]
+    ) -> None:
+        """Register a callback to collect metrics after each step."""
+        self.evaluation_hooks.append(hook)
+
+    def _collect_metrics(self: Self, _events: list[Any]) -> dict[str, Any]:
+        """Default metrics: coalition count and average sentiment."""
+        coalition_count = sum(
+            1 for proj in self.projects.values() if len(proj.get("members", [])) > 1
+        )
+        avg_sentiment = (
+            sum(agent.state.mood_level for agent in self.agents) / len(self.agents)
+            if self.agents
+            else 0.0
+        )
+        return {"coalitions": coalition_count, "sentiment": avg_sentiment}
+
     async def run_step(self: Self, max_turns: int = 1) -> int:
         """Dispatch up to ``max_turns`` events via the kernel."""
         if not self.agents:
@@ -997,6 +1020,27 @@ class Simulation:
             )
 
         events = await self.event_kernel.step(max_turns)
+
+        metrics: dict[str, Any] = {}
+        for hook in self.evaluation_hooks:
+            try:
+                result = hook(self, events) or {}
+                metrics.update(result)
+            except Exception:
+                logger.exception("Evaluation hook failed")
+        if metrics:
+            self.metrics.append({"step": self.current_step, **metrics})
+            eval_event = log_event(
+                {"type": "evaluation", "step": self.current_step, **metrics}
+            )
+            if eval_event is None:
+                eval_event = {
+                    "type": "evaluation",
+                    "step": self.current_step,
+                    **metrics,
+                }
+                eval_event["trace_hash"] = compute_trace_hash(eval_event)
+            await emit_event(SimulationEvent(type="evaluation", data=eval_event))
 
         return len(events)
 

--- a/tools/export_traces.py
+++ b/tools/export_traces.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Generate plots from evaluation events in trace datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+
+
+def load_metrics(file: str | Path) -> dict[str, list[tuple[int, float]]]:
+    data: dict[str, list[tuple[int, float]]] = defaultdict(list)
+    with Path(file).open("r", encoding="utf-8") as fh:
+        for line in fh:
+            obj: dict[str, Any] = json.loads(line)
+            if obj.get("type") != "evaluation":
+                continue
+            step = obj.get("step")
+            if not isinstance(step, int):
+                continue
+            for key, value in obj.items():
+                if key in {"type", "step", "trace_hash"}:
+                    continue
+                if isinstance(value, (int, float)):
+                    data[key].append((step, float(value)))
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Export evaluation plots from traces")
+    parser.add_argument("traces", help="Path to JSONL trace file")
+    parser.add_argument("--outdir", default="plots", help="Directory to store plots")
+    args = parser.parse_args(argv)
+
+    metrics = load_metrics(args.traces)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    for metric, pairs in metrics.items():
+        if not pairs:
+            continue
+        pairs.sort()
+        steps, values = zip(*pairs)
+        plt.figure()
+        plt.plot(steps, values)
+        plt.xlabel("Step")
+        plt.ylabel(metric.replace("_", " ").title())
+        plt.title(metric.replace("_", " ").title())
+        plt.tight_layout()
+        plt.savefig(outdir / f"{metric}.png")
+        plt.close()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add planning_project scenario with roles, goals, and beats
- introduce evaluation hooks in Simulation to log coalition and sentiment metrics
- export evaluation plots from traces via new tools/export_traces.py

## Testing
- `ruff check src/sim/simulation.py tools/export_traces.py`
- `pytest tests/unit/scripts/test_export_traces.py tests/integration/sim/test_snapshot_knowledge_board.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689541c5d2c0832684e80e40aafe092a