### PR TITLE
Add retriever node with token budget

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -38,6 +38,7 @@ from .graph_nodes import (
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
+    retriever_node,
 )
 from .interaction_handlers import (
     handle_ask_clarification_node,
@@ -62,6 +63,7 @@ def build_graph() -> Any:
     graph_builder = StateGraph(AgentTurnState)
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)
+    graph_builder.add_node("retrieve_memories", retriever_node)
     graph_builder.add_node("retrieve_and_summarize_memories", retrieve_and_summarize_memories_node)
     graph_builder.add_node("generate_thought_and_message", generate_thought_and_message_node)
 
@@ -83,7 +85,8 @@ def build_graph() -> Any:
 
     graph_builder.set_entry_point("analyze_perception_sentiment")
     graph_builder.add_edge("analyze_perception_sentiment", "prepare_relationship_prompt")
-    graph_builder.add_edge("prepare_relationship_prompt", "retrieve_and_summarize_memories")
+    graph_builder.add_edge("prepare_relationship_prompt", "retrieve_memories")
+    graph_builder.add_edge("retrieve_memories", "retrieve_and_summarize_memories")
     graph_builder.add_edge("retrieve_and_summarize_memories", "generate_thought_and_message")
 
     graph_builder.add_conditional_edges(

--- a/src/agents/graphs/basic_agent_types.py
+++ b/src/agents/graphs/basic_agent_types.py
@@ -120,3 +120,4 @@ class AgentTurnState(TypedDict):
     collective_ip: float | None
     collective_du: float | None
     trace_hash: NotRequired[str]
+    token_budget: NotRequired[int]

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -81,6 +81,38 @@ def prepare_relationship_prompt_node(state: AgentTurnState) -> dict[str, str]:
     return {"prompt_modifier": "Relationships:\n" + "\n".join(lines)}
 
 
+async def retriever_node(state: AgentTurnState) -> dict[str, Any]:
+    service = cast(MemoryService | None, state.get("memory_service"))
+    if service is None:
+        return {"memory_context": [], "memory_history_list": []}
+
+    token_budget = cast(int | None, state.get("token_budget"))
+    episodic, semantic = await service.get_context_pipeline(
+        state["agent_id"], token_budget=token_budget
+    )
+
+    tokens = 0
+    combined: list[str] = []
+    limited_episodic: list[dict[str, Any]] = []
+    for mem in episodic:
+        text = str(mem.get("content", ""))
+        t = len(text.split())
+        if token_budget is not None and tokens + t > token_budget:
+            break
+        limited_episodic.append(mem)
+        combined.append(text)
+        tokens += t
+
+    for summary in semantic:
+        t = len(summary.split())
+        if token_budget is not None and tokens + t > token_budget:
+            break
+        combined.append(summary)
+        tokens += t
+
+    return {"memory_context": combined, "memory_history_list": limited_episodic}
+
+
 async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[str, Any]:
     service = cast(MemoryService | None, state.get("memory_service"))
     if service is None:
@@ -89,16 +121,21 @@ async def retrieve_and_summarize_memories_node(state: AgentTurnState) -> dict[st
     agent = cast(SummaryAgent | None, state.get("agent_instance"))
     if not service or not agent:
         return {"rag_summary": "(No memory retrieval)", "memory_history_list": []}
+    memories = cast(list[dict[str, Any]], state.get("memory_history_list", []))
+    memories_content = cast(list[str], state.get("memory_context", []))
 
-    k = 5
-    semantic_limit = 2
-    memories, semantic = await service.get_context_pipeline(
-        state["agent_id"], query="", k=k, semantic_limit=semantic_limit
-    )
-    metrics.RAG_HIT_RATE.set(
-        (len(memories) + len(semantic)) / (k + semantic_limit) if (k + semantic_limit) else 0
-    )
-    memories_content = [m.get("content", "") for m in memories] + list(semantic)
+    if not memories_content:
+        k = 5
+        semantic_limit = 2
+        memories, semantic = await service.get_context_pipeline(
+            state["agent_id"], query="", k=k, semantic_limit=semantic_limit
+        )
+        metrics.RAG_HIT_RATE.set(
+            (len(memories) + len(semantic)) / (k + semantic_limit)
+            if (k + semantic_limit)
+            else 0
+        )
+        memories_content = [m.get("content", "") for m in memories] + list(semantic)
 
     agent_state = state.get("state")
     role_prompt = getattr(agent_state, "role_prompt", state.get("current_role", ""))

--- a/tests/integration/graph/test_async_agent_graph.py
+++ b/tests/integration/graph/test_async_agent_graph.py
@@ -20,7 +20,13 @@ class DummyVectorStore:
 
 class DummyService:
     async def get_context_pipeline(
-        self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2
+        self,
+        agent_id: str,
+        query: str = "",
+        k: int = 5,
+        semantic_limit: int = 2,
+        *,
+        token_budget: int | None = None,
     ) -> tuple[list[dict[str, str]], list[str]]:
         return [{"content": "memory1"}], ["summary1"]
 
@@ -43,6 +49,7 @@ from src.agents.graphs.graph_nodes import (
     finalize_message_agent_node,
     generate_thought_and_message_node,
     retrieve_and_summarize_memories_node,
+    retriever_node,
 )
 from src.infra.async_dspy_manager import AsyncDSPyManager
 
@@ -139,6 +146,7 @@ async def test_dspy_call_timeout_in_graph(
     )
 
     async def dummy_ainvoke(state: AgentTurnState) -> AgentTurnState:
+        state.update(await retriever_node(state))
         state.update(await retrieve_and_summarize_memories_node(state))
         state.update(await generate_thought_and_message_node(state))
         state.update(await finalize_message_agent_node(state))

--- a/tests/unit/graphs/test_graph_nodes.py
+++ b/tests/unit/graphs/test_graph_nodes.py
@@ -12,6 +12,7 @@ from src.agents.graphs.graph_nodes import (
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
+    retriever_node,
 )
 
 
@@ -56,12 +57,18 @@ async def test_retrieve_and_summarize_memories_node_no_manager() -> None:
 
 class DummyService:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, int, int]] = []
