### PR TITLE
feat: add moderation helpers

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -91,3 +91,16 @@ curl -X POST -H 'Content-Type: application/json' \
 ```
 The staked amount counts toward the `sqrt(ip_balance + staked_ip)` formula used
 for default voting weight.
+
+## Moderation API
+
+The event kernel exposes helper functions for moderation that can be invoked via
+slash commands or other external interfaces:
+
+- `mute_agent(agent_id)`: prevent an agent from sending messages.
+- `reset_memory(agent_id)`: clear all stored memories for the agent.
+- `apply_penalty(agent_id, ip, du)`: subtract Influence Points (IP) and/or
+  Development Units (DU) from an agent's balance.
+
+Each call publishes a `moderation` event through the kernel so that the
+simulation and connected clients can react accordingly.

--- a/src/sim/resources.py
+++ b/src/sim/resources.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.infra.ledger import ledger
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from .simulation import Simulation
+
+logger = logging.getLogger(__name__)
+
+
+async def mute_agent(sim: Simulation, agent_id: str) -> None:
+    """Mute ``agent_id`` and broadcast the action."""
+    sim.muted_agents.add(agent_id)
+    event = {
+        "type": "moderation",
+        "action": "mute",
+        "agent_id": agent_id,
+        "step": sim.current_step,
+    }
+    await sim.event_kernel.emit_environment_event(event)
+
+
+async def reset_memory(sim: Simulation, agent_id: str) -> None:
+    """Reset the memory of ``agent_id`` and broadcast the action."""
+    try:
+        sim.memory_service.reset_agent(agent_id)
+    except Exception:  # pragma: no cover - defensive
+        logger.error("Failed to reset memory for %s", agent_id, exc_info=True)
+        return
+    event = {
+        "type": "moderation",
+        "action": "reset_memory",
+        "agent_id": agent_id,
+        "step": sim.current_step,
+    }
+    await sim.event_kernel.emit_environment_event(event)
+
+
+async def apply_penalty(sim: Simulation, agent_id: str, ip: float = 0.0, du: float = 0.0) -> None:
+    """Apply an IP/DU penalty to ``agent_id`` and broadcast the action."""
+    try:
+        ledger.log_change(agent_id, -abs(ip), -abs(du), "moderation_penalty")
+    except Exception:  # pragma: no cover - defensive
+        logger.error("Failed to apply penalty to %s", agent_id, exc_info=True)
+        return
+    event = {
+        "type": "moderation",
+        "action": "penalty",
+        "agent_id": agent_id,
+        "ip": ip,
+        "du": du,
+        "step": sim.current_step,
+    }
+    await sim.event_kernel.emit_environment_event(event)
+
+
+__all__ = ["apply_penalty", "mute_agent", "reset_memory"]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -438,24 +438,42 @@ class Simulation:
                     )
                     _ = task
 
+    async def mute_agent(self: Self, agent_id: str) -> None:
+        from .resources import mute_agent as _mute_agent
+
+        await _mute_agent(self, agent_id)
+
+    async def reset_memory(self: Self, agent_id: str) -> None:
+        from .resources import reset_memory as _reset_memory
+
+        await _reset_memory(self, agent_id)
+
+    async def apply_penalty(self: Self, agent_id: str, ip: float, du: float) -> None:
+        from .resources import apply_penalty as _apply_penalty
+
+        await _apply_penalty(self, agent_id, ip, du)
+
     async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process moderation actions like muting or penalties."""
         action = cmd.get("command")
         agent_id = cmd.get("agent_id")
         if action == "mute" and agent_id:
-            self.muted_agents.add(str(agent_id))
+            await self.event_kernel.schedule_immediate(
+                lambda aid=str(agent_id): self.mute_agent(aid),
+                vector=self.vector,
+            )
         elif action == "reset_memory" and agent_id:
-            try:
-                self.memory_service.reset_agent(str(agent_id))
-            except Exception:
-                logger.error("Failed to reset memory for %s", agent_id, exc_info=True)
+            await self.event_kernel.schedule_immediate(
+                lambda aid=str(agent_id): self.reset_memory(aid),
+                vector=self.vector,
+            )
         elif action == "penalty" and agent_id:
             ip = float(cmd.get("ip", 0))
             du = float(cmd.get("du", 0))
-            try:
-                ledger.log_change(str(agent_id), -abs(ip), -abs(du), "moderation_penalty")
-            except Exception:
-                logger.error("Failed to apply penalty to %s", agent_id, exc_info=True)
+            await self.event_kernel.schedule_immediate(
+                lambda aid=str(agent_id), ip=ip, du=du: self.apply_penalty(aid, ip, du),
+                vector=self.vector,
+            )
 
     async def spawn_agent(
         self: Self,
@@ -616,9 +634,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -633,9 +649,9 @@ class Simulation:
         async with self._msg_lock:
             perception_data["perceived_messages"] = list(self.messages_to_perceive_this_round)
         if self.knowledge_board:
-            perception_data[
-                "knowledge_board_content"
-            ] = self.knowledge_board.get_recent_entries_for_prompt()
+            perception_data["knowledge_board_content"] = (
+                self.knowledge_board.get_recent_entries_for_prompt()
+            )
 
         agent_output = await agent.run_turn(
             simulation_step=self.current_step,
@@ -1030,9 +1046,7 @@ class Simulation:
                 logger.exception("Evaluation hook failed")
         if metrics:
             self.metrics.append({"step": self.current_step, **metrics})
-            eval_event = log_event(
-                {"type": "evaluation", "step": self.current_step, **metrics}
-            )
+            eval_event = log_event({"type": "evaluation", "step": self.current_step, **metrics})
             if eval_event is None:
                 eval_event = {
                     "type": "evaluation",

--- a/tests/stress/test_event_kernel_stress.py
+++ b/tests/stress/test_event_kernel_stress.py
@@ -70,6 +70,7 @@ class _DummyAgent:
         self,
         simulation_step: int,
         environment_perception: dict[str, Any] | None = None,
+        memory_service: Any | None = None,
         vector_store_manager: Any | None = None,
         knowledge_board: Any | None = None,
     ) -> dict[str, int]:

--- a/tests/utils/mock_llm.py
+++ b/tests/utils/mock_llm.py
@@ -116,7 +116,21 @@ def MockLLM(
             patch("src.infra.llm_client.client.chat", side_effect=mock_ollama_chat)
         )
         stack.enter_context(
+            patch(
+                "src.infra.llm_client.client.chat_sync",
+                side_effect=mock_ollama_chat,
+                create=True,
+            )
+        )
+        stack.enter_context(
             patch("src.infra.llm_client.ollama.chat", side_effect=mock_ollama_chat)
+        )
+        stack.enter_context(
+            patch(
+                "src.infra.llm_client.ollama.chat_sync",
+                side_effect=mock_ollama_chat,
+                create=True,
+            )
         )
         if caller_module is not None:
             stack.enter_context(


### PR DESCRIPTION
## Summary
- add moderation helper functions for muting agents, resetting memory, and applying penalties
- expose helpers through simulation and document moderation API
- fix failing tests by mocking synchronous chat methods and aligning stress dummy agent with new signature

## Testing
- `ruff check --config=pyproject.toml --fix src/sim/simulation.py src/sim/resources.py tests/utils/mock_llm.py tests/stress/test_event_kernel_stress.py`
- `mypy --config-file=pyproject.toml tests/utils/mock_llm.py tests/stress/test_event_kernel_stress.py` *(fails: Interrupted)*
- `pytest tests/stress/test_event_kernel_stress.py::test_run_turns_concurrent_no_race -m stress`
- `pytest tests/unit/core/test_llm_monitoring.py::test_llm_monitoring`
- `pytest tests/unit/agents/graphs/test_graph_nodes.py::test_nodes_flow` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68969ae1a0c08326a3a2069206ce1951