### PR TITLE
Trace event log and evaluation metrics

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -10,6 +10,8 @@ from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Any
 
+from opentelemetry import trace
+
 try:  # pragma: no cover - optional dependency
     from confluent_kafka import Consumer as KafkaConsumer
     from confluent_kafka import Producer as KafkaProducer
@@ -17,6 +19,8 @@ except Exception:  # pragma: no cover - fallback
     KafkaConsumer = KafkaProducer = Any
 
 from src.infra.snapshot import compute_trace_hash
+
+tracer = trace.get_tracer(__name__)
 
 _broker = os.getenv("REDPANDA_BROKER", "localhost:9092")
 _topic = os.getenv("REDPANDA_TOPIC", "culture.events")
@@ -166,38 +170,46 @@ def fetch_events(
     path: str | Path | None = None,
 ) -> list[dict[str, Any]]:
     """Retrieve events from the log after ``after_step``."""
+    source = "redpanda" if os.getenv("ENABLE_REDPANDA", "0") == "1" else "file"
+    with tracer.start_as_current_span("event_log.fetch_events") as span:
+        span.set_attribute("event.source", source)
+        span.set_attribute("tick.start", after_step)
+        if end_step is not None:
+            span.set_attribute("tick.end", end_step)
 
-    if os.getenv("ENABLE_REDPANDA", "0") != "1":
-        events = list(_iter_file_events(after_step, end_step, path=path))
-        return _filter_events(events, after_step=after_step)
+        if source == "file":
+            events = list(_iter_file_events(after_step, end_step, path=path))
+            return _filter_events(events, after_step=after_step)
 
-    raw_events: list[dict[str, Any]] = []
-    try:
-        consumer = KafkaConsumer(_consumer_conf)
-        consumer.subscribe([_topic])
-        while True:
-            msg = consumer.poll(0.1)
-            if msg is None:
-                break
-            if msg.error():
-                break
-            try:
-                event = json.loads(msg.value().decode("utf-8"))
-            except Exception:
-                continue
-            step = event.get("step", 0)
-            if step > after_step and (end_step is None or step <= end_step):
-                raw_events.append(event)
-    except Exception as exc:  # pragma: no cover - best effort
-        import logging
-
-        logging.getLogger(__name__).debug("Failed to fetch events: %s", exc)
-    finally:
+        raw_events: list[dict[str, Any]] = []
+        consumer: Any | None = None
         try:
