### PR TITLE
Add moderation interaction fixtures and flow tests

### DIFF
--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Callable
 from unittest.mock import AsyncMock
 
 import pytest
@@ -16,14 +17,35 @@ class DummyContext:
 
 
 class DummyBot:
-    def __init__(self) -> None:
-        self.context = DummyContext()
+    def __init__(self, context: DummyContext) -> None:
+        self.context = context
 
 
 class DummyInteraction:
     def __init__(self) -> None:
         self.user = SimpleNamespace(id=123)
         self.response = SimpleNamespace(send_message=AsyncMock())
+
+
+@pytest.fixture()
+def bot(monkeypatch: pytest.MonkeyPatch) -> DummyBot:
+    ctx = DummyContext()
+    dummy = DummyBot(ctx)
+    monkeypatch.setattr(discord_moderation, "get_active_bot", lambda: dummy)
+    return dummy
+
+
+@pytest.fixture()
+def interaction() -> DummyInteraction:
+    return DummyInteraction()
+
+
+@pytest.fixture()
+def interaction_factory() -> "Callable[[], DummyInteraction]":
+    def factory() -> DummyInteraction:
+        return DummyInteraction()
+
+    return factory
 
 
 @pytest.mark.unit
@@ -45,23 +67,75 @@ async def test_rate_limit_includes_agent_id(monkeypatch: pytest.MonkeyPatch) -> 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_slash_mute_per_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_slash_mute_per_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    bot: DummyBot,
+    interaction_factory: Callable[[], DummyInteraction],
+) -> None:
     async def fake_eval(content: str) -> tuple[bool, str]:
         if content == "123:mute:agent1":
             return False, ""
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", fake_eval)
-    monkeypatch.setattr(discord_moderation, "get_active_bot", lambda: DummyBot())
 
-    interaction1 = DummyInteraction()
+    interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
-    interaction1.response.send_message.assert_awaited_once_with(
-        "rate limited", ephemeral=True
-    )
+    interaction1.response.send_message.assert_awaited_once_with("rate limited", ephemeral=True)
 
-    interaction2 = DummyInteraction()
+    interaction2 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction2, "agent2")
-    interaction2.response.send_message.assert_awaited_once_with(
-        "muted", ephemeral=True
-    )
+    interaction2.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_mute_flow(
+    monkeypatch: pytest.MonkeyPatch, bot: DummyBot, interaction: DummyInteraction
+) -> None:
+    async def allow_eval(content: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    await discord_moderation.slash_mute.callback(interaction, "agent1")
+    interaction.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
+    event = await bot.context.get_event_queue().get()
+    assert event.type == "moderation"
+    assert event.data == {"command": "mute", "agent_id": "agent1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_penalty_flow(
+    monkeypatch: pytest.MonkeyPatch, bot: DummyBot, interaction: DummyInteraction
+) -> None:
+    async def allow_eval(content: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    await discord_moderation.slash_penalty.callback(interaction, "agent1", 1.0, 2.0)
+    interaction.response.send_message.assert_awaited_once_with("penalty applied", ephemeral=True)
+    event = await bot.context.get_event_queue().get()
+    assert event.type == "moderation"
+    assert event.data == {
+        "command": "penalty",
+        "agent_id": "agent1",
+        "ip": 1.0,
+        "du": 2.0,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_reset_memory_flow(
+    monkeypatch: pytest.MonkeyPatch, bot: DummyBot, interaction: DummyInteraction
+) -> None:
+    async def allow_eval(content: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    await discord_moderation.slash_reset_memory.callback(interaction, "agent1")
+    interaction.response.send_message.assert_awaited_once_with("memory reset", ephemeral=True)
+    event = await bot.context.get_event_queue().get()
+    assert event.type == "moderation"
+    assert event.data == {"command": "reset_memory", "agent_id": "agent1"}


### PR DESCRIPTION
## Summary
- add pytest fixtures for dummy Discord interactions and bot context
- test moderation commands for mute, penalty, and reset-memory flows

## Testing
- `pre-commit run --files tests/unit/interfaces/test_discord_moderation.py`
- `pytest tests/unit/interfaces/test_discord_moderation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689baa9e4a188326a9cf3e9e95afc486