### PR TITLE
feat: log and filter misbehavior events

### DIFF
--- a/docs/replay.md
+++ b/docs/replay.md
@@ -28,3 +28,21 @@ python tools/export_traces.py traces.jsonl --start 11 --end 20
 ```
 
 This produces plots and optional replay bundles containing only the selected range of events.
+
+## Logging misbehavior
+
+Misbehavior events can be recorded separately for audit purposes:
+
+```python
+from src.infra import event_log
+
+event_log.log_misbehavior({"step": 42, "detail": "unexpected action"})
+```
+
+These entries include the simulation seed, previous event hash and a trace hash.
+They can be retrieved via `fetch_events`:
+
+```python
+mis = event_log.fetch_events(event_type="misbehavior")
+```
+

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -244,13 +244,27 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
         return event_with_hash
 
 
+def log_misbehavior(event: dict[str, Any]) -> dict[str, Any]:
+    """Log a misbehavior event and record a dedicated span."""
+
+    mis_event = {**event, "type": "misbehavior"}
+    with tracer.start_as_current_span("event_log.misbehavior") as span:
+        span.set_attribute("event.type", "misbehavior")
+        span.set_attribute("step", mis_event.get("step"))
+    return log_event(mis_event)
+
+
 def fetch_events(
     after_step: int = 0,
     *,
     end_step: int | None = None,
     path: str | Path | None = None,
+    event_type: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Retrieve events from the log after ``after_step``."""
+    """Retrieve events from the log after ``after_step``.
+
+    Specify ``event_type`` to return only events of the given type.
+    """
     source = "redpanda" if os.getenv("ENABLE_REDPANDA", "0") == "1" else "file"
     with tracer.start_as_current_span("event_log.fetch_events") as span:
         span.set_attribute("event.source", source)
@@ -260,7 +274,10 @@ def fetch_events(
 
         if source == "file":
             events = list(_iter_file_events(after_step, end_step, path=path))
-            return _filter_events(events, after_step=after_step)
+            events = _filter_events(events, after_step=after_step)
+            if event_type is not None:
+                events = [ev for ev in events if ev.get("type") == event_type]
+            return events
 
         raw_events: list[dict[str, Any]] = []
         consumer: Any | None = None
@@ -290,7 +307,10 @@ def fetch_events(
                     consumer.close()
             except Exception:  # pragma: no cover - ignore
                 pass
-        return _filter_events(raw_events, after_step=after_step)
+        events = _filter_events(raw_events, after_step=after_step)
+        if event_type is not None:
+            events = [ev for ev in events if ev.get("type") == event_type]
+        return events
 
 
 def stream_events(

--- a/tests/unit/infra/test_event_log_misbehavior.py
+++ b/tests/unit/infra/test_event_log_misbehavior.py
@@ -1,0 +1,61 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra.event_log import fetch_events, log_event, log_misbehavior
+
+
+class MockSpan:
+    def __init__(self, name):
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class MockTracer:
+    def __init__(self):
+        self.spans: list[MockSpan] = []
+
+    def start_as_current_span(self, name):
+        span = MockSpan(name)
+        self.spans.append(span)
+        return span
+
+
+@pytest.mark.unit
+def test_log_misbehavior_and_fetch(monkeypatch, tmp_path):
+    tracer = MockTracer()
+    monkeypatch.setattr("src.infra.event_log.tracer", tracer)
+    monkeypatch.setenv("ENABLE_REDPANDA", "0")
+    log_file = tmp_path / "event_log.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
+    monkeypatch.setattr("src.infra.event_log._last_hash", None, raising=False)
+    monkeypatch.setattr("src.infra.event_log._seed", None, raising=False)
+    monkeypatch.setattr("src.infra.event_log._header_written", False, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.checkpoint",
+        SimpleNamespace(capture_rng_state=lambda: {}),
+    )
+
+    log_event({"type": "normal", "step": 1})
+    mis = log_misbehavior({"step": 2, "detail": "bad"})
+    assert mis["type"] == "misbehavior"
+    assert {"seed", "prev_hash", "trace_hash"}.issubset(mis)
+
+    span = next(s for s in tracer.spans if s.name == "event_log.misbehavior")
+    assert span.attributes["event.type"] == "misbehavior"
+    assert span.attributes["step"] == 2
+
+    events = fetch_events(after_step=0, event_type="misbehavior", path=log_file)
+    assert len(events) == 1
+    assert events[0]["type"] == "misbehavior"

--- a/tests/unit/infra/test_event_log_spans.py
+++ b/tests/unit/infra/test_event_log_spans.py
@@ -1,3 +1,6 @@
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from src.infra.event_log import fetch_events, log_event, stream_events
@@ -72,6 +75,11 @@ def test_log_event_tracing(monkeypatch, tmp_path):
     monkeypatch.setenv("ENABLE_REDPANDA", "0")
     log_file = tmp_path / "event_log.jsonl"
     monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.checkpoint",
+        SimpleNamespace(capture_rng_state=lambda: {}),
+    )
 
     event = {"type": "test", "step": 7}
     log_event(event)

--- a/tests/unit/interfaces/test_board_payload_embed.py
+++ b/tests/unit/interfaces/test_board_payload_embed.py
@@ -1,6 +1,5 @@
 import sys
 from types import SimpleNamespace
-from typing import Any
 
 import pytest
 
@@ -14,7 +13,12 @@ from src.interfaces.dashboard_backend import board_payload_to_embed  # noqa: E40
 
 
 @pytest.mark.unit
-def test_board_payload_to_embed(snapshot: Any) -> None:
+def test_board_payload_to_embed() -> None:
     payload = {"agent_id": "agent12345678", "content": "hello", "step": 5}
     embed = board_payload_to_embed(payload)
-    assert embed == snapshot
+    assert embed == {
+        "author": {"name": "Posted by Agent agent123"},
+        "color": 0xFFD700,
+        "description": "```hello```",
+        "title": "📝 New Knowledge Board Entry (Step 5)",
+    }

--- a/tests/unit/interfaces/test_discord_bot.py
+++ b/tests/unit/interfaces/test_discord_bot.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib
 import sys
 from types import SimpleNamespace
+from typing import Callable
 from unittest.mock import AsyncMock
 
 import pytest


### PR DESCRIPTION
## Summary
- add `log_misbehavior` helper that records a dedicated telemetry span
- allow `fetch_events` to filter by event type for misbehavior lookups
- document misbehavior logging and retrieval
- stabilize event log and interface tests by stubbing heavy dependencies and using direct assertions

## Testing
- `ruff check src tests`
- `pytest tests/unit/infra/test_event_log_misbehavior.py tests/unit/infra/test_event_log_spans.py tests/unit/interfaces/test_board_payload_embed.py tests/unit/interfaces/test_discord_bot.py tests/integration/event_log/test_redpanda_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f39cc81083269260e5bca50fa63e