### PR TITLE
feat: expose cost metrics

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -77,3 +77,19 @@ export async function registerWidgetBackend(widget: WidgetRegistration): Promise
   return data.widgets
 }
 
+export interface ObservabilityMetrics {
+  du_per_1k_tokens: number
+  llm_latency_p95_ms: number
+}
+
+export async function fetchObservabilityMetrics(): Promise<ObservabilityMetrics> {
+  const res = await fetch('/api/observability_metrics')
+  return (await res.json()) as ObservabilityMetrics
+}
+
+export async function displayObservabilityMetrics(): Promise<void> {
+  const metrics = await fetchObservabilityMetrics()
+  console.log('DU/1k tokens:', metrics.du_per_1k_tokens)
+  console.log('p95 latency (ms):', metrics.llm_latency_p95_ms)
+}
+

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -70,6 +70,18 @@ Each agent exposes its remaining DU balance and efficiency via Prometheus gauges
 Create Grafana panels with queries such as `agent_remaining_du` or `agent_du_per_1k_tokens`
 to alert when budgets run low or spike unexpectedly.
 
+### Dashboard Cost Metrics Endpoint
+
+The dashboard backend provides `/api/observability_metrics` for quick visibility into
+LLM usage. The endpoint returns:
+
+- `du_per_1k_tokens` – average digital units spent per 1,000 tokens. Lower values
+  indicate more efficient usage of the DU budget.
+- `llm_latency_p95_ms` – 95th percentile latency of recent LLM calls in milliseconds,
+  useful for spotting tail latency issues.
+
+These metrics can be fetched directly by the UI or external monitoring systems.
+
 ## 4. Running Grafana Locally
 
 If you want to run Grafana locally for quick testing, you can use Docker. The default login is `admin`/`admin`:

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -684,15 +684,27 @@ async def api_token_balances() -> Response:
     return JSONResponse({"agents": agents})
 
 
+def _cost_metrics_data() -> dict[str, float]:
+    """Collect DU cost and latency metrics."""
+
+    return {
+        "du_per_1k_tokens": metrics.get_du_per_1k_tokens(),
+        "llm_latency_p95_ms": metrics.get_llm_latency_p95(),
+    }
+
+
 @app.get("/api/cost_metrics")
 async def api_cost_metrics() -> Response:
     """Return DU cost and latency metrics for dashboards."""
 
-    data = {
-        "du_per_1k_tokens": metrics.get_du_per_1k_tokens(),
-        "llm_latency_p95_ms": metrics.get_llm_latency_p95(),
-    }
-    return JSONResponse(data)
+    return JSONResponse(_cost_metrics_data())
+
+
+@app.get("/api/observability_metrics")
+async def api_observability_metrics() -> Response:
+    """Return DU cost and latency metrics for dashboards."""
+
+    return JSONResponse(_cost_metrics_data())
 
 
 @app.get("/api/auctions")


### PR DESCRIPTION
## Summary
- expose DU/1k tokens and p95 latency via `/api/observability_metrics`
- fetch and log cost metrics from the UI API helpers
- document cost metric meanings

## Testing
- `ruff check src/interfaces/dashboard_backend.py`
- `mypy src/interfaces/dashboard_backend.py` *(failed: process interrupted)*
- `pytest tests/integration/test_collective_metrics.py -q`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72003b9388326b0cfc586766589a0