### PR TITLE
Add control slash commands for Discord bot

### DIFF
--- a/docs/discord_manual_run.md
+++ b/docs/discord_manual_run.md
@@ -39,6 +39,21 @@ These commands are helpful for manual smoke testing of the Discord interface.
 When channels are mapped to specific agents you can also use slash commands:
 
 ```text
+/start
+```
+Starts the simulation if it is currently paused.
+
+```text
+/stop
+```
+Stops the simulation.
+
+```text
+/spawn agent_4
+```
+Spawns a new agent with the given ID.
+
+```text
 /status
 ```
 Shows the agent's current IP and DU balance as an ephemeral message.

--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from scripts.export_traces import export_latest
 from src.agents.core.base_agent import Agent
@@ -39,28 +39,20 @@ restore_environment = _restore_environment
 async def start_simulation(ctx: SimulationContext | None = None) -> None:
     """Enqueue a control command to start the simulation."""
     context = ctx or DEFAULT_CONTEXT
-    await context.get_event_queue().put(
-        SimulationEvent(type="control", data={"command": "start"})
-    )
+    await context.get_event_queue().put(SimulationEvent(type="control", data={"command": "start"}))
 
 
 async def stop_simulation(ctx: SimulationContext | None = None) -> None:
     """Enqueue a control command to stop the simulation."""
     context = ctx or DEFAULT_CONTEXT
-    await context.get_event_queue().put(
-        SimulationEvent(type="control", data={"command": "stop"})
-    )
+    await context.get_event_queue().put(SimulationEvent(type="control", data={"command": "stop"}))
 
 
-async def spawn_agent_command(
-    agent_id: str, ctx: SimulationContext | None = None
-) -> None:
+async def spawn_agent_command(agent_id: str, ctx: SimulationContext | None = None) -> None:
     """Request spawning of a new agent via the event queue."""
     context = ctx or DEFAULT_CONTEXT
     await context.get_event_queue().put(
-        SimulationEvent(
-            type="control", data={"command": "spawn", "agent_id": agent_id}
-        )
+        SimulationEvent(type="control", data={"command": "spawn", "agent_id": agent_id})
     )
 
 
@@ -111,7 +103,10 @@ use_uvloop_if_available()
 
 # Discord bot integration is imported lazily to avoid circular imports when
 # ``src.interfaces.discord_bot`` references functions from this module.
-simulation_discord_bot_class: Optional[type[object]] = None
+if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
+    from src.interfaces.discord_bot import SimulationDiscordBot
+
+simulation_discord_bot_class: type["SimulationDiscordBot"] | None = None
 
 DEFAULT_SCENARIO = "Agents collaborate to design a specification for a communication protocol."
 
