### PR TITLE
Enforce DU budgets and surface LLM cost metrics

### DIFF
--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -18,6 +18,7 @@ from opentelemetry import trace
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
 
+from src.infra import metrics as infra_metrics
 from src.interfaces import metrics
 from src.shared.decorator_utils import llm_perf_logger, monitor_llm_call
 from src.shared.typing import (
@@ -91,6 +92,28 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         state = cast("AgentState | None", kwargs.get("agent_state"))
+        if state is not None:
+            try:
+                try:
+                    base_price, token_price = ledger.calculate_gas_price(state.agent_id)
+                except AttributeError:
+                    base_price = float(get_config("GAS_PRICE_PER_CALL"))
+                    token_price = float(get_config("GAS_PRICE_PER_TOKEN"))
+                # Ensure the agent has at least enough DU for the base call
+                try:
+                    from src.sim.resource_manager import get_resource_manager
+
+                    get_resource_manager().ensure_du_budget(state.agent_id, base_price)
+                except Exception:
+                    logger.warning(
+                        "Insufficient DU for agent %s: required=%s, available=%s",
+                        state.agent_id,
+                        base_price,
+                        state.du,
+                    )
+                    raise
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"Failed to validate DU budget: {e}")
         result = func(*args, **kwargs)
         if state is not None:
             try:
@@ -107,12 +130,11 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                             usage.get("completion_tokens", 0)
                         )
                 cost = base_price + token_price * tokens
-                # Enforce DU budget via the simulation resource manager
                 try:
                     from src.sim.resource_manager import get_resource_manager
 
                     get_resource_manager().charge_du(state.agent_id, cost)
-                except Exception as exc:
+                except Exception:
                     logger.warning(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
@@ -121,10 +143,9 @@ def charge_du_cost(func: Callable[P, T]) -> Callable[P, T]:
                     )
                     raise
                 state.du -= cost
-                # Update cost metrics
                 if tokens > 0:
                     du_per_1k = cost / (tokens / 1000)
-                    metrics.LLM_DU_PER_1K_TOKENS.set(du_per_1k)
+                    infra_metrics.record_du_per_1k_tokens(du_per_1k)
                 try:
                     ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
                 except Exception:  # pragma: no cover - optional
@@ -143,6 +164,27 @@ def async_charge_du_cost(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitab
     @functools.wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         state = cast("AgentState | None", kwargs.get("agent_state"))
+        if state is not None:
+            try:
+                try:
+                    base_price, token_price = ledger.calculate_gas_price(state.agent_id)
+                except AttributeError:
+                    base_price = float(get_config("GAS_PRICE_PER_CALL"))
+                    token_price = float(get_config("GAS_PRICE_PER_TOKEN"))
+                try:
+                    from src.sim.resource_manager import get_resource_manager
+
+                    get_resource_manager().ensure_du_budget(state.agent_id, base_price)
+                except Exception:
+                    logger.warning(
+                        "Insufficient DU for agent %s: required=%s, available=%s",
+                        state.agent_id,
+                        base_price,
+                        state.du,
+                    )
+                    raise
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"Failed to validate DU budget: {e}")
         result = await func(*args, **kwargs)
         if state is not None:
             try:
