### PR TITLE
feat(discord): log misbehavior events and expose log

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -21,12 +21,13 @@ from opentelemetry import trace
 from typing_extensions import Self
 
 from src.app import spawn_agent_command, start_simulation, stop_simulation
-from src.infra import config
+from src.infra import config, event_log
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
 from src.interfaces import metrics
 from src.interfaces.dashboard_backend import (
     DEFAULT_CONTEXT,
+    SNAPSHOT_DIR,
     AgentMessage,
     SimulationEvent,
 )
@@ -525,9 +526,7 @@ class SimulationDiscordBot:
 
                 @tree.command(name="nudge")
                 @app_commands.describe(prompt="Prompt to nudge the simulation")
-                async def _tree_nudge(
-                    interaction: "discord.Interaction", prompt: str
-                ) -> None:
+                async def _tree_nudge(interaction: "discord.Interaction", prompt: str) -> None:
                     with command_span("nudge", interaction) as span:
                         span.set_attribute("discord.message.length", len(prompt))
                         await self.event_queue.put(
@@ -1139,6 +1138,29 @@ if hasattr(bot.tree, "add_check"):
     bot.tree.add_check(_rate_limit_check)
 
 
+async def record_misbehavior(interaction: Any, agent_id: str, reason: str) -> None:
+    """Record a misbehavior event and capture a replay slice."""
+    bot_instance = get_active_bot()
+    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+    sim = ctx.sim_state.get("simulation")
+    step = int(getattr(sim, "current_step", 0))
+    path: str | None = None
+    try:
+        slice_path = event_log.store_replay_slice(step, step, directory=SNAPSHOT_DIR)
+    except Exception:  # pragma: no cover - best effort
+        slice_path = None
+    if slice_path is not None:
+        path = str(slice_path)
+    event: dict[str, Any] = {"step": step, "agent_id": agent_id, "reason": reason}
+    if path is not None:
+        event["replay_path"] = path
+    try:  # pragma: no cover - best effort
+        event_log.log_misbehavior(event)
+    except Exception:
+        pass
+    await ctx.get_event_queue().put(SimulationEvent(type="misbehavior", data=event))
+    await send_interaction_response(interaction, "misbehavior recorded", ephemeral=True)
+
 
 _MOD_ACTION_COUNTS: dict[str, int] = {}
 _MOD_COOLDOWNS: dict[str, float] = {}
@@ -1292,9 +1314,7 @@ async def slash_nudge(interaction: Any, prompt: str) -> None:
         span.set_attribute("discord.message.length", len(prompt))
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(type="nudge", data={"prompt": prompt})
-        )
+        await ctx.get_event_queue().put(SimulationEvent(type="nudge", data={"prompt": prompt}))
         await send_interaction_response(interaction, "nudge sent", ephemeral=True)
 
 
@@ -1577,3 +1597,19 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
         await send_interaction_response(
             interaction, "Vote cast" if cast else "Vote rejected", ephemeral=True
         )
+
+
+@bot.tree.command(name="misbehavior_log")
+async def slash_misbehavior_log(interaction: Any, limit: int = 20) -> None:
+    """Return last ``limit`` misbehavior events."""
+    events = await asyncio.to_thread(event_log.fetch_events, event_type="misbehavior")
+    events = events[-limit:]
+    lines = []
+    for evt in events:
+        step = evt.get("step")
+        agent = evt.get("agent_id")
+        reason = evt.get("reason")
+        path = evt.get("replay_path")
+        lines.append(f"{step}: {agent} - {reason} ({path})")
+    msg = "\n".join(lines) if lines else "no misbehavior"
+    await send_interaction_response(interaction, msg, ephemeral=True)

