### PR TITLE
Add telemetry spans for LLM and messaging

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from opentelemetry import trace
 from typing_extensions import Self
 
 from src.interfaces import metrics
+from src.shared.telemetry import trace_agent_action
 
 from .level3_summary_manager import Level3SummaryManager
 from .multi_layer_retriever import MultiLayerRetriever
 from .semantic_memory_manager import SemanticMemoryManager
 from .vector_store import ChromaVectorStoreManager
-
-tracer = trace.get_tracer(__name__)
 
 
 class MemoryService:
@@ -42,7 +40,9 @@ class MemoryService:
     ) -> str:
         if not self.vector_store:
             return ""
-        with tracer.start_as_current_span("memory.add_memory"):
+        with trace_agent_action(
+            "memory.add_memory", agent_id=agent_id, event_type=event_type
+        ):
             return self.vector_store.add_memory(
                 agent_id, step, event_type, content, memory_type, metadata
             )
@@ -72,7 +72,9 @@ class MemoryService:
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
         try:
-            with tracer.start_as_current_span("memory.retrieve_relevant"):
+            with trace_agent_action(
+                "memory.retrieve_relevant", agent_id=agent_id, query=query, k=k
+            ):
                 result = await self.retriever.retrieve(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
@@ -87,7 +89,9 @@ class MemoryService:
             metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
             return []
         try:
-            with tracer.start_as_current_span("memory.retrieve_semantic"):
+            with trace_agent_action(
+                "memory.retrieve_semantic", agent_id=agent_id, query=query, k=k
+            ):
                 result = self.semantic_manager.retrieve_context(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
@@ -102,7 +106,9 @@ class MemoryService:
         self: Self, agent_id: str, query: str = "", k: int = 5
     ) -> list[dict[str, Any]]:
         try:
-            with tracer.start_as_current_span("memory.retrieve_and_update_semantic"):
+            with trace_agent_action(
+                "memory.retrieve_and_update_semantic", agent_id=agent_id, query=query, k=k
+            ):
                 result = await self.retriever.retrieve_and_update_semantic(agent_id, query, k)
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return result
@@ -127,7 +133,14 @@ class MemoryService:
         tuple[list[dict[str, Any]], list[str]] | tuple[list[dict[str, Any]], list[str], list[str]]
     ):
         """Return episodic, semantic, and optionally long-term summaries."""
-        with tracer.start_as_current_span("memory.get_context_pipeline"):
+        with trace_agent_action(
+            "memory.get_context_pipeline",
+            agent_id=agent_id,
+            query=query,
+            k=k,
+            semantic_limit=semantic_limit,
+            long_term_limit=long_term_limit or 0,
+        ):
             episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
             semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
             hits = len(episodic) + len(semantic)

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -49,7 +49,14 @@ def capture_rng_state() -> dict[str, Any]:
     try:  # pragma: no cover - optional dependency
         import numpy as np
 
