### PR TITLE
Broadcast control command embeds and rate limit messages

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -598,7 +598,12 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
                     },
                 ),
             )
-        return base_model.dict(exclude={"llm_client", "mock_llm_client", "memory_store_manager"})
+        return cast(
+            dict[str, Any],
+            base_model.dict(
+                exclude={"llm_client", "mock_llm_client", "memory_store_manager"}
+            ),
+        )
 
     @classmethod
     def from_dict(cls: type[Self], data: dict[str, Any]) -> "AgentState":

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -203,15 +203,39 @@ class SimulationDiscordBot:
                 async def _tree_start(interaction: "discord.Interaction") -> None:
                     with tracer.start_as_current_span("discord.command") as span:
                         span.set_attribute("discord.command.name", "start")
-                        await start_simulation(self.context)
-                        await interaction.response.send_message("start", ephemeral=True)
+                        try:
+                            await start_simulation(self.context)
+                        except Exception as exc:
+                            embed = self.create_start_embed(False, str(exc))
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                "start failed", ephemeral=True
+                            )
+                        else:
+                            embed = self.create_start_embed(True)
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                "start", ephemeral=True
+                            )
 
                 @tree.command(name="stop")
                 async def _tree_stop(interaction: "discord.Interaction") -> None:
                     with tracer.start_as_current_span("discord.command") as span:
                         span.set_attribute("discord.command.name", "stop")
-                        await stop_simulation(self.context)
-                        await interaction.response.send_message("stop", ephemeral=True)
+                        try:
+                            await stop_simulation(self.context)
+                        except Exception as exc:
+                            embed = self.create_stop_embed(False, str(exc))
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                "stop failed", ephemeral=True
+                            )
+                        else:
+                            embed = self.create_stop_embed(True)
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                "stop", ephemeral=True
+                            )
 
                 @tree.command(name="spawn")
                 @app_commands.describe(agent_id="ID of the agent to spawn")
@@ -221,10 +245,20 @@ class SimulationDiscordBot:
                     with tracer.start_as_current_span("discord.command") as span:
                         span.set_attribute("discord.command.name", "spawn")
                         span.set_attribute("discord.agent.id", agent_id)