@@ -163,7 +205,7 @@ def async_charge_du_cost(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitab
                     from src.sim.resource_manager import get_resource_manager
 
                     get_resource_manager().charge_du(state.agent_id, cost)
-                except Exception as exc:
+                except Exception:
                     logger.warning(
                         "Insufficient DU for agent %s: cost=%s, available=%s",
                         state.agent_id,
@@ -174,7 +216,7 @@ def async_charge_du_cost(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitab
                 state.du -= cost
                 if tokens > 0:
                     du_per_1k = cost / (tokens / 1000)
-                    metrics.LLM_DU_PER_1K_TOKENS.set(du_per_1k)
+                    infra_metrics.record_du_per_1k_tokens(du_per_1k)
                 try:
                     ledger.log_change(state.agent_id, 0.0, -cost, "llm_gas")
                 except Exception:  # pragma: no cover - optional
@@ -223,9 +265,9 @@ def async_monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data[
-                            "error_message"
-                        ] = "Function returned None, indicating an error"
+                        metrics_data["error_message"] = (
+                            "Function returned None, indicating an error"
+                        )
                 else:
                     metrics_data["success"] = True
                     if hasattr(result, "usage"):
@@ -251,7 +293,7 @@ def async_monitor_llm_call(
                 metrics.LLM_CALLS_TOTAL.inc()
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
-                metrics.LLM_LATENCY_MS.set(metrics_data["duration_ms"])
+                infra_metrics.record_llm_latency(metrics_data["duration_ms"])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
 
         return wrapper
@@ -267,8 +309,7 @@ class OllamaClientProtocol(Protocol):
         model: str,
         messages: list[LLMMessage],
         options: dict[str, Any] | None = None,
-    ) -> LLMChatResponse:
-        ...
+    ) -> LLMChatResponse: ...
 
 
 class LLMClientConfig(BaseModel):
@@ -579,9 +620,7 @@ def generate_text(
                             result = None
                         return result
 
-                mock_response = _MOCK_RESPONSES.get(
-                    "text_generation", _MOCK_RESPONSES["default"]
-                )
+                mock_response = _MOCK_RESPONSES.get("text_generation", _MOCK_RESPONSES["default"])
                 # Simulate the structure of the real response to get the content
                 return {"message": {"content": mock_response}}["message"]["content"]
 
@@ -613,7 +652,11 @@ def generate_text(
             if error:
                 logger.error(f"Failed to generate text after retries: {error}")
                 return None
-            if isinstance(response, dict) and "message" in response and "content" in response["message"]:
+            if (
+                isinstance(response, dict)
+                and "message" in response
+                and "content" in response["message"]
+            ):
                 usage = response.get("usage", {})
                 if isinstance(usage, dict):
                     prompt_tokens = int(usage.get("prompt_tokens", 0))

--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -1,0 +1,53 @@
+"""Internal metrics tracking for simulation infrastructure."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque
+
+from src.interfaces import metrics as prom_metrics
+
+# Store the most recent DU-per-1k-tokens value
+_last_du_per_1k_tokens: float = 0.0
+
+# Keep a rolling window of recent LLM latencies in milliseconds
+_LATENCY_SAMPLES: Deque[float] = deque(maxlen=100)
+
+
+def record_du_per_1k_tokens(value: float) -> None:
+    """Record DU cost per 1k tokens for the latest LLM call."""
+    global _last_du_per_1k_tokens
+    _last_du_per_1k_tokens = float(value)
+    prom_metrics.LLM_DU_PER_1K_TOKENS.set(_last_du_per_1k_tokens)
+
+
+def get_du_per_1k_tokens() -> float:
+    """Return the most recently recorded DU-per-1k-tokens value."""
+    return _last_du_per_1k_tokens
+
+
+def record_llm_latency(latency_ms: float) -> None:
+    """Record latency for an LLM call and update p95 statistics."""
+    prom_metrics.LLM_LATENCY_MS.set(latency_ms)
+    _LATENCY_SAMPLES.append(latency_ms)
+    if _LATENCY_SAMPLES:
+        ordered = sorted(_LATENCY_SAMPLES)
+        idx = int(0.95 * (len(ordered) - 1))
+        prom_metrics.LLM_LATENCY_P95_MS.set(ordered[idx])
+
+
+def get_llm_latency_p95() -> float:
+    """Return the p95 latency of recent LLM calls in milliseconds."""
+    if not _LATENCY_SAMPLES:
+        return 0.0
+    ordered = sorted(_LATENCY_SAMPLES)
+    idx = int(0.95 * (len(ordered) - 1))
+    return ordered[idx]
+
+
+__all__ = [
+    "get_du_per_1k_tokens",
+    "get_llm_latency_p95",
+    "record_du_per_1k_tokens",
+    "record_llm_latency",
+]

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -55,6 +55,17 @@ tracer = trace.get_tracer(__name__)
 message_sse_queue = dashboard_message_queue
 
 
+def notify_budget_exceeded(agent_id: str, required: float, remaining: float) -> None:
+    """Notify via Discord when an agent exceeds its DU budget."""
+    msg = (
+        f"Agent {agent_id} exceeded DU budget: required {required:.2f}, remaining {remaining:.2f}"
+    )
+    try:
+        message_sse_queue.put_nowait(AgentMessage(agent_id=agent_id, content=msg, step=0))
+    except Exception:  # pragma: no cover - best effort
+        logger.exception("Failed to enqueue budget exceeded notification")
+
+
 class SimulationDiscordBot:
     """
     A Discord bot that provides real-time updates about the Culture simulation.

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -3,9 +3,9 @@ import json
 import sys
 import time
 import uuid
-from collections import deque
 from typing import Any, Callable, Optional, ParamSpec, TypeVar
 
+from src.infra import metrics as infra_metrics
 from src.interfaces import metrics
 from src.shared.logging_utils import get_logger
 
@@ -14,8 +14,6 @@ llm_perf_logger = get_logger("llm_performance")
 
 P = ParamSpec("P")
 R = TypeVar("R")
-
-_LATENCY_SAMPLES: "deque[float]" = deque(maxlen=100)
 
 
 def monitor_llm_call(
@@ -68,9 +66,9 @@ def monitor_llm_call(
                             metrics_data["error_message"] = exc_value.response.text
                     else:
                         metrics_data["error_type"] = "UnknownError"
-                        metrics_data[
-                            "error_message"
-                        ] = "Function returned None, indicating an error"
+                        metrics_data["error_message"] = (
+                            "Function returned None, indicating an error"
+                        )
                 else:
                     metrics_data["success"] = True
                     if result is not None and hasattr(result, "usage"):
@@ -95,12 +93,7 @@ def monitor_llm_call(
                 metrics.LLM_CALLS_TOTAL.inc()
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
-                metrics.LLM_LATENCY_MS.set(metrics_data["duration_ms"])
-                _LATENCY_SAMPLES.append(metrics_data["duration_ms"])
-                if _LATENCY_SAMPLES:
-                    ordered = sorted(_LATENCY_SAMPLES)
-                    idx = int(0.95 * (len(ordered) - 1))
-                    metrics.LLM_LATENCY_P95_MS.set(ordered[idx])
+                infra_metrics.record_llm_latency(metrics_data["duration_ms"])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
             return result
 

--- a/src/sim/resource_manager.py
+++ b/src/sim/resource_manager.py
@@ -28,10 +28,22 @@ class ResourceManager:
     def set_du_budget(self, agent_id: str, budget: float) -> None:
         self._du_budgets[agent_id] = float(budget)
 
-    def charge_du(self, agent_id: str, amount: float) -> None:
+    def ensure_du_budget(self, agent_id: str, amount: float) -> None:
+        """Verify that the agent has at least ``amount`` DU available."""
         remaining = self._du_budgets.get(agent_id, 0.0)
         if amount > remaining:
+            try:
+                from src.interfaces.discord_bot import notify_budget_exceeded
+
+                notify_budget_exceeded(agent_id, amount, remaining)
+            except Exception:  # pragma: no cover - best effort
+                pass
+            self._du_budgets[agent_id] = 0.0
             raise RuntimeError(f"Agent {agent_id} exceeded DU budget")
+
+    def charge_du(self, agent_id: str, amount: float) -> None:
+        self.ensure_du_budget(agent_id, amount)
+        remaining = self._du_budgets.get(agent_id, 0.0)
         self._du_budgets[agent_id] = remaining - amount
 
     def get_du_budget(self, agent_id: str) -> float:


### PR DESCRIPTION
## Summary
- add DU budget pre-checks and discord notifications for over-budget agents
- track DU-per-1k tokens and p95 latency in new infra metrics module
- enforce budgets in LLM client wrappers and record latency metrics

## Testing
- `ruff check src/sim/resource_manager.py src/infra/metrics.py src/infra/llm_client.py src/shared/decorator_utils.py src/interfaces/discord_bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8215e7c48326bb9155b342415d69