### PR TITLE
Add signature demo runner script and docs

### DIFF
--- a/docs/scenario_hooks.md
+++ b/docs/scenario_hooks.md
@@ -48,6 +48,15 @@ plotting.
 
 ## Running and replaying `signature_demo`
 
+Run the demo and automatically export its event log and metrics:
+
+```bash
+python scripts/run_signature_demo.py
+```
+
+The script writes `event_log.jsonl` and `metrics.json` to
+`results/signature_demo/`.
+
 1. Run the scenario and generate snapshots and an event log (default
    `event_log.jsonl`):
 

--- a/scripts/run_signature_demo.py
+++ b/scripts/run_signature_demo.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Run the signature_demo scenario and export artifacts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import yaml
+
+from scripts.export_traces import load_metrics
+from src.app import create_simulation
+
+RESULT_DIR = Path("results/signature_demo")
+SCENARIO_PATH = Path("scenarios/signature_demo.yaml")
+
+
+async def main() -> None:
+    """Execute the signature_demo scenario and save outputs."""
+    RESULT_DIR.mkdir(parents=True, exist_ok=True)
+    os.environ["EVENT_LOG_PATH"] = str(RESULT_DIR / "event_log.jsonl")
+
+    with SCENARIO_PATH.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    scenario_desc = data.get("description", "")
+    steps = int(data.get("steps", 0) or 0)
+    num_agents = int(data.get("agents", 3) or 3)
+    beats = data.get("beats") or []
+    eval_hooks = data.get("evaluation_hooks") or []
+
+    sim = create_simulation(
+        num_agents=num_agents,
+        steps=steps,
+        scenario=scenario_desc,
+        beats=beats,
+        seed=42,
+    )
+    if eval_hooks:
+        sim.register_named_evaluation_hooks(list(map(str, eval_hooks)))
+
+    await sim.async_run(steps)
+
+    metrics_path = RESULT_DIR / "metrics.json"
+    metrics = load_metrics(RESULT_DIR / "event_log.jsonl")
+    with metrics_path.open("w", encoding="utf-8") as fh:
+        json.dump(metrics, fh, indent=2)
+
+    print(f"Event log: {RESULT_DIR / 'event_log.jsonl'}")
+    print(f"Metrics: {metrics_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a helper script to run the `signature_demo` scenario and export its event log and metrics
- document how to launch the demo with the new script

## Testing
- `black scripts/run_signature_demo.py`
- `ruff check scripts/run_signature_demo.py`
- `mypy scripts/run_signature_demo.py`
- `python scripts/run_tests.py tests/integration/scenario/test_signature_demo.py` *(no tests run: 1 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c85887c8326877ff0deba957953