### PR TITLE
Expose recall and latency benchmark metrics

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,8 +74,10 @@ Culture.ai uses [pytest-xdist](https://pytest-xdist.readthedocs.io/) for paralle
   ```bash
   pytest tests/integration/memory/test_recall_benchmark.py::test_recall_benchmark -v
   ```
-  This logs precision@k and latency, exposing the values via the `P_AT_K` and
-  `RETRIEVAL_LATENCY_MS` Prometheus gauges.
+  Runs 30 retrievals and reports precision@5 and latency for each case.
+  The running average precision@5 and 95th percentile latency are exposed via the
+  `recall_p5` and `retrieval_latency_p95_ms` Prometheus gauges. A passing run
+  should yield `recall_p5` ≥ 0.7 and `retrieval_latency_p95_ms` ≤ 50ms.
 
 - On Windows, run these commands from **Git Bash** or **WSL** for full Bash compatibility.
 - Use `scripts\lint.bat --format` to run the same linters as CI.

--- a/src/infra/checkpoint.py
+++ b/src/infra/checkpoint.py
@@ -49,13 +49,13 @@ def capture_rng_state() -> dict[str, Any]:
     try:  # pragma: no cover - optional dependency
         import numpy as np
 
-        np_state = np.random.get_state()
+        np_state_tuple = cast(tuple[Any, ...], np.random.get_state())
         state["numpy"] = (
-            np_state[0],
-            np_state[1].tolist(),
-            np_state[2],
-            np_state[3],
-            np_state[4],
+            np_state_tuple[0],
+            np_state_tuple[1].tolist(),
+            np_state_tuple[2],
+            np_state_tuple[3],
+            np_state_tuple[4],
         )
     except ImportError:
         # ``numpy`` is optional; ignore if unavailable

--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -14,6 +14,10 @@ _last_du_per_1k_tokens: float = 0.0
 # Keep a rolling window of recent LLM latencies in milliseconds
 _LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
 
+# Keep rolling windows for retrieval benchmark metrics
+_RETRIEVAL_LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
+_RECALL_P5_SAMPLES: deque[float] = deque(maxlen=100)
+
 
 def record_du_per_1k_tokens(agent_id: str, value: float) -> None:
     """Record DU cost per 1k tokens for the latest LLM call."""
@@ -41,6 +45,24 @@ def record_llm_latency(latency_ms: float) -> None:
         prom_metrics.LLM_LATENCY_P95_MS.set(ordered[idx])
 
 
+def record_retrieval_latency(latency_ms: float) -> None:
+    """Record retrieval latency and update p95 statistics."""
+    prom_metrics.RETRIEVAL_LATENCY_MS.set(latency_ms)
+    _RETRIEVAL_LATENCY_SAMPLES.append(latency_ms)
+    if _RETRIEVAL_LATENCY_SAMPLES:
+        ordered = sorted(_RETRIEVAL_LATENCY_SAMPLES)
+        idx = int(0.95 * (len(ordered) - 1))
+        prom_metrics.RETRIEVAL_LATENCY_P95_MS.set(ordered[idx])
+
+
+def record_recall_p5(value: float) -> None:
+    """Record recall@5 and update the running average."""
+    _RECALL_P5_SAMPLES.append(float(value))
+    if _RECALL_P5_SAMPLES:
+        avg = sum(_RECALL_P5_SAMPLES) / len(_RECALL_P5_SAMPLES)
+        prom_metrics.RECALL_P5.set(avg)
+
+
 def get_llm_latency_p95() -> float:
     """Return the p95 latency of recent LLM calls in milliseconds."""
     if not _LATENCY_SAMPLES:
@@ -50,9 +72,29 @@ def get_llm_latency_p95() -> float:
     return ordered[idx]
 
 
+def get_retrieval_latency_p95() -> float:
+    """Return the p95 latency of recent retrievals in milliseconds."""
+    if not _RETRIEVAL_LATENCY_SAMPLES:
+        return 0.0
+    ordered = sorted(_RETRIEVAL_LATENCY_SAMPLES)
+    idx = int(0.95 * (len(ordered) - 1))
+    return ordered[idx]
+
+
+def get_recall_p5() -> float:
+    """Return the average recall@5 for recent retrievals."""
+    if not _RECALL_P5_SAMPLES:
+        return 0.0
+    return sum(_RECALL_P5_SAMPLES) / len(_RECALL_P5_SAMPLES)
+
+
 __all__ = [
     "get_du_per_1k_tokens",
     "get_llm_latency_p95",
+    "get_recall_p5",
+    "get_retrieval_latency_p95",
     "record_du_per_1k_tokens",
     "record_llm_latency",
+    "record_recall_p5",
+    "record_retrieval_latency",
 ]

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -68,6 +68,11 @@ RETRIEVAL_LATENCY_MS = Gauge(
     "retrieval_latency_ms", "Latency of retrieval operations in milliseconds"
 )
 P_AT_K = Gauge("p_at_k", "Precision at k for retrieval operations")
+RETRIEVAL_LATENCY_P95_MS = Gauge(
+    "retrieval_latency_p95_ms",
+    "95th percentile latency of retrieval operations in milliseconds",
+)
+RECALL_P5 = Gauge("recall_p5", "Average recall@5 across retrieval operations")
 
 # Human interaction metrics
 HUMAN_MESSAGES_TOTAL = Counter(
@@ -84,9 +89,7 @@ PROPOSAL_THROUGHPUT = Gauge("proposal_throughput", "Proposals processed per minu
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")
 GAS_PRICE_PER_TOKEN = Gauge("gas_price_per_token", "Current gas price charged per generated token")
 LLM_DU_PER_1K_TOKENS = Gauge("llm_du_per_1k_tokens", "DU cost per 1k tokens for the last LLM call")
-AGENT_REMAINING_DU = Gauge(
-    "agent_remaining_du", "Remaining DU balance per agent", ["agent_id"]
-)
+AGENT_REMAINING_DU = Gauge("agent_remaining_du", "Remaining DU balance per agent", ["agent_id"])
 AGENT_DU_PER_1K_TOKENS = Gauge(
     "agent_du_per_1k_tokens", "DU cost per 1k tokens per agent", ["agent_id"]
 )
@@ -153,6 +156,16 @@ def get_p_at_k() -> float:
     return float(P_AT_K._value.get())
 
 
+def get_retrieval_latency_p95_ms() -> float:
+    """Return the 95th percentile retrieval latency in milliseconds."""
+    return float(RETRIEVAL_LATENCY_P95_MS._value.get())
+
+
+def get_recall_p5() -> float:
+    """Return the average recall@5 across retrieval operations."""
+    return float(RECALL_P5._value.get())
+
+
 def get_human_messages() -> int:
     """Return the total human messages received."""
     return int(HUMAN_MESSAGES_TOTAL._value.get())
@@ -190,9 +203,11 @@ __all__ = [
     "MEMORY_RETRIEVALS_TOTAL",
     "MEMORY_RETRIEVAL_ERRORS_TOTAL",
     "PROPOSAL_THROUGHPUT",
-    "RAG_HIT_RATE",
-    "RETRIEVAL_LATENCY_MS",
     "P_AT_K",
+    "RAG_HIT_RATE",
+    "RECALL_P5",
+    "RETRIEVAL_LATENCY_MS",
+    "RETRIEVAL_LATENCY_P95_MS",
     "Counter",
     "Gauge",
     "get_average_sentiment",
@@ -206,12 +221,11 @@ __all__ = [
     "get_llm_latency_p95",
     "get_memory_retrieval_errors",
     "get_memory_retrievals",
-    "get_rag_hit_rate",
-    "get_retrieval_latency_ms",
     "get_p_at_k",
-    "get_coalition_count",
-    "get_average_sentiment",
     "get_proposal_throughput",
     "get_rag_hit_rate",
+    "get_recall_p5",
+    "get_retrieval_latency_ms",
+    "get_retrieval_latency_p95_ms",
     "start_http_server",
 ]

--- a/tests/integration/memory/test_recall_benchmark.py
+++ b/tests/integration/memory/test_recall_benchmark.py
@@ -12,6 +12,7 @@ pytest.importorskip("chromadb")
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaVectorStoreManager
+from src.infra import metrics as infra_metrics
 from src.interfaces import metrics
 from src.utils import retrieval_metrics
 from src.utils.retrieval_metrics import p95
@@ -38,6 +39,8 @@ def recall_benchmark() -> BenchFixture:
         logger.info("p@%d=%.3f latency=%.2fms", k, p_at_k, latency_ms)
         metrics.P_AT_K.set(p_at_k)
         metrics.RETRIEVAL_LATENCY_MS.set(latency_ms)
+        infra_metrics.record_recall_p5(p_at_k)
+        infra_metrics.record_retrieval_latency(latency_ms)
         return {"p_at_k": p_at_k, "latency": latency}
 
     return _bench


### PR DESCRIPTION
## Summary
- log precision@5 and latency for each recall benchmark case
- expose `recall_p5` and `retrieval_latency_p95_ms` Prometheus gauges
- document running the recall benchmark and interpreting metrics
- fix mypy failure by casting numpy RNG state and deduplicate metrics exports

## Testing
- `ruff check src/ tests/`
- `black --check src/infra/metrics.py src/interfaces/metrics.py tests/integration/memory/test_recall_benchmark.py src/infra/checkpoint.py`
- `mypy src/infra/metrics.py src/interfaces/metrics.py src/infra/checkpoint.py --follow-imports=skip`
- `pytest tests/integration/memory/test_recall_benchmark.py::test_recall_benchmark -m integration -v`


------
https://chatgpt.com/codex/tasks/task_e_689dfd49e2f883269130d64a1ae28cf7