### PR TITLE
Add prompts and metric hooks to signature demo scenario

### DIFF
--- a/docs/scenario.md
+++ b/docs/scenario.md
@@ -53,10 +53,18 @@ This lightweight scenario highlights evaluation hooks for common group metrics.
    python tools/export_traces.py data/traces.jsonl --outdir plots --bundle run_bundle
    ```
 
+### Prompts
+
+- **Proposal** – "Kick off the project by proposing a plan for everyone to sign."
+- **Critique** – "Review and refine the proposal, noting strengths and weaknesses."
+- **Vote** – "Decide whether to adopt the proposal."
+- **Deliverable** – "Summarize the approved plan and outline next steps."
+
 ### Expected Arc
 
-1. **Introduction** – agents share initial perspectives and set intent.
-2. **Collaboration** – members coordinate to sign onto a shared plan.
-3. **Resolution** – the group finalizes the plan and reflects on the process.
+1. **Proposal** – agents introduce an initial plan.
+2. **Critique** – members challenge and refine the idea.
+3. **Vote** – the group decides on adopting the plan.
+4. **Deliverable** – the final plan is summarized and shared.
 
-Evaluation hooks record coalition counts, sentiment, and collective DU/IP curves for analysis.
+Evaluation hooks record coalition counts, sentiment trends, and collective DU/IP usage for analysis.

--- a/scenarios/signature_demo.yaml
+++ b/scenarios/signature_demo.yaml
@@ -3,9 +3,19 @@ description: Demo scenario showcasing evaluation hooks for coalition and sentime
 goal: Agents collaborate to sign a shared plan while monitoring group dynamics
 steps: 30
 beats:
-  - introduction
-  - collaboration
-  - resolution
+  - proposal
+  - critique
+  - vote
+  - deliverable
+prompts:
+  proposal: >-
+    Kick off the project by proposing a plan for everyone to sign.
+  critique: >-
+    Review and refine the proposal, noting strengths and weaknesses.
+  vote: >-
+    Decide whether to adopt the proposal.
+  deliverable: >-
+    Summarize the approved plan and outline next steps.
 evaluation_hooks:
   - coalitions
   - sentiment


### PR DESCRIPTION
## Summary
- add proposal, critique, vote, and deliverable prompts to signature demo scenario
- register evaluation hooks for coalition count, sentiment, and resource usage
- document scripted phases and hooks in scenario guide

## Testing
- `pre-commit run --files scenarios/signature_demo.yaml docs/scenario.md`
- `pytest -m "integration" tests/integration/scenario/test_signature_demo.py::test_signature_demo -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d4dd5aac832681a241468a3efe5a