-            consumer.close()
-        except Exception:  # pragma: no cover - ignore
-            pass
-    return _filter_events(raw_events, after_step=after_step)
+            consumer = KafkaConsumer(_consumer_conf)
+            consumer.subscribe([_topic])
+            while True:
+                msg = consumer.poll(0.1)
+                if msg is None:
+                    break
+                if msg.error():
+                    break
+                try:
+                    event = json.loads(msg.value().decode("utf-8"))
+                except Exception:
+                    continue
+                step = event.get("step", 0)
+                if step > after_step and (end_step is None or step <= end_step):
+                    raw_events.append(event)
+        except Exception as exc:  # pragma: no cover - best effort
+            import logging
+
+            logging.getLogger(__name__).debug("Failed to fetch events: %s", exc)
+        finally:
+            try:
+                if consumer is not None:
+                    consumer.close()
+            except Exception:  # pragma: no cover - ignore
+                pass
+        return _filter_events(raw_events, after_step=after_step)
 
 
 def stream_events(
@@ -208,41 +220,47 @@ def stream_events(
     path: str | Path | None = None,
 ) -> Generator[dict[str, Any], None, None]:
     """Yield events from the log or Redpanda until ``timeout`` of inactivity."""
+    source = "redpanda" if os.getenv("ENABLE_REDPANDA", "0") == "1" else "file"
+    with tracer.start_as_current_span("event_log.stream_events") as span:
+        span.set_attribute("event.source", source)
+        span.set_attribute("tick.start", after_step)
+        if end_step is not None:
+            span.set_attribute("tick.end", end_step)
 
-    if os.getenv("ENABLE_REDPANDA", "0") != "1":
-        yield from _filter_events(
-            _iter_file_events(after_step, end_step, path=path), after_step=after_step
-        )
-        return
+        if source == "file":
+            yield from _filter_events(
+                _iter_file_events(after_step, end_step, path=path), after_step=after_step
+            )
+            return
 
-    start = time.time()
-    consumer = KafkaConsumer(_consumer_conf)
-    consumer.subscribe([_topic])
-    last_step = after_step
-    last_hash: str | None = None
-    try:
-        while True:
-            msg = consumer.poll(0.1)
-            if msg is None:
-                if time.time() - start > timeout:
-                    break
-                continue
-            start = time.time()
-            if msg.error():
-                break
-            try:
-                event = json.loads(msg.value().decode("utf-8"))
-            except Exception:
-                continue
-            if _is_valid_event(event, last_step, last_hash):
-                last_step = event.get("step", last_step)
-                last_hash = event.get("trace_hash")
-                step = event.get("step", 0)
-                if end_step is not None and step > end_step:
-                    break
-                yield event
-    finally:
+        start = time.time()
+        consumer = KafkaConsumer(_consumer_conf)
+        consumer.subscribe([_topic])
+        last_step = after_step
+        last_hash: str | None = None
         try:
-            consumer.close()
-        except Exception:  # pragma: no cover - ignore
-            pass
+            while True:
+                msg = consumer.poll(0.1)
+                if msg is None:
+                    if time.time() - start > timeout:
+                        break
+                    continue
+                start = time.time()
+                if msg.error():
+                    break
+                try:
+                    event = json.loads(msg.value().decode("utf-8"))
+                except Exception:
+                    continue
+                if _is_valid_event(event, last_step, last_hash):
+                    last_step = event.get("step", last_step)
+                    last_hash = event.get("trace_hash")
+                    step = event.get("step", 0)
+                    if end_step is not None and step > end_step:
+                        break
+                    yield event
+        finally:
+            try:
+                consumer.close()
+            except Exception:  # pragma: no cover - ignore
+                pass

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -931,7 +931,17 @@ class Simulation:
             metrics: dict[str, Any] = {}
             for hook in self.evaluation_hooks:
                 try:
-                    metrics.update(hook(self, []) or {})
+                    with tracer.start_as_current_span(
+                        "simulation.evaluation_hook"
+                    ) as span:
+                        span.set_attribute(
+                            "hook.name", getattr(hook, "__name__", repr(hook))
+                        )
+                        span.set_attribute("simulation.step", self.current_step)
+                        result = hook(self, []) or {}
+                        for key, value in result.items():
+                            span.set_attribute(f"metric.{key}", value)
+                        metrics.update(result)
                 except Exception:  # pragma: no cover - defensive
                     logger.exception("Evaluation hook failed")
             metrics["beat"] = self.beats[self._beat_index]
@@ -1116,8 +1126,17 @@ class Simulation:
             metrics: dict[str, Any] = {}
             for hook in self.evaluation_hooks:
                 try:
-                    result = hook(self, events) or {}
-                    metrics.update(result)
+                    with tracer.start_as_current_span(
+                        "simulation.evaluation_hook"
+                    ) as span:
+                        span.set_attribute(
+                            "hook.name", getattr(hook, "__name__", repr(hook))
+                        )
+                        span.set_attribute("simulation.step", self.current_step)
+                        result = hook(self, events) or {}
+                        for key, value in result.items():
+                            span.set_attribute(f"metric.{key}", value)
+                        metrics.update(result)
                 except Exception:
                     logger.exception("Evaluation hook failed")
             if metrics:

--- a/tests/unit/infra/test_event_log_spans.py
+++ b/tests/unit/infra/test_event_log_spans.py
@@ -1,0 +1,103 @@
+
+import pytest
+
+from src.infra.event_log import fetch_events, stream_events
+
+
+class MockSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockTracer:
+    def __init__(self):
+        self.spans: list[MockSpan] = []
+
+    def start_as_current_span(self, name):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_redpanda", [False, True])
+def test_fetch_events_tracing(monkeypatch, tmp_path, use_redpanda):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.event_log.tracer", tracer)
+    if use_redpanda:
+        monkeypatch.setenv("ENABLE_REDPANDA", "1")
+
+        class DummyConsumer:
+            def __init__(self, conf):
+                pass
+
+            def subscribe(self, topics):
+                pass
+
+            def poll(self, timeout):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr("src.infra.event_log.KafkaConsumer", DummyConsumer)
+        fetch_events(after_step=1, end_step=5)
+    else:
+        monkeypatch.setenv("ENABLE_REDPANDA", "0")
+        log_file = tmp_path / "event_log.jsonl"
+        log_file.write_text("")
+        fetch_events(after_step=1, end_step=5, path=log_file)
+
+    span = tracer.spans[0]
+    assert span.name == "event_log.fetch_events"
+    assert span.attributes["tick.start"] == 1
+    assert span.attributes["tick.end"] == 5
+    expected_source = "redpanda" if use_redpanda else "file"
+    assert span.attributes["event.source"] == expected_source
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("use_redpanda", [False, True])
+def test_stream_events_tracing(monkeypatch, tmp_path, use_redpanda):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.event_log.tracer", tracer)
+    if use_redpanda:
+        monkeypatch.setenv("ENABLE_REDPANDA", "1")
+
+        class DummyConsumer:
+            def __init__(self, conf):
+                pass
+
+            def subscribe(self, topics):
+                pass
+
+            def poll(self, timeout):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr("src.infra.event_log.KafkaConsumer", DummyConsumer)
+        list(stream_events(after_step=2, end_step=6, timeout=0.01))
+    else:
+        monkeypatch.setenv("ENABLE_REDPANDA", "0")
+        log_file = tmp_path / "event_log.jsonl"
+        log_file.write_text("")
+        list(stream_events(after_step=2, end_step=6, path=log_file))
+
+    span = tracer.spans[0]
+    assert span.name == "event_log.stream_events"
+    assert span.attributes["tick.start"] == 2
+    assert span.attributes["tick.end"] == 6
+    expected_source = "redpanda" if use_redpanda else "file"
+    assert span.attributes["event.source"] == expected_source

--- a/tests/unit/sim/test_simulation_spans.py
+++ b/tests/unit/sim/test_simulation_spans.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -55,6 +56,7 @@ class DummyAgent:
         return self.agent_id
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_agent_action_tracing(monkeypatch):
     tracer = MockTracer()
@@ -76,6 +78,11 @@ async def test_agent_action_tracing(monkeypatch):
     )
     sim.resource_manager = rm
 
