### PR TITLE
Add span verification test for Discord bot

### DIFF
--- a/tests/unit/interfaces/test_discord_bot.py
+++ b/tests/unit/interfaces/test_discord_bot.py
@@ -266,7 +266,7 @@ async def test_span_emission(monkeypatch: pytest.MonkeyPatch) -> None:
         user=SimpleNamespace(id=7),
         response=SimpleNamespace(send_message=AsyncMock()),
     )
-    await discord_module.slash_status(interaction)
+    await discord_module.slash_status.callback(interaction)
 
     span = tracer.spans[0]
     assert span.name == "discord.command"


### PR DESCRIPTION
## Summary
- ensure Discord message and slash-command handlers emit tracing spans with channel, agent, and latency metadata
- test span emission for Discord bot and call slash-command callback directly

## Testing
- `ruff check tests/unit/interfaces/test_discord_bot.py`
- `pytest tests/unit/interfaces/test_discord_bot.py::test_span_emission -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32e890c68832686b6cbd7e92f36c6