### PR TITLE
Add tracing for log events

### DIFF
--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
 from typing import cast
 
 from typing_extensions import Self
@@ -110,11 +110,11 @@ class GovernanceService:
                     staked = 0.0
                 weights.append(quadratic_vote_weight(base_ip, staked))
         else:
-            start_balances = await asyncio.gather(
-                *[ledger.get_balance_async(a.agent_id) for a in agents],
-                return_exceptions=True,
-            )
-            spend_tasks = []
+            balance_tasks: list[Awaitable[tuple[float, float]]] = [
+                ledger.get_balance_async(a.agent_id) for a in agents
+            ]
+            start_balances = await asyncio.gather(*balance_tasks, return_exceptions=True)
+            spend_tasks: list[Awaitable[tuple[float, float]]] = []
             for a in agents:
                 w = int(vote_weights.get(a.agent_id, 1))
                 weights.append(float(w))

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -194,48 +194,54 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     global _last_hash
     _ensure_header()
 
-    if "trace_hash" in event:
-        event = {**event}
-        event.pop("trace_hash", None)
-    from src.infra.checkpoint import capture_rng_state
+    with tracer.start_as_current_span("event_log.log_event") as span:
+        span.set_attribute("event.type", event.get("type"))
+        span.set_attribute("step", event.get("step"))
 
-    global _seed
-    if _seed is None:
-        try:
-            _seed = random.getstate()[1][0]
-        except Exception:  # pragma: no cover - fallback
-            _seed = 0
-
-    event = {**event, "rng_state": capture_rng_state(), "seed": _seed}
-    if "step" in event and "tick" not in event:
-        event["tick"] = event["step"]
-    if _last_hash is not None:
-        event["prev_hash"] = _last_hash
-    event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
-    _last_hash = event_with_hash["trace_hash"]
-
-    # Append to local log file
-    try:  # pragma: no cover - best effort
         path = _log_file()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(event_with_hash))
-            fh.write("\n")
-    except Exception:  # pragma: no cover - ignore
-        pass
+        span.set_attribute("log.file_path", str(path))
 
-    if os.getenv("ENABLE_REDPANDA", "0") != "1":
+        if "trace_hash" in event:
+            event = {**event}
+            event.pop("trace_hash", None)
+        from src.infra.checkpoint import capture_rng_state
+
+        global _seed
+        if _seed is None:
+            try:
+                _seed = random.getstate()[1][0]
+            except Exception:  # pragma: no cover - fallback
+                _seed = 0
+
+        event = {**event, "rng_state": capture_rng_state(), "seed": _seed}
+        if "step" in event and "tick" not in event:
+            event["tick"] = event["step"]
+        if _last_hash is not None:
+            event["prev_hash"] = _last_hash
+        event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
+        _last_hash = event_with_hash["trace_hash"]
+
+        # Append to local log file
+        try:  # pragma: no cover - best effort
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event_with_hash))
+                fh.write("\n")
+        except Exception:  # pragma: no cover - ignore
+            pass
+
+        if os.getenv("ENABLE_REDPANDA", "0") != "1":
+            return event_with_hash
+        try:  # pragma: no cover - best effort
+            payload = json.dumps(event_with_hash).encode("utf-8")
+            producer = _get_producer()
+            producer.produce(_topic, payload)
+            producer.poll(0)
+        except Exception as exc:  # pragma: no cover - best effort
+            import logging
+
+            logging.getLogger(__name__).debug("Failed to log event: %s", exc)
         return event_with_hash
