### PR TITLE
feat: add retrieval metrics gauges

### DIFF
--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -63,6 +63,12 @@ MEMORY_RETRIEVAL_ERRORS_TOTAL = Counter(
 # Retrieval Augmented Generation (RAG) metrics
 RAG_HIT_RATE = Gauge("rag_hit_rate", "Hit rate for RAG memory retrieval")
 
+# Retrieval evaluation metrics
+RETRIEVAL_LATENCY_MS = Gauge(
+    "retrieval_latency_ms", "Latency of retrieval operations in milliseconds"
+)
+P_AT_K = Gauge("p_at_k", "Precision at k for retrieval operations")
+
 # Human interaction metrics
 HUMAN_MESSAGES_TOTAL = Counter(
     "human_messages_total",
@@ -131,6 +137,16 @@ def get_rag_hit_rate() -> float:
     return float(RAG_HIT_RATE._value.get())
 
 
+def get_retrieval_latency_ms() -> float:
+    """Return the latency of the last retrieval in milliseconds."""
+    return float(RETRIEVAL_LATENCY_MS._value.get())
+
+
+def get_p_at_k() -> float:
+    """Return the most recent precision@k value."""
+    return float(P_AT_K._value.get())
+
+
 def get_human_messages() -> int:
     """Return the total human messages received."""
     return int(HUMAN_MESSAGES_TOTAL._value.get())
@@ -167,6 +183,8 @@ __all__ = [
     "MEMORY_RETRIEVALS_TOTAL",
     "MEMORY_RETRIEVAL_ERRORS_TOTAL",
     "RAG_HIT_RATE",
+    "RETRIEVAL_LATENCY_MS",
+    "P_AT_K",
     "Counter",
     "Gauge",
     "get_du_per_1k_tokens",
@@ -179,6 +197,8 @@ __all__ = [
     "get_memory_retrieval_errors",
     "get_memory_retrievals",
     "get_rag_hit_rate",
+    "get_retrieval_latency_ms",
+    "get_p_at_k",
     "get_coalition_count",
     "get_average_sentiment",
     "get_proposal_throughput",

--- a/src/utils/retrieval_metrics.py
+++ b/src/utils/retrieval_metrics.py
@@ -6,6 +6,8 @@ import time
 from collections.abc import Awaitable, Sequence
 from typing import Any, Callable
 
+from src.interfaces import metrics
+
 
 def p95(values: Sequence[float]) -> float:
     """Return the 95th percentile of ``values``.
@@ -28,11 +30,15 @@ def precision_at_k(retrieved_ids: Sequence[str], relevant_ids: set[str], k: int)
     if not top_k:
         return 0.0
     hits = sum(1 for _id in top_k if _id in relevant_ids)
-    return hits / float(min(k, len(top_k)))
+    precision = hits / float(min(k, len(top_k)))
+    metrics.P_AT_K.set(precision)
+    return precision
 
 
 async def time_call(coro: Callable[[], Awaitable[Sequence[Any]]]) -> tuple[Sequence[Any], float]:
     """Execute ``coro`` and return its result and runtime in seconds."""
     start = time.perf_counter()
     result = await coro()
-    return result, time.perf_counter() - start
+    latency = time.perf_counter() - start
+    metrics.RETRIEVAL_LATENCY_MS.set(latency * 1000)
+    return result, latency


### PR DESCRIPTION
## Summary
- expose Prometheus gauges for retrieval latency and precision@k
- update retrieval metrics utilities to record these gauges

## Testing
- `SKIP=unit-tests pre-commit run --files src/interfaces/metrics.py src/utils/retrieval_metrics.py`
- `pytest -m "integration" tests/integration/memory/test_recall_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_689b596601388326892f9623067d695f