### PR TITLE
Use tokenizer for retriever node

### DIFF
--- a/docs/memory_pruning_strategies.md
+++ b/docs/memory_pruning_strategies.md
@@ -10,6 +10,8 @@ As the "Culture: An AI Genesis Engine" simulation progresses, agents continually
 4. **Response quality deterioration**: Too many competing memories may cause confusing or diluted agent responses
 
 This document outlines strategies for memory pruning to maintain optimal performance while preserving critical information.
+Accurate token budgeting should rely on model-aware tokenizers (e.g., ``tiktoken``)
+rather than simple whitespace counts so multilingual content is handled correctly.
 
 ## Strategy 1: Age-Based Pruning with Hierarchical Preservation
 

--- a/src/langgraph/retriever_node.py
+++ b/src/langgraph/retriever_node.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import tiktoken
 from typing_extensions import Self
 
 
@@ -12,13 +13,20 @@ class RetrieverNode:
 
     The provided ``memory_service`` is expected to merge episodic and semantic
     memories. Retrieved items are truncated so that the combined number of
-    whitespace-separated tokens does not exceed ``token_cap``.
+    model tokens, measured via ``tiktoken``, does not exceed ``token_cap``.
     """
 
-    def __init__(self: Self, memory_service: Any, k: int = 5, token_cap: int = 1000) -> None:
+    def __init__(
+        self: Self,
+        memory_service: Any,
+        k: int = 5,
+        token_cap: int = 1000,
+        tokenizer: tiktoken.Encoding | None = None,
+    ) -> None:
         self.memory_service = memory_service
         self.k = k
         self.token_cap = token_cap
+        self.tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
 
     async def __call__(self: Self, state: dict[str, Any]) -> dict[str, Any]:
         """Retrieve relevant memories for the given state."""
@@ -29,7 +37,7 @@ class RetrieverNode:
         tokens = 0
         for mem in memories:
             text = mem.get("content", "")
-            tokens += len(text.split())
+            tokens += len(self.tokenizer.encode(text))
             if tokens > self.token_cap:
                 break
             limited.append(mem)

--- a/tests/unit/langgraph/test_retriever_node.py
+++ b/tests/unit/langgraph/test_retriever_node.py
@@ -1,4 +1,5 @@
 import pytest
+import tiktoken
 
 from src.agents.core.agent_state import AgentState
 
@@ -6,20 +7,21 @@ from src.agents.core.agent_state import AgentState
 class DummyMemoryService:
     async def retrieve_relevant_memories(self, agent_id: str, query: str, k: int):
         return [
-            {"content": "one two three four"},
-            {"content": "five six seven eight"},
-            {"content": "nine ten eleven twelve"},
+            {"content": "こんにちは世界"},
+            {"content": "hello world"},
         ]
 
 
 @pytest.mark.asyncio
-async def test_retriever_node_respects_token_cap() -> None:
+@pytest.mark.unit
+async def test_retriever_node_respects_token_cap_non_ascii() -> None:
     service = DummyMemoryService()
     agent_state = AgentState(agent_id="a1", name="A1")
     agent_state.memory_retriever_top_k = 5
-    agent_state.memory_retriever_token_cap = 8
+    agent_state.memory_retriever_token_cap = 5
     node = agent_state.get_retriever_node(service)
     result = await node({"agent_id": "a1", "query": ""})
-    assert len(result["memories"]) == 2
+    assert len(result["memories"]) == 1
     combined = " ".join(m["content"] for m in result["memories"])
-    assert len(combined.split()) <= agent_state.memory_retriever_token_cap
+    enc = tiktoken.get_encoding("cl100k_base")
+    assert len(enc.encode(combined)) <= agent_state.memory_retriever_token_cap


### PR DESCRIPTION
## Summary
- use `tiktoken` to enforce RetrieverNode token budget
- test non-ASCII token cap enforcement
- document tokenizer-based memory budgeting

## Testing
- `SKIP=unit-tests pre-commit run --files src/langgraph/retriever_node.py tests/unit/langgraph/test_retriever_node.py docs/memory_pruning_strategies.md`
- `python scripts/run_tests.py tests/unit/langgraph/test_retriever_node.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfd48d00c8326b99a9ae0b7d201ec