### PR TITLE
feat: show per-agent metrics on dashboard

### DIFF
--- a/culture-ui/src/TokenBalances.test.tsx
+++ b/culture-ui/src/TokenBalances.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import TokenBalances from './pages/TokenBalances'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('TokenBalances', () => {
+  it('shows DU/1k and latency metrics', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo) => {
+        if (input === '/api/token_balances') {
+          return Promise.resolve({
+            json: () =>
+              Promise.resolve({
+                agents: { 'agent-1': { ip: 1, du: 2, tokens: { TOK: 3 } } },
+              }),
+          }) as unknown as Response
+        }
+        return Promise.resolve({
+          json: () =>
+            Promise.resolve({
+              agent_du_per_1k_tokens: { 'agent-1': 4.5 },
+              agent_llm_latency_p95_ms: { 'agent-1': 123 },
+            }),
+        }) as unknown as Response
+      }) as typeof fetch,
+    )
+
+    render(<TokenBalances />)
+
+    expect(await screen.findByText('agent-1')).toBeInTheDocument()
+    expect(screen.getByText('4.5')).toBeInTheDocument()
+    expect(screen.getByText('123')).toBeInTheDocument()
+  })
+})
+

--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -80,6 +80,8 @@ export async function registerWidgetBackend(widget: WidgetRegistration): Promise
 export interface ObservabilityMetrics {
   du_per_1k_tokens: number
   llm_latency_p95_ms: number
+  agent_du_per_1k_tokens: Record<string, number>
+  agent_llm_latency_p95_ms: Record<string, number>
 }
 
 export async function fetchObservabilityMetrics(): Promise<ObservabilityMetrics> {
@@ -91,5 +93,7 @@ export async function displayObservabilityMetrics(): Promise<void> {
   const metrics = await fetchObservabilityMetrics()
   console.log('DU/1k tokens:', metrics.du_per_1k_tokens)
   console.log('p95 latency (ms):', metrics.llm_latency_p95_ms)
+  console.log('Agent DU/1k tokens:', metrics.agent_du_per_1k_tokens)
+  console.log('Agent p95 latency (ms):', metrics.agent_llm_latency_p95_ms)
 }
 

--- a/culture-ui/src/pages/TokenBalances.tsx
+++ b/culture-ui/src/pages/TokenBalances.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { fetchObservabilityMetrics } from '../lib/api'
 import { registerWidget } from '../lib/widgetRegistry'
 
 interface BalanceInfo {
@@ -9,6 +10,10 @@ interface BalanceInfo {
 
 export default function TokenBalances() {
   const [data, setData] = useState<Record<string, BalanceInfo>>({})
+  const [metrics, setMetrics] = useState({
+    agent_du_per_1k_tokens: {} as Record<string, number>,
+    agent_llm_latency_p95_ms: {} as Record<string, number>,
+  })
 
   useEffect(() => {
     let cancelled = false
@@ -21,7 +26,20 @@ export default function TokenBalances() {
         /* ignore */
       }
     }
+    async function loadMetrics() {
+      try {
+        const m = await fetchObservabilityMetrics()
+        if (!cancelled)
+          setMetrics({
+            agent_du_per_1k_tokens: m.agent_du_per_1k_tokens || {},
+            agent_llm_latency_p95_ms: m.agent_llm_latency_p95_ms || {},
+          })
+      } catch {
+        /* ignore */
+      }
+    }
     void load()
+    void loadMetrics()
     return () => {
       cancelled = true
     }
@@ -37,6 +55,8 @@ export default function TokenBalances() {
             <th className="border px-2">IP</th>
             <th className="border px-2">DU</th>
             <th className="border px-2">Tokens</th>
+            <th className="border px-2">DU/1k</th>
+            <th className="border px-2">Latency</th>
           </tr>
         </thead>
         <tbody>
@@ -49,6 +69,12 @@ export default function TokenBalances() {
                 {Object.entries(info.tokens || {})
                   .map(([tok, amt]) => `${tok}:${amt}`)
                   .join(', ')}
+              </td>
+              <td className="border px-2">
+                {metrics.agent_du_per_1k_tokens[id] ?? 'n/a'}
+              </td>
+              <td className="border px-2">
+                {metrics.agent_llm_latency_p95_ms[id] ?? 'n/a'}
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- fetch per-agent DU/1k and latency metrics
- display DU/1k and latency for each agent on token balances page
- test token balances metrics rendering

## Testing
- `pnpm lint`
- `pnpm test`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a72f83609483269905a2015f6aa23c