### PR TITLE
feat: add misbehavior feed endpoint

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,26 @@
+# Dashboard
+
+## Misbehavior feed
+
+The dashboard backend exposes a `GET /api/misbehavior` endpoint for auditing
+misbehavior events. It accepts an optional `limit` query parameter (default
+`20`) to cap the number of returned records; non-positive values yield an empty
+list. Each entry contains:
+
+- `step`: Simulation tick when the event occurred.
+- `detail`: Description of the misbehavior.
+- `replay`: Filename of a replay slice covering the step.
+
+Example response:
+
+```json
+{
+  "events": [
+    {
+      "step": 42,
+      "detail": "unexpected action",
+      "replay": "replay_42_42.jsonl"
+    }
+  ]
+}
+```

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -140,7 +140,7 @@ def get_event_queue(
     ctx: SimulationContext = DEFAULT_CONTEXT,
 ) -> asyncio.Queue[SimulationEvent | None]:
     """Return a shared event queue bound to the active loop."""
-    return ctx.get_event_queue()
+    return cast(asyncio.Queue[SimulationEvent | None], ctx.get_event_queue())
 
 
 # Simulation control state
@@ -762,6 +762,40 @@ async def api_memory_snapshot(step: int) -> Response:
             resp.status_code = 404
         return resp
     resp = JSONResponse(data)
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
+
+
+@app.get("/api/misbehavior")
+async def api_misbehavior(limit: int = 20) -> Response:
+    """Return recent misbehavior events with replay slice paths.
+
+    Args:
+        limit: Maximum number of events to return. Non-positive values yield an
+            empty list.
+    """
+
+    events = await asyncio.to_thread(
+        event_log.fetch_events, event_type="misbehavior"
+    )
+    recent = events[-limit:] if limit > 0 else []
+    items: list[dict[str, Any]] = []
+    for evt in recent:
+        step = int(evt.get("step", evt.get("tick", 0)))
+        detail = str(evt.get("detail", ""))
+        try:
+            slice_path = event_log.store_replay_slice(
+                step, step, directory=SNAPSHOT_DIR
+            )
+            slice_name = slice_path.name
+        except Exception:  # pragma: no cover - best effort
+            slice_name = f"replay_{step}_{step}.jsonl"
+        items.append(
+            {"step": step, "detail": detail, "replay": slice_name}
+        )
+
+    resp = JSONResponse({"events": items})
     if not hasattr(resp, "status_code"):
         resp.status_code = 200
     return resp

--- a/tests/unit/interfaces/test_misbehavior_feed.py
+++ b/tests/unit/interfaces/test_misbehavior_feed.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_misbehavior_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    events = [
+        {"type": "misbehavior", "step": 1, "detail": "bad"},
+        {"type": "misbehavior", "step": 2, "detail": "worse"},
+        {"type": "misbehavior", "step": 3, "detail": "awful"},
+    ]
+
+    monkeypatch.setattr(db.event_log, "fetch_events", lambda *a, **k: events)
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+
+    calls: list[tuple[int, int, Path | None]] = []
+
+    def fake_store(start: int, end: int, directory: Path | None = None) -> Path:
+        calls.append((start, end, directory))
+        return tmp_path / f"replay_{start}_{end}.jsonl"
+
+    monkeypatch.setattr(db.event_log, "store_replay_slice", fake_store)
+
+    resp = await db.api_misbehavior(limit=2)
+    assert json.loads(resp.body) == {
+        "events": [
+            {"step": 2, "detail": "worse", "replay": "replay_2_2.jsonl"},
+            {"step": 3, "detail": "awful", "replay": "replay_3_3.jsonl"},
+        ]
+    }
+    assert calls == [(2, 2, tmp_path), (3, 3, tmp_path)]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_misbehavior_non_positive_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = [{"type": "misbehavior", "step": 1, "detail": "bad"}]
+
+    monkeypatch.setattr(db.event_log, "fetch_events", lambda *a, **k: events)
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+
+    calls: list[tuple[int, int, Path | None]] = []
+
+    def fake_store(start: int, end: int, directory: Path | None = None) -> Path:
+        calls.append((start, end, directory))
+        return tmp_path / f"replay_{start}_{end}.jsonl"
+
+    monkeypatch.setattr(db.event_log, "store_replay_slice", fake_store)
+
+    resp = await db.api_misbehavior(limit=0)
+    assert json.loads(resp.body) == {"events": []}
+    assert calls == []


### PR DESCRIPTION
## Summary
- expose `/api/misbehavior` to stream recent misbehavior events with replay slice references
- document misbehavior feed in dashboard docs and describe `limit` query parameter
- cover endpoint with unit tests, including `limit` edge cases

## Testing
- `ruff check src/interfaces/dashboard_backend.py tests/unit/interfaces/test_misbehavior_feed.py`
- `mypy --follow-imports=skip src/interfaces/dashboard_backend.py`
- `pytest tests/unit/interfaces/test_misbehavior_feed.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75b5705bc8326afef55b4baafda1e