-                        await spawn_agent_command(agent_id, self.context)
-                        await interaction.response.send_message(
-                            f"spawn {agent_id}", ephemeral=True
-                        )
+                        try:
+                            await spawn_agent_command(agent_id, self.context)
+                        except Exception as exc:
+                            embed = self.create_spawn_embed(agent_id, False, str(exc))
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                f"spawn {agent_id} failed", ephemeral=True
+                            )
+                        else:
+                            embed = self.create_spawn_embed(agent_id, True)
+                            await self.send_simulation_update(embed=embed)
+                            await interaction.response.send_message(
+                                f"spawn {agent_id}", ephemeral=True
+                            )
 
             @client.event
             async def on_ready(
@@ -428,6 +462,42 @@ class SimulationDiscordBot:
             except (RuntimeError, ValueError, TypeError) as e:
                 logger.error(f"Unexpected error sending Discord message: {e}", exc_info=True)
                 return False
+
+    def create_start_embed(self: Self, success: bool, reason: str | None = None) -> Any:
+        """Create an embed indicating simulation start success or failure."""
+        title = "✅ Simulation Started" if success else "❌ Simulation Start Failed"
+        embed = discord.Embed(
+            title=title,
+            description=None if success else reason,
+            color=discord.Color.green() if success else discord.Color.red(),
+        )
+        return embed
+
+    def create_stop_embed(self: Self, success: bool, reason: str | None = None) -> Any:
+        """Create an embed indicating simulation stop success or failure."""
+        title = "🛑 Simulation Stopped" if success else "❌ Simulation Stop Failed"
+        embed = discord.Embed(
+            title=title,
+            description=None if success else reason,
+            color=discord.Color.green() if success else discord.Color.red(),
+        )
+        return embed
+
+    def create_spawn_embed(
+        self: Self, agent_id: str, success: bool, reason: str | None = None
+    ) -> Any:
+        """Create an embed indicating agent spawn success or failure."""
+        title = (
+            f"🚀 Agent {agent_id[:8]} Spawned"
+            if success
+            else f"❌ Failed to Spawn Agent {agent_id[:8]}"
+        )
+        embed = discord.Embed(
+            title=title,
+            description=None if success else reason,
+            color=discord.Color.green() if success else discord.Color.red(),
+        )
+        return embed
 
     def create_step_start_embed(self: Self, step: int) -> Any:
         """Creates an embed for simulation step start"""
@@ -870,8 +940,18 @@ async def slash_start(interaction: Any) -> None:
     """Start the simulation via a control command."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await start_simulation(ctx)
-    await interaction.response.send_message("start", ephemeral=True)
+    try:
+        await start_simulation(ctx)
+    except Exception as exc:
+        if bot_instance is not None:
+            embed = bot_instance.create_start_embed(False, str(exc))
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message("start failed", ephemeral=True)
+    else:
+        if bot_instance is not None:
+            embed = bot_instance.create_start_embed(True)
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message("start", ephemeral=True)
 
 
 @bot.tree.command(name="stop")
@@ -879,8 +959,18 @@ async def slash_stop(interaction: Any) -> None:
     """Stop the simulation via a control command."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await stop_simulation(ctx)
-    await interaction.response.send_message("stop", ephemeral=True)
+    try:
+        await stop_simulation(ctx)
+    except Exception as exc:
+        if bot_instance is not None:
+            embed = bot_instance.create_stop_embed(False, str(exc))
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message("stop failed", ephemeral=True)
+    else:
+        if bot_instance is not None:
+            embed = bot_instance.create_stop_embed(True)
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message("stop", ephemeral=True)
 
 
 @bot.tree.command(name="spawn")
@@ -888,8 +978,22 @@ async def slash_spawn(interaction: Any, agent_id: str) -> None:
     """Spawn a new agent in the simulation."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await spawn_agent_command(agent_id, ctx)
-    await interaction.response.send_message(f"spawn {agent_id}", ephemeral=True)
+    try:
+        await spawn_agent_command(agent_id, ctx)
+    except Exception as exc:
+        if bot_instance is not None:
+            embed = bot_instance.create_spawn_embed(agent_id, False, str(exc))
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message(
+            f"spawn {agent_id} failed", ephemeral=True
+        )
+    else:
+        if bot_instance is not None:
+            embed = bot_instance.create_spawn_embed(agent_id, True)
+            await bot_instance.send_simulation_update(embed=embed)
+        await interaction.response.send_message(
+            f"spawn {agent_id}", ephemeral=True
+        )
 
 
 @bot.tree.command(name="set_speed")

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -136,6 +136,12 @@ class Simulation:
 
         # Lock for concurrent access to message queues
         self._msg_lock = asyncio.Lock()
+        self._last_kb_time = 0.0
+        self._last_relay_time = 0.0
+        self._kb_cooldown = float(config.get_config("DISCORD_KB_RATE_LIMIT_SECONDS") or 1.0)
+        self._relay_cooldown = float(
+            config.get_config("DISCORD_MESSAGE_RATE_LIMIT_SECONDS") or 1.0
+        )
 
         # --- Store the simulation scenario ---
         self.scenario = scenario
@@ -303,7 +309,11 @@ class Simulation:
 
     async def _handle_human_command(self: Self, text: str) -> None:
         """Handle a human-issued command or prompt."""
+        now = time.monotonic()
         if text.startswith("/kb ") and self.knowledge_board:
+            if now - self._last_kb_time < self._kb_cooldown:
+                return
+            self._last_kb_time = now
             entry = text[4:].strip()
             if entry:
                 async with self.knowledge_board.lock:
@@ -314,6 +324,10 @@ class Simulation:
                         self.vector.to_dict(),
                     )
             return
+
+        if now - self._last_relay_time < self._relay_cooldown:
+            return
+        self._last_relay_time = now
 
         if not self.agents:
             return

--- a/tests/unit/interfaces/test_discord_commands.py
+++ b/tests/unit/interfaces/test_discord_commands.py
@@ -1,0 +1,174 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class DummyBot:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.tree = SimpleNamespace(command=lambda *a, **k: (lambda f: f))
+
+    def command(self, *args: object, **kwargs: object):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def reload_module(monkeypatch: pytest.MonkeyPatch):
+    dummy_commands = SimpleNamespace(Bot=DummyBot)
+    dummy_discord = SimpleNamespace(
+        Intents=SimpleNamespace(default=lambda: SimpleNamespace(message_content=True)),
+        Client=object,
+        Embed=object,
+        TextChannel=object,
+        Thread=object,
+        DiscordException=Exception,
+        Color=SimpleNamespace(green=lambda: None, red=lambda: None),
+        app_commands=SimpleNamespace(CommandTree=object),
+    )
+    monkeypatch.setitem(sys.modules, "discord", dummy_discord)
+    monkeypatch.setitem(sys.modules, "discord.app_commands", dummy_discord.app_commands)
+    monkeypatch.setitem(sys.modules, "discord.ext", SimpleNamespace(commands=dummy_commands))
+    monkeypatch.setitem(sys.modules, "discord.ext.commands", dummy_commands)
+    module = importlib.reload(importlib.import_module("src.interfaces.discord_bot"))
+    return module
+
+
+@pytest.fixture()
+def discord_module(monkeypatch: pytest.MonkeyPatch):
+    module = reload_module(monkeypatch)
+    yield module
+    importlib.reload(module)
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.response = SimpleNamespace(send_message=AsyncMock())
+        self.channel = None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_start_broadcasts_success_embed(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_start_embed=MagicMock(return_value="embed"),
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "start_simulation", AsyncMock())
+    interaction = DummyInteraction()
+    await discord_module.slash_start(interaction)
+    bot.create_start_embed.assert_called_once_with(True)
+    bot.send_simulation_update.assert_awaited_once_with(embed="embed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_start_broadcasts_failure_embed(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_start_embed=MagicMock(return_value="embed"),
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "start_simulation", AsyncMock(side_effect=RuntimeError("boom")))
+    interaction = DummyInteraction()
+    await discord_module.slash_start(interaction)
+    bot.create_start_embed.assert_called_once()
+    args = bot.create_start_embed.call_args[0]
+    assert args[0] is False and "boom" in args[1]
+    bot.send_simulation_update.assert_awaited_once_with(embed="embed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_stop_broadcasts_success_embed(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_stop_embed=MagicMock(return_value="embed"),
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "stop_simulation", AsyncMock())
+    interaction = DummyInteraction()
+    await discord_module.slash_stop(interaction)
+    bot.create_stop_embed.assert_called_once_with(True)
+    bot.send_simulation_update.assert_awaited_once_with(embed="embed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_spawn_broadcasts_success_embed(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_spawn_embed=MagicMock(return_value="embed"),
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "spawn_agent_command", AsyncMock())
+    interaction = DummyInteraction()
+    await discord_module.slash_spawn(interaction, "agent")
+    bot.create_spawn_embed.assert_called_once_with("agent", True)
+    bot.send_simulation_update.assert_awaited_once_with(embed="embed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_spawn_broadcasts_failure_embed(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_spawn_embed=MagicMock(return_value="embed"),
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "spawn_agent_command", AsyncMock(side_effect=RuntimeError("bad")))
+    interaction = DummyInteraction()
+    await discord_module.slash_spawn(interaction, "agent")
+    bot.create_spawn_embed.assert_called_once()
+    args = bot.create_spawn_embed.call_args[0]
+    assert args[0] == "agent" and args[1] is False
+    bot.send_simulation_update.assert_awaited_once_with(embed="embed")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kb_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.sim.simulation import Simulation
+
+    class DummyAgent:
+        def get_id(self) -> str:
+            return "a"
+
+        agent_id = "a"
+        state = SimpleNamespace(ip=10.0, du=10.0)
+
+    sim = Simulation([DummyAgent()])
+    sim.knowledge_board.add_entry = MagicMock()
+    await sim._handle_human_command("/kb first")
+    await sim._handle_human_command("/kb second")
+    sim.knowledge_board.add_entry.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_message_relay_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.infra import ledger as ledger_module
+    from src.sim.simulation import Simulation
+
+    class DummyAgent:
+        def get_id(self) -> str:
+            return "a"
+
+        agent_id = "a"
+        state = SimpleNamespace(ip=10.0, du=10.0)
+
+    sim = Simulation([])
+    sim.agents = [DummyAgent()]
+    monkeypatch.setattr(ledger_module.ledger, "spend", AsyncMock())
+    await sim._handle_human_command("hello")
+    await sim._handle_human_command("hello again")
+    ledger_module.ledger.spend.assert_awaited_once()


### PR DESCRIPTION
## Summary
- broadcast start/stop/spawn command results using embeds
- add rate limits for knowledge board posts and human message relays
- fix AgentState serialization typing for mypy
- test discord command embeds and rate limiting

## Testing
- `ruff check tests/unit/interfaces/test_discord_commands.py src/interfaces/discord_bot.py src/sim/simulation.py src/agents/core/agent_state.py`
- `python -m mypy --no-site-packages src/interfaces/discord_bot.py src/sim/simulation.py`
- `pytest tests/unit/interfaces/test_discord_commands.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d38004d648326898a66e34f6b1fa2