### PR TITLE
Add deterministic beat checks for signature demo

### DIFF
--- a/tests/integration/scenario/test_signature_demo.py
+++ b/tests/integration/scenario/test_signature_demo.py
@@ -1,11 +1,13 @@
 import json
+from itertools import cycle
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from scripts import export_traces
 from src.agents.graphs.basic_agent_types import AgentActionOutput
-from src.app import create_simulation
+from src.app import create_simulation, load_scenario
 from src.infra import event_log
 from src.infra import snapshot as snap
 from src.sim.simulation import Simulation
@@ -17,8 +19,12 @@ from tests.utils.mock_llm import MockLLM
 async def test_signature_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Run the signature_demo scenario and verify evaluation metrics."""
     monkeypatch.setenv("SNAPSHOT_INTERVAL_STEPS", "1")
+    monkeypatch.setenv("EVENT_LOG_PATH", str(tmp_path / "event_log.jsonl"))
     monkeypatch.setattr(event_log, "_get_producer", lambda: None)
     monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", False, raising=False)
+    event_log.set_seed(42)
     monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda *a, **k: None)
 
     def save(step: int, data: dict, directory: Path = tmp_path) -> None:
@@ -38,36 +44,65 @@ async def test_signature_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(snap, "load_snapshot", load_no_verify)
     monkeypatch.setattr(export_traces, "load_snapshot", load_no_verify)
 
-    structured = AgentActionOutput(
-        thought="t",
-        message_content="hi",
-        message_recipient_id=None,
-        action_intent="continue_collaboration",
-        requested_role_change=None,
-        project_name_to_create=None,
-        project_description_for_creation=None,
-        project_id_to_join_or_leave=None,
-    )
-    responses = {"structured_output": structured, "default": "text"}
+    scenario_desc, _, _, beats = load_scenario("scenarios/signature_demo.yaml")
+    beat_cycle = cycle(beats)
 
-    with MockLLM(responses):
-        sim = create_simulation(num_agents=3, steps=30, scenario="signature_demo.yaml")
+    def next_structured_output() -> AgentActionOutput:
+        beat = next(beat_cycle)
+        return AgentActionOutput(
+            thought="t",
+            message_content=f"{beat} message",
+            message_recipient_id=None,
+            action_intent="continue_collaboration",
+            requested_role_change=None,
+            project_name_to_create=None,
+            project_description_for_creation=None,
+            project_id_to_join_or_leave=None,
+        )
+
+    responses = {"default": "text"}
+    with MockLLM(responses, strict_mode=False):
+        monkeypatch.setattr(
+            "src.infra.llm_client.generate_structured_output",
+            lambda *a, **k: next_structured_output(),
+        )
+        monkeypatch.setattr(
+            "src.infra.llm_client.async_generate_structured_output",
+            AsyncMock(side_effect=lambda *a, **k: next_structured_output()),
+        )
+        sim = create_simulation(
+            num_agents=3,
+            steps=30,
+            scenario=scenario_desc,
+            seed=42,
+            beats=beats,
+        )
+        sim._beat_interval = max(1, sim.steps_to_run // len(beats))
         sim.evaluation_hooks = [Simulation._collect_metrics]
         for _ in range(30):
             await sim.run_step()
 
     metrics = sim.metrics
-    assert len(metrics) == 30
+    assert len(metrics) == sim.steps_to_run + len(beats)
     assert all(m["coalitions"] == 0 for m in metrics)
     sentiments = [m["sentiment"] for m in metrics]
     assert all(s == 0.0 for s in sentiments)
     ip_values = [m["collective_ip"] for m in metrics]
     du_values = [m["collective_du"] for m in metrics]
-    assert ip_values == [ip_values[0]] * len(ip_values)
-    assert du_values == [du_values[0]] * len(du_values)
+    assert ip_values == [ip_values[0]] * len(metrics)
+    assert du_values == [du_values[0]] * len(metrics)
 
     out = tmp_path / "traces.jsonl"
     ret = export_traces.main(["--snapshots", str(tmp_path), "-o", str(out)])
     assert ret == 0
     lines = out.read_text().splitlines()
-    assert len(lines) == 30
+    assert len(lines) == sim.steps_to_run
+
+    log_path = tmp_path / "event_log.jsonl"
+    events = [
+        json.loads(line)
+        for line in log_path.read_text().splitlines()
+        if line.strip() and "beat" in line
+    ]
+    beat_events = [ev["beat"] for ev in events if ev.get("type") == "evaluation"]
+    assert beat_events == beats


### PR DESCRIPTION
## Summary
- mock LLM outputs to cycle through scenario beats
- verify event log beat ordering in signature demo integration test

## Testing
- `ruff check tests/integration/scenario/test_signature_demo.py`
- `pytest tests/integration/scenario/test_signature_demo.py -m "integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4dc4938832696114c7c65d57a6c