### PR TITLE
Add retrieval benchmark with p95 and Grafana panels

### DIFF
--- a/docs/grafana_dashboard.json
+++ b/docs/grafana_dashboard.json
@@ -79,6 +79,42 @@
         "x": 0,
         "y": 24
       }
+    },
+    {
+      "type": "graph",
+      "title": "Memory Retrieval P@5",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "memory_retrieval_precision_at_5",
+          "legendFormat": "p@5",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      }
+    },
+    {
+      "type": "graph",
+      "title": "Memory Retrieval p95 Latency",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "memory_retrieval_latency_p95_ms",
+          "legendFormat": "p95 ms",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      }
     }
   ]
 }

--- a/src/utils/retrieval_metrics.py
+++ b/src/utils/retrieval_metrics.py
@@ -7,6 +7,19 @@ from collections.abc import Awaitable, Sequence
 from typing import Any, Callable
 
 
+def p95(values: Sequence[float]) -> float:
+    """Return the 95th percentile of ``values``.
+
+    Values are assumed to be non-empty and expressed in the same units
+    (e.g. seconds). If ``values`` is empty, ``0.0`` is returned.
+    """
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    index = int(0.95 * (len(sorted_vals) - 1))
+    return sorted_vals[index]
+
+
 def precision_at_k(retrieved_ids: Sequence[str], relevant_ids: set[str], k: int) -> float:
     """Return precision at ``k`` for retrieved versus relevant IDs."""
     if k <= 0:

--- a/tests/integration/memory/conftest.py
+++ b/tests/integration/memory/conftest.py
@@ -9,7 +9,7 @@ def recall_benchmark():
 
     async def _bench(retrieval_coro, relevant_ids, k):
         results, latency = await time_call(retrieval_coro)
-        ids = [m.get("id") for m in results]
+        ids = [m.get("memory_id") or m.get("id") for m in results]
         metrics = {
             "p_at_k": precision_at_k(ids, set(relevant_ids), k),
             "latency": latency,

--- a/tests/integration/memory/test_recall_benchmark.py
+++ b/tests/integration/memory/test_recall_benchmark.py
@@ -5,31 +5,59 @@ import pytest
 pytest.importorskip("sklearn")
 pytest.importorskip("chromadb")
 
+import asyncio
+
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.utils.retrieval_metrics import p95
 from tests.unit.memory.test_semantic_memory_manager import DummyDriver
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-@pytest.mark.memory
-@pytest.mark.usefixtures("chroma_test_dir")
-async def test_recall_benchmark(recall_benchmark, chroma_test_dir: Path) -> None:
+@pytest.fixture
+def benchmark_cases(chroma_test_dir: Path, event_loop: asyncio.AbstractEventLoop):
+    """Prepare 30 retrieval cases for benchmarking."""
+    class _Embed:
+        def __call__(self, input: list[str]) -> list[list[float]]:
+            return [[1.0 if "cat" in x else 0.0] for x in input]
+
+        def name(self) -> str:  # pragma: no cover - simple attribute
+            return "dummy"
+
     vector = ChromaVectorStoreManager(
         persist_directory=chroma_test_dir,
-        embedding_function=lambda t: [[1.0 if "cat" in x else 0.0] for x in t],
+        embedding_function=_Embed(),
     )
     driver = DummyDriver()
     semantic = SemanticMemoryManager(vector, driver)
     service = MemoryService(vector, semantic)
 
-    cat_id = vector.add_memory("agent", 1, "thought", "cat", memory_type="raw")
-    await service.run_semantic_job("agent")
+    relevant_ids = set()
+    for i in range(5):
+        mid = vector.add_memory("agent", i, "thought", f"cat {i}", memory_type="raw")
+        relevant_ids.add(mid)
+    for i in range(5):
+        vector.add_memory("agent", i + 5, "thought", f"dog {i}", memory_type="raw")
+
+    event_loop.run_until_complete(service.run_semantic_job("agent"))
 
     async def retrieval():
-        return await service.retrieve_relevant_memories("agent", "cat", k=1)
+        return await service.retrieve_relevant_memories("agent", "cat", k=5)
 
-    metrics = await recall_benchmark(retrieval, {cat_id}, 1)
-    assert 0.0 <= metrics["p_at_k"] <= 1.0
-    assert metrics["latency"] >= 0.0
+    return [(retrieval, relevant_ids) for _ in range(30)]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.memory
+async def test_recall_benchmark(recall_benchmark, benchmark_cases) -> None:
+    latencies = []
+    precisions = []
+    for retrieval, relevant_ids in benchmark_cases:
+        metrics = await recall_benchmark(retrieval, relevant_ids, 5)
+        precisions.append(metrics["p_at_k"])
+        latencies.append(metrics["latency"])
+    avg_p5 = sum(precisions) / len(precisions)
+    latency_p95 = p95(latencies) * 1000.0  # convert to milliseconds
+    assert avg_p5 >= 0.7
+    assert latency_p95 <= 50


### PR DESCRIPTION
## Summary
- add `p95` percentile helper for retrieval metrics
- expand memory recall benchmark to 30 cases with p@5 and p95 latency checks
- expose retrieval precision and latency on Grafana dashboard

## Testing
- `ruff check src/utils/retrieval_metrics.py tests/integration/memory/test_recall_benchmark.py tests/integration/memory/conftest.py`
- `pytest -m "integration" tests/integration/memory/test_recall_benchmark.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ba35f88c8326965b72b863336a73