### PR TITLE
feat: add file-based event log with replay seeking

### DIFF
--- a/scripts/export_traces.py
+++ b/scripts/export_traces.py
@@ -51,48 +51,66 @@ def iter_snapshots(directory: str | Path) -> Iterable[dict[str, Any]]:
 
 
 def iter_events(
-    from_redpanda: bool = False, file: str | Path | None = None
+    from_redpanda: bool = False,
+    file: str | Path | None = None,
+    *,
+    start_tick: int | None = None,
+    end_tick: int | None = None,
 ) -> Iterable[dict[str, Any]]:
-    """Yield events from Redpanda or a JSON file."""
+    """Yield events from Redpanda or an append-only log file."""
+
+    after = (start_tick or 0) - 1
+
     if from_redpanda:
-        yield from event_log.stream_events(after_step=0, timeout=1.0)
+        yield from event_log.stream_events(
+            after_step=after, timeout=1.0, end_step=end_tick
+        )
         return
 
     if file is None:
         raise ValueError("Event file path required when not using --redpanda")
 
-    with Path(file).open("r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    events = data if isinstance(data, list) else data.get("events", [])
-    yield from events
+    yield from event_log.stream_events(
+        after_step=after, timeout=0.0, end_step=end_tick, path=file
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Export traces to JSONL dataset")
     src_group = parser.add_mutually_exclusive_group(required=True)
     src_group.add_argument("--snapshots", help="Snapshot directory to read")
-    src_group.add_argument("--events", help="JSON file containing event log")
+    src_group.add_argument("--events", help="Path to event log file")
     src_group.add_argument("--redpanda", action="store_true", help="Fetch events from Redpanda")
     parser.add_argument("-o", "--output", help="Output JSONL file (default: stdout)")
     parser.add_argument("--agent", help="Only include events for this agent_id")
-    parser.add_argument("--start-step", type=int, help="First step to include (inclusive)")
-    parser.add_argument("--end-step", type=int, help="Last step to include (inclusive)")
+    parser.add_argument(
+        "--replay-start", type=int, help="First tick to include (inclusive)"
+    )
+    parser.add_argument(
+        "--replay-end", type=int, help="Last tick to include (inclusive)"
+    )
     args = parser.parse_args(argv)
 
     if args.snapshots:
         iterator = iter_snapshots(args.snapshots)
     elif args.redpanda:
-        iterator = iter_events(from_redpanda=True)
+        iterator = iter_events(
+            from_redpanda=True,
+            start_tick=args.replay_start,
+            end_tick=args.replay_end,
+        )
     else:
-        iterator = iter_events(file=args.events)
+        iterator = iter_events(
+            file=args.events, start_tick=args.replay_start, end_tick=args.replay_end
+        )
 
     out = open(args.output, "w", encoding="utf-8") if args.output else sys.stdout
     for item in iterator:
         step = item.get("step")
         if step is not None:
-            if args.start_step is not None and step < args.start_step:
+            if args.replay_start is not None and step < args.replay_start:
                 continue
-            if args.end_step is not None and step > args.end_step:
+            if args.replay_end is not None and step > args.replay_end:
                 continue
         if args.agent and item.get("agent_id") != args.agent:
             continue

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 import logging
 import sys
 from pathlib import Path
@@ -10,7 +11,7 @@ from src.agents.core.base_agent import Agent
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
 from src.extensions import load_plugins
-from src.infra import config
+from src.infra import config, event_log
 from src.infra.checkpoint import (
     load_checkpoint,
     save_checkpoint,
@@ -339,10 +340,24 @@ def main() -> None:
         }
         if args.seed is not None:
             replay_kwargs["seed"] = args.seed
-        sim = Simulation.replay_from_snapshot(
+        Simulation.replay_from_snapshot(
             args.replay,
             **replay_kwargs,
         )
+        if args.export_dataset:
+            out_path = Path(args.export_dataset)
+            with out_path.open("w", encoding="utf-8") as fh:
+                after = (args.replay_start or 0) - 1
+                for ev in event_log.stream_events(
+                    after_step=after, end_step=args.replay_end
+                ):
+                    step = int(ev.get("step", 0))
+                    if args.replay_start is not None and step < args.replay_start:
+                        continue
+                    if args.replay_end is not None and step > args.replay_end:
+                        break
+                    fh.write(json.dumps(ev))
+                    fh.write("\n")
         return
 
     if args.checkpoint and Path(args.checkpoint).exists():

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -7,6 +7,7 @@ import os
 import random
 import time
 from collections.abc import Generator, Iterable
+from pathlib import Path
 from typing import Any
 
 try:  # pragma: no cover - optional dependency
@@ -29,6 +30,13 @@ _consumer_conf = {
     "group.id": os.getenv("REPLAY_GROUP", "culture-replay"),
     "auto.offset.reset": "earliest",
 }
+
+
+def _log_file(path: str | Path | None = None) -> Path:
+    """Return the event log file path."""
+    if path is not None:
+        return Path(path)
+    return Path(os.getenv("EVENT_LOG_PATH", "event_log.jsonl"))
 
 
 def _is_valid_event(
@@ -69,8 +77,36 @@ def _get_producer() -> Any:
     return _producer
 
 
+def _iter_file_events(
+    start_tick: int = 0,
+    end_tick: int | None = None,
+    *,
+    path: str | Path | None = None,
+) -> Generator[dict[str, Any], None, None]:
+    """Yield events from the append-only log file."""
+
+    file = _log_file(path)
+    if not file.exists():
+        return
+    with file.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except Exception:  # pragma: no cover - defensive
+                continue
+            tick = int(event.get("tick", event.get("step", 0)))
+            if tick <= start_tick:
+                continue
+            if end_tick is not None and tick > end_tick:
+                break
+            yield event
+
+
 def log_event(event: dict[str, Any]) -> dict[str, Any]:
-    """Send an event dictionary to Redpanda and return it with ``trace_hash``."""
+    """Log an event to the append-only file and Redpanda if enabled."""
 
     global _last_hash
 
@@ -94,9 +130,19 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
     _last_hash = event_with_hash["trace_hash"]
 
+    # Append to local log file
+    try:  # pragma: no cover - best effort
+        path = _log_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event_with_hash))
+            fh.write("\n")
+    except Exception:  # pragma: no cover - ignore
+        pass
+
     if os.getenv("ENABLE_REDPANDA", "0") != "1":
         return event_with_hash
-    try:
+    try:  # pragma: no cover - best effort
         payload = json.dumps(event_with_hash).encode("utf-8")
         producer = _get_producer()
         producer.produce(_topic, payload)
@@ -108,10 +154,18 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     return event_with_hash
 
 
-def fetch_events(after_step: int = 0) -> list[dict[str, Any]]:
-    """Retrieve events from Redpanda after ``after_step``."""
+def fetch_events(
+    after_step: int = 0,
+    *,
+    end_step: int | None = None,
+    path: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve events from the log after ``after_step``."""
+
     if os.getenv("ENABLE_REDPANDA", "0") != "1":
-        return []
+        events = list(_iter_file_events(after_step, end_step, path=path))
+        return _filter_events(events, after_step=after_step)
+
     raw_events: list[dict[str, Any]] = []
     try:
         consumer = KafkaConsumer(_consumer_conf)
@@ -126,7 +180,8 @@ def fetch_events(after_step: int = 0) -> list[dict[str, Any]]:
                 event = json.loads(msg.value().decode("utf-8"))
             except Exception:
                 continue
-            if event.get("step", 0) > after_step:
+            step = event.get("step", 0)
+            if step > after_step and (end_step is None or step <= end_step):
                 raw_events.append(event)
     except Exception as exc:  # pragma: no cover - best effort
         import logging
@@ -141,13 +196,20 @@ def fetch_events(after_step: int = 0) -> list[dict[str, Any]]:
 
 
 def stream_events(
-    after_step: int = 0, timeout: float = 1.0
+    after_step: int = 0,
+    timeout: float = 1.0,
+    *,
+    end_step: int | None = None,
+    path: str | Path | None = None,
 ) -> Generator[dict[str, Any], None, None]:
-    """Yield events from Redpanda until ``timeout`` seconds of inactivity."""
+    """Yield events from the log or Redpanda until ``timeout`` of inactivity."""
+
     if os.getenv("ENABLE_REDPANDA", "0") != "1":
-        if False:
-            yield {}
+        yield from _filter_events(
+            _iter_file_events(after_step, end_step, path=path), after_step=after_step
+        )
         return
+
     start = time.time()
     consumer = KafkaConsumer(_consumer_conf)
     consumer.subscribe([_topic])
@@ -170,6 +232,9 @@ def stream_events(
             if _is_valid_event(event, last_step, last_hash):
                 last_step = event.get("step", last_step)
                 last_hash = event.get("trace_hash")
+                step = event.get("step", 0)
+                if end_step is not None and step > end_step:
+                    break
                 yield event
     finally:
         try:

--- a/tests/integration/event_log/test_replay.py
+++ b/tests/integration/event_log/test_replay.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from src.app import create_simulation
+from src.infra.snapshot import compute_trace_hash, save_snapshot
+from src.sim.simulation import Simulation
+from tests.utils.mock_llm import MockLLM
+
+
+def _snapshot_from_sim(sim: Simulation) -> dict:
+    snapshot = {
+        "step": sim.current_step,
+        "collective_ip": sim.collective_ip,
+        "collective_du": sim.collective_du,
+        "knowledge_board": sim.knowledge_board.to_dict(),
+        "world_map": sim.world_map.to_dict(),
+        "agents": [
+            {
+                "agent_id": ag.agent_id,
+                "ip": ag.state.ip,
+                "du": ag.state.du,
+                "mood": ag.state.mood_level,
+            }
+            for ag in sim.agents
+        ],
+    }
+    snapshot_no_vector = {
+        **{k: v for k, v in snapshot.items() if k != "trace_hash"},
+        "knowledge_board": {
+            k: v for k, v in snapshot["knowledge_board"].items() if k != "vector"
+        },
+        "world_map": {k: v for k, v in snapshot["world_map"].items() if k != "vector"},
+    }
+    snapshot["trace_hash"] = compute_trace_hash(snapshot_no_vector)
+    return snapshot
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_replay_matches_trace_hash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SNAPSHOT_INTERVAL_STEPS", "1")
+    log_path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_path))
+    monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda *a, **k: None)
+
+    def save(step: int, data: dict, directory: Path = tmp_path) -> None:
+        from src.infra.snapshot import save_snapshot as real_save
+
+        real_save(step, data, directory)
+
+    monkeypatch.setattr("src.sim.simulation.save_snapshot", save)
+
+    with MockLLM():
+        sim = create_simulation(num_agents=1, steps=1, scenario="test")
+        snap0 = _snapshot_from_sim(sim)
+        save_snapshot(0, snap0, directory=tmp_path)
+        await sim.run_step()
+        snap1 = _snapshot_from_sim(sim)
+
+    expected_hash = snap1["trace_hash"]
+    replay = Simulation.replay_from_snapshot(
+        tmp_path / "snapshot_0.json", start_step=1, end_step=1
+    )
+    replay_snap = _snapshot_from_sim(replay)
+    assert replay_snap["trace_hash"] == expected_hash


### PR DESCRIPTION
## Summary
- persist events to a local append-only JSONL log and enable tick-based replay
- allow CLI and export script to replay between ticks and emit JSONL datasets
- add integration test verifying replay trace hash matches original run

## Testing
- `ruff check src/infra/event_log/__init__.py scripts/export_traces.py src/app.py tests/integration/event_log/test_replay.py`
- `pytest tests/unit/scripts/test_export_traces.py tests/integration/event_log/test_event_replay.py tests/integration/event_log/test_redpanda_logging.py tests/integration/test_log_replay.py tests/integration/event_log/test_replay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d283fac048326976b5f7015b3ac60