+    if sim._event_listener_task:
+        sim._event_listener_task.cancel()
+    if sim._event_task:
+        sim._event_task.cancel()
+
     await sim._run_agent_turn(0)
 
     span = tracer.spans[0]
@@ -83,3 +90,66 @@ async def test_agent_action_tracing(monkeypatch):
     assert span.attributes["llm.tokens.prompt"] == 0
     assert span.attributes["llm.tokens.completion"] == 0
     assert "simulation.latency_ms" in span.attributes
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_evaluation_hook_tracing(monkeypatch):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.sim.simulation.tracer", tracer)
+
+    @contextmanager
+    def noop_trace_agent_action(*args, **kwargs):
+        yield
+
+    monkeypatch.setattr("src.sim.simulation.trace_agent_action", noop_trace_agent_action)
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event",
+        lambda data: {**data, "trace_hash": "hash"},
+    )
+    monkeypatch.setattr("src.sim.simulation.emit_event", AsyncMock())
+
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    class DummyKernel:
+        def __init__(self):
+            self._empty = True
+
+        def empty(self):
+            return self._empty
+
+        def schedule_immediate_nowait(self, func, **kwargs):
+            self._empty = False
+
+        async def step(self, max_turns):
+            self._empty = True
+            return []
+
+    sim = Simulation(
+        [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+    sim.resource_manager = rm
+    sim.event_kernel = DummyKernel()
+    sim.vector = SimpleNamespace(increment=lambda agent_id: None)
+    sim.start_event_listener = AsyncMock()
+
+    def hook(_sim, _events):
+        return {"test_metric": 1}
+
+    sim.evaluation_hooks = [hook]
+
+    await sim.run_step()
+
+    if sim._event_listener_task:
+        sim._event_listener_task.cancel()
+    if sim._event_task:
+        sim._event_task.cancel()
+
+    span = tracer.spans[0]
+    assert span.name == "simulation.evaluation_hook"
+    assert span.attributes["hook.name"] == "hook"
+    assert span.attributes["metric.test_metric"] == 1
+    assert span.attributes["simulation.step"] == sim.current_step


### PR DESCRIPTION
## Summary
- instrument event log fetch and stream operations with spans that record tick ranges and data source
- add telemetry for evaluation hooks in simulation to capture metric computations
- cover event log and simulation spans with unit tests

## Testing
- `ruff check src/infra/event_log/__init__.py src/sim/simulation.py tests/unit/infra/test_event_log_spans.py tests/unit/sim/test_simulation_spans.py`
- `pytest tests/unit/infra/test_event_log_spans.py tests/unit/sim/test_simulation_spans.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2d7e20e0832695034dec49c024d9