--- a/tests/unit/interfaces/test_discord_misbehavior.py
+++ b/tests/unit/interfaces/test_discord_misbehavior.py
@@ -1,0 +1,166 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class DummyContext:
+    def __init__(self) -> None:
+        self.sim_state: dict[str, object] = {}
+        self._event_queue: asyncio.Queue = asyncio.Queue()
+        self._event_queue_loop = None
+        self.message_queue: asyncio.Queue = asyncio.Queue()
+
+    def get_event_queue(self) -> asyncio.Queue:
+        return self._event_queue
+
+
+class DummyBot:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.tree = SimpleNamespace(command=lambda *a, **k: (lambda f: f))
+
+    def command(self, *args: object, **kwargs: object):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def reload_module(monkeypatch: pytest.MonkeyPatch):
+    dummy_commands = SimpleNamespace(Bot=DummyBot)
+
+    class DummyCommandTree:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def command(self, *a: object, **k: object):
+            return lambda f: f
+
+        def add_check(self, *a: object, **k: object) -> None:
+            return None
+
+    dummy_discord = SimpleNamespace(
+        Intents=SimpleNamespace(default=lambda: SimpleNamespace(message_content=True)),
+        Client=object,
+        Embed=lambda *a, **k: None,
+        TextChannel=object,
+        Thread=object,
+        DiscordException=Exception,
+        Color=SimpleNamespace(),
+        app_commands=SimpleNamespace(
+            CommandTree=DummyCommandTree,
+            describe=lambda *a, **k: (lambda f: f),
+        ),
+    )
+
+    dummy_app = SimpleNamespace(
+        spawn_agent_command=AsyncMock(),
+        start_simulation=AsyncMock(),
+        stop_simulation=AsyncMock(),
+    )
+
+    ctx = DummyContext()
+    dummy_db = SimpleNamespace(
+        DEFAULT_CONTEXT=ctx,
+        AgentMessage=SimpleNamespace,
+        SimulationEvent=SimpleNamespace,
+        message_sse_queue=SimpleNamespace(),
+        SNAPSHOT_DIR=Path("/tmp"),
+    )
+
+    store_calls: list[tuple[int, int, Path | None]] = []
+    log_calls: list[dict[str, object]] = []
+    fetch_events_list: list[dict[str, object]] = []
+
+    def store_replay_slice(start: int, end: int, directory: Path | None = None) -> Path:
+        store_calls.append((start, end, directory))
+        directory = directory or Path("/tmp")
+        return directory / f"replay_{start}_{end}.jsonl"
+
+    def log_misbehavior(event: dict[str, object]) -> dict[str, object]:
+        log_calls.append(event)
+        return event
+
+    def fetch_events(event_type: str | None = None):
+        return list(fetch_events_list)
+
+    dummy_event_log = SimpleNamespace(
+        store_replay_slice=store_replay_slice,
+        log_misbehavior=log_misbehavior,
+        fetch_events=fetch_events,
+    )
+
+    monkeypatch.setitem(sys.modules, "src.app", dummy_app)
+    monkeypatch.setitem(
+        sys.modules, "src.infra.config", SimpleNamespace(get_config=lambda *a, **k: None)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.ledger",
+        SimpleNamespace(
+            ledger=SimpleNamespace(get_balance_async=AsyncMock()), log_penalty=lambda *a, **k: None
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "src.interfaces.dashboard_backend", dummy_db)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.interfaces.metrics",
+        SimpleNamespace(get_llm_latency=lambda: 0, get_kb_size=lambda: 0),
+    )
+    monkeypatch.setitem(
+        sys.modules, "src.sim.context", SimpleNamespace(SimulationContext=DummyContext)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "src.utils.policy",
+        SimpleNamespace(allow_message=lambda *a, **k: True, evaluate_with_opa=lambda c: (True, c)),
+    )
+    monkeypatch.setitem(sys.modules, "src.infra.event_log", dummy_event_log)
+    monkeypatch.setitem(sys.modules, "discord", dummy_discord)
+    monkeypatch.setitem(sys.modules, "discord.app_commands", dummy_discord.app_commands)
+    monkeypatch.setitem(sys.modules, "discord.ext", SimpleNamespace(commands=dummy_commands))
+    monkeypatch.setitem(sys.modules, "discord.ext.commands", dummy_commands)
+
+    module = importlib.reload(importlib.import_module("src.interfaces.discord_bot"))
+    return module, ctx, store_calls, log_calls, fetch_events_list
+
+
+@pytest.fixture()
+def discord_module(monkeypatch: pytest.MonkeyPatch):
+    module, ctx, store_calls, log_calls, fetch_events_list = reload_module(monkeypatch)
+    return module, ctx, store_calls, log_calls, fetch_events_list
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_record_misbehavior(discord_module):
+    module, ctx, store_calls, log_calls, _ = discord_module
+    interaction = SimpleNamespace(response=SimpleNamespace(send_message=AsyncMock()))
+    await module.record_misbehavior(interaction, "agent1", "bad")
+    assert store_calls == [(0, 0, module.SNAPSHOT_DIR)]
+    assert log_calls[0]["agent_id"] == "agent1"
+    evt = ctx._event_queue.get_nowait()
+    assert evt.type == "misbehavior"
+    assert evt.data["reason"] == "bad"
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_misbehavior_log(discord_module):
+    module, ctx, store_calls, log_calls, fetch_events_list = discord_module
+    fetch_events_list.extend(
+        [
+            {"step": 1, "agent_id": "a", "reason": "bad", "replay_path": "p1"},
+            {"step": 2, "agent_id": "b", "reason": "worse", "replay_path": "p2"},
+        ]
+    )
+    interaction = SimpleNamespace(response=SimpleNamespace(send_message=AsyncMock()))
+    await module.slash_misbehavior_log(interaction, limit=1)
+    interaction.response.send_message.assert_awaited_once()
+    sent = interaction.response.send_message.call_args[0][0]
+    assert "worse" in sent and "p2" in sent


### PR DESCRIPTION
## Summary
- record misbehavior events via Discord bot and capture replay slice paths
- expose `/misbehavior_log` slash command to view recent misbehavior entries
- cover misbehavior logging with unit tests

## Testing
- `SKIP=unit-tests pre-commit run --files src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_misbehavior.py`
- `pytest tests/unit/interfaces/test_discord_misbehavior.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75b5669f0832687ee5da3759c9643