### PR TITLE
feat: add rate-limited moderation ledger logging

### DIFF
--- a/docs/discord_manual_run.md
+++ b/docs/discord_manual_run.md
@@ -99,7 +99,19 @@ Clears an agent's memory.
 Applies an IP/DU penalty to the agent.
 
 All moderation commands are rate limited on a per-agent basis. Exceeding the
-limit automatically issues IP and DU penalties as a safety rail.
+limit automatically issues IP and DU penalties as a safety rail and records the
+deduction in the ledger. For example:
+
+```text
+/mute agent_4
+/mute agent_4
+```
+The second call returns:
+
+```text
+rate limited
+```
+and `agent_4` loses IP and DU according to the configured penalty values.
 
 ### Administrative Commands
 

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -1,8 +1,10 @@
 """Discord moderation commands with OPA-based rate limiting."""
 
 import time
-from typing import Any
+from functools import wraps
+from typing import Any, Callable
 
+from src.infra.ledger import log_reward
 from src.interfaces.dashboard_backend import DEFAULT_CONTEXT, SimulationEvent
 from src.interfaces.discord_bot import bot, get_active_bot, has_admin_permission
 from src.utils.policy import evaluate_with_opa
@@ -36,31 +38,51 @@ async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bo
     return allow
 
 
+def moderation_rate_limit(action: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator applying per-user rate limiting for moderation commands."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        async def wrapper(interaction: Any, agent_id: str, *args: Any, **kwargs: Any) -> Any:
+            bot_instance = get_active_bot()
+            ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+            if not await _rate_limit(getattr(interaction, "user", None), action, agent_id):
+                await ctx.get_event_queue().put(
+                    SimulationEvent(
+                        type="moderation",
+                        data={"command": action, "agent_id": agent_id, "violation": True},
+                    )
+                )
+                await ctx.get_event_queue().put(
+                    SimulationEvent(
+                        type="moderation",
+                        data={
+                            "command": "penalty",
+                            "agent_id": agent_id,
+                            "ip": _IP_PENALTY,
+                            "du": _DU_PENALTY,
+                        },
+                    )
+                )
+                try:  # pragma: no cover - best effort
+                    log_reward(agent_id, -_IP_PENALTY, -_DU_PENALTY, "rate_limit_violation")
+                except Exception:
+                    pass
+                await interaction.response.send_message("rate limited", ephemeral=True)
+                return None
+            return await func(interaction, agent_id, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 @bot.tree.command(name="mute")
+@moderation_rate_limit("mute")
 async def slash_mute(interaction: Any, agent_id: str) -> None:
     """Mute an agent in the simulation."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    if not await _rate_limit(getattr(interaction, "user", None), "mute", agent_id):
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={"command": "mute", "agent_id": agent_id, "violation": True},
-            )
-        )
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={
-                    "command": "penalty",
-                    "agent_id": agent_id,
-                    "ip": _IP_PENALTY,
-                    "du": _DU_PENALTY,
-                },
-            )
-        )
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     await ctx.get_event_queue().put(
         SimulationEvent(type="moderation", data={"command": "mute", "agent_id": agent_id})
     )
@@ -68,32 +90,13 @@ async def slash_mute(interaction: Any, agent_id: str) -> None:
 
 
 @bot.tree.command(name="reset_memory")
+@moderation_rate_limit("reset_memory")
 async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
     """Reset the memory of an agent."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
     if not has_admin_permission(getattr(interaction, "user", None)):
         await interaction.response.send_message("unauthorized", ephemeral=True)
-        return
-    if not await _rate_limit(getattr(interaction, "user", None), "reset_memory", agent_id):
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={"command": "reset_memory", "agent_id": agent_id, "violation": True},
-            )
-        )
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={
-                    "command": "penalty",
-                    "agent_id": agent_id,
-                    "ip": _IP_PENALTY,
-                    "du": _DU_PENALTY,
-                },
-            )
-        )
-        await interaction.response.send_message("rate limited", ephemeral=True)
         return
     await ctx.get_event_queue().put(
         SimulationEvent(type="moderation", data={"command": "reset_memory", "agent_id": agent_id})
@@ -102,64 +105,30 @@ async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
 
 
 @bot.tree.command(name="penalty")
+@moderation_rate_limit("penalty")
 async def slash_penalty(interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0) -> None:
     """Apply an IP/DU penalty to an agent."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    if not await _rate_limit(getattr(interaction, "user", None), "penalty", agent_id):
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={"command": "penalty", "agent_id": agent_id, "violation": True},
-            )
-        )
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={
-                    "command": "penalty",
-                    "agent_id": agent_id,
-                    "ip": _IP_PENALTY,
-                    "du": _DU_PENALTY,
-                },
-            )
-        )
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     await ctx.get_event_queue().put(
         SimulationEvent(
             type="moderation",
             data={"command": "penalty", "agent_id": agent_id, "ip": ip, "du": du},
         )
     )
+    try:  # pragma: no cover - best effort
+        log_reward(agent_id, -abs(ip), -abs(du), "moderation_penalty")
+    except Exception:
+        pass
     await interaction.response.send_message("penalty applied", ephemeral=True)
 
 
 @bot.tree.command(name="unmute")
+@moderation_rate_limit("unmute")
 async def slash_unmute(interaction: Any, agent_id: str) -> None:
     """Unmute an agent in the simulation."""
     bot_instance = get_active_bot()
     ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    if not await _rate_limit(getattr(interaction, "user", None), "unmute", agent_id):
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={"command": "unmute", "agent_id": agent_id, "violation": True},
-            )
-        )
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="moderation",
-                data={
-                    "command": "penalty",
-                    "agent_id": agent_id,
-                    "ip": _IP_PENALTY,
-                    "du": _DU_PENALTY,
-                },
-            )
-        )
-        await interaction.response.send_message("rate limited", ephemeral=True)
-        return
     await ctx.get_event_queue().put(
         SimulationEvent(type="moderation", data={"command": "unmute", "agent_id": agent_id})
     )

--- a/tests/integration/interfaces/test_discord_rate_limit.py
+++ b/tests/integration/interfaces/test_discord_rate_limit.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -28,6 +28,8 @@ async def test_mute_unmute_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(discord_moderation.time, "monotonic", lambda: 0.0)
     discord_moderation._ACTION_COUNTS.clear()
     discord_moderation._COOLDOWNS.clear()
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     interaction = DummyInteraction()
 
     await discord_moderation.slash_mute.callback(interaction, "agent1")
@@ -50,6 +52,12 @@ async def test_mute_unmute_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
         "du": discord_moderation._DU_PENALTY,
     }
     assert events[3].data == {"command": "unmute", "agent_id": "agent1"}
+    mock_reward.assert_called_once_with(
+        "agent1",
+        -discord_moderation._IP_PENALTY,
+        -discord_moderation._DU_PENALTY,
+        "rate_limit_violation",
+    )
 
 
 @pytest.mark.integration
@@ -65,6 +73,8 @@ async def test_reset_memory_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(discord_moderation.time, "monotonic", lambda: 0.0)
     discord_moderation._ACTION_COUNTS.clear()
     discord_moderation._COOLDOWNS.clear()
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     interaction = DummyInteraction()
 
     await discord_moderation.slash_reset_memory.callback(interaction, "agent1")
@@ -88,3 +98,9 @@ async def test_reset_memory_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
         "ip": discord_moderation._IP_PENALTY,
         "du": discord_moderation._DU_PENALTY,
     }
+    mock_reward.assert_called_once_with(
+        "agent1",
+        -discord_moderation._IP_PENALTY,
+        -discord_moderation._DU_PENALTY,
+        "rate_limit_violation",
+    )

--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -1,7 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 from typing import Callable
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -85,6 +85,8 @@ async def test_slash_mute_per_agent(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", fake_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
 
     interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
@@ -93,6 +95,12 @@ async def test_slash_mute_per_agent(
     interaction2 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction2, "agent2")
     interaction2.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
+    mock_reward.assert_called_once_with(
+        "agent1",
+        -discord_moderation._IP_PENALTY,
+        -discord_moderation._DU_PENALTY,
+        "rate_limit_violation",
+    )
 
 
 @pytest.mark.unit
@@ -104,11 +112,14 @@ async def test_slash_mute_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     await discord_moderation.slash_mute.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "mute", "agent_id": "agent1"}
+    mock_reward.assert_not_called()
 
 
 @pytest.mark.unit
@@ -120,6 +131,8 @@ async def test_slash_penalty_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     await discord_moderation.slash_penalty.callback(interaction, "agent1", 1.0, 2.0)
     interaction.response.send_message.assert_awaited_once_with("penalty applied", ephemeral=True)
     event = await bot.context.get_event_queue().get()
@@ -130,6 +143,7 @@ async def test_slash_penalty_flow(
         "ip": 1.0,
         "du": 2.0,
     }
+    mock_reward.assert_called_once_with("agent1", -1.0, -2.0, "moderation_penalty")
 
 
 @pytest.mark.unit
@@ -141,11 +155,14 @@ async def test_slash_reset_memory_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     await discord_moderation.slash_reset_memory.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("memory reset", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "reset_memory", "agent_id": "agent1"}
+    mock_reward.assert_not_called()
 
 
 @pytest.mark.unit
@@ -157,11 +174,14 @@ async def test_slash_unmute_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
     await discord_moderation.slash_unmute.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("unmuted", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "unmute", "agent_id": "agent1"}
+    mock_reward.assert_not_called()
 
 
 @pytest.mark.unit
@@ -179,6 +199,8 @@ async def test_rate_limit_counts_and_violation(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_reward = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
 
     interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
@@ -198,3 +220,9 @@ async def test_rate_limit_counts_and_violation(
         "du": discord_moderation._DU_PENALTY,
     }
     assert discord_moderation._ACTION_COUNTS["123:mute:agent1"] == 2
+    mock_reward.assert_called_once_with(
+        "agent1",
+        -discord_moderation._IP_PENALTY,
+        -discord_moderation._DU_PENALTY,
+        "rate_limit_violation",
+    )


### PR DESCRIPTION
## Summary
- add reusable `moderation_rate_limit` decorator for slash commands
- log DU/IP penalties to ledger for moderation actions
- document moderation command usage and automatic penalty example

## Testing
- `pre-commit run --files src/interfaces/discord_moderation.py tests/unit/interfaces/test_discord_moderation.py tests/integration/interfaces/test_discord_rate_limit.py docs/discord_manual_run.md` (mypy, unit-tests skipped)
- `pytest tests/unit/interfaces/test_discord_moderation.py tests/integration/interfaces/test_discord_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d43b393c83268799bd157b5ef43f