### PR TITLE
Add unmute command and track moderation cooldowns

### DIFF
--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -1,5 +1,6 @@
 """Discord moderation commands with OPA-based rate limiting."""
 
+import time
 from typing import Any
 
 from src.interfaces.dashboard_backend import (
@@ -9,31 +10,47 @@ from src.interfaces.dashboard_backend import (
 from src.interfaces.discord_bot import bot, get_active_bot
 from src.utils.policy import evaluate_with_opa
 
+_ACTION_COUNTS: dict[str, int] = {}
+_COOLDOWNS: dict[str, float] = {}
+_COOLDOWN_SECONDS = 1.0
+
 
 async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bool:
     """Use OPA to determine if the action is allowed for the user and agent."""
     user_id = str(getattr(user, "id", ""))
-    key = f"{user_id}:{action}"
+    opa_key = f"{user_id}:{action}"
     if agent_id is not None:
-        key += f":{agent_id}"
-    allow, _ = await evaluate_with_opa(key)
+        opa_key += f":{agent_id}"
+
+    count_key = f"{user_id}:{action}"
+    _ACTION_COUNTS[count_key] = _ACTION_COUNTS.get(count_key, 0) + 1
+
+    now = time.monotonic()
+    if _COOLDOWNS.get(count_key, 0.0) > now:
+        return False
+
+    allow, _ = await evaluate_with_opa(opa_key)
+    if allow:
+        _COOLDOWNS[count_key] = now + _COOLDOWN_SECONDS
     return allow
 
 
 @bot.tree.command(name="mute")
 async def slash_mute(interaction: Any, agent_id: str) -> None:
     """Mute an agent in the simulation."""
-    if not await _rate_limit(
-        getattr(interaction, "user", None), "mute", agent_id
-    ):
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(
-            type="moderation", data={"command": "mute", "agent_id": agent_id}
+    if not await _rate_limit(getattr(interaction, "user", None), "mute", agent_id):
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={"command": "mute", "agent_id": agent_id, "violation": True},
+            )
         )
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    await ctx.get_event_queue().put(
+        SimulationEvent(type="moderation", data={"command": "mute", "agent_id": agent_id})
     )
     await interaction.response.send_message("muted", ephemeral=True)
 
@@ -41,33 +58,37 @@ async def slash_mute(interaction: Any, agent_id: str) -> None:
 @bot.tree.command(name="reset_memory")
 async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
     """Reset the memory of an agent."""
-    if not await _rate_limit(
-        getattr(interaction, "user", None), "reset_memory", agent_id
-    ):
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(
-            type="moderation", data={"command": "reset_memory", "agent_id": agent_id}
+    if not await _rate_limit(getattr(interaction, "user", None), "reset_memory", agent_id):
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={"command": "reset_memory", "agent_id": agent_id, "violation": True},
+            )
         )
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    await ctx.get_event_queue().put(
+        SimulationEvent(type="moderation", data={"command": "reset_memory", "agent_id": agent_id})
     )
     await interaction.response.send_message("memory reset", ephemeral=True)
 
 
 @bot.tree.command(name="penalty")
-async def slash_penalty(
-    interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0
-) -> None:
+async def slash_penalty(interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0) -> None:
     """Apply an IP/DU penalty to an agent."""
-    if not await _rate_limit(
-        getattr(interaction, "user", None), "penalty", agent_id
-    ):
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    if not await _rate_limit(getattr(interaction, "user", None), "penalty", agent_id):
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={"command": "penalty", "agent_id": agent_id, "violation": True},
+            )
+        )
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
     await ctx.get_event_queue().put(
         SimulationEvent(
             type="moderation",
@@ -77,5 +98,24 @@ async def slash_penalty(
     await interaction.response.send_message("penalty applied", ephemeral=True)
 
 
-__all__ = ["slash_mute", "slash_penalty", "slash_reset_memory"]
+@bot.tree.command(name="unmute")
+async def slash_unmute(interaction: Any, agent_id: str) -> None:
+    """Unmute an agent in the simulation."""
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    if not await _rate_limit(getattr(interaction, "user", None), "unmute", agent_id):
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={"command": "unmute", "agent_id": agent_id, "violation": True},
+            )
+        )
+        await interaction.response.send_message("rate limited", ephemeral=True)
+        return
+    await ctx.get_event_queue().put(
+        SimulationEvent(type="moderation", data={"command": "unmute", "agent_id": agent_id})
+    )
+    await interaction.response.send_message("unmuted", ephemeral=True)
 
+
+__all__ = ["slash_mute", "slash_penalty", "slash_reset_memory", "slash_unmute"]

--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -48,6 +48,12 @@ def interaction_factory() -> "Callable[[], DummyInteraction]":
     return factory
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limit() -> None:
+    discord_moderation._ACTION_COUNTS.clear()
+    discord_moderation._COOLDOWNS.clear()
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_rate_limit_includes_agent_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -139,3 +145,48 @@ async def test_slash_reset_memory_flow(
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "reset_memory", "agent_id": "agent1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_unmute_flow(
+    monkeypatch: pytest.MonkeyPatch, bot: DummyBot, interaction: DummyInteraction
+) -> None:
+    async def allow_eval(content: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    await discord_moderation.slash_unmute.callback(interaction, "agent1")
+    interaction.response.send_message.assert_awaited_once_with("unmuted", ephemeral=True)
+    event = await bot.context.get_event_queue().get()
+    assert event.type == "moderation"
+    assert event.data == {"command": "unmute", "agent_id": "agent1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rate_limit_counts_and_violation(
+    monkeypatch: pytest.MonkeyPatch,
+    bot: DummyBot,
+    interaction_factory: Callable[[], DummyInteraction],
+) -> None:
+    discord_moderation._ACTION_COUNTS.clear()
+    discord_moderation._COOLDOWNS.clear()
+    monkeypatch.setattr(discord_moderation, "_COOLDOWN_SECONDS", 999.0)
+
+    async def allow_eval(content: str) -> tuple[bool, str]:
+        return True, ""
+
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+
+    interaction1 = interaction_factory()
+    await discord_moderation.slash_mute.callback(interaction1, "agent1")
+    await bot.context.get_event_queue().get()
+    assert discord_moderation._ACTION_COUNTS["123:mute"] == 1
+
+    interaction2 = interaction_factory()
+    await discord_moderation.slash_mute.callback(interaction2, "agent1")
+    interaction2.response.send_message.assert_awaited_once_with("rate limited", ephemeral=True)
+    event = await bot.context.get_event_queue().get()
+    assert event.data == {"command": "mute", "agent_id": "agent1", "violation": True}
+    assert discord_moderation._ACTION_COUNTS["123:mute"] == 2


### PR DESCRIPTION
## Summary
- add per-user action counters and cooldowns to Discord moderation rate limiting
- surface moderation violations via `SimulationEvent`
- implement OPA-protected `/unmute` command
- test unmute flow and rate-limit violation handling

## Testing
- `ruff check src/interfaces/discord_moderation.py tests/unit/interfaces/test_discord_moderation.py`
- `pytest tests/unit/interfaces/test_discord_moderation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3800b55c8326a8d883e7f345d1ac