### PR TITLE
feat: add multi-layer retriever node

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -38,7 +38,6 @@ from .graph_nodes import (
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
     retrieve_and_summarize_memories_node,
-    retriever_node,
 )
 from .interaction_handlers import (
     handle_ask_clarification_node,
@@ -51,6 +50,7 @@ from .interaction_handlers import (
     handle_propose_idea_node,
     handle_send_direct_message_node,  # - imported for future use
 )
+from .retriever_node import retriever_node
 
 
 def route_action_intent(state: AgentTurnState) -> str:

--- a/src/agents/graphs/basic_agent_types.py
+++ b/src/agents/graphs/basic_agent_types.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Extra, Field
 from typing_extensions import NotRequired
 
 from src.agents.core.agent_state import AgentState
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 
 
 class AgentActionOutput(BaseModel):
@@ -100,6 +101,8 @@ class AgentTurnState(TypedDict):
     environment_perception: dict[str, object]
     perceived_messages: list[dict[str, object]]
     memory_history_list: list[dict[str, Any]]
+    memory_context: NotRequired[list[str]]
+    memory_retriever: NotRequired[MultiLayerRetriever]
     turn_sentiment_score: int
     prompt_modifier: str
     structured_output: AgentActionOutput | None

--- a/src/agents/graphs/retriever_node.py
+++ b/src/agents/graphs/retriever_node.py
@@ -1,0 +1,56 @@
+"""LangGraph node wrapping ``MultiLayerRetriever.retrieve``."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import tiktoken
+from opentelemetry import trace
+
+from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
+
+from .basic_agent_types import AgentTurnState
+
+tracer = trace.get_tracer(__name__)
+
+
+async def retriever_node(state: AgentTurnState) -> dict[str, Any]:
+    """Retrieve memories while enforcing a per-call token budget.
+
+    The state is expected to provide a ``memory_retriever`` key containing a
+    ``MultiLayerRetriever`` instance. Results are pruned so that the total
+    token count does not exceed ``state['token_budget']`` (when provided).
+    If pruning occurs a ``memory.token_budget_exceeded`` span is emitted.
+    """
+
+    retriever = cast(MultiLayerRetriever | None, state.get("memory_retriever"))
+    if retriever is None:
+        return {"memory_context": [], "memory_history_list": []}
+
+    agent_id = cast(str, state.get("agent_id", ""))
+    query = cast(str, state.get("query", ""))
+    k = cast(int, state.get("k", 5))
+
+    results = await retriever.retrieve(agent_id, query, k)
+
+    token_budget = cast(int | None, state.get("token_budget"))
+    if token_budget is not None:
+        tokenizer = retriever.tokenizer or tiktoken.get_encoding("cl100k_base")
+        tokens = 0
+        limited: list[dict[str, Any]] = []
+        for mem in results:
+            text = str(mem.get("content", ""))
+            t = len(tokenizer.encode(text))
+            if tokens + t > token_budget:
+                with tracer.start_as_current_span("memory.token_budget_exceeded") as span:
+                    span.set_attribute("memory.agent_id", agent_id)
+                    span.set_attribute("memory.token_budget", token_budget)
+                break
+            limited.append(mem)
+            tokens += t
+        results = limited
+
+    return {
+        "memory_history_list": results,
+        "memory_context": [str(m.get("content", "")) for m in results],
+    }

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -767,40 +767,6 @@ async def api_memory_snapshot(step: int) -> Response:
     return resp
 
 
-@app.get("/api/misbehavior")
-async def api_misbehavior(limit: int = 20) -> Response:
-    """Return recent misbehavior events with replay slice paths.
-
-    Args:
-        limit: Maximum number of events to return. Non-positive values yield an
-            empty list.
-    """
-
-    events = await asyncio.to_thread(
-        event_log.fetch_events, event_type="misbehavior"
-    )
-    recent = events[-limit:] if limit > 0 else []
-    items: list[dict[str, Any]] = []
-    for evt in recent:
-        step = int(evt.get("step", evt.get("tick", 0)))
-        detail = str(evt.get("detail", ""))
-        try:
-            slice_path = event_log.store_replay_slice(
-                step, step, directory=SNAPSHOT_DIR
-            )
-            slice_name = slice_path.name
-        except Exception:  # pragma: no cover - best effort
-            slice_name = f"replay_{step}_{step}.jsonl"
-        items.append(
-            {"step": step, "detail": detail, "replay": slice_name}
-        )
-
-    resp = JSONResponse({"events": items})
-    if not hasattr(resp, "status_code"):
-        resp.status_code = 200
-    return resp
-
-
 @app.get("/api/flagged_messages")
 async def api_flagged_messages(limit: int = 20) -> Response:
     """Return flagged messages with snapshot references."""


### PR DESCRIPTION
## Summary
- add LangGraph node wrapping MultiLayerRetriever with token budget enforcement
- extend AgentTurnState with memory context and retriever fields
- plug new retriever node into agent graph builder
- remove duplicate misbehavior endpoint

## Testing
- `SKIP=unit-tests pre-commit run --files src/agents/graphs/retriever_node.py src/agents/graphs/basic_agent_types.py src/agents/graphs/agent_graph_builder.py src/interfaces/dashboard_backend.py`
- `pytest tests/unit/graphs/test_graph_nodes.py::test_retriever_node_merges_and_truncates tests/unit/interfaces/test_misbehavior_feed.py::test_api_misbehavior -q`


------
https://chatgpt.com/codex/tasks/task_e_68b849278ac883269b3c8292424613fc