### PR TITLE
Add tracing spans for LLM batch, memory retrieval, and simulation actions

### DIFF
--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
+from opentelemetry import trace
 from typing_extensions import Self
 
 from src.interfaces import metrics
 
 from .semantic_memory_manager import SemanticMemoryManager
 from .vector_store import ChromaVectorStoreManager
+
+tracer = trace.get_tracer(__name__)
 
 
 class MultiLayerRetriever:
@@ -29,15 +33,40 @@ class MultiLayerRetriever:
         try:
             episodic: list[dict[str, Any]] = []
             if self.vector_store:
-                episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+                with tracer.start_as_current_span("memory.episodic_retrieve") as span:
+                    span.set_attribute("llm.tokens.prompt", 0)
+                    span.set_attribute("llm.tokens.completion", 0)
+                    span.set_attribute("llm.tokens.total", 0)
+                    start = time.perf_counter()
+                    try:
+                        episodic = await self.vector_store.aretrieve_relevant_memories(
+                            agent_id, query, k
+                        )
+                    finally:
+                        span.set_attribute(
+                            "memory.latency_ms", (time.perf_counter() - start) * 1000
+                        )
 
             semantic: list[dict[str, Any]] = []
             if self.semantic_manager:
                 import asyncio
 
-                semantic = await asyncio.to_thread(
-                    self.semantic_manager.retrieve_context_with_scores, agent_id, query, k
-                )
+                with tracer.start_as_current_span("memory.semantic_retrieve") as span:
+                    span.set_attribute("llm.tokens.prompt", 0)
+                    span.set_attribute("llm.tokens.completion", 0)
+                    span.set_attribute("llm.tokens.total", 0)
+                    start = time.perf_counter()
+                    try:
+                        semantic = await asyncio.to_thread(
+                            self.semantic_manager.retrieve_context_with_scores,
+                            agent_id,
+                            query,
+                            k,
+                        )
+                    finally:
+                        span.set_attribute(
+                            "memory.latency_ms", (time.perf_counter() - start) * 1000
+                        )
 
             combined = episodic + semantic
             combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
@@ -53,7 +82,19 @@ class MultiLayerRetriever:
         try:
             episodic = []
             if self.vector_store:
-                episodic = await self.vector_store.aretrieve_relevant_memories(agent_id, query, k)
+                with tracer.start_as_current_span("memory.episodic_retrieve") as span:
+                    span.set_attribute("llm.tokens.prompt", 0)
+                    span.set_attribute("llm.tokens.completion", 0)
+                    span.set_attribute("llm.tokens.total", 0)
+                    start = time.perf_counter()
+                    try:
+                        episodic = await self.vector_store.aretrieve_relevant_memories(
+                            agent_id, query, k
+                        )
+                    finally:
+                        span.set_attribute(
+                            "memory.latency_ms", (time.perf_counter() - start) * 1000
+                        )
             if self.semantic_manager:
                 try:
                     await self.semantic_manager.run_nightly_job(agent_id, episodic)

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -275,9 +275,7 @@ def async_monitor_llm_call(
                     metrics_data["success"] = True
                     if hasattr(result, "usage"):
                         prompt_tokens = getattr(result.usage, "prompt_tokens", None)
-                        completion_tokens = getattr(
-                            result.usage, "completion_tokens", None
-                        )
+                        completion_tokens = getattr(result.usage, "completion_tokens", None)
                         try:
                             metrics_data["prompt_tokens"] = (
                                 int(prompt_tokens) if prompt_tokens is not None else None
@@ -286,9 +284,7 @@ def async_monitor_llm_call(
                             metrics_data["prompt_tokens"] = None
                         try:
                             metrics_data["completion_tokens"] = (
-                                int(completion_tokens)
-                                if completion_tokens is not None
-                                else None
+                                int(completion_tokens) if completion_tokens is not None else None
                             )
                         except Exception:
                             metrics_data["completion_tokens"] = None
@@ -310,9 +306,7 @@ def async_monitor_llm_call(
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
                 infra_metrics.record_llm_latency(metrics_data["duration_ms"])
-                llm_perf_logger.info(
-                    f"LLM_CALL_METRICS: {json.dumps(metrics_data, default=str)}"
-                )
+                llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data, default=str)}")
 
         return wrapper
 
@@ -354,7 +348,7 @@ class LLMClient:
             tuple[str, list[LLMMessage], dict[str, Any] | None, asyncio.Future[LLMChatResponse]]
         ] = []
         self._lock = asyncio.Lock()
-        self._flush_task: asyncio.Task | None = None
+        self._flush_task: asyncio.Task[None] | None = None
 
     async def _chat_single(
         self: LLMClient,
@@ -362,7 +356,6 @@ class LLMClient:
         messages: list[LLMMessage],
         options: dict[str, Any] | None,
     ) -> LLMChatResponse:
-
         if ":" in model:
             small_client = self._client or _create_ollama_client()
 
@@ -408,9 +401,7 @@ class LLMClient:
             if batch_func and asyncio.iscoroutinefunction(batch_func):
                 responses = await cast(Any, batch_func)(payload)
             else:
-                responses = [
-                    await self._chat_single(m, msgs, opts) for m, msgs, opts in payload
-                ]
+                responses = [await self._chat_single(m, msgs, opts) for m, msgs, opts in payload]
             for fut, resp in zip(futures, responses):
                 fut.set_result(resp)
         except Exception as exc:
@@ -447,9 +438,7 @@ class LLMClient:
             should_flush = len(self._pending) >= self.batch_size
             if should_flush and self._flush_task and not self._flush_task.done():
                 self._flush_task.cancel()
-            elif not should_flush and (
-                not self._flush_task or self._flush_task.done()
-            ):
+            elif not should_flush and (not self._flush_task or self._flush_task.done()):
                 self._flush_task = asyncio.create_task(self._flush_after_timeout())
         if should_flush:
             await self._flush_pending()
@@ -586,9 +575,7 @@ def _create_vllm_client() -> OllamaClientProtocol:
                         "usage": usage,
                     }
                 finally:
-                    span.set_attribute(
-                        "llm.latency_ms", (time.perf_counter() - start_time) * 1000
-                    )
+                    span.set_attribute("llm.latency_ms", (time.perf_counter() - start_time) * 1000)
 
         async def async_chat_batch(
             self: _Client,
@@ -596,6 +583,9 @@ def _create_vllm_client() -> OllamaClientProtocol:
         ) -> list[LLMChatResponse]:
             """Send multiple chat requests using vLLM's batching API."""
             with tracer.start_as_current_span("llm.batch") as span:
+                span.set_attribute("llm.tokens.prompt", 0)
+                span.set_attribute("llm.tokens.completion", 0)
+                span.set_attribute("llm.tokens.total", 0)
                 models_used: list[str] = []
                 requests_payload: list[JSONDict] = []
                 for model, messages, opts in batch:
@@ -643,14 +633,10 @@ def _create_vllm_client() -> OllamaClientProtocol:
                         outputs.append({"message": cast(LLMMessage, message), "usage": usage})
                     span.set_attribute("llm.tokens.prompt", prompt_tokens)
                     span.set_attribute("llm.tokens.completion", completion_tokens)
-                    span.set_attribute(
-                        "llm.tokens.total", prompt_tokens + completion_tokens
-                    )
+                    span.set_attribute("llm.tokens.total", prompt_tokens + completion_tokens)
                     return outputs
                 finally:
