### PR TITLE
Enforce DU budgets and track per-agent metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -60,6 +60,16 @@ Additional Prometheus metrics include:
 - `memory_retrievals_total` – counts successful memory lookups.
 - `memory_retrieval_errors_total` – counts memory retrieval failures.
 
+### Monitoring DU Budgets
+
+Each agent exposes its remaining DU balance and efficiency via Prometheus gauges:
+
+- `agent_remaining_du{agent_id="<id>"}` shows the DU balance for a given agent.
+- `agent_du_per_1k_tokens{agent_id="<id>"}` reports DU spent per 1k tokens on the last LLM call.
+
+Create Grafana panels with queries such as `agent_remaining_du` or `agent_du_per_1k_tokens`
+to alert when budgets run low or spike unexpectedly.
+
 ## 4. Running Grafana Locally
 
 If you want to run Grafana locally for quick testing, you can use Docker. The default login is `admin`/`admin`:

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -33,6 +33,7 @@ from src.infra import config
 from src.infra.async_dspy_manager import AsyncDSPyManager
 from src.infra.config import get_config
 from src.infra.llm_client import LLMClientInitError, get_ollama_client
+from src.sim.resource_manager import get_resource_manager
 
 from .embedding_utils import compute_embedding
 from .roles import ensure_profile
@@ -435,6 +436,10 @@ class Agent:
         # Log received perception data
         if environment_perception:
             logger.debug(f"  Received environment perception: {environment_perception}")
+
+        # Enforce per-turn DU budget cap before any LLM calls
+        budget_cap = min(self._state.du, float(get_config("MAX_DU_PER_TICK")))
+        get_resource_manager().set_du_budget(self.agent_id, budget_cap)
 
         # --- Retrieve previous thought ---
         for memory in self._state.short_term_memory:

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -305,7 +305,9 @@ def async_monitor_llm_call(
                 metrics.LLM_CALLS_TOTAL.inc()
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
-                infra_metrics.record_llm_latency(metrics_data["duration_ms"])
+                agent_state = kwargs.get("agent_state")
+                agent_id = getattr(agent_state, "agent_id", "unknown")
+                infra_metrics.record_llm_latency(agent_id, metrics_data["duration_ms"])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data, default=str)}")
 
         return wrapper

--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -10,16 +10,23 @@ from .ledger import ledger
 
 # Store the most recent DU-per-1k-tokens value
 _last_du_per_1k_tokens: float = 0.0
+# Track DU-per-1k-tokens per agent for quick lookup
+_agent_du_per_1k_tokens: dict[str, float] = {}
 
 # Keep a rolling window of recent LLM latencies in milliseconds
 _LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
+# Per-agent latency samples for p95 calculations
+_LATENCY_SAMPLES_PER_AGENT: dict[str, deque[float]] = {}
 
 
 def record_du_per_1k_tokens(agent_id: str, value: float) -> None:
     """Record DU cost per 1k tokens for the latest LLM call."""
     global _last_du_per_1k_tokens
     _last_du_per_1k_tokens = float(value)
+    _agent_du_per_1k_tokens[agent_id] = _last_du_per_1k_tokens
     prom_metrics.LLM_DU_PER_1K_TOKENS.set(_last_du_per_1k_tokens)
+    if hasattr(prom_metrics.AGENT_DU_PER_1K_TOKENS, "labels"):
+        prom_metrics.AGENT_DU_PER_1K_TOKENS.labels(agent_id=agent_id).set(_last_du_per_1k_tokens)
     try:  # pragma: no cover - optional dependency
         ledger.record_du_per_1k_tokens(agent_id, value)
     except Exception:
@@ -31,7 +38,12 @@ def get_du_per_1k_tokens() -> float:
     return _last_du_per_1k_tokens
 
 
-def record_llm_latency(latency_ms: float) -> None:
+def get_agent_du_per_1k_tokens(agent_id: str) -> float:
+    """Return the DU-per-1k-tokens value for ``agent_id``."""
+    return float(_agent_du_per_1k_tokens.get(agent_id, 0.0))
+
+
+def record_llm_latency(agent_id: str, latency_ms: float) -> None:
     """Record latency for an LLM call and update p95 statistics."""
     prom_metrics.LLM_LATENCY_MS.set(latency_ms)
     _LATENCY_SAMPLES.append(latency_ms)
@@ -39,6 +51,15 @@ def record_llm_latency(latency_ms: float) -> None:
         ordered = sorted(_LATENCY_SAMPLES)
         idx = int(0.95 * (len(ordered) - 1))
         prom_metrics.LLM_LATENCY_P95_MS.set(ordered[idx])
+
+    agent_samples = _LATENCY_SAMPLES_PER_AGENT.setdefault(agent_id, deque(maxlen=100))
+    agent_samples.append(latency_ms)
+    ordered_agent = sorted(agent_samples)
+    idx_agent = int(0.95 * (len(ordered_agent) - 1))
+    if hasattr(prom_metrics.AGENT_LLM_LATENCY_P95_MS, "labels"):
+        prom_metrics.AGENT_LLM_LATENCY_P95_MS.labels(agent_id=agent_id).set(
+            ordered_agent[idx_agent]
+        )
 
 
 def get_llm_latency_p95() -> float:
@@ -50,9 +71,21 @@ def get_llm_latency_p95() -> float:
     return ordered[idx]
 
 
