### PR TITLE
Record and expose remaining DU budgets

### DIFF
--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -12,6 +12,8 @@ from .ledger import ledger
 _last_du_per_1k_tokens: float = 0.0
 # Track DU-per-1k-tokens per agent for quick lookup
 _agent_du_per_1k_tokens: dict[str, float] = {}
+# Track remaining DU budget per agent
+_agent_du_budget: dict[str, float] = {}
 
 # Keep a rolling window of recent LLM latencies in milliseconds
 _LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
@@ -45,6 +47,19 @@ def get_du_per_1k_tokens() -> float:
 def get_agent_du_per_1k_tokens(agent_id: str) -> float:
     """Return the DU-per-1k-tokens value for ``agent_id``."""
     return float(_agent_du_per_1k_tokens.get(agent_id, 0.0))
+
+
+def record_du_budget(agent_id: str, remaining: float) -> None:
+    """Record the remaining DU budget for ``agent_id``."""
+    remaining_du = float(remaining)
+    _agent_du_budget[agent_id] = remaining_du
+    if hasattr(prom_metrics.AGENT_REMAINING_DU, "labels"):
+        prom_metrics.AGENT_REMAINING_DU.labels(agent_id=agent_id).set(remaining_du)
+
+
+def get_agent_du_budget(agent_id: str) -> float:
+    """Return the remaining DU budget for ``agent_id``."""
+    return float(_agent_du_budget.get(agent_id, 0.0))
 
 
 def record_llm_latency(agent_id: str, latency_ms: float) -> None:
@@ -110,10 +125,12 @@ def get_recall_p5() -> float:
 
 
 __all__ = [
+    "get_agent_du_budget",
     "get_du_per_1k_tokens",
     "get_llm_latency_p95",
     "get_recall_p5",
     "get_retrieval_latency_p95",
+    "record_du_budget",
     "record_du_per_1k_tokens",
     "record_llm_latency",
     "record_recall_p5",

--- a/src/sim/resource_manager.py
+++ b/src/sim/resource_manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from src.infra.metrics import record_du_budget
+
 
 class HasResources(Protocol):
     ip: float
@@ -26,7 +28,9 @@ class ResourceManager:
             obj.du = du_start + self.max_du_per_tick
 
     def set_du_budget(self, agent_id: str, budget: float) -> None:
-        self._du_budgets[agent_id] = float(budget)
+        remaining = float(budget)
+        self._du_budgets[agent_id] = remaining
+        record_du_budget(agent_id, remaining)
 
     def ensure_du_budget(self, agent_id: str, amount: float) -> None:
         """Verify that the agent has at least ``amount`` DU available."""
@@ -44,7 +48,9 @@ class ResourceManager:
     def charge_du(self, agent_id: str, amount: float) -> None:
         self.ensure_du_budget(agent_id, amount)
         remaining = self._du_budgets.get(agent_id, 0.0)
-        self._du_budgets[agent_id] = remaining - amount
+        updated = max(remaining - amount, 0.0)
+        self._du_budgets[agent_id] = updated
+        record_du_budget(agent_id, updated)
 
     def get_du_budget(self, agent_id: str) -> float:
         return float(self._du_budgets.get(agent_id, 0.0))

--- a/tools/export_traces.py
+++ b/tools/export_traces.py
@@ -8,10 +8,14 @@ import json
 import shutil
 import tempfile
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import matplotlib.pyplot as plt
+
+# Optional scenario-level metrics to include when bundling replay artifacts.
+scenario_metrics: dict[str, Any] = {}
 
 
 def iter_events(


### PR DESCRIPTION
## Summary
- add metrics helpers to store and report remaining DU budgets per agent
- update the resource manager to publish budget changes when setting or charging DU
- define a default `scenario_metrics` placeholder so the replay export tool can always write its bundle

## Testing
- ruff check
- pytest -m integration tests/integration/event_log/test_replay_slice.py

------
https://chatgpt.com/codex/tasks/task_e_68c990cc50308326b98e6177c1cef6ab