@@ -162,9 +157,7 @@ def create_simulation(
                 if bot.is_ready:
                     discord_bot = bot
                 else:
-                    logging.warning(
-                        "Discord bot not ready, running without integration."
-                    )
+                    logging.warning("Discord bot not ready, running without integration.")
 
     agents = [Agent(agent_id=f"agent_{i + 1}", name=f"Agent_{i + 1}") for i in range(num_agents)]
 

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -17,6 +17,7 @@ import httpx
 from opentelemetry import trace
 from typing_extensions import Self
 
+from src.app import spawn_agent_command, start_simulation, stop_simulation
 from src.infra import config
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
@@ -34,16 +35,19 @@ from src.utils.policy import allow_message, evaluate_with_opa
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     import discord
+    from discord import app_commands
     from discord.ext import commands
 else:  # pragma: no cover - runtime import with fallback
     try:
         import discord
+        from discord import app_commands
         from discord.ext import commands
     except ImportError:  # pragma: no cover - optional dependency
         from unittest.mock import MagicMock
 
         discord = MagicMock()
         commands = MagicMock()
+        app_commands = MagicMock()
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -171,12 +175,39 @@ class SimulationDiscordBot:
             self.message_queue = context.message_queue
         self._forward_task: asyncio.Task[Any] | None = None
         self._client_tasks: list[asyncio.Task[Any]] = []
+        self.command_trees: dict[str, app_commands.CommandTree] = {}
 
-        # Set up event handlers for all clients
+        # Set up event handlers and slash commands for all clients
         for _token, client in self.clients.items():
+            tree: app_commands.CommandTree | None = None
+            try:
+                if hasattr(client, "http"):
+                    tree = app_commands.CommandTree(client)
+            except Exception:
+                tree = None
+            if tree is not None:
+                self.command_trees[_token] = tree
+
+                @tree.command(name="start")
+                async def _tree_start(interaction: "discord.Interaction") -> None:
+                    await start_simulation(self.context)
+                    await interaction.response.send_message("start", ephemeral=True)
+
+                @tree.command(name="stop")
+                async def _tree_stop(interaction: "discord.Interaction") -> None:
+                    await stop_simulation(self.context)
+                    await interaction.response.send_message("stop", ephemeral=True)
+
+                @tree.command(name="spawn")
+                @app_commands.describe(agent_id="ID of the agent to spawn")
+                async def _tree_spawn(interaction: "discord.Interaction", agent_id: str) -> None:
+                    await spawn_agent_command(agent_id, self.context)
+                    await interaction.response.send_message(f"spawn {agent_id}", ephemeral=True)
 
             @client.event
-            async def on_ready(client: Any = client) -> None:
+            async def on_ready(
+                client: Any = client, tree: app_commands.CommandTree | None = tree
+            ) -> None:
                 """Event handler that fires when the bot connects to Discord."""
                 self.is_ready = True
                 logger.info(f"Discord bot {client.user} connected and ready!")
@@ -203,6 +234,12 @@ class SimulationDiscordBot:
                             logger.warning("Attempted to send message to a None channel.")
                 else:
                     logger.warning(f"Could not find Discord channel with ID: {self.channel_id}")
+
+                if tree is not None:
+                    try:
+                        await tree.sync()
+                    except Exception:  # pragma: no cover - sync may fail in tests
+                        logger.exception("Failed to sync command tree")
 
             @client.event
             async def on_message(message: Any, client: Any = client) -> None:
@@ -602,7 +639,10 @@ class SimulationDiscordBot:
                     agent_id=msg.agent_id,
                     recipient=recipient,
                 )
-        except (asyncio.CancelledError, RuntimeError):  # pragma: no cover - task cancelled or loop closed
+        except (
+            asyncio.CancelledError,
+            RuntimeError,
+        ):  # pragma: no cover - task cancelled or loop closed
             pass
 
     async def _start_client_with_backoff(
@@ -783,9 +823,7 @@ async def slash_start(interaction: Any) -> None:
     """Start the simulation via a control command."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(type="control", data={"command": "start"})
-    )
+    await start_simulation(ctx)
     await interaction.response.send_message("start", ephemeral=True)
 
 
@@ -794,9 +832,7 @@ async def slash_stop(interaction: Any) -> None:
     """Stop the simulation via a control command."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(type="control", data={"command": "stop"})
-    )
+    await stop_simulation(ctx)
     await interaction.response.send_message("stop", ephemeral=True)
 
 
@@ -805,11 +841,7 @@ async def slash_spawn(interaction: Any, agent_id: str) -> None:
     """Spawn a new agent in the simulation."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(
-            type="control", data={"command": "spawn", "agent_id": agent_id}
-        )
-    )
+    await spawn_agent_command(agent_id, ctx)
     await interaction.response.send_message(f"spawn {agent_id}", ephemeral=True)
 
 


### PR DESCRIPTION
## Summary
- expose start, stop, and spawn simulation hooks via Discord slash commands
- document new Discord control commands
- fix SimulationDiscordBot type annotation so mypy can resolve `.create`

## Testing
- `ruff check src/app.py src/interfaces/discord_bot.py`
- `pre-commit run --hook-stage manual ruff-format --files src/app.py src/interfaces/discord_bot.py`
- `pre-commit run --hook-stage manual mypy --files src/app.py src/interfaces/discord_bot.py`
- `pytest tests/integration/interfaces/test_discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68969ae11e188326ae01c29a0b9c4300