### PR TITLE
feat: prefer vllm client and improve local startup

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -14,13 +14,13 @@ This runbook outlines routine operations for working with Culture.ai.
    VLLM_MODEL="mistralai/Mistral-7B-Instruct-v0.2" VLLM_PORT=8001 scripts/start_vllm.sh
    export VLLM_API_BASE="http://localhost:$VLLM_PORT"
    ```
-   The vLLM server supports request batching for higher throughput. Tune
-   `VLLM_MAX_BATCH_TOKENS` and `VLLM_MAX_NUM_SEQS` to control the maximum
-   tokens and sequence count processed per batch. In internal tests, enabling
-   batching reduced average latency by ~30% compared to single-request
-   handling. Smaller, colon-delimited models (for example `mistral:latest`)
-   can still run via Ollama, which avoids GPU overhead for lightweight models.
-   Ollama can be used as a fallback backend:
+   `scripts/start_vllm.sh` enables continuous batching via
+   `--enable-chunked-prefill` and resolves models from the local Hugging Face
+   cache first (override with `VLLM_DOWNLOAD_DIR`). Adjust
+   `VLLM_MAX_BATCH_TOKENS` and `VLLM_MAX_NUM_SEQS` to control batch size.
+   Smaller, colon-delimited models (for example `mistral:latest`) can still run
+   via Ollama, which avoids GPU overhead for lightweight models. Ollama can be
+   used as a fallback backend:
    ```bash
    ollama pull mistral:latest
    ollama serve &
@@ -73,12 +73,14 @@ export VLLM_API_BASE="http://localhost:$VLLM_PORT"
 export LLM_API_BASE="$VLLM_API_BASE"  # overrides Ollama when set
 ```
 
-Run `scripts/benchmark_llm.py` after the server starts to compare vLLM and Ollama performance. The script reports average latency and request throughput:
+Run `scripts/benchmark_llm.py` after the server starts to compare vLLM and Ollama performance. The script reports average latency, throughput, and an approximate cost per million tokens:
 
-| Backend | Avg latency (s) | Throughput (req/s) |
-|---------|----------------:|-------------------:|
-| vLLM    | 0.25            | 4.00               |
-| Ollama  | 1.20            | 0.83               |
+| Backend | Avg latency (s) | Throughput (req/s) | Cost per 1M tokens* |
+|---------|----------------:|-------------------:|--------------------:|
+| vLLM    | 0.25            | 4.00               | ~$0 (local GPU)     |
+| Ollama  | 1.20            | 0.83               | ~$0 (local CPU)     |
+
+*Hardware and electricity costs not included; remote APIs would add per-token charges.
 
 Add `--output results.json` to persist the results for later analysis.
 

--- a/scripts/start_vllm.sh
+++ b/scripts/start_vllm.sh
@@ -18,6 +18,7 @@ TP_SIZE=${VLLM_TENSOR_PARALLEL_SIZE:-${TP_SIZE:-1}}
 GPU_UTIL=${VLLM_GPU_MEMORY_UTILIZATION:-${GPU_UTIL:-0.9}}
 MAX_BATCH_TOKENS=${VLLM_MAX_BATCH_TOKENS:-${MAX_BATCH_TOKENS:-8192}}
 MAX_NUM_SEQS=${VLLM_MAX_NUM_SEQS:-${MAX_NUM_SEQS:-32}}
+DOWNLOAD_DIR=${VLLM_DOWNLOAD_DIR:-${HF_HOME:-"$HOME/.cache/huggingface"}}
 
 echo "Starting vLLM server with model '${MODEL}' on port ${PORT} using GPUs ${GPUS}" >&2
 echo "Set VLLM_API_BASE=http://localhost:${PORT} to connect" >&2
@@ -29,4 +30,6 @@ CUDA_VISIBLE_DEVICES=${GPUS} python -m vllm.entrypoints.openai.api_server \
   --tensor-parallel-size "${TP_SIZE}" \
   --gpu-memory-utilization "${GPU_UTIL}" \
   --max-num-batched-tokens "${MAX_BATCH_TOKENS}" \
-  --max-num-seqs "${MAX_NUM_SEQS}"
+  --max-num-seqs "${MAX_NUM_SEQS}" \
+  --enable-chunked-prefill \
+  --download-dir "${DOWNLOAD_DIR}"

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -518,8 +518,8 @@ def is_ollama_available() -> bool:
 
 # Determine which LLM backend to use and initialize the client accordingly
 if not VLLM_API_BASE:
-    VLLM_API_BASE = "http://localhost:8000"
-    logger.warning("VLLM_API_BASE not set in config, using default: %s", VLLM_API_BASE)
+    USE_VLLM = False
+    logger.info("VLLM_API_BASE not set; defaulting to Ollama")
 else:
     logger.info("Using VLLM_API_BASE: %s", VLLM_API_BASE)
 if not LLM_API_BASE:
@@ -682,13 +682,19 @@ def get_llm_client() -> OllamaClientProtocol:
         client = None
 
     if client is None:
-        client, err = _retry_with_backoff(_create_vllm_client)
+        err: Exception | None = None
+        if VLLM_API_BASE:
+            client, err = _retry_with_backoff(_create_vllm_client)
+            if client is not None:
+                logger.info(f"Using vLLM API base: {VLLM_API_BASE}")
+                USE_VLLM = True
+            else:
+                logger.error(
+                    "Failed to initialize vLLM client: %s",
+                    err,
+                    exc_info=True,
+                )
         if client is None:
-            logger.error(
-                "Failed to initialize vLLM client: %s",
-                err,
-                exc_info=True,
-            )
             client, err = _retry_with_backoff(_create_ollama_client)
             if client is None:
                 logger.error(
@@ -698,9 +704,6 @@ def get_llm_client() -> OllamaClientProtocol:
                 )
                 raise LLMClientInitError("Failed to initialize vLLM and Ollama clients")
             USE_VLLM = False
-        else:
-            logger.info(f"Using vLLM API base: {VLLM_API_BASE or LLM_API_BASE}")
-            USE_VLLM = True
     return client
 
 

--- a/tests/integration/test_start_vllm_script.py
+++ b/tests/integration/test_start_vllm_script.py
@@ -49,4 +49,7 @@ def test_start_vllm_script(tmp_path: Path) -> None:
         "8192",
         "--max-num-seqs",
         "32",
+        "--enable-chunked-prefill",
+        "--download-dir",
+        f"{Path.home()}/.cache/huggingface",
     ]


### PR DESCRIPTION
## Summary
- enable vLLM chunked prefill and local model cache in start script
- choose vLLM client when VLLM_API_BASE is set, else fall back to Ollama
- document setup details and add cost comparison table

## Testing
- `SKIP=unit-tests pre-commit run --files scripts/start_vllm.sh src/infra/llm_client.py docs/runbook.md tests/integration/test_start_vllm_script.py`
- `pytest tests/unit/infra/test_llm_client_vllm.py tests/unit/infra/test_llm_client_url.py tests/unit/infra/test_get_llm_client_fallback.py`
- `PYTEST_ADDOPTS='' pytest tests/integration/test_start_vllm_script.py -m integration`


------
https://chatgpt.com/codex/tasks/task_e_689dfd4ae2408326a48d056e533e0771