+        self.calls: list[tuple[str | None, int | None]] = []
 
     async def get_context_pipeline(
-        self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2
+        self,
+        agent_id: str,
+        query: str = "",
+        k: int = 5,
+        semantic_limit: int = 2,
+        *,
+        token_budget: int | None = None,
     ) -> tuple[list[dict[str, str]], list[str]]:
-        self.calls.append((agent_id, query, k, semantic_limit))
+        self.calls.append((agent_id, token_budget))
         return [{"content": "m1"}, {"content": "m2"}], ["sem1"]
 
     def blend_with_recent_semantic(
@@ -88,9 +95,56 @@ async def test_retrieve_and_summarize_memories_node_with_manager() -> None:
         "current_role": "r",
     }
     out = await retrieve_and_summarize_memories_node(cast(object, state))
-    assert service.calls == [("a", "", 5, 2)]
+    assert service.calls == [("a", None)]
     assert out["rag_summary"] == "SUM\nsem1"
     assert out["memory_history_list"] == [{"content": "m1"}, {"content": "m2"}]
+
+
+class DummyRetrieverService:
+    def __init__(self) -> None:
+        self.calls: list[int | None] = []
+
+    async def get_context_pipeline(
+        self, agent_id: str, query: str = "", k: int = 5, semantic_limit: int = 2, *, token_budget: int | None = None
+    ) -> tuple[list[dict[str, str]], list[str]]:
+        self.calls.append(token_budget)
+        return (
+            [{"content": "one two three"}, {"content": "four five"}],
+            ["six seven"],
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_retriever_node_merges_and_truncates() -> None:
+    service = DummyRetrieverService()
+    state = {"agent_id": "a", "memory_service": service, "token_budget": 5}
+    out = await retriever_node(cast(object, state))
+    assert service.calls == [5]
+    assert out["memory_context"] == ["one two three", "four five"]
+    assert out["memory_history_list"] == [
+        {"content": "one two three"},
+        {"content": "four five"},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_summarize_uses_pre_retrieved_context() -> None:
+    service = DummyService()
+    agent = DummyAgent()
+    state = {
+        "agent_id": "a",
+        "memory_service": service,
+        "agent_instance": agent,
+        "current_role": "r",
+        "memory_context": ["m1", "sem1"],
+        "memory_history_list": [{"content": "m1"}],
+    }
+    out = await retrieve_and_summarize_memories_node(cast(object, state))
+    assert service.calls == []
+    assert out["rag_summary"] == "SUM\nsem1"
+    assert out["memory_history_list"] == [{"content": "m1"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- introduce retriever node to merge episodic & semantic memories within a token budget
- update agent turn graph and state typing for token budgeting
- add tests covering memory retrieval and summarization

## Testing
- `ruff check src tests`
- `mypy`
- `pytest tests/unit tests/integration/graph/test_async_agent_graph.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689f496791448326a919688ae5105d57