### PR TITLE
feat: persist and reuse simulation seed for event-log replay

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -334,6 +334,7 @@ def main() -> None:
     if args.seed is None and args.replay:
         stored = event_log.get_seed()
         if stored is not None:
+            logging.info("Using seed %s from event log", stored)
             args.seed = stored
     if args.seed is not None:
         event_log.set_seed(args.seed)

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -101,6 +101,10 @@ def _ensure_header(path: str | Path | None = None) -> None:
             except Exception:
                 existing = {}
             if existing.get("type") == "header" and "seed" in existing:
+                # Populate the cached seed from the existing header to ensure
+                # subsequent ``log_event`` calls embed the same seed value.
+                if _seed is None and isinstance(existing.get("seed"), int):
+                    _seed = existing["seed"]
                 _header_written = True
                 return
         file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integration/sim/test_snapshot_rng_state.py
+++ b/tests/integration/sim/test_snapshot_rng_state.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import pytest
 
 from src.infra import event_log
-from src.infra.snapshot import load_snapshot
 from src.sim.simulation import Simulation
 
 
@@ -70,15 +69,13 @@ async def test_snapshot_rng_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     await sim.run_step()
     original_ip = sim.agents[0].state.ip
 
-    # Replay from snapshot_2 and run step 3 again
-    monkeypatch.setenv("EVENT_LOG_PATH", str(tmp_path / "replay_events.jsonl"))
+    # Replay from snapshot_2 using the stored seed and event log
     event_log._last_hash = None
     event_log._seed = None
-    event_log.set_seed(event_log.get_seed(str(tmp_path / "events.jsonl")) or seed)
-
-    snap = load_snapshot(snap_path)
-    sim_replay = Simulation.from_snapshot(snap)
-    await sim_replay.run_step()
-    replay_ip = sim_replay.agents[0].state.ip
+    stored = event_log.get_seed(str(tmp_path / "events.jsonl")) or seed
+    replay = Simulation.replay_from_snapshot(
+        snap_path, start_step=3, end_step=3, seed=stored
+    )
+    replay_ip = replay.agents[0].state.ip
 
     assert replay_ip == original_ip


### PR DESCRIPTION
## Summary
- ensure event log caches seed from existing log header
- log seed retrieval when replaying from event log
- add integration test to verify replay reproduces agent state

## Testing
- `ruff check src/infra/event_log/__init__.py src/app.py tests/integration/sim/test_snapshot_rng_state.py`
- `pytest tests/integration/sim/test_snapshot_rng_state.py -m "integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68a32e886cd4832693a57f3a49edf901