-        state["numpy"] = cast(Any, np.random.get_state())
+        np_state = np.random.get_state()
+        state["numpy"] = (
+            np_state[0],
+            np_state[1].tolist(),
+            np_state[2],
+            np_state[3],
+            np_state[4],
+        )
     except ImportError:
         # ``numpy`` is optional; ignore if unavailable
         pass

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -563,55 +563,72 @@ def generate_text(
     Returns:
         str | None: The generated text, or None if an error occurred.
     """
-    with tracer.start_as_current_span("llm.generate_text"):
-        if is_mock_mode_enabled():
-            # Even in mock mode, allow a monkeypatched side_effect to run for failure tests.
-            if client and hasattr(client, "chat") and hasattr(client.chat, "side_effect"):
-                if client.chat.side_effect:
-                    try:
-                        return client.chat(model=model, messages=[{"role": "user", "content": prompt}])
-                    except _RequestException:
-                        return None  # Ensure side_effect exceptions are caught and handled.
-
-            mock_response = _MOCK_RESPONSES.get("text_generation", _MOCK_RESPONSES["default"])
-            # Simulate the structure of the real response to get the content
-            return {"message": {"content": mock_response}}["message"]["content"]
-
-        def call() -> LLMChatResponse:
-            """Invoke the LLM using ``LLMClient`` so the method can be monkeypatched
-            in tests.
-
-            Previous implementations called ``get_llm_client`` directly which
-            returned the underlying Ollama client.  Tests expecting to patch
-            ``LLMClient.chat`` would therefore bypass the patch and attempt a real
-            network request.  Instantiating ``LLMClient`` here preserves the public
-            API while allowing unit tests to mock ``LLMClient.chat`` easily.
-            """
-
-            wrapper = LLMClient(LLMClientConfig())
-            messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
-            return wrapper.chat_sync(
-                model=model,
-                messages=messages,
-                options={"temperature": temperature},
-            )
-
+    with tracer.start_as_current_span("llm.generate_text") as span:
+        span.set_attribute("llm.model", model)
+        start_time = time.perf_counter()
         try:
-            response, error = _retry_with_backoff(call)
-        except LLMClientInitError as exc:
-            logger.error(f"Failed to initialize LLM client: {exc}")
-            return None
+            if is_mock_mode_enabled():
+                # Even in mock mode, allow a monkeypatched side_effect to run for failure tests.
+                if client and hasattr(client, "chat") and hasattr(client.chat, "side_effect"):
+                    if client.chat.side_effect:
+                        try:
+                            result = client.chat(
+                                model=model, messages=[{"role": "user", "content": prompt}]
+                            )
+                        except _RequestException:
+                            result = None
+                        return result
 
-        if error:
-            logger.error(f"Failed to generate text after retries: {error}")
-            return None
-        if isinstance(response, dict) and "message" in response and "content" in response["message"]:
-            generated_text = response["message"]["content"]
-            logger.debug(f"Received response from Ollama: {generated_text}")
-            return str(generated_text).strip()
-        else:
-            logger.error(f"Unexpected response structure from Ollama: {response}")
-            return None
+                mock_response = _MOCK_RESPONSES.get(
+                    "text_generation", _MOCK_RESPONSES["default"]
+                )
+                # Simulate the structure of the real response to get the content
+                return {"message": {"content": mock_response}}["message"]["content"]
+
+            def call() -> LLMChatResponse:
+                """Invoke the LLM using ``LLMClient`` so the method can be monkeypatched
+                in tests.
+
+                Previous implementations called ``get_llm_client`` directly which
+                returned the underlying Ollama client.  Tests expecting to patch
+                ``LLMClient.chat`` would therefore bypass the patch and attempt a real
+                network request.  Instantiating ``LLMClient`` here preserves the public
+                API while allowing unit tests to mock ``LLMClient.chat`` easily.
+                """
+
+                wrapper = LLMClient(LLMClientConfig())
+                messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
+                return wrapper.chat_sync(
+                    model=model,
+                    messages=messages,
+                    options={"temperature": temperature},
+                )
+
+            try:
+                response, error = _retry_with_backoff(call)
+            except LLMClientInitError as exc:
+                logger.error(f"Failed to initialize LLM client: {exc}")
+                return None
+
+            if error:
+                logger.error(f"Failed to generate text after retries: {error}")
+                return None
+            if isinstance(response, dict) and "message" in response and "content" in response["message"]:
+                usage = response.get("usage", {})
+                if isinstance(usage, dict):
+                    prompt_tokens = int(usage.get("prompt_tokens", 0))
+                    completion_tokens = int(usage.get("completion_tokens", 0))
+                    span.set_attribute("llm.tokens.prompt", prompt_tokens)
+                    span.set_attribute("llm.tokens.completion", completion_tokens)
+                    span.set_attribute("llm.tokens.total", prompt_tokens + completion_tokens)
+                generated_text = response["message"]["content"]
+                logger.debug(f"Received response from Ollama: {generated_text}")
+                return str(generated_text).strip()
+            else:
+                logger.error(f"Unexpected response structure from Ollama: {response}")
+                return None
+        finally:
+            span.set_attribute("llm.latency_ms", (time.perf_counter() - start_time) * 1000)
 
 
 @charge_du_cost

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -156,12 +156,13 @@ class SimulationDiscordBot:
             token: discord.Client(intents=intents) for token in self.bot_tokens
         }
         self.client = self.clients[self.bot_tokens[0]]
-        queue = db.get_event_queue()
+        queue = context._event_queue or db.get_event_queue()
         self.context._event_queue = queue
-        try:
-            self.context._event_queue_loop = asyncio.get_event_loop()
-        except RuntimeError:  # pragma: no cover - no running loop
-            self.context._event_queue_loop = None
+        if self.context._event_queue_loop is None:
+            try:
+                self.context._event_queue_loop = asyncio.get_event_loop()
+            except RuntimeError:  # pragma: no cover - no running loop
+                self.context._event_queue_loop = None
         self.event_queue = queue
         if message_sse_queue is not dashboard_message_queue:
             self.message_queue = message_sse_queue
@@ -205,10 +206,15 @@ class SimulationDiscordBot:
 
             @client.event
             async def on_message(message: Any, client: Any = client) -> None:
-                with tracer.start_as_current_span("discord.on_message"):
+                with tracer.start_as_current_span("discord.on_message") as span:
                     if getattr(message, "author", None) == client.user:
                         return
                     content = getattr(message, "content", "")
+                    span.set_attribute("discord.message_length", len(content))
+                    channel = getattr(message, "channel", None)
+                    span.set_attribute("discord.channel_id", getattr(channel, "id", None))
+                    user = getattr(message, "author", None)
+                    span.set_attribute("discord.user_id", getattr(user, "id", None))
                     if not allow_message(content):
                         logger.debug("Message blocked by policy")
                         return
@@ -217,9 +223,7 @@ class SimulationDiscordBot:
                         logger.debug("Message blocked by OPA policy")
                         return
                     metrics.HUMAN_MESSAGES_TOTAL.inc()
-                    channel = getattr(message, "channel", None)
                     channel_id = getattr(channel, "id", None)
-                    user = getattr(message, "author", None)
                     user_id = getattr(user, "id", None)
                     if user_id and channel_id:
                         self.user_channels[str(user_id)] = channel_id
@@ -293,7 +297,13 @@ class SimulationDiscordBot:
         Returns:
             bool: True if message was sent successfully, False otherwise
         """
-        with tracer.start_as_current_span("discord.send_simulation_update"):
+        with tracer.start_as_current_span("discord.send_simulation_update") as span:
+            span.set_attribute("discord.agent_id", agent_id or "")
+            span.set_attribute("discord.content_length", len(content) if content else 0)
+            if target_channel_id is not None:
+                span.set_attribute("discord.target_channel_id", target_channel_id)
+            if recipient is not None:
+                span.set_attribute("discord.recipient_id", recipient)
             if not self.is_ready:
                 logger.warning("Discord bot not ready yet, message not sent")
                 return False
@@ -312,6 +322,7 @@ class SimulationDiscordBot:
                     chan_id = self.user_channels.get(recipient)
                 if chan_id is None:
                     chan_id = self.channel_map.get(agent_id, self.channel_id)
+                span.set_attribute("discord.channel_id", chan_id)
                 channel = client.get_channel(chan_id)
                 if not channel:
                     logger.warning(f"Could not find Discord channel with ID: {chan_id}")
@@ -591,7 +602,7 @@ class SimulationDiscordBot:
                     agent_id=msg.agent_id,
                     recipient=recipient,
                 )
