### PR TITLE
feat: record simulation seed in event log

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -331,6 +331,10 @@ def main() -> None:
         log_suppressed=args.log_suppressed_warnings,
     )
 
+    if args.seed is None and args.replay:
+        stored = event_log.get_seed()
+        if stored is not None:
+            args.seed = stored
     if args.seed is not None:
         event_log.set_seed(args.seed)
 

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -28,12 +28,42 @@ _topic = os.getenv("REDPANDA_TOPIC", "culture.events")
 _producer: Any | None = None
 _last_hash: str | None = None
 _seed: int | None = None
+_header_written: bool = False
 
 
 def set_seed(seed: int) -> None:
     """Inject a stable seed value for event logging."""
     global _seed
     _seed = seed
+
+
+def get_log_header(path: str | Path | None = None) -> dict[str, Any]:
+    """Return the header information from the event log if present."""
+    file = _log_file(path)
+    if not file.exists():
+        return {}
+    try:
+        with file.open("r", encoding="utf-8") as fh:
+            first = fh.readline().strip()
+        header = json.loads(first)
+        if isinstance(header, dict) and header.get("type") == "header":
+            return header
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return {}
+
+
+def get_seed(path: str | Path | None = None) -> int | None:
+    """Return the seed from the event log header if available."""
+    global _seed
+    if _seed is not None:
+        return _seed
+    header = get_log_header(path)
+    seed = header.get("seed") if isinstance(header, dict) else None
+    if isinstance(seed, int):
+        _seed = seed
+        return seed
+    return None
 
 
 _consumer_conf = {
@@ -48,6 +78,46 @@ def _log_file(path: str | Path | None = None) -> Path:
     if path is not None:
         return Path(path)
     return Path(os.getenv("EVENT_LOG_PATH", "event_log.jsonl"))
+
+
+def _ensure_header(path: str | Path | None = None) -> None:
+    """Write the log header containing the simulation seed if missing."""
+    global _header_written, _seed
+    if _header_written:
+        return
+    file = _log_file(path)
+    if _seed is None:
+        try:
+            _seed = random.getstate()[1][0]
+        except Exception:  # pragma: no cover - fallback
+            _seed = 0
+    header = {"type": "header", "seed": _seed}
+    try:  # pragma: no cover - best effort
+        if file.exists():
+            with file.open("r", encoding="utf-8") as fh:
+                first = fh.readline().strip()
+            try:
+                existing = json.loads(first)
+            except Exception:
+                existing = {}
+            if existing.get("type") == "header" and "seed" in existing:
+                _header_written = True
+                return
+        file.parent.mkdir(parents=True, exist_ok=True)
+        if not file.exists() or file.stat().st_size == 0:
+            with file.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(header))
+                fh.write("\n")
+        _header_written = True
+        if os.getenv("ENABLE_REDPANDA", "0") == "1":
+            try:
+                producer = _get_producer()
+                producer.produce(_topic, json.dumps(header).encode("utf-8"))
+                producer.poll(0)
+            except Exception:
+                pass
+    except Exception:  # pragma: no cover - ignore
+        pass
 
 
 def _is_valid_event(event: dict[str, Any], last_step: int, last_hash: str | None) -> bool:
@@ -118,6 +188,7 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     """Log an event to the append-only file and Redpanda if enabled."""
 
     global _last_hash
+    _ensure_header()
 
     if "trace_hash" in event:
         event = {**event}

--- a/tests/integration/sim/test_snapshot_rng_state.py
+++ b/tests/integration/sim/test_snapshot_rng_state.py
@@ -1,38 +1,84 @@
 import random
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from src.app import create_simulation
-from src.infra.checkpoint import capture_rng_state
+from src.infra import event_log
+from src.infra.snapshot import load_snapshot
 from src.sim.simulation import Simulation
-from tests.utils.mock_llm import MockLLM
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    mood_level: float = 0.0
+
+
+class RandomAgent:
+    def __init__(self, agent_id: str = "agent") -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:  # pragma: no cover - used by scheduler
+        return self.agent_id
+
+    def update_state(self, new_state: DummyState) -> None:  # pragma: no cover - simple
+        self.state = new_state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+        memory_service: object | None = None,
+    ) -> dict:
+        self.state.ip = random.random()
+        return {}
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_snapshot_restores_rng_state() -> None:
-    with MockLLM():
-        sim = create_simulation(num_agents=1, steps=1, scenario="test", seed=123)
-        await sim.run_step()
-        snapshot = {
-            "step": sim.current_step,
-            "collective_ip": sim.collective_ip,
-            "collective_du": sim.collective_du,
-            "knowledge_board": sim.knowledge_board.to_dict(),
-            "world_map": sim.world_map.to_dict(),
-            "agents": [
-                {
-                    "agent_id": ag.agent_id,
-                    "ip": ag.state.ip,
-                    "du": ag.state.du,
-                    "mood": ag.state.mood_level,
-                }
-                for ag in sim.agents
-            ],
-            "seed": sim.seed,
-            "rng_state": capture_rng_state(),
-        }
-        expected = random.random()
-        Simulation.from_snapshot(snapshot)
-        actual = random.random()
-        assert expected == actual
+async def test_snapshot_rng_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("EVENT_LOG_PATH", str(tmp_path / "events.jsonl"))
+    monkeypatch.setenv("SNAPSHOT_INTERVAL_STEPS", "1")
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr("src.agents.core.base_agent.Agent", RandomAgent)
+    monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda step: None)
+
+    def _save(step: int, data: dict, directory: Path = tmp_path) -> None:
+        from src.infra.snapshot import save_snapshot as real_save
+
+        real_save(step, data, directory)
+
+    monkeypatch.setattr("src.sim.simulation.save_snapshot", _save)
+
+    event_log._last_hash = None
+    event_log._seed = None
+    seed = 1234
+    random.seed(seed)
+    event_log.set_seed(seed)
+
+    sim = Simulation([RandomAgent()], seed=seed)
+    await sim.run_step()  # step 1
+    await sim.run_step()  # step 2
+    snap_path = tmp_path / "snapshot_2.json"
+
+    # Continue original run to step 3
+    await sim.run_step()
+    original_ip = sim.agents[0].state.ip
+
+    # Replay from snapshot_2 and run step 3 again
+    monkeypatch.setenv("EVENT_LOG_PATH", str(tmp_path / "replay_events.jsonl"))
+    event_log._last_hash = None
+    event_log._seed = None
+    event_log.set_seed(event_log.get_seed(str(tmp_path / "events.jsonl")) or seed)
+
+    snap = load_snapshot(snap_path)
+    sim_replay = Simulation.from_snapshot(snap)
+    await sim_replay.run_step()
+    replay_ip = sim_replay.agents[0].state.ip
+
+    assert replay_ip == original_ip


### PR DESCRIPTION
## Summary
- record and expose simulation seed in event log header
- load stored seed when replaying snapshots via CLI
- verify RNG state replay with new integration test

## Testing
- `ruff check src/infra/event_log/__init__.py src/app.py tests/integration/sim/test_snapshot_rng_state.py`
- `pytest tests/integration/test_seed_replay.py tests/integration/sim/test_snapshot_rng_state.py -m "integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ca844bac832693d0333f77dc7fe1