### PR TITLE
feat: add per-agent discord moderation rate limiting

### DIFF
--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -10,17 +10,22 @@ from src.interfaces.discord_bot import bot, get_active_bot
 from src.utils.policy import evaluate_with_opa
 
 
-async def _rate_limit(user: Any, action: str) -> bool:
-    """Use OPA to determine if the action is allowed for the user."""
+async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bool:
+    """Use OPA to determine if the action is allowed for the user and agent."""
     user_id = str(getattr(user, "id", ""))
-    allow, _ = await evaluate_with_opa(f"{user_id}:{action}")
+    key = f"{user_id}:{action}"
+    if agent_id is not None:
+        key += f":{agent_id}"
+    allow, _ = await evaluate_with_opa(key)
     return allow
 
 
 @bot.tree.command(name="mute")
 async def slash_mute(interaction: Any, agent_id: str) -> None:
     """Mute an agent in the simulation."""
-    if not await _rate_limit(getattr(interaction, "user", None), "mute"):
+    if not await _rate_limit(
+        getattr(interaction, "user", None), "mute", agent_id
+    ):
         await interaction.response.send_message("rate limited", ephemeral=True)
         return
     bot_instance = get_active_bot()
@@ -36,7 +41,9 @@ async def slash_mute(interaction: Any, agent_id: str) -> None:
 @bot.tree.command(name="reset_memory")
 async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
     """Reset the memory of an agent."""
-    if not await _rate_limit(getattr(interaction, "user", None), "reset_memory"):
+    if not await _rate_limit(
+        getattr(interaction, "user", None), "reset_memory", agent_id
+    ):
         await interaction.response.send_message("rate limited", ephemeral=True)
         return
     bot_instance = get_active_bot()
@@ -54,7 +61,9 @@ async def slash_penalty(
     interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0
 ) -> None:
     """Apply an IP/DU penalty to an agent."""
-    if not await _rate_limit(getattr(interaction, "user", None), "penalty"):
+    if not await _rate_limit(
+        getattr(interaction, "user", None), "penalty", agent_id
+    ):
         await interaction.response.send_message("rate limited", ephemeral=True)
         return
     bot_instance = get_active_bot()

--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -1,0 +1,67 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.interfaces import discord_moderation
+
+
+class DummyContext:
+    def __init__(self) -> None:
+        self.queue = asyncio.Queue()
+
+    def get_event_queue(self) -> asyncio.Queue:
+        return self.queue
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.context = DummyContext()
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.user = SimpleNamespace(id=123)
+        self.response = SimpleNamespace(send_message=AsyncMock())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rate_limit_includes_agent_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    async def fake_eval(content: str) -> tuple[bool, str]:
+        calls.append(content)
+        return True, content
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", fake_eval)
+
+    user = SimpleNamespace(id=123)
+    allowed = await discord_moderation._rate_limit(user, "mute", "agentX")
+    assert allowed is True
+    assert calls == ["123:mute:agentX"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_mute_per_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_eval(content: str) -> tuple[bool, str]:
+        if content == "123:mute:agent1":
+            return False, ""
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", fake_eval)
+    monkeypatch.setattr(discord_moderation, "get_active_bot", lambda: DummyBot())
+
+    interaction1 = DummyInteraction()
+    await discord_moderation.slash_mute.callback(interaction1, "agent1")
+    interaction1.response.send_message.assert_awaited_once_with(
+        "rate limited", ephemeral=True
+    )
+
+    interaction2 = DummyInteraction()
+    await discord_moderation.slash_mute.callback(interaction2, "agent2")
+    interaction2.response.send_message.assert_awaited_once_with(
+        "muted", ephemeral=True
+    )


### PR DESCRIPTION
## Summary
- include target agent when checking moderation rate limits
- test moderation commands enforce rate limiting per agent

## Testing
- `ruff check src/interfaces/discord_moderation.py tests/unit/interfaces/test_discord_moderation.py`
- `pytest tests/unit/interfaces/test_discord_moderation.py`

------
https://chatgpt.com/codex/tasks/task_e_689b5964c0a88326824739fdb815e676