### PR TITLE
Add signature demo scenario and metrics bundling

### DIFF
--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -33,3 +33,30 @@ coalition counts and sentiment snapshots for plotting.
 - **Sentiment curves**: average agent mood over time.
 
 The resulting plots appear in the `plots/` directory.
+
+## Signature Demo Scenario
+
+This lightweight scenario highlights evaluation hooks for common group metrics.
+
+### Usage
+
+1. Run the simulation with the signature demo:
+   ```bash
+   python src/app.py --scenario scenarios/signature_demo.yaml
+   ```
+2. Export trace data:
+   ```bash
+   python scripts/export_traces.py --snapshots snapshots --output data/traces.jsonl
+   ```
+3. Generate plots and bundle metrics:
+   ```bash
+   python tools/export_traces.py data/traces.jsonl --outdir plots --bundle run_bundle
+   ```
+
+### Expected Arc
+
+1. **Introduction** – agents share initial perspectives and set intent.
+2. **Collaboration** – members coordinate to sign onto a shared plan.
+3. **Resolution** – the group finalizes the plan and reflects on the process.
+
+Evaluation hooks record coalition counts, sentiment, and collective DU/IP curves for analysis.

--- a/scenarios/signature_demo.yaml
+++ b/scenarios/signature_demo.yaml
@@ -1,0 +1,13 @@
+name: signature_demo
+description: Demo scenario showcasing evaluation hooks for coalition and sentiment tracking
+goal: Agents collaborate to sign a shared plan while monitoring group dynamics
+steps: 30
+beats:
+  - introduction
+  - collaboration
+  - resolution
+evaluation_hooks:
+  - coalitions
+  - sentiment
+  - collective_du
+  - collective_ip

--- a/tools/export_traces.py
+++ b/tools/export_traces.py
@@ -33,7 +33,7 @@ def load_metrics(file: str | Path) -> dict[str, list[tuple[int, float]]]:
 
 
 def bundle_replay(trace_file: str | Path, bundle: str | Path) -> Path:
-    """Package logs, metrics and RNG seed into a single archive.
+    """Package logs, metrics, scenario metrics, and RNG seed into a single archive.
 
     Parameters
     ----------
@@ -49,6 +49,10 @@ def bundle_replay(trace_file: str | Path, bundle: str | Path) -> Path:
     """
     trace_path = Path(trace_file)
     metrics = load_metrics(trace_path)
+    scenario_metrics = {
+        key: metrics.get(key, [])
+        for key in ("coalitions", "sentiment", "collective_du", "collective_ip")
+    }
     seed: int | None = None
     with trace_path.open("r", encoding="utf-8") as fh:
         for line in fh:
@@ -62,6 +66,8 @@ def bundle_replay(trace_file: str | Path, bundle: str | Path) -> Path:
         shutil.copy(trace_path, tmp / "logs.jsonl")
         with (tmp / "metrics.json").open("w", encoding="utf-8") as mfh:
             json.dump(metrics, mfh)
+        with (tmp / "scenario_metrics.json").open("w", encoding="utf-8") as smfh:
+            json.dump(scenario_metrics, smfh)
         if seed is not None:
             with (tmp / "seed.txt").open("w", encoding="utf-8") as sfh:
                 sfh.write(str(seed))


### PR DESCRIPTION
## Summary
- add signature_demo scenario with beats and evaluation hooks
- bundle scenario metrics (coalitions, sentiment, DU/IP curves) in export_traces
- document new scenario usage and arc

## Testing
- `ruff check tools/export_traces.py`
- `pytest tests/unit/scripts/test_export_traces.py tests/integration/tools/test_export_traces.py`
- `pytest` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689dfd4a9d708326b53fe13b6e70b1fb