### PR TITLE
Use tokenizer for context pipeline token budgeting

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import tiktoken
 from typing_extensions import Self
 
 from src.interfaces import metrics
@@ -23,11 +24,13 @@ class MemoryService:
         vector_store: ChromaVectorStoreManager | None = None,
         semantic_manager: SemanticMemoryManager | None = None,
         level3_manager: Level3SummaryManager | None = None,
+        tokenizer: tiktoken.Encoding | None = None,
     ) -> None:
         self.vector_store = vector_store
         self.semantic_manager = semantic_manager
         self.level3_manager = level3_manager
-        self.retriever = MultiLayerRetriever(vector_store, semantic_manager)
+        self.tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
+        self.retriever = MultiLayerRetriever(vector_store, semantic_manager, self.tokenizer)
 
     def add_memory(
         self: Self,
@@ -40,9 +43,7 @@ class MemoryService:
     ) -> str:
         if not self.vector_store:
             return ""
-        with trace_agent_action(
-            "memory.add_memory", agent_id=agent_id, event_type=event_type
-        ):
+        with trace_agent_action("memory.add_memory", agent_id=agent_id, event_type=event_type):
             return self.vector_store.add_memory(
                 agent_id, step, event_type, content, memory_type, metadata
             )
@@ -149,11 +150,12 @@ class MemoryService:
                 long_term = self.get_long_term_summaries(agent_id, long_term_limit)
 
             if token_budget is not None:
+                tokenizer = self.tokenizer
                 tokens = 0
                 limited_episodic: list[dict[str, Any]] = []
                 for mem in episodic:
                     text = str(mem.get("content", ""))
-                    t = len(text.split())
+                    t = len(tokenizer.encode(text))
                     if tokens + t > token_budget:
                         break
                     limited_episodic.append(mem)
@@ -162,7 +164,7 @@ class MemoryService:
 
                 limited_semantic: list[str] = []
                 for summary in semantic:
-                    t = len(summary.split())
+                    t = len(tokenizer.encode(summary))
                     if tokens + t > token_budget:
                         break
                     limited_semantic.append(summary)
@@ -172,7 +174,7 @@ class MemoryService:
                 if long_term:
                     limited_long_term: list[str] = []
                     for summary in long_term:
-                        t = len(summary.split())
+                        t = len(tokenizer.encode(summary))
                         if tokens + t > token_budget:
                             break
                         limited_long_term.append(summary)

--- a/tests/unit/memory/test_token_budget.py
+++ b/tests/unit/memory/test_token_budget.py
@@ -48,10 +48,10 @@ async def test_context_pipeline_respects_token_budget(monkeypatch: pytest.Monkey
     service = MemoryService()
 
     async def fake_retrieve(agent_id: str, query: str, k: int) -> list[dict[str, str]]:
-        return [{"content": "one"}, {"content": "two"}, {"content": "three four"}]
+        return [{"content": "hello-world"}, {"content": "two"}, {"content": "three"}]
 
     def fake_semantic(agent_id: str, limit: int) -> list[str]:
-        return ["alpha", "beta"]
+        return ["alpha-beta", "gamma"]
 
     monkeypatch.setattr(service, "retrieve_episodic_and_update_semantic", fake_retrieve)
     monkeypatch.setattr(service, "get_recent_semantic_summaries", fake_semantic)
@@ -59,5 +59,5 @@ async def test_context_pipeline_respects_token_budget(monkeypatch: pytest.Monkey
     episodic, semantic = await service.get_context_pipeline(
         "agent", token_budget=3, semantic_limit=2
     )
-    assert [m["content"] for m in episodic] == ["one", "two"]
-    assert semantic == ["alpha"]
+    assert [m["content"] for m in episodic] == ["hello-world", "two"]
+    assert semantic == []


### PR DESCRIPTION
## Summary
- use tiktoken in `MemoryService` for token-aware context budgeting
- update token budget unit test to account for tokenizer behavior

## Testing
- `SKIP=unit-tests pre-commit run --files src/agents/memory/memory_service.py tests/unit/memory/test_token_budget.py`
- `pytest tests/unit/memory/test_token_budget.py`


------
https://chatgpt.com/codex/tasks/task_e_68af11d896f48326a20e3948406a61b9