### PR TITLE
Add unit tests for replay CLI and ledger tracing

### DIFF
--- a/tests/unit/infra/test_ledger_tracing.py
+++ b/tests/unit/infra/test_ledger_tracing.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from src.infra.ledger import Ledger
+
+
+class MockSpan:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __enter__(self):  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
+        return False
+
+
+class MockTracer:
+    def __init__(self) -> None:
+        self.spans: list[MockSpan] = []
+
+    def start_as_current_span(self, name: str):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_ledger_emits_spans(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.ledger.tracer", tracer)
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    ledger.log_change("a1", 5.0, 2.0, "init")
+    ledger.get_balance("a1")
+
+    span_names = [span.name for span in tracer.spans]
+    assert "Ledger.log_change" in span_names
+    assert "Ledger.get_balance" in span_names

--- a/tests/unit/tools/test_replay_cli.py
+++ b/tests/unit/tools/test_replay_cli.py
@@ -1,0 +1,37 @@
+import pytest
+
+from tools import replay_cli
+
+
+@pytest.mark.unit
+def test_replay_cli_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, object] = {}
+
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None):
+        called.update(snapshot=snapshot, start=start_step, end=end_step, seed=seed)
+
+    monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
+
+    assert (
+        replay_cli.main(["snap.json", "--from", "2", "--to", "4", "--seed", "99"]) == 0
+    )
+    assert called == {
+        "snapshot": "snap.json",
+        "start": 2,
+        "end": 4,
+        "seed": 99,
+    }
+
+
+@pytest.mark.unit
+def test_replay_cli_tick_range_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, object] = {}
+
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None):
+        called.update(start=start_step, end=end_step)
+
+    monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
+
+    replay_cli.main(["snap.json", "--from-tick", "5", "--to-tick", "7"])
+    assert called["start"] == 5
+    assert called["end"] == 7


### PR DESCRIPTION
## Summary
- test replay_cli argument forwarding and tick-range aliases
- ensure ledger operations emit tracing spans

## Testing
- `ruff check tests/unit/tools/test_replay_cli.py tests/unit/infra/test_ledger_tracing.py`
- `pytest tests/unit/tools/test_replay_cli.py tests/unit/infra/test_ledger_tracing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac76ca9a44832680aef2a1e6257414