### PR TITLE
Add token budget enforcement to memory retrieval

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -129,6 +129,7 @@ class MemoryService:
         k: int = 5,
         semantic_limit: int = 3,
         long_term_limit: int | None = None,
+        token_budget: int | None = None,
     ) -> (
         tuple[list[dict[str, Any]], list[str]] | tuple[list[dict[str, Any]], list[str], list[str]]
     ):
@@ -143,15 +144,46 @@ class MemoryService:
         ):
             episodic = await self.retrieve_episodic_and_update_semantic(agent_id, query, k)
             semantic = self.get_recent_semantic_summaries(agent_id, semantic_limit)
-            hits = len(episodic) + len(semantic)
-            total = k + semantic_limit
+            long_term: list[str] = []
             if long_term_limit:
                 long_term = self.get_long_term_summaries(agent_id, long_term_limit)
-                hits += len(long_term)
-                total += long_term_limit
-                metrics.RAG_HIT_RATE.set(hits / total if total else 0)
-                return episodic, semantic, long_term
+
+            if token_budget is not None:
+                tokens = 0
+                limited_episodic: list[dict[str, Any]] = []
+                for mem in episodic:
+                    text = str(mem.get("content", ""))
+                    t = len(text.split())
+                    if tokens + t > token_budget:
+                        break
+                    limited_episodic.append(mem)
+                    tokens += t
+                episodic = limited_episodic
+
+                limited_semantic: list[str] = []
+                for summary in semantic:
+                    t = len(summary.split())
+                    if tokens + t > token_budget:
+                        break
+                    limited_semantic.append(summary)
+                    tokens += t
+                semantic = limited_semantic
+
+                if long_term:
+                    limited_long_term: list[str] = []
+                    for summary in long_term:
+                        t = len(summary.split())
+                        if tokens + t > token_budget:
+                            break
+                        limited_long_term.append(summary)
+                        tokens += t
+                    long_term = limited_long_term
+
+            hits = len(episodic) + len(semantic) + len(long_term)
+            total = k + semantic_limit + (long_term_limit or 0)
             metrics.RAG_HIT_RATE.set(hits / total if total else 0)
+            if long_term_limit:
+                return episodic, semantic, long_term
             return episodic, semantic
 
     async def run_semantic_job(

--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -28,7 +28,11 @@ class MultiLayerRetriever:
         self.semantic_manager = semantic_manager
 
     async def retrieve(
-        self: Self, agent_id: str, query: str = "", k: int = 5
+        self: Self,
+        agent_id: str,
+        query: str = "",
+        k: int = 5,
+        token_budget: int | None = None,
     ) -> list[dict[str, Any]]:
         try:
             episodic: list[dict[str, Any]] = []
@@ -70,6 +74,16 @@ class MultiLayerRetriever:
 
             combined = episodic + semantic
             combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+            if token_budget is not None:
+                limited: list[dict[str, Any]] = []
+                tokens = 0
+                for mem in combined:
+                    text = str(mem.get("content", ""))
+                    tokens += len(text.split())
+                    if tokens > token_budget:
+                        break
+                    limited.append(mem)
+                combined = limited
             metrics.MEMORY_RETRIEVALS_TOTAL.inc()
             return combined[:k]
         except Exception:

--- a/tests/unit/memory/test_token_budget.py
+++ b/tests/unit/memory/test_token_budget.py
@@ -1,0 +1,49 @@
+import pytest
+
+from src.agents.memory.memory_service import MemoryService
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
+
+pytestmark = pytest.mark.unit
+
+
+class DummyVectorStore:
+    async def aretrieve_relevant_memories(self, agent_id: str, query: str, k: int) -> list[dict[str, str]]:
+        return [
+            {"content": "episodic one", "relevance_score": 0.9},
+            {"content": "episodic two", "relevance_score": 0.8},
+        ]
+
+
+class DummySemantic:
+    def retrieve_context_with_scores(self, agent_id: str, query: str, k: int) -> list[dict[str, str]]:
+        return [
+            {"content": "semantic one", "relevance_score": 0.85},
+            {"content": "semantic two", "relevance_score": 0.7},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_retriever_respects_token_budget() -> None:
+    retriever = MultiLayerRetriever(DummyVectorStore(), DummySemantic())
+    results = await retriever.retrieve("agent", "q", k=10, token_budget=5)
+    assert [r["content"] for r in results] == ["episodic one", "semantic one"]
+
+
+@pytest.mark.asyncio
+async def test_context_pipeline_respects_token_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MemoryService()
+
+    async def fake_retrieve(agent_id: str, query: str, k: int) -> list[dict[str, str]]:
+        return [{"content": "one"}, {"content": "two"}, {"content": "three four"}]
+
+    def fake_semantic(agent_id: str, limit: int) -> list[str]:
+        return ["alpha", "beta"]
+
+    monkeypatch.setattr(service, "retrieve_episodic_and_update_semantic", fake_retrieve)
+    monkeypatch.setattr(service, "get_recent_semantic_summaries", fake_semantic)
+
+    episodic, semantic = await service.get_context_pipeline(
+        "agent", token_budget=3, semantic_limit=2
+    )
+    assert [m["content"] for m in episodic] == ["one", "two"]
+    assert semantic == ["alpha"]


### PR DESCRIPTION
## Summary
- allow `MultiLayerRetriever.retrieve` to accept a `token_budget` and trim results accordingly
- add optional `token_budget` to `MemoryService.get_context_pipeline` and trim episodic, semantic, and long-term context
- add unit tests for token budget behavior

## Testing
- `ruff check src/agents/memory/multi_layer_retriever.py src/agents/memory/memory_service.py tests/unit/memory/test_token_budget.py`
- `pytest tests/unit/memory/test_token_budget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d41197330832690d8495cc0f6f99e