### PR TITLE
feat: expose misbehavior feed endpoint

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,29 @@
+# Dashboard API
+
+## Misbehavior Feed
+
+The dashboard backend exposes `/api/misbehavior` to retrieve recent misbehavior events recorded during simulation runs.
+
+### Endpoint
+
+`GET /api/misbehavior?limit=20`
+
+- `limit` *(optional)*: maximum number of events to return. Defaults to 20.
+
+### Response
+
+```json
+{
+  "events": [
+    {
+      "step": 42,
+      "agent_id": "abc123",
+      "reason": "unauthorized action",
+      "replay_path": "replay_42_42.jsonl"
+    }
+  ]
+}
+```
+
+Each object contains the simulation `step`, the offending `agent_id`, the `reason` for the misbehavior, and a `replay_path` pointing to a replay slice containing events around that step.
+

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -796,6 +796,35 @@ async def api_flagged_messages(limit: int = 20) -> Response:
     return resp
 
 
+@app.get("/api/misbehavior")
+async def api_misbehavior(limit: int = 20) -> Response:
+    """Return misbehavior events with replay slice paths."""
+
+    events = await asyncio.to_thread(event_log.fetch_events, event_type="misbehavior")
+    events = events[-limit:]
+    mis_events: list[dict[str, Any]] = []
+    for evt in events:
+        step = int(evt.get("step", evt.get("tick", 0)))
+        agent_id = str(evt.get("agent_id", ""))
+        reason = str(evt.get("reason", ""))
+        path = evt.get("replay_path")
+        if not isinstance(path, str) or not path:
+            try:
+                slice_path = event_log.store_replay_slice(step, step, directory=SNAPSHOT_DIR)
+                path = str(slice_path)
+            except Exception:  # pragma: no cover - best effort
+                path = ""
+        event_data = {"step": step, "agent_id": agent_id, "reason": reason}
+        if path:
+            event_data["replay_path"] = path
+        mis_events.append(event_data)
+
+    resp = JSONResponse({"events": mis_events})
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
+
+
 async def register_widget(widget: dict[str, Any]) -> Response:
     """Register a widget provided by the UI or a plugin."""
     name = widget.get("name")
@@ -966,6 +995,7 @@ __all__ = [
     "api_memory",
     "api_memory_snapshot",
     "api_memory_snapshots",
+    "api_misbehavior",
     "api_propose_law",
     "api_recent_proposals",
     "api_stake_ip",

--- a/tests/unit/interfaces/test_misbehavior_feed.py
+++ b/tests/unit/interfaces/test_misbehavior_feed.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_misbehavior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    events = [
+        {"step": 1, "agent_id": "a", "reason": "bad"},
+        {"step": 2, "agent_id": "b", "reason": "worse"},
+    ]
+
+    monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(db.event_log, "fetch_events", lambda event_type=None: events)
+
+    calls: list[tuple[int, int, Path | None]] = []
+
+    def fake_store(start: int, end: int, directory: Path | None = None) -> Path:
+        calls.append((start, end, directory))
+        return tmp_path / f"replay_{start}_{end}.jsonl"
+
+    monkeypatch.setattr(db.event_log, "store_replay_slice", fake_store)
+
+    resp = await db.api_misbehavior()
+    assert json.loads(resp.body) == {
+        "events": [
+            {
+                "step": 1,
+                "agent_id": "a",
+                "reason": "bad",
+                "replay_path": str(tmp_path / "replay_1_1.jsonl"),
+            },
+            {
+                "step": 2,
+                "agent_id": "b",
+                "reason": "worse",
+                "replay_path": str(tmp_path / "replay_2_2.jsonl"),
+            },
+        ]
+    }
+    assert calls == [(1, 1, tmp_path), (2, 2, tmp_path)]


### PR DESCRIPTION
## Summary
- add `/api/misbehavior` endpoint to serve recent misbehavior events with replay slice paths
- document misbehavior feed JSON schema
- test misbehavior feed

## Testing
- `ruff format src/interfaces/dashboard_backend.py tests/unit/interfaces/test_misbehavior_feed.py`
- `ruff check src/interfaces/dashboard_backend.py tests/unit/interfaces/test_misbehavior_feed.py`
- `pytest tests/unit/interfaces/test_misbehavior_feed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b842b139d88326959d63c32f6bf9e1