### PR TITLE
Add flagged messages API and replay slice storage

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -339,3 +339,23 @@ def stream_events(
                 consumer.close()
             except Exception:  # pragma: no cover - ignore
                 pass
+
+
+def store_replay_slice(
+    start_step: int, end_step: int, directory: str | Path | None = None
+) -> Path:
+    """Persist events between ``start_step`` and ``end_step`` inclusive.
+
+    The slice is saved as ``replay_<start>_<end>.jsonl`` in ``directory`` and
+    can later be used for replaying portions of the simulation.
+    """
+
+    events = fetch_events(after_step=start_step - 1, end_step=end_step)
+    dest_dir = Path(directory) if directory is not None else _log_file().parent
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out = dest_dir / f"replay_{start_step}_{end_step}.jsonl"
+    with out.open("w", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event))
+            fh.write("\n")
+    return out

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from src.governance.law_board import law_board
 from src.governance.service import governance
+from src.infra import event_log
 from src.infra.ledger import ledger
 from src.infra.snapshot import load_snapshot
 from src.interfaces import metrics
@@ -766,6 +767,35 @@ async def api_memory_snapshot(step: int) -> Response:
     return resp
 
 
+@app.get("/api/flagged_messages")
+async def api_flagged_messages(limit: int = 20) -> Response:
+    """Return flagged messages with snapshot references."""
+
+    events = await asyncio.to_thread(event_log.fetch_events)
+    flagged = [e for e in events if e.get("type") == "flagged_message"]
+    flagged = flagged[-limit:]
+    messages: list[dict[str, Any]] = []
+    for evt in flagged:
+        step = int(evt.get("step", evt.get("tick", 0)))
+        msg = str(evt.get("message", ""))
+        try:
+            event_log.store_replay_slice(step, step, directory=SNAPSHOT_DIR)
+        except Exception:  # pragma: no cover - best effort
+            pass
+        messages.append(
+            {
+                "step": step,
+                "message": msg,
+                "snapshot": f"snapshot_{step}.json",
+            }
+        )
+
+    resp = JSONResponse({"messages": messages})
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
+
+
 async def register_widget(widget: dict[str, Any]) -> Response:
     """Register a widget provided by the UI or a plugin."""
     name = widget.get("name")
@@ -928,6 +958,7 @@ __all__ = [
     "VotesResponse",
     "api_agent_stats",
     "api_auctions",
+    "api_flagged_messages",
     "api_get_laws",
     "api_get_proposals",
     "api_get_votes",

--- a/src/sim/context.py
+++ b/src/sim/context.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .event_bus import get_event_bus
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from src.interfaces.dashboard_backend import SimulationEvent
 
 
 @dataclass
@@ -21,10 +24,10 @@ class SimulationContext:
         }
     )
     message_queue: asyncio.Queue[Any] = field(default_factory=lambda: asyncio.Queue(maxsize=1000))
-    _event_queue: asyncio.Queue[Any] | None = field(default=None, init=False)
+    _event_queue: asyncio.Queue[SimulationEvent | None] | None = field(default=None, init=False)
     _event_queue_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False)
 
-    def get_event_queue(self: SimulationContext) -> asyncio.Queue[Any]:
+    def get_event_queue(self: SimulationContext) -> asyncio.Queue[SimulationEvent | None]:
         """Return an event queue bound to the current loop."""
         bus = get_event_bus()
         try:

--- a/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
+++ b/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
@@ -44,3 +44,32 @@ async def test_api_memory_snapshot_missing(
     resp = await db.api_memory_snapshot(42)
     assert resp.status_code == 404
     assert json.loads(resp.body) == {"error": "not_found"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_flagged_messages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    events = [
+        {"type": "flagged_message", "step": 1, "message": "bad"},
+        {"type": "flagged_message", "step": 2, "message": "worse"},
+    ]
+
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(db.event_log, "fetch_events", lambda *a, **k: events)
+
+    calls: list[tuple[int, int, Path | None]] = []
+
+    def fake_store(start: int, end: int, directory: Path | None = None) -> Path:
+        calls.append((start, end, directory))
+        return tmp_path / f"replay_{start}_{end}.jsonl"
+
+    monkeypatch.setattr(db.event_log, "store_replay_slice", fake_store)
+
+    resp = await db.api_flagged_messages()
+    assert json.loads(resp.body) == {
+        "messages": [
+            {"step": 1, "message": "bad", "snapshot": "snapshot_1.json"},
+            {"step": 2, "message": "worse", "snapshot": "snapshot_2.json"},
+        ]
+    }
+    assert calls == [(1, 1, tmp_path), (2, 2, tmp_path)]


### PR DESCRIPTION
## Summary
- add `/api/flagged_messages` route to dashboard backend aggregating flagged messages and saving replay slices
- add `store_replay_slice` helper to event log
- cover flagged message aggregation with new unit test
- type SimulationContext event queue to satisfy mypy

## Testing
- `ruff check src/interfaces/dashboard_backend.py src/infra/event_log/__init__.py src/sim/context.py tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py`
- `mypy --follow-imports=skip src/interfaces/dashboard_backend.py src/infra/event_log/__init__.py src/sim/context.py`
- `pytest tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py`


------
https://chatgpt.com/codex/tasks/task_e_68a729e89ca88326905c5ca088971a92