### PR TITLE
feat: add beat-based evaluation events

### DIFF
--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -17,6 +17,9 @@ This scenario guides a small group through a structured planning process.
    python tools/export_traces.py data/traces.jsonl --outdir plots
    ```
 
+During the run, evaluation events are emitted at the end of each beat, recording
+coalition counts and sentiment snapshots for plotting.
+
 ## Scripted Beats
 
 1. **Proposal** – the planner presents a project idea.

--- a/scenarios/planning_project.yaml
+++ b/scenarios/planning_project.yaml
@@ -1,3 +1,4 @@
+name: planning_project
 description: Collaborative project planning with proposal, critique, vote, and deliverable phases
 steps: 40
 agents:

--- a/src/app.py
+++ b/src/app.py
@@ -73,8 +73,8 @@ def _simple_yaml(path: Path) -> dict[str, object]:
     return data
 
 
-def load_scenario(value: str) -> tuple[str, int | None, int | None]:
-    """Return scenario description and optional overrides from a file."""
+def load_scenario(value: str) -> tuple[str, int | None, int | None, list[str]]:
+    """Return scenario description, overrides, and optional beats from a file."""
     path = Path(value)
     if path.is_file():
         try:  # Try full YAML parsing if PyYAML is available
@@ -88,15 +88,18 @@ def load_scenario(value: str) -> tuple[str, int | None, int | None]:
             desc = str(content.get("description") or content.get("scenario") or "")
             steps = content.get("steps")
             agents = content.get("agents")
+            beats = content.get("beats")
+            beat_list = [str(b) for b in beats] if isinstance(beats, list) else []
             return (
                 desc,
                 int(steps) if steps is not None else None,
                 int(agents) if agents is not None else None,
+                beat_list,
             )
         if isinstance(content, str):
-            return content, None, None
-        return str(content), None, None
-    return value, None, None
+            return content, None, None, []
+        return str(content), None, None, []
+    return value, None, None, []
 
 
 use_uvloop_if_available()
@@ -115,6 +118,7 @@ def create_simulation(
     num_agents: int = 3,
     steps: int = 10,
     scenario: str = DEFAULT_SCENARIO,
+    beats: list[str] | None = None,
     use_discord: bool = False,
     use_vector_store: bool = False,
     vector_store_dir: str = "./chroma_db",
@@ -186,6 +190,7 @@ def create_simulation(
         vector_store_manager=vector_store,
         semantic_manager=semantic_manager,
         scenario=scenario,
+        beats=beats,
         discord_bot=discord_bot,
     )
     if config.KNOWLEDGE_BOARD_BACKEND == "graph":
@@ -299,7 +304,7 @@ def main() -> None:
     # Load optional plugins before argument parsing
     asyncio.run(load_plugins())
     args = parse_args()
-    desc, file_steps, file_agents = load_scenario(args.scenario)
+    desc, file_steps, file_agents, beats = load_scenario(args.scenario)
     if file_steps is not None:
         args.steps = file_steps
     if file_agents is not None:
@@ -336,6 +341,7 @@ def main() -> None:
             num_agents=args.agents,
             steps=args.steps,
             scenario=args.scenario,
+            beats=beats,
             use_discord=args.discord,
             use_vector_store=args.vector_store,
             vector_store_dir=args.vector_dir,

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -70,6 +70,7 @@ class Simulation:
         vector_store_manager: Optional["ChromaVectorStoreManager"] = None,
         semantic_manager: Optional["SemanticMemoryManager"] = None,
         scenario: str = "",
+        beats: list[str] | None = None,
         discord_bot: Optional["SimulationDiscordBot"] = None,
     ) -> None:
         """
@@ -85,6 +86,8 @@ class Simulation:
                 vector-based agent memory storage and retrieval.
             scenario (str): Description of the simulation scenario that provides
                 context for agent interactions.
+            beats (list[str] | None): Optional beat names that segment the
+                scenario into phases for evaluation.
             discord_bot (Optional[SimulationDiscordBot]): Discord bot for sending
                 simulation updates to Discord.
         """
@@ -105,6 +108,9 @@ class Simulation:
         self.speed: float = 1.0
         self.agent_initial_token_budget = int(config.get_config("AGENT_TOKEN_BUDGET"))
         self.muted_agents: set[str] = set()
+        self.beats: list[str] = beats or []
+        self._beat_index = 0
+        self._beat_interval = 0
         # Add other simulation-wide state if needed (e.g., environment properties)
         # self.environment_state = {}
 
@@ -877,6 +883,31 @@ class Simulation:
             )
             self._last_quest_step = self.current_step
 
+        if (
+            self.beats
+            and self._beat_interval > 0
+            and self._beat_index < len(self.beats)
+            and self.current_step >= (self._beat_index + 1) * self._beat_interval
+        ):
+            metrics: dict[str, Any] = {}
+            for hook in self.evaluation_hooks:
+                try:
+                    metrics.update(hook(self, []) or {})
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception("Evaluation hook failed")
+            metrics["beat"] = self.beats[self._beat_index]
+            self.metrics.append({"step": self.current_step, **metrics})
+            eval_event = log_event({"type": "evaluation", "step": self.current_step, **metrics})
+            if eval_event is None:
+                eval_event = {
+                    "type": "evaluation",
+                    "step": self.current_step,
+                    **metrics,
+                }
+                eval_event["trace_hash"] = compute_trace_hash(eval_event)
+            await emit_event(SimulationEvent(type="evaluation", data=eval_event))
+            self._beat_index += 1
+
         self.vector.increment(self.agents[next_agent_index].get_id())
         await self.event_kernel.schedule_in(
             1,
@@ -1066,6 +1097,9 @@ class Simulation:
             num_steps (int): Number of steps to run.
         """
         logger.info(f"Starting simulation run for {num_steps} steps (async)")
+        self.steps_to_run = num_steps
+        if self.beats and self._beat_interval == 0:
+            self._beat_interval = max(1, num_steps // len(self.beats))
         start_time = time.time()
         total_steps_executed = 0
         try:

--- a/tests/unit/test_app_cli.py
+++ b/tests/unit/test_app_cli.py
@@ -60,6 +60,7 @@ def test_main_invokes_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
         num_agents=2,
         steps=3,
         scenario=app.DEFAULT_SCENARIO,
+        beats=[],
         use_discord=False,
         use_vector_store=False,
         vector_store_dir="./chroma_db",
@@ -79,11 +80,12 @@ def test_load_scenario_from_file(tmp_path) -> None:
     path = tmp_path / "demo.yaml"
     path.write_text("""description: Test scenario\nsteps: 7\nagents: 4\n""")
 
-    desc, steps, agents = app.load_scenario(str(path))
+    desc, steps, agents, beats = app.load_scenario(str(path))
 
     assert desc == "Test scenario"
     assert steps == 7
     assert agents == 4
+    assert beats == []
 
 
 def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -109,6 +111,7 @@ def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> N
         num_agents=1,
         steps=2,
         scenario="File scenario",
+        beats=[],
         use_discord=False,
         use_vector_store=False,
         vector_store_dir="./chroma_db",


### PR DESCRIPTION
## Summary
- add planning_project scenario with defined beats
- emit evaluation events at each scenario beat
- document running scenarios and evaluation output

## Testing
- `ruff check src/app.py src/sim/simulation.py tests/unit/test_app_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ba17886c8326aca226dbd1b502d2