-                    span.set_attribute(
-                        "llm.latency_ms", (time.perf_counter() - start_time) * 1000
-                    )
+                    span.set_attribute("llm.latency_ms", (time.perf_counter() - start_time) * 1000)
 
         def chat(
             self: _Client,
@@ -1323,6 +1309,4 @@ def generate_response(
         return str(val) if isinstance(val, str) else None
 
     # Otherwise use the real client
-    return cast(
-        str | None, generate_text(prompt, model, temperature, agent_state=agent_state)
-    )
+    return cast(str | None, generate_text(prompt, model, temperature, agent_state=agent_state))

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import numpy as np
+from opentelemetry import trace
 from pydantic import ValidationError
 from typing_extensions import Self
 
@@ -45,6 +46,8 @@ from src.sim.version_vector import VersionVector
 from src.sim.world_map import WorldMap
 
 from .event_bus import get_event_bus
+
+tracer = trace.get_tracer(__name__)
 
 # Use TYPE_CHECKING to avoid circular import issues if Agent needs Simulation later
 if TYPE_CHECKING:
@@ -777,28 +780,38 @@ class Simulation:
         logger.info(f"  - IP: {current_agent_state.ip:.1f} (from {ip_start})")
         logger.info(f"  - DU: {current_agent_state.du:.1f} (from {du_start})")
 
-        event = log_event(
-            {
-                "type": "agent_action",
-                "agent_id": agent_id,
-                "step": self.current_step,
-                "action_intent": action_intent_str,
-                "ip": current_agent_state.ip,
-                "du": current_agent_state.du,
-            }
-        )
-        if event is None:
-            event = {
-                "type": "agent_action",
-                "agent_id": agent_id,
-                "step": self.current_step,
-                "action_intent": action_intent_str,
-                "ip": current_agent_state.ip,
-                "du": current_agent_state.du,
-            }
-            event["trace_hash"] = compute_trace_hash(event)
-        trace_hash = event["trace_hash"]
-        await emit_event(SimulationEvent(type="agent_action", data=event))
+        with tracer.start_as_current_span("simulation.agent_action") as span:
+            span.set_attribute("agent.id", agent_id)
+            span.set_attribute("simulation.step", self.current_step)
+            span.set_attribute("llm.tokens.prompt", 0)
+            span.set_attribute("llm.tokens.completion", 0)
+            span.set_attribute("llm.tokens.total", 0)
+            start = time.perf_counter()
+            try:
+                event = log_event(
+                    {
+                        "type": "agent_action",
+                        "agent_id": agent_id,
+                        "step": self.current_step,
+                        "action_intent": action_intent_str,
+                        "ip": current_agent_state.ip,
+                        "du": current_agent_state.du,
+                    }
+                )
+                if event is None:
+                    event = {
+                        "type": "agent_action",
+                        "agent_id": agent_id,
+                        "step": self.current_step,
+                        "action_intent": action_intent_str,
+                        "ip": current_agent_state.ip,
+                        "du": current_agent_state.du,
+                    }
+                    event["trace_hash"] = compute_trace_hash(event)
+                trace_hash = event["trace_hash"]
+                await emit_event(SimulationEvent(type="agent_action", data=event))
+            finally:
+                span.set_attribute("simulation.latency_ms", (time.perf_counter() - start) * 1000)
 
         if self.current_step % int(config.SNAPSHOT_INTERVAL_STEPS) == 0:
             snapshot = {

--- a/tests/unit/infra/test_llm_client_spans.py
+++ b/tests/unit/infra/test_llm_client_spans.py
@@ -1,0 +1,77 @@
+import pytest
+
+from src.infra.llm_client import _create_vllm_client
+
+
+class MockSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+class MockAsyncClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json, timeout):
+        json_module = __import__("json")
+
+        class Resp:
+            text = json_module.dumps(
+                {
+                    "responses": [
+                        {
+                            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                            "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+                        }
+                    ]
+                }
+            )
+
+            def raise_for_status(self):
+                return None
+
+        return Resp()
+
+
+@pytest.mark.asyncio
+async def test_async_chat_batch_tracing(monkeypatch):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.llm_client.tracer", tracer)
+    monkeypatch.setattr("src.infra.llm_client.httpx.AsyncClient", MockAsyncClient)
+    monkeypatch.setattr("src.infra.llm_client.VLLM_API_BASE", "http://test")
+    monkeypatch.setattr("src.infra.llm_client.LLM_API_BASE", "http://test")
+
+    client = _create_vllm_client()
+    batch = [("model", [{"role": "user", "content": "hi"}], None)]
+    result = await client.async_chat_batch(batch)
+
+    assert result[0]["message"]["role"] == "assistant"
+    assert tracer.spans[0].name == "llm.batch"
+    span = tracer.spans[0]
+    assert span.attributes["llm.tokens.prompt"] == 1
+    assert span.attributes["llm.tokens.completion"] == 2
+    assert span.attributes["llm.tokens.total"] == 3
+    assert "llm.latency_ms" in span.attributes

--- a/tests/unit/memory/test_multi_layer_retriever_spans.py
+++ b/tests/unit/memory/test_multi_layer_retriever_spans.py
@@ -1,0 +1,54 @@
+import pytest
+
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
+
+
+class MockSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+@pytest.mark.asyncio
+async def test_retrieve_tracing(monkeypatch):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.agents.memory.multi_layer_retriever.tracer", tracer)
+
+    class DummyVectorStore:
+        async def aretrieve_relevant_memories(self, agent_id, query, k):
+            return [{"relevance_score": 1.0}]
+
+    class DummySemantic:
+        def retrieve_context_with_scores(self, agent_id, query, k):
+            return [{"relevance_score": 2.0}]
+
+    retriever = MultiLayerRetriever(DummyVectorStore(), DummySemantic())
+    result = await retriever.retrieve("a", "q", 2)
+    assert len(result) == 2
+
+    span_names = [s.name for s in tracer.spans]
+    assert "memory.episodic_retrieve" in span_names
+    assert "memory.semantic_retrieve" in span_names
+    for span in tracer.spans:
+        assert span.attributes["llm.tokens.prompt"] == 0
+        assert span.attributes["llm.tokens.completion"] == 0
+        assert "memory.latency_ms" in span.attributes

--- a/tests/unit/sim/test_simulation_spans.py
+++ b/tests/unit/sim/test_simulation_spans.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.sim.simulation import Simulation
+
+
+class MockSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockTracer:
+    def __init__(self):
+        self.spans = []
+
+    def start_as_current_span(self, name):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+class DummyAgent:
+    def __init__(self):
+        self.agent_id = "agent"
+        self.state = SimpleNamespace(
+            agent_id="agent",
+            ip=1.0,
+            du=1.0,
+            messages_sent_count=0,
+            last_message_step=0,
+            short_term_memory=[],
+            mood_level=0.0,
+            is_alive=True,
+        )
+
+    async def run_turn(self, **kwargs):
+        return {"action_intent": "idle"}
+
+    def update_state(self, state):
+        self.state = state
+
+    def get_id(self):
+        return self.agent_id
+
+
+@pytest.mark.asyncio
+async def test_agent_action_tracing(monkeypatch):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.sim.simulation.tracer", tracer)
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event",
+        lambda data: {**data, "trace_hash": "hash"},
+    )
+    monkeypatch.setattr("src.sim.simulation.emit_event", AsyncMock())
+
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    sim = Simulation(
+        [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+    sim.resource_manager = rm
+
+    await sim._run_agent_turn(0)
+
+    span = tracer.spans[0]
+    assert span.name == "simulation.agent_action"
+    assert span.attributes["llm.tokens.prompt"] == 0
+    assert span.attributes["llm.tokens.completion"] == 0
+    assert "simulation.latency_ms" in span.attributes


### PR DESCRIPTION
## Summary
- instrument llm async batch requests with token and latency span attributes
- trace episodic and semantic memory retrieval calls
- capture simulation agent action spans
- add unit tests covering span attributes with mock tracer

## Testing
- `pre-commit run ruff --files src/agents/memory/multi_layer_retriever.py src/infra/llm_client.py src/sim/simulation.py tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py`
- `pre-commit run ruff-format --files src/agents/memory/multi_layer_retriever.py src/infra/llm_client.py src/sim/simulation.py tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py`
- `pre-commit run mypy --files src/agents/memory/multi_layer_retriever.py src/infra/llm_client.py src/sim/simulation.py tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py`
- `pre-commit run forbid-direct-dspy-imports --files src/agents/memory/multi_layer_retriever.py src/infra/llm_client.py src/sim/simulation.py tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py`
- `pre-commit run pydantic-v2-compat --files src/agents/memory/multi_layer_retriever.py src/infra/llm_client.py src/sim/simulation.py tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py`
- `pre-commit run ruff --files tests/unit/sim/test_simulation_spans.py`
- `pre-commit run ruff-format --files tests/unit/sim/test_simulation_spans.py`
- `pre-commit run mypy --files tests/unit/sim/test_simulation_spans.py`
- `pytest -m '' tests/unit/infra/test_llm_client_spans.py tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/sim/test_simulation_spans.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d284037988326914db7fd8ff880b9