### PR TITLE
feat(memory): add scoring hook for memory storage

### DIFF
--- a/src/agents/memory/memory_service.py
+++ b/src/agents/memory/memory_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 import tiktoken
 from typing_extensions import Self
@@ -25,12 +25,27 @@ class MemoryService:
         semantic_manager: SemanticMemoryManager | None = None,
         level3_manager: Level3SummaryManager | None = None,
         tokenizer: tiktoken.Encoding | None = None,
+        memory_score_threshold: float = 0.0,
+        memory_scorer: Callable[[str, dict[str, Any] | None], float] | None = None,
     ) -> None:
         self.vector_store = vector_store
         self.semantic_manager = semantic_manager
         self.level3_manager = level3_manager
         self.tokenizer = tokenizer or tiktoken.get_encoding("cl100k_base")
         self.retriever = MultiLayerRetriever(vector_store, semantic_manager, self.tokenizer)
+        self.memory_score_threshold = memory_score_threshold
+        self.memory_scorer = memory_scorer or self._default_score_memory
+
+    def _default_score_memory(
+        self: Self, content: str, metadata: dict[str, Any] | None = None
+    ) -> float:
+        return float(len(self.tokenizer.encode(content)))
+
+    def should_store_memory(
+        self: Self, content: str, metadata: dict[str, Any] | None = None
+    ) -> bool:
+        score = self.memory_scorer(content, metadata)
+        return score >= self.memory_score_threshold
 
     def add_memory(
         self: Self,
@@ -42,6 +57,8 @@ class MemoryService:
         metadata: dict[str, Any] | None = None,
     ) -> str:
         if not self.vector_store:
+            return ""
+        if not self.should_store_memory(content, metadata):
             return ""
         with trace_agent_action("memory.add_memory", agent_id=agent_id, event_type=event_type):
             return self.vector_store.add_memory(

--- a/tests/unit/memory/test_memory_score_threshold.py
+++ b/tests/unit/memory/test_memory_score_threshold.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+
+from src.agents.memory.memory_service import MemoryService
+from src.agents.memory.vector_store import ChromaVectorStoreManager
+
+pytest.importorskip("sklearn")
+pytest.importorskip("chromadb")
+
+
+@pytest.mark.unit
+@pytest.mark.memory
+@pytest.mark.usefixtures("chroma_test_dir")
+def test_memory_score_threshold(chroma_test_dir: Path) -> None:
+    vector = ChromaVectorStoreManager(
+        persist_directory=chroma_test_dir,
+        embedding_function=lambda t: [[0.0] for _ in t],
+    )
+
+    def scorer(content: str, metadata: dict | None = None) -> int:
+        return len(content)
+
+    service = MemoryService(
+        vector_store=vector,
+        memory_score_threshold=5,
+        memory_scorer=scorer,
+    )
+
+    low = service.add_memory("agent", 1, "thought", "hi")
+    assert low == ""
+    assert vector.collection.count() == 0
+
+    high = service.add_memory("agent", 2, "thought", "hello world")
+    assert high
+    assert vector.collection.count() == 1


### PR DESCRIPTION
## Summary
- add configurable scoring hook for deciding whether to store a memory
- skip memory storage when score below threshold
- test that low-scoring memories are not persisted

## Testing
- `SKIP=unit-tests pre-commit run --files src/agents/memory/memory_service.py tests/unit/memory/test_memory_score_threshold.py`
- `pytest tests/unit/memory/test_memory_score_threshold.py`

------
https://chatgpt.com/codex/tasks/task_e_68c81dbb92148326b6ff57aec6a64191