-        except asyncio.CancelledError:  # pragma: no cover - task cancelled on stop
+        except (asyncio.CancelledError, RuntimeError):  # pragma: no cover - task cancelled or loop closed
             pass
 
     async def _start_client_with_backoff(

--- a/src/shared/telemetry.py
+++ b/src/shared/telemetry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+
+@contextmanager
+def trace_agent_action(action: str, agent_id: str | None = None, **attrs: Any) -> Iterator[None]:
+    """Context manager for tracing agent actions.
+
+    Args:
+        action: Name of the action to record in the span.
+        agent_id: Optional identifier for the agent performing the action.
+        **attrs: Additional span attributes.
+    """
+    span_name = f"agent.{action}"
+    with tracer.start_as_current_span(span_name) as span:
+        if agent_id is not None:
+            span.set_attribute("agent.id", agent_id)
+        for key, value in attrs.items():
+            span.set_attribute(key, value)
+        yield

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -218,6 +218,10 @@ class EventKernel:
             executed.append(event)
         return executed
 
+    async def step(self: Self, limit: int) -> list[Event]:
+        """Compatibility wrapper for old ``step`` API."""
+        return await self.dispatch(limit)
+
     def empty(self: Self) -> bool:
         return not self._queue
 


### PR DESCRIPTION
## Summary
- track model, tokens, and latency for LLM generate_text
- trace memory retrieval and expose helper for agent spans
- instrument Discord bot message send/receive spans
- respect pre-set event queues and ensure Discord forwarding tasks cancel cleanly
- serialize RNG state for checkpoint hashing and add event-kernel step wrapper

## Testing
- `ruff check src/interfaces/discord_bot.py src/infra/checkpoint.py src/sim/event_kernel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896493bdda083269562063f1e307328