### PR TITLE
Use tiktoken for memory token budgeting

### DIFF
--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+import tiktoken
 from opentelemetry import trace
 from typing_extensions import Self
 
@@ -23,9 +24,11 @@ class MultiLayerRetriever:
         self: Self,
         vector_store: ChromaVectorStoreManager | None = None,
         semantic_manager: SemanticMemoryManager | None = None,
+        tokenizer: tiktoken.Encoding | None = None,
     ) -> None:
         self.vector_store = vector_store
         self.semantic_manager = semantic_manager
+        self.tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
 
     async def retrieve(
         self: Self,
@@ -100,7 +103,8 @@ class MultiLayerRetriever:
                         mem = s_mem if choose_semantic else e_mem
                         if mem is None:
                             break
-                        mem_tokens = len(str(mem.get("content", "")).split())
+                        text = str(mem.get("content", ""))
+                        mem_tokens = len(self.tokenizer.encode(text))
                         if tokens + mem_tokens > token_budget:
                             break
                         combined.append(mem)

--- a/tests/unit/memory/test_token_budget.py
+++ b/tests/unit/memory/test_token_budget.py
@@ -1,4 +1,5 @@
 import pytest
+import tiktoken
 
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
@@ -24,8 +25,9 @@ class DummySemantic:
 
 @pytest.mark.asyncio
 async def test_retriever_respects_token_budget() -> None:
-    retriever = MultiLayerRetriever(DummyVectorStore(), DummySemantic())
-    results = await retriever.retrieve("agent", "q", k=10, token_budget=5)
+    tokenizer = tiktoken.get_encoding("cl100k_base")
+    retriever = MultiLayerRetriever(DummyVectorStore(), DummySemantic(), tokenizer)
+    results = await retriever.retrieve("agent", "q", k=10, token_budget=6)
     assert [r["content"] for r in results] == ["episodic one", "semantic one"]
 
 


### PR DESCRIPTION
## Summary
- count tokens in `MultiLayerRetriever` using a tiktoken tokenizer
- inject tokenizer into token-budget test and adjust expectations

## Testing
- `ruff check src/agents/memory/multi_layer_retriever.py tests/unit/memory/test_token_budget.py`
- `pytest tests/unit/memory/test_token_budget.py tests/unit/memory/test_multi_layer_retriever.py tests/unit/memory/test_multi_layer_retriever_spans.py`

------
https://chatgpt.com/codex/tasks/task_e_68a72f81f7908326bef2a045efa640e6