### PR TITLE
feat: apply per-user moderation limits

### DIFF
--- a/docs/discord_manual_run.md
+++ b/docs/discord_manual_run.md
@@ -98,20 +98,20 @@ Clears an agent's memory.
 ```
 Applies an IP/DU penalty to the agent.
 
-All moderation commands are rate limited on a per-agent basis. Exceeding the
+All moderation commands are rate limited on a per-user basis. Exceeding the
 limit automatically issues IP and DU penalties as a safety rail and records the
 deduction in the ledger. For example:
 
 ```text
 /mute agent_4
-/mute agent_4
+/mute agent_5
 ```
 The second call returns:
 
 ```text
 rate limited
 ```
-and `agent_4` loses IP and DU according to the configured penalty values.
+and `agent_5` loses IP and DU according to the configured penalty values.
 
 ### Administrative Commands
 

--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -173,9 +173,7 @@ class Ledger:
             ),
         )
         self.conn.commit()
-        row = cur.execute(
-            "SELECT du FROM agent_balances WHERE agent_id=?", (agent_id,)
-        ).fetchone()
+        row = cur.execute("SELECT du FROM agent_balances WHERE agent_id=?", (agent_id,)).fetchone()
         du_balance = float(row[0]) if row else 0.0
         self._agent_du_balance[agent_id] = du_balance
         try:  # pragma: no cover - optional dependency
@@ -739,9 +737,15 @@ def log_reward(agent_id: str, delta_ip: float, delta_du: float, reason: str) -> 
         logging.getLogger(__name__).debug("Ledger logging failed", exc_info=True)
 
 
+def log_penalty(agent_id: str, ip: float, du: float, reason: str) -> None:
+    """Safely log a DU/IP penalty to the ledger."""
+    log_reward(agent_id, -abs(ip), -abs(du), reason)
+
+
 __all__ = [
     "Ledger",
     "ledger",
     "log_reward",
+    "log_penalty",
     "run_auction",
 ]

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -1,10 +1,10 @@
-"""Discord moderation commands with OPA-based rate limiting."""
+"""Discord moderation commands with OPA-based per-user rate limiting."""
 
 import time
 from functools import wraps
 from typing import Any, Callable
 
-from src.infra.ledger import log_reward
+from src.infra.ledger import log_penalty
 from src.interfaces.dashboard_backend import DEFAULT_CONTEXT, SimulationEvent
 from src.interfaces.discord_bot import bot, get_active_bot, has_admin_permission
 from src.utils.policy import evaluate_with_opa
@@ -24,8 +24,6 @@ async def _rate_limit(user: Any, action: str, agent_id: str | None = None) -> bo
         opa_key += f":{agent_id}"
 
     count_key = f"{user_id}:{action}"
-    if agent_id is not None:
-        count_key += f":{agent_id}"
     _ACTION_COUNTS[count_key] = _ACTION_COUNTS.get(count_key, 0) + 1
 
     now = time.monotonic()
@@ -65,7 +63,7 @@ def moderation_rate_limit(action: str) -> Callable[[Callable[..., Any]], Callabl
                     )
                 )
                 try:  # pragma: no cover - best effort
-                    log_reward(agent_id, -_IP_PENALTY, -_DU_PENALTY, "rate_limit_violation")
+                    log_penalty(agent_id, _IP_PENALTY, _DU_PENALTY, "rate_limit_violation")
                 except Exception:
                     pass
                 await interaction.response.send_message("rate limited", ephemeral=True)
@@ -117,7 +115,7 @@ async def slash_penalty(interaction: Any, agent_id: str, ip: float = 0.0, du: fl
         )
     )
     try:  # pragma: no cover - best effort
-        log_reward(agent_id, -abs(ip), -abs(du), "moderation_penalty")
+        log_penalty(agent_id, abs(ip), abs(du), "moderation_penalty")
     except Exception:
         pass
     await interaction.response.send_message("penalty applied", ephemeral=True)

--- a/tests/unit/interfaces/test_discord_moderation.py
+++ b/tests/unit/interfaces/test_discord_moderation.py
@@ -74,31 +74,29 @@ async def test_rate_limit_includes_agent_id(monkeypatch: pytest.MonkeyPatch) -> 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_slash_mute_per_agent(
+async def test_slash_mute_per_user(
     monkeypatch: pytest.MonkeyPatch,
     bot: DummyBot,
     interaction_factory: Callable[[], DummyInteraction],
 ) -> None:
-    async def fake_eval(content: str) -> tuple[bool, str]:
-        if content == "123:mute:agent1":
-            return False, ""
+    async def allow_eval(content: str) -> tuple[bool, str]:
         return True, ""
 
-    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", fake_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
 
     interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
-    interaction1.response.send_message.assert_awaited_once_with("rate limited", ephemeral=True)
+    interaction1.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
 
     interaction2 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction2, "agent2")
-    interaction2.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
-    mock_reward.assert_called_once_with(
-        "agent1",
-        -discord_moderation._IP_PENALTY,
-        -discord_moderation._DU_PENALTY,
+    interaction2.response.send_message.assert_awaited_once_with("rate limited", ephemeral=True)
+    mock_penalty.assert_called_once_with(
+        "agent2",
+        discord_moderation._IP_PENALTY,
+        discord_moderation._DU_PENALTY,
         "rate_limit_violation",
     )
 
@@ -112,14 +110,14 @@ async def test_slash_mute_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
     await discord_moderation.slash_mute.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "mute", "agent_id": "agent1"}
-    mock_reward.assert_not_called()
+    mock_penalty.assert_not_called()
 
 
 @pytest.mark.unit
@@ -131,8 +129,8 @@ async def test_slash_penalty_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
     await discord_moderation.slash_penalty.callback(interaction, "agent1", 1.0, 2.0)
     interaction.response.send_message.assert_awaited_once_with("penalty applied", ephemeral=True)
     event = await bot.context.get_event_queue().get()
@@ -143,7 +141,7 @@ async def test_slash_penalty_flow(
         "ip": 1.0,
         "du": 2.0,
     }
-    mock_reward.assert_called_once_with("agent1", -1.0, -2.0, "moderation_penalty")
+    mock_penalty.assert_called_once_with("agent1", 1.0, 2.0, "moderation_penalty")
 
 
 @pytest.mark.unit
@@ -155,14 +153,14 @@ async def test_slash_reset_memory_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
     await discord_moderation.slash_reset_memory.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("memory reset", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "reset_memory", "agent_id": "agent1"}
-    mock_reward.assert_not_called()
+    mock_penalty.assert_not_called()
 
 
 @pytest.mark.unit
@@ -174,14 +172,14 @@ async def test_slash_unmute_flow(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
     await discord_moderation.slash_unmute.callback(interaction, "agent1")
     interaction.response.send_message.assert_awaited_once_with("unmuted", ephemeral=True)
     event = await bot.context.get_event_queue().get()
     assert event.type == "moderation"
     assert event.data == {"command": "unmute", "agent_id": "agent1"}
-    mock_reward.assert_not_called()
+    mock_penalty.assert_not_called()
 
 
 @pytest.mark.unit
@@ -199,13 +197,13 @@ async def test_rate_limit_counts_and_violation(
         return True, ""
 
     monkeypatch.setattr(discord_moderation, "evaluate_with_opa", allow_eval)
-    mock_reward = MagicMock()
-    monkeypatch.setattr(discord_moderation, "log_reward", mock_reward)
+    mock_penalty = MagicMock()
+    monkeypatch.setattr(discord_moderation, "log_penalty", mock_penalty)
 
     interaction1 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction1, "agent1")
     await bot.context.get_event_queue().get()
-    assert discord_moderation._ACTION_COUNTS["123:mute:agent1"] == 1
+    assert discord_moderation._ACTION_COUNTS["123:mute"] == 1
 
     interaction2 = interaction_factory()
     await discord_moderation.slash_mute.callback(interaction2, "agent1")
@@ -219,10 +217,10 @@ async def test_rate_limit_counts_and_violation(
         "ip": discord_moderation._IP_PENALTY,
         "du": discord_moderation._DU_PENALTY,
     }
-    assert discord_moderation._ACTION_COUNTS["123:mute:agent1"] == 2
-    mock_reward.assert_called_once_with(
+    assert discord_moderation._ACTION_COUNTS["123:mute"] == 2
+    mock_penalty.assert_called_once_with(
         "agent1",
-        -discord_moderation._IP_PENALTY,
-        -discord_moderation._DU_PENALTY,
+        discord_moderation._IP_PENALTY,
+        discord_moderation._DU_PENALTY,
         "rate_limit_violation",
     )


### PR DESCRIPTION
## Summary
- enforce per-user moderation cooldowns and ledger penalties
- log moderation penalties through ledger helper
- document moderation command usage and rate limits

## Testing
- `SKIP=unit-tests pre-commit run --files src/infra/ledger.py src/interfaces/discord_moderation.py tests/unit/interfaces/test_discord_moderation.py docs/discord_manual_run.md`
- `pytest tests/unit/interfaces/test_discord_moderation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49175c0288326847a5a8f7fd487eb