### PR TITLE
Allow replay CLI to use logged seed and require tick slice

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -391,7 +391,13 @@ def store_replay_slice(
     dest_dir = Path(directory) if directory is not None else _log_file().parent
     dest_dir.mkdir(parents=True, exist_ok=True)
     out = dest_dir / f"replay_{start_step}_{end_step}.jsonl"
+    seed = get_seed()
     with out.open("w", encoding="utf-8") as fh:
+        header: dict[str, Any] = {"type": "header"}
+        if seed is not None:
+            header["seed"] = seed
+        fh.write(json.dumps(header))
+        fh.write("\n")
         for event in events:
             fh.write(json.dumps(event))
             fh.write("\n")

--- a/tools/replay_cli.py
+++ b/tools/replay_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 
+from src.infra import event_log
 from src.sim.simulation import Simulation
 
 
@@ -16,6 +17,7 @@ def main(argv: list[str] | None = None) -> int:
         "--from",
         dest="start",
         type=int,
+        required=True,
         help="First tick to replay",
     )
     parser.add_argument(
@@ -23,13 +25,22 @@ def main(argv: list[str] | None = None) -> int:
         "--to",
         dest="end",
         type=int,
+        required=True,
         help="Last tick to replay",
     )
-    parser.add_argument("--seed", type=int, help="Override RNG seed")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Override RNG seed (defaults to seed from event log)",
+    )
     args = parser.parse_args(argv)
 
+    seed = args.seed
+    if seed is None:
+        seed = event_log.get_seed()
+
     Simulation.replay_from_snapshot(
-        args.snapshot, start_step=args.start, end_step=args.end, seed=args.seed
+        args.snapshot, start_step=args.start, end_step=args.end, seed=seed
     )
     return 0
 


### PR DESCRIPTION
## Summary
- replay CLI pulls default seed from event log and requires explicit tick range
- event log replay slices embed seed metadata for CLI consumption

## Testing
- `ruff check tools/replay_cli.py src/infra/event_log/__init__.py`
- `mypy tools/replay_cli.py src/infra/event_log/__init__.py`
- `pytest -q` *(fails: AttributeError: module 'pytest_asyncio' has no attribute 'fixture')*


------
https://chatgpt.com/codex/tasks/task_e_68c02d183d5c8326b79cf33cef9091eb