### PR TITLE
feat(discord): moderation commands and safety rails

### DIFF
--- a/docs/discord_manual_run.md
+++ b/docs/discord_manual_run.md
@@ -74,6 +74,33 @@ Sends a broadcast message to all agents.
 ```
 Adds a new entry to the shared Knowledge Board.
 
+### Moderation Commands
+
+The bot exposes moderation-oriented commands:
+
+```text
+/mute agent_4
+```
+Mutes an agent until it is explicitly unmuted.
+
+```text
+/unmute agent_4
+```
+Restores the agent's ability to speak.
+
+```text
+/reset_memory agent_4
+```
+Clears an agent's memory.
+
+```text
+/penalty agent_4 ip:1 du:1
+```
+Applies an IP/DU penalty to the agent.
+
+All moderation commands are rate limited on a per-agent basis. Exceeding the
+limit automatically issues IP and DU penalties as a safety rail.
+
 ### Using Multiple Bot Tokens
 You can run the simulation with several Discord bot accounts. Tokens are stored
 in a PostgreSQL table named `discord_tokens` with columns `agent_id` and

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -208,15 +208,11 @@ class SimulationDiscordBot:
                         except Exception as exc:
                             embed = self.create_start_embed(False, str(exc))
                             await self.send_simulation_update(embed=embed)
-                            await interaction.response.send_message(
-                                "start failed", ephemeral=True
-                            )
+                            await interaction.response.send_message("start failed", ephemeral=True)
                         else:
                             embed = self.create_start_embed(True)
                             await self.send_simulation_update(embed=embed)
-                            await interaction.response.send_message(
-                                "start", ephemeral=True
-                            )
+                            await interaction.response.send_message("start", ephemeral=True)
 
                 @tree.command(name="stop")
                 async def _tree_stop(interaction: "discord.Interaction") -> None:
@@ -227,21 +223,15 @@ class SimulationDiscordBot:
                         except Exception as exc:
                             embed = self.create_stop_embed(False, str(exc))
                             await self.send_simulation_update(embed=embed)
-                            await interaction.response.send_message(
-                                "stop failed", ephemeral=True
-                            )
+                            await interaction.response.send_message("stop failed", ephemeral=True)
                         else:
                             embed = self.create_stop_embed(True)
                             await self.send_simulation_update(embed=embed)
-                            await interaction.response.send_message(
-                                "stop", ephemeral=True
-                            )
+                            await interaction.response.send_message("stop", ephemeral=True)
 
                 @tree.command(name="spawn")
                 @app_commands.describe(agent_id="ID of the agent to spawn")
-                async def _tree_spawn(
-                    interaction: "discord.Interaction", agent_id: str
-                ) -> None:
+                async def _tree_spawn(interaction: "discord.Interaction", agent_id: str) -> None:
                     with tracer.start_as_current_span("discord.command") as span:
                         span.set_attribute("discord.command.name", "spawn")
                         span.set_attribute("discord.agent.id", agent_id)
@@ -259,6 +249,52 @@ class SimulationDiscordBot:
                             await interaction.response.send_message(
                                 f"spawn {agent_id}", ephemeral=True
                             )
+
+                @tree.command(name="pause")
+                async def _tree_pause(interaction: "discord.Interaction") -> None:
+                    with tracer.start_as_current_span("discord.command") as span:
+                        span.set_attribute("discord.command.name", "pause")
+                        await self.event_queue.put(
+                            SimulationEvent(type="control", data={"command": "pause"})
+                        )
+                        await interaction.response.send_message("pause", ephemeral=True)
+
+                @tree.command(name="resume")
+                async def _tree_resume(interaction: "discord.Interaction") -> None:
+                    with tracer.start_as_current_span("discord.command") as span:
+                        span.set_attribute("discord.command.name", "resume")
+                        await self.event_queue.put(
+                            SimulationEvent(type="control", data={"command": "resume"})
+                        )
+                        await interaction.response.send_message("resume", ephemeral=True)
+
+                @tree.command(name="mute")
+                @app_commands.describe(agent_id="ID of the agent to mute")
+                async def _tree_mute(interaction: "discord.Interaction", agent_id: str) -> None:
+                    with tracer.start_as_current_span("discord.command") as span:
+                        span.set_attribute("discord.command.name", "mute")
+                        span.set_attribute("discord.agent.id", agent_id)
+                        await self.event_queue.put(
+                            SimulationEvent(
+                                type="moderation",
+                                data={"command": "mute", "agent_id": agent_id},
+                            )
+                        )
+                        await interaction.response.send_message("muted", ephemeral=True)
+
+                @tree.command(name="unmute")
+                @app_commands.describe(agent_id="ID of the agent to unmute")
+                async def _tree_unmute(interaction: "discord.Interaction", agent_id: str) -> None:
+                    with tracer.start_as_current_span("discord.command") as span:
+                        span.set_attribute("discord.command.name", "unmute")
+                        span.set_attribute("discord.agent.id", agent_id)
+                        await self.event_queue.put(
+                            SimulationEvent(
+                                type="moderation",
+                                data={"command": "unmute", "agent_id": agent_id},
+                            )
+                        )
+                        await interaction.response.send_message("unmuted", ephemeral=True)
 
             @client.event
             async def on_ready(
@@ -984,16 +1020,12 @@ async def slash_spawn(interaction: Any, agent_id: str) -> None:
         if bot_instance is not None:
             embed = bot_instance.create_spawn_embed(agent_id, False, str(exc))
             await bot_instance.send_simulation_update(embed=embed)
-        await interaction.response.send_message(
-            f"spawn {agent_id} failed", ephemeral=True
-        )
+        await interaction.response.send_message(f"spawn {agent_id} failed", ephemeral=True)
     else:
         if bot_instance is not None:
             embed = bot_instance.create_spawn_embed(agent_id, True)
             await bot_instance.send_simulation_update(embed=embed)
-        await interaction.response.send_message(
-            f"spawn {agent_id}", ephemeral=True
-        )
+        await interaction.response.send_message(f"spawn {agent_id}", ephemeral=True)
 
 
 @bot.tree.command(name="set_speed")

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -3,16 +3,15 @@
 import time
 from typing import Any
 
-from src.interfaces.dashboard_backend import (
-    DEFAULT_CONTEXT,
-    SimulationEvent,
-)
+from src.interfaces.dashboard_backend import DEFAULT_CONTEXT, SimulationEvent
 from src.interfaces.discord_bot import bot, get_active_bot
 from src.utils.policy import evaluate_with_opa
 
 _ACTION_COUNTS: dict[str, int] = {}
 _COOLDOWNS: dict[str, float] = {}
 _COOLDOWN_SECONDS = 1.0
+_IP_PENALTY = 1.0
+_DU_PENALTY = 1.0
 
 
 async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bool:
@@ -23,6 +22,8 @@ async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bo
         opa_key += f":{agent_id}"
 
     count_key = f"{user_id}:{action}"
+    if agent_id is not None:
+        count_key += f":{agent_id}"
     _ACTION_COUNTS[count_key] = _ACTION_COUNTS.get(count_key, 0) + 1
 
     now = time.monotonic()
@@ -47,6 +48,17 @@ async def slash_mute(interaction: Any, agent_id: str) -> None:
                 data={"command": "mute", "agent_id": agent_id, "violation": True},
             )
         )
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={
+                    "command": "penalty",
+                    "agent_id": agent_id,
+                    "ip": _IP_PENALTY,
+                    "du": _DU_PENALTY,
+                },
+            )
+        )
         await interaction.response.send_message("rate limited", ephemeral=True)
         return
     await ctx.get_event_queue().put(
@@ -67,6 +79,17 @@ async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
                 data={"command": "reset_memory", "agent_id": agent_id, "violation": True},
             )
         )
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={
+                    "command": "penalty",
+                    "agent_id": agent_id,
+                    "ip": _IP_PENALTY,
+                    "du": _DU_PENALTY,
+                },
+            )
+        )
         await interaction.response.send_message("rate limited", ephemeral=True)
         return
     await ctx.get_event_queue().put(
@@ -85,6 +108,17 @@ async def slash_penalty(interaction: Any, agent_id: str, ip: float = 0.0, du: fl
             SimulationEvent(
                 type="moderation",
                 data={"command": "penalty", "agent_id": agent_id, "violation": True},
+            )
+        )
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={
+                    "command": "penalty",
+                    "agent_id": agent_id,
+                    "ip": _IP_PENALTY,
+                    "du": _DU_PENALTY,
+                },
             )
         )
         await interaction.response.send_message("rate limited", ephemeral=True)
@@ -108,6 +142,17 @@ async def slash_unmute(interaction: Any, agent_id: str) -> None:
             SimulationEvent(
                 type="moderation",
                 data={"command": "unmute", "agent_id": agent_id, "violation": True},
+            )
+        )
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="moderation",
+                data={
+                    "command": "penalty",
+                    "agent_id": agent_id,
+                    "ip": _IP_PENALTY,
+                    "du": _DU_PENALTY,
+                },
             )
         )
         await interaction.response.send_message("rate limited", ephemeral=True)

--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -182,11 +182,18 @@ async def test_rate_limit_counts_and_violation(
     interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
     await bot.context.get_event_queue().get()
-    assert discord_moderation._ACTION_COUNTS["123:mute"] == 1
+    assert discord_moderation._ACTION_COUNTS["123:mute:agent1"] == 1
 
     interaction2 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction2, "agent1")
     interaction2.response.send_message.assert_awaited_once_with("rate limited", ephemeral=True)
-    event = await bot.context.get_event_queue().get()
-    assert event.data == {"command": "mute", "agent_id": "agent1", "violation": True}
-    assert discord_moderation._ACTION_COUNTS["123:mute"] == 2
+    event1 = await bot.context.get_event_queue().get()
+    assert event1.data == {"command": "mute", "agent_id": "agent1", "violation": True}
+    event2 = await bot.context.get_event_queue().get()
+    assert event2.data == {
+        "command": "penalty",
+        "agent_id": "agent1",
+        "ip": discord_moderation._IP_PENALTY,
+        "du": discord_moderation._DU_PENALTY,
+    }
+    assert discord_moderation._ACTION_COUNTS["123:mute:agent1"] == 2


### PR DESCRIPTION
## Summary
- expose pause/resume and mute/unmute slash commands on SimulationDiscordBot
- apply per-agent rate limits with automatic IP/DU penalties
- document Discord moderation commands and safety rails

## Testing
- `SKIP=unit-tests pre-commit run --files src/interfaces/discord_bot.py src/interfaces/discord_moderation.py tests/unit/interfaces/test_discord_moderation.py docs/discord_manual_run.md`
- `pytest tests/unit/interfaces/test_discord_moderation.py`

------
https://chatgpt.com/codex/tasks/task_e_689dfd4806a88326be979296a527659b