### PR TITLE
feat: add nudge command to discord bot

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -232,7 +232,7 @@ def notify_budget_exceeded(agent_id: str, required: float, remaining: float) -> 
     bot_instance = get_active_bot()
     if bot_instance is not None:
         try:
-            asyncio.create_task(bot_instance.send_simulation_update(embed=embed))
+            asyncio.create_task(bot_instance.send_simulation_update(embed=embed))  # noqa: RUF006
         except Exception:  # pragma: no cover - best effort
             logger.exception("Failed to send budget exceeded embed")
 
@@ -522,6 +522,18 @@ class SimulationDiscordBot:
                             )
                         )
                         await interaction.response.send_message("unmuted", ephemeral=True)
+
+                @tree.command(name="nudge")
+                @app_commands.describe(prompt="Prompt to nudge the simulation")
+                async def _tree_nudge(
+                    interaction: "discord.Interaction", prompt: str
+                ) -> None:
+                    with command_span("nudge", interaction) as span:
+                        span.set_attribute("discord.message.length", len(prompt))
+                        await self.event_queue.put(
+                            SimulationEvent(type="nudge", data={"prompt": prompt})
+                        )
+                        await interaction.response.send_message("nudge sent", ephemeral=True)
 
             @client.event
             async def on_ready(
@@ -1270,6 +1282,20 @@ async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
             SimulationEvent(type="control", data={"command": "kill_agent", "agent_id": agent_id})
         )
         await send_interaction_response(interaction, "killed", ephemeral=True)
+
+
+@bot.tree.command(name="nudge")
+@app_commands.describe(prompt="Prompt to nudge the simulation")
+async def slash_nudge(interaction: Any, prompt: str) -> None:
+    """Send a custom prompt to the simulation."""
+    with command_span("nudge", interaction) as span:
+        span.set_attribute("discord.message.length", len(prompt))
+        bot_instance = get_active_bot()
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        await ctx.get_event_queue().put(
+            SimulationEvent(type="nudge", data={"prompt": prompt})
+        )
+        await send_interaction_response(interaction, "nudge sent", ephemeral=True)
 
 
 @bot.tree.command(name="start")

--- a/tests/unit/interfaces/test_discord_commands.py
+++ b/tests/unit/interfaces/test_discord_commands.py
@@ -1,6 +1,8 @@
+import asyncio
 import importlib
 import sys
 from types import SimpleNamespace
+from typing import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -190,3 +192,21 @@ async def test_message_relay_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     await sim._handle_human_command("hello")
     await sim._handle_human_command("hello again")
     ledger_module.ledger.spend.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_nudge_enqueues_event(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    ctx = SimpleNamespace(get_event_queue=lambda: queue)
+    bot = SimpleNamespace(context=ctx)
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    interaction = DummyInteraction()
+    await discord_module.slash_nudge(interaction, "hi there")
+    event = await queue.get()
+    assert event.type == "nudge" and event.data == {"prompt": "hi there"}
+    interaction.response.send_message.assert_awaited_once_with(
+        "nudge sent", ephemeral=True
+    )


### PR DESCRIPTION
## Summary
- add `/nudge` slash command to send custom prompts into the simulation
- cover `/nudge` via unit tests

## Testing
- `ruff check src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_commands.py`
- `pytest tests/unit/interfaces/test_discord_commands.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1d679db8832697834fd0a3445e24