+def get_agent_llm_latency_p95(agent_id: str) -> float:
+    """Return the p95 latency for recent LLM calls by ``agent_id``."""
+    samples = _LATENCY_SAMPLES_PER_AGENT.get(agent_id)
+    if not samples:
+        return 0.0
+    ordered = sorted(samples)
+    idx = int(0.95 * (len(ordered) - 1))
+    return ordered[idx]
+
+
 __all__ = [
     "get_du_per_1k_tokens",
     "get_llm_latency_p95",
+    "get_agent_du_per_1k_tokens",
+    "get_agent_llm_latency_p95",
     "record_du_per_1k_tokens",
     "record_llm_latency",
 ]

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -84,11 +84,14 @@ PROPOSAL_THROUGHPUT = Gauge("proposal_throughput", "Proposals processed per minu
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
 LLM_DU_PER_1K_TOKENS = Gauge("llm_du_per_1k_tokens", "DU cost per 1k tokens for the last LLM call")
-AGENT_REMAINING_DU = Gauge(
-    "agent_remaining_du", "Remaining DU balance per agent", ["agent_id"]
-)
+AGENT_REMAINING_DU = Gauge("agent_remaining_du", "Remaining DU balance per agent", ["agent_id"])
 AGENT_DU_PER_1K_TOKENS = Gauge(
     "agent_du_per_1k_tokens", "DU cost per 1k tokens per agent", ["agent_id"]
+)
+AGENT_LLM_LATENCY_P95_MS = Gauge(
+    "agent_llm_latency_p95_ms",
+    "95th percentile latency of recent LLM calls per agent in milliseconds",
+    ["agent_id"],
 )
 
 # Start the metrics HTTP server when this module is imported
@@ -175,6 +178,7 @@ def get_proposal_throughput() -> float:
 
 __all__ = [
     "AGENT_DU_PER_1K_TOKENS",
+    "AGENT_LLM_LATENCY_P95_MS",
     "AGENT_REMAINING_DU",
     "AVERAGE_SENTIMENT",
     "COALITION_COUNT",

--- a/src/shared/decorator_utils.py
+++ b/src/shared/decorator_utils.py
@@ -93,7 +93,9 @@ def monitor_llm_call(
                 metrics.LLM_CALLS_TOTAL.inc()
                 if not metrics_data.get("success", False):
                     metrics.LLM_ERRORS_TOTAL.inc()
-                infra_metrics.record_llm_latency(metrics_data["duration_ms"])
+                agent_state = kwargs.get("agent_state")
+                agent_id = getattr(agent_state, "agent_id", "unknown")
+                infra_metrics.record_llm_latency(agent_id, metrics_data["duration_ms"])
                 llm_perf_logger.info(f"LLM_CALL_METRICS: {json.dumps(metrics_data)}")
             return result
 

--- a/tests/unit/infra/test_llm_du_cost.py
+++ b/tests/unit/infra/test_llm_du_cost.py
@@ -104,3 +104,67 @@ def test_du_never_negative(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result == "hi"
     assert state.du == pytest.approx(0.5)
     assert not log_called
+
+
+@pytest.mark.unit
+def test_llm_call_fails_without_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(llm_client_mod)
+    state = AgentState(agent_id="A", name="Agent")
+
+    class DummyClient:
+        def chat(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "message": {"content": "hi"},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            }
+
+    monkeypatch.setattr(module, "get_llm_client", lambda: DummyClient())
+    monkeypatch.setattr(
+        module,
+        "_retry_with_backoff",
+        lambda func, *a, **kw: (func(), None),
+    )
+    monkeypatch.setattr(module.ledger, "calculate_gas_price", lambda *_a, **_k: (1.0, 0.0))
+
+    from src.sim.resource_manager import get_resource_manager
+
+    rm = get_resource_manager()
+    rm.set_du_budget(state.agent_id, 0.5)
+    start_du = state.du
+
+    module.generate_text("hi", agent_state=state)
+    assert rm.get_du_budget(state.agent_id) == pytest.approx(0.0)
+    assert state.du == pytest.approx(start_du)
+
+
+@pytest.mark.unit
+def test_llm_budget_consumed(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = importlib.reload(llm_client_mod)
+    state = AgentState(agent_id="A", name="Agent")
+
+    class DummyClient:
+        def chat(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "message": {"content": "hi"},
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+            }
+
+    monkeypatch.setattr(module, "get_llm_client", lambda: DummyClient())
+    monkeypatch.setattr(
+        module,
+        "_retry_with_backoff",
+        lambda func, *a, **kw: (func(), None),
+    )
+    monkeypatch.setattr(module.ledger, "calculate_gas_price", lambda *_a, **_k: (1.0, 0.0))
+
+    from src.sim.resource_manager import get_resource_manager
+
+    rm = get_resource_manager()
+    rm.set_du_budget(state.agent_id, 1.0)
+
+    module.generate_text("hi", agent_state=state)
+    assert rm.get_du_budget(state.agent_id) == pytest.approx(0.0)
+    first_du = state.du
+
+    module.generate_text("hi", agent_state=state)
+    assert state.du == pytest.approx(first_du)


### PR DESCRIPTION
## Summary
- enforce per-turn DU budget caps before agents call LLMs
- record DU/1k tokens and p95 latency per agent
- test DU budget enforcement edge cases and document monitoring

## Testing
- `SKIP=unit-tests pre-commit run --files src/infra/metrics.py src/agents/core/base_agent.py src/interfaces/metrics.py src/shared/decorator_utils.py src/infra/llm_client.py tests/unit/infra/test_llm_du_cost.py docs/observability.md`
- `pytest tests/unit/infra/test_llm_du_cost.py`

------
https://chatgpt.com/codex/tasks/task_e_689dfd4c34648326bf6a277f3f75beec