### PR TITLE
feat(event-log): add misbehavior logging

### DIFF
--- a/docs/replay.md
+++ b/docs/replay.md
@@ -40,9 +40,12 @@ event_log.log_misbehavior({"step": 42, "detail": "unexpected action"})
 ```
 
 These entries include the simulation seed, previous event hash and a trace hash.
-They can be retrieved via `fetch_events`:
+They are excluded from normal `fetch_events` results. Retrieve them with
+`event_type="misbehavior"` or include them alongside other events by setting
+`include_misbehavior=True`:
 
 ```python
 mis = event_log.fetch_events(event_type="misbehavior")
+all_events = event_log.fetch_events(include_misbehavior=True)
 ```
 

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -251,7 +251,11 @@ def log_misbehavior(event: dict[str, Any]) -> dict[str, Any]:
     with tracer.start_as_current_span("event_log.misbehavior") as span:
         span.set_attribute("event.type", "misbehavior")
         span.set_attribute("step", mis_event.get("step"))
-    return log_event(mis_event)
+        logged = log_event(mis_event)
+        span.set_attribute("seed", logged.get("seed"))
+        span.set_attribute("prev_hash", logged.get("prev_hash"))
+        span.set_attribute("trace_hash", logged.get("trace_hash"))
+        return logged
 
 
 def fetch_events(
@@ -260,10 +264,13 @@ def fetch_events(
     end_step: int | None = None,
     path: str | Path | None = None,
     event_type: str | None = None,
+    include_misbehavior: bool = False,
 ) -> list[dict[str, Any]]:
     """Retrieve events from the log after ``after_step``.
 
-    Specify ``event_type`` to return only events of the given type.
+    Specify ``event_type`` to return only events of the given type. By default,
+    misbehavior events are filtered out. Set ``include_misbehavior`` to
+    ``True`` to include them in the results.
     """
     source = "redpanda" if os.getenv("ENABLE_REDPANDA", "0") == "1" else "file"
     with tracer.start_as_current_span("event_log.fetch_events") as span:
@@ -277,6 +284,8 @@ def fetch_events(
             events = _filter_events(events, after_step=after_step)
             if event_type is not None:
                 events = [ev for ev in events if ev.get("type") == event_type]
+            elif not include_misbehavior:
+                events = [ev for ev in events if ev.get("type") != "misbehavior"]
             return events
 
         raw_events: list[dict[str, Any]] = []
@@ -310,6 +319,8 @@ def fetch_events(
         events = _filter_events(raw_events, after_step=after_step)
         if event_type is not None:
             events = [ev for ev in events if ev.get("type") == event_type]
+        elif not include_misbehavior:
+            events = [ev for ev in events if ev.get("type") != "misbehavior"]
         return events
 
 

--- a/tests/unit/infra/test_event_log_misbehavior.py
+++ b/tests/unit/infra/test_event_log_misbehavior.py
@@ -55,7 +55,18 @@ def test_log_misbehavior_and_fetch(monkeypatch, tmp_path):
     span = next(s for s in tracer.spans if s.name == "event_log.misbehavior")
     assert span.attributes["event.type"] == "misbehavior"
     assert span.attributes["step"] == 2
+    assert {"seed", "prev_hash", "trace_hash"}.issubset(span.attributes)
 
-    events = fetch_events(after_step=0, event_type="misbehavior", path=log_file)
+    # Misbehavior events are filtered out by default
+    events = fetch_events(after_step=0, path=log_file)
     assert len(events) == 1
-    assert events[0]["type"] == "misbehavior"
+    assert events[0]["type"] == "normal"
+
+    # They can be explicitly included
+    all_events = fetch_events(after_step=0, include_misbehavior=True, path=log_file)
+    assert [ev["type"] for ev in all_events] == ["normal", "misbehavior"]
+
+    # Or filtered directly
+    mis_events = fetch_events(after_step=0, event_type="misbehavior", path=log_file)
+    assert len(mis_events) == 1
+    assert mis_events[0]["type"] == "misbehavior"


### PR DESCRIPTION
## Summary
- add `log_misbehavior` helper that records dedicated telemetry span
- allow `fetch_events` to ignore misbehavior entries by default
- document misbehavior logging and retrieval

## Testing
- `SKIP=mypy,unit-tests python -m pre_commit run --files src/infra/event_log/__init__.py tests/unit/infra/test_event_log_misbehavior.py docs/replay.md`
- `pytest tests/unit/infra/test_event_log_misbehavior.py tests/unit/infra/test_event_log_spans.py`


------
https://chatgpt.com/codex/tasks/task_e_68b733d607a483268536004f1e7293c9