-    try:  # pragma: no cover - best effort
-        payload = json.dumps(event_with_hash).encode("utf-8")
-        producer = _get_producer()
-        producer.produce(_topic, payload)
-        producer.poll(0)
-    except Exception as exc:  # pragma: no cover - best effort
-        import logging
-
-        logging.getLogger(__name__).debug("Failed to log event: %s", exc)
-    return event_with_hash
 
 
 def fetch_events(

--- a/src/infra/ledger.py
+++ b/src/infra/ledger.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import sqlite3
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from functools import wraps
 from pathlib import Path
+from typing import ParamSpec, TypeVar, cast, overload
 
 from opentelemetry import trace
 
@@ -15,21 +16,34 @@ from .settings import settings
 tracer = trace.get_tracer(__name__)
 
 
-def traced(func: Callable[..., object]) -> Callable[..., object]:
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@overload
+def traced(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]: ...
+
+
+@overload
+def traced(func: Callable[P, R]) -> Callable[P, R]: ...
+
+
+def traced(func: Callable[P, Awaitable[R] | R]) -> Callable[P, Awaitable[R] | R]:
     """Wrap ``func`` execution in an OpenTelemetry span."""
 
     if asyncio.iscoroutinefunction(func):
+
         @wraps(func)
-        async def async_wrapper(*args: object, **kwargs: object) -> object:
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             with tracer.start_as_current_span(func.__qualname__):
-                return await func(*args, **kwargs)
+                return await cast(Callable[P, Awaitable[R]], func)(*args, **kwargs)
 
         return async_wrapper
 
     @wraps(func)
-    def sync_wrapper(*args: object, **kwargs: object) -> object:
+    def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         with tracer.start_as_current_span(func.__qualname__):
-            return func(*args, **kwargs)
+            return cast(Callable[P, R], func)(*args, **kwargs)
 
     return sync_wrapper
 
@@ -721,7 +735,8 @@ class Ledger:
     @traced
     async def get_balance_async(self, agent_id: str) -> tuple[float, float]:
         """Return the balance for ``agent_id`` asynchronously."""
-        return await asyncio.to_thread(self.get_balance, agent_id)
+        result = await asyncio.to_thread(self.get_balance, agent_id)
+        return cast(tuple[float, float], result)
 
     @traced
     async def spend(

--- a/src/sim/quests/__init__.py
+++ b/src/sim/quests/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable, Mapping
+from typing import cast
 
 from pydantic import BaseModel
 
@@ -124,7 +126,7 @@ def get_quests() -> list[Quest]:
     """
 
     try:
-        rows = ledger.get_quests()
+        rows = cast(Iterable[Mapping[str, object]], ledger.get_quests())
         return [Quest(**r) for r in rows]
     except Exception:  # pragma: no cover - defensive
         return list(QUESTS)

--- a/tests/unit/infra/test_event_log_spans.py
+++ b/tests/unit/infra/test_event_log_spans.py
@@ -1,7 +1,6 @@
-
 import pytest
 
-from src.infra.event_log import fetch_events, stream_events
+from src.infra.event_log import fetch_events, log_event, stream_events
 
 
 class MockSpan:
@@ -64,6 +63,24 @@ def test_fetch_events_tracing(monkeypatch, tmp_path, use_redpanda):
     assert span.attributes["tick.end"] == 5
     expected_source = "redpanda" if use_redpanda else "file"
     assert span.attributes["event.source"] == expected_source
+
+
+@pytest.mark.unit
+def test_log_event_tracing(monkeypatch, tmp_path):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.event_log.tracer", tracer)
+    monkeypatch.setenv("ENABLE_REDPANDA", "0")
+    log_file = tmp_path / "event_log.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
+
+    event = {"type": "test", "step": 7}
+    log_event(event)
+
+    span = tracer.spans[0]
+    assert span.name == "event_log.log_event"
+    assert span.attributes["event.type"] == "test"
+    assert span.attributes["step"] == 7
+    assert span.attributes["log.file_path"] == str(log_file)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- trace `log_event` to capture event details and log path
- test logging spans include new name and attributes
- resolve mypy errors by tightening type hints across ledger, governance, and quests modules

## Testing
- `SKIP=unit-tests pre-commit run --files src/infra/event_log/__init__.py tests/unit/infra/test_event_log_spans.py src/infra/ledger.py src/sim/quests/__init__.py src/governance/service.py`
- `pytest tests/unit/infra/test_event_log_spans.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb04d883c8326b21f5f396f4a5eb4