### PR TITLE
feat(memory): track retrieval latencies and shared token budget

### DIFF
--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -38,6 +38,7 @@ class MultiLayerRetriever:
             span.set_attribute("memory.agent_id", agent_id)
             span.set_attribute("memory.query.length", len(query))
             span.set_attribute("memory.k", k)
+            start_total = time.perf_counter()
             try:
                 episodic: list[dict[str, Any]] = []
                 if self.vector_store:
@@ -80,24 +81,48 @@ class MultiLayerRetriever:
                                 (time.perf_counter() - start) * 1000,
                             )
 
-                combined = episodic + semantic
-                combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
+                combined: list[dict[str, Any]] = []
                 if token_budget is not None:
-                    limited: list[dict[str, Any]] = []
+                    e_idx = s_idx = 0
                     tokens = 0
-                    for mem in combined:
-                        text = str(mem.get("content", ""))
-                        tokens += len(text.split())
-                        if tokens > token_budget:
+                    while tokens < token_budget and (
+                        e_idx < len(episodic) or s_idx < len(semantic)
+                    ):
+                        e_mem = episodic[e_idx] if e_idx < len(episodic) else None
+                        s_mem = semantic[s_idx] if s_idx < len(semantic) else None
+                        choose_semantic = False
+                        if s_mem is not None and (
+                            e_mem is None
+                            or s_mem.get("relevance_score", 0.0)
+                            > e_mem.get("relevance_score", 0.0)
+                        ):
+                            choose_semantic = True
+                        mem = s_mem if choose_semantic else e_mem
+                        if mem is None:
                             break
-                        limited.append(mem)
-                    combined = limited
+                        mem_tokens = len(str(mem.get("content", "")).split())
+                        if tokens + mem_tokens > token_budget:
+                            break
+                        combined.append(mem)
+                        tokens += mem_tokens
+                        if choose_semantic:
+                            s_idx += 1
+                        else:
+                            e_idx += 1
+                else:
+                    combined = episodic + semantic
+
+                combined.sort(key=lambda m: m.get("relevance_score", 0.0), reverse=True)
                 metrics.MEMORY_RETRIEVALS_TOTAL.inc()
                 span.set_attribute("memory.results", len(combined))
                 return combined[:k]
             except Exception:
                 metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
                 raise
+            finally:
+                span.set_attribute(
+                    "memory.latency_ms", (time.perf_counter() - start_total) * 1000
+                )
 
     async def retrieve_and_update_semantic(
         self: Self, agent_id: str, query: str = "", k: int = 5
@@ -106,6 +131,7 @@ class MultiLayerRetriever:
             span.set_attribute("memory.agent_id", agent_id)
             span.set_attribute("memory.query.length", len(query))
             span.set_attribute("memory.k", k)
+            start_total = time.perf_counter()
             try:
                 episodic = []
                 if self.vector_store:
@@ -139,6 +165,10 @@ class MultiLayerRetriever:
             except Exception:
                 metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
                 raise
+            finally:
+                span.set_attribute(
+                    "memory.latency_ms", (time.perf_counter() - start_total) * 1000
+                )
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         if not self.semantic_manager:

--- a/tests/unit/memory/test_multi_layer_retriever_spans.py
+++ b/tests/unit/memory/test_multi_layer_retriever_spans.py
@@ -2,6 +2,8 @@ import pytest
 
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 
+pytestmark = pytest.mark.unit
+
 
 class MockSpan:
     def __init__(self, name):
@@ -46,9 +48,11 @@ async def test_retrieve_tracing(monkeypatch):
     assert len(result) == 2
 
     span_names = [s.name for s in tracer.spans]
+    assert "memory.retrieve" in span_names
     assert "memory.episodic_retrieve" in span_names
     assert "memory.semantic_retrieve" in span_names
     for span in tracer.spans:
-        assert span.attributes["llm.tokens.prompt"] == 0
-        assert span.attributes["llm.tokens.completion"] == 0
         assert "memory.latency_ms" in span.attributes
+        if span.name != "memory.retrieve":
+            assert span.attributes["llm.tokens.prompt"] == 0
+            assert span.attributes["llm.tokens.completion"] == 0


### PR DESCRIPTION
## Summary
- measure total and per-layer retrieval latency in MultiLayerRetriever
- enforce a shared token budget when merging episodic and semantic memories
- test span latency collection

## Testing
- `ruff check src/agents/memory/multi_layer_retriever.py tests/unit/memory/test_multi_layer_retriever_spans.py`
- `pytest tests/unit/memory/test_multi_layer_retriever_spans.py tests/unit/memory/test_token_budget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c5a3113c8326b44eef153f40880f