### PR TITLE
Improve token balances metrics integration

### DIFF
--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
+from typing import Any
 
 from src.interfaces import metrics as prom_metrics
 
@@ -47,6 +48,76 @@ def get_agent_du_per_1k_tokens(agent_id: str) -> float:
     return float(_agent_du_per_1k_tokens.get(agent_id, 0.0))
 
 
+def _get_labeled_gauge_value(gauge: Any, labels: dict[str, str]) -> float | None:
+    """Safely extract a labeled gauge value without mutating its registry."""
+
+    label_names = getattr(gauge, "_labelnames", None)
+    metrics_map = getattr(gauge, "_metrics", None)
+    if label_names and metrics_map:
+        try:
+            key = tuple(labels[name] for name in label_names)
+        except KeyError:
+            key = None
+        else:
+            if key is not None:
+                child = metrics_map.get(key)
+                value_attr = getattr(child, "_value", None) if child is not None else None
+                if value_attr is not None:
+                    try:
+                        return float(value_attr.get())
+                    except Exception:
+                        pass
+
+    if hasattr(gauge, "labels"):
+        try:
+            child = gauge.labels(**labels)
+        except Exception:
+            child = None
+        else:
+            value_attr = getattr(child, "_value", None)
+            if value_attr is not None:
+                try:
+                    return float(value_attr.get())
+                except Exception:
+                    pass
+
+    value_attr = getattr(gauge, "_value", None)
+    if value_attr is not None:
+        try:
+            return float(value_attr.get())
+        except Exception:
+            pass
+    return None
+
+
+def get_agent_du_budget(agent_id: str) -> float:
+    """Return the remaining DU budget tracked for ``agent_id``."""
+
+    manager: Any | None = None
+    try:
+        from src.sim.resource_manager import get_resource_manager
+
+        manager = get_resource_manager()
+    except Exception:
+        manager = None
+
+    if manager is not None:
+        get_budget = getattr(manager, "get_du_budget", None)
+        if callable(get_budget):
+            try:
+                return float(get_budget(agent_id))
+            except Exception:
+                pass
+
+    gauge = getattr(prom_metrics, "AGENT_REMAINING_DU", None)
+    if gauge is not None:
+        value = _get_labeled_gauge_value(gauge, {"agent_id": agent_id})
+        if value is not None:
+            return value
+
+    return 0.0
+
+
 def record_llm_latency(agent_id: str, latency_ms: float) -> None:
     """Record latency for an LLM call and update p95 statistics."""
     prom_metrics.LLM_LATENCY_MS.set(latency_ms)
@@ -64,6 +135,24 @@ def record_llm_latency(agent_id: str, latency_ms: float) -> None:
         prom_metrics.AGENT_LLM_LATENCY_P95_MS.labels(agent_id=agent_id).set(
             ordered_agent[idx_agent]
         )
+
+
+def get_agent_llm_latency_p95(agent_id: str) -> float:
+    """Return the per-agent p95 LLM latency in milliseconds."""
+
+    samples = _LATENCY_SAMPLES_PER_AGENT.get(agent_id)
+    if samples:
+        ordered = sorted(samples)
+        idx = int(0.95 * (len(ordered) - 1))
+        return ordered[idx]
+
+    gauge = getattr(prom_metrics, "AGENT_LLM_LATENCY_P95_MS", None)
+    if gauge is not None:
+        value = _get_labeled_gauge_value(gauge, {"agent_id": agent_id})
+        if value is not None:
+            return value
+
+    return 0.0
 
 
 def record_retrieval_latency(latency_ms: float) -> None:
@@ -110,6 +199,8 @@ def get_recall_p5() -> float:
 
 
 __all__ = [
+    "get_agent_du_budget",
+    "get_agent_llm_latency_p95",
     "get_du_per_1k_tokens",
     "get_llm_latency_p95",
     "get_recall_p5",

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -691,6 +691,11 @@ async def api_token_balances() -> Response:
         for agent_id, token, amount in cur.fetchall():
             agent = balances.setdefault(agent_id, {"ip": 0.0, "du": 0.0, "tokens": {}})
             agent["tokens"][token] = int(amount)
+        for agent_id, agent in balances.items():
+            agent["remaining_du_budget"] = infra_metrics.get_agent_du_budget(agent_id)
+            agent["llm_latency_p95_ms"] = infra_metrics.get_agent_llm_latency_p95(
+                agent_id
+            )
         return balances
 
     agents = await asyncio.to_thread(_load)

--- a/tests/integration/interfaces/test_dashboard_backend_api.py
+++ b/tests/integration/interfaces/test_dashboard_backend_api.py
@@ -201,6 +201,51 @@ async def test_websocket_events() -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_token_balances_includes_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.interfaces import dashboard_backend as db
+
+    class _Cursor:
+        def __init__(self, rows: list[tuple[object, ...]]) -> None:
+            self._rows = rows
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return list(self._rows)
+
+    class _Conn:
+        def execute(self, query: str, params: tuple[object, ...] = ()) -> _Cursor:
+            if "FROM agent_balances" in query:
+                return _Cursor([("agent-1", 1.0, 2.0)])
+            if "FROM agent_tokens" in query:
+                return _Cursor([("agent-1", "token-a", 3)])
+            raise AssertionError(f"Unexpected query: {query}")
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_budget(agent_id: str) -> float:
+        calls.append(("budget", agent_id))
+        return 7.5
+
+    def fake_latency(agent_id: str) -> float:
+        calls.append(("latency", agent_id))
+        return 123.4
+
+    monkeypatch.setattr(db.ledger, "conn", _Conn(), raising=False)
+    monkeypatch.setattr(db.infra_metrics, "get_agent_du_budget", fake_budget)
+    monkeypatch.setattr(db.infra_metrics, "get_agent_llm_latency_p95", fake_latency)
+
+    resp = await db.api_token_balances()
+    payload = json.loads(resp.body)
+
+    agent = payload["agents"]["agent-1"]
+    assert agent["remaining_du_budget"] == pytest.approx(7.5)
+    assert agent["llm_latency_p95_ms"] == pytest.approx(123.4)
+    assert agent["tokens"]["token-a"] == 3
+    assert ("budget", "agent-1") in calls
+    assert ("latency", "agent-1") in calls
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_message_queue_overflow(monkeypatch: pytest.MonkeyPatch) -> None:
     import asyncio
 

--- a/tests/unit/infra/test_metrics_helpers.py
+++ b/tests/unit/infra/test_metrics_helpers.py
@@ -1,0 +1,99 @@
+import pytest
+
+from collections import deque
+from types import SimpleNamespace
+
+from src.infra import metrics as infra_metrics
+import src.sim.resource_manager as resource_manager_mod
+
+
+class GaugeChildStub:
+    def __init__(self, value: float) -> None:
+        self._value = SimpleNamespace(get=lambda: value)
+
+
+class GaugeStub:
+    def __init__(self, mapping: dict[tuple[str, ...], float]) -> None:
+        self._metrics = {
+            key: GaugeChildStub(val) for key, val in mapping.items()
+        }
+        self._labelnames = ("agent_id",)
+
+    def labels(self, **labels: str) -> GaugeChildStub:
+        key = tuple(labels.get(name) for name in self._labelnames)
+        if key not in self._metrics:
+            self._metrics[key] = GaugeChildStub(0.0)
+        return self._metrics[key]
+
+
+@pytest.mark.unit
+def test_get_agent_du_budget_prefers_resource_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyManager:
+        def get_du_budget(self, agent_id: str) -> float:
+            assert agent_id == "agent-1"
+            return 42.5
+
+    manager = DummyManager()
+    monkeypatch.setattr(resource_manager_mod, "_resource_manager", manager)
+    monkeypatch.setattr(resource_manager_mod, "get_resource_manager", lambda: manager)
+    monkeypatch.setattr(
+        infra_metrics.prom_metrics,
+        "AGENT_REMAINING_DU",
+        GaugeStub({("agent-1",): 7.0}),
+        raising=False,
+    )
+
+    assert infra_metrics.get_agent_du_budget("agent-1") == pytest.approx(42.5)
+
+
+@pytest.mark.unit
+def test_get_agent_du_budget_falls_back_to_gauge(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> resource_manager_mod.ResourceManager:
+        raise RuntimeError("no manager")
+
+    monkeypatch.setattr(resource_manager_mod, "_resource_manager", None)
+    monkeypatch.setattr(resource_manager_mod, "get_resource_manager", boom)
+    monkeypatch.setattr(
+        infra_metrics.prom_metrics,
+        "AGENT_REMAINING_DU",
+        GaugeStub({("agent-2",): 13.37}),
+        raising=False,
+    )
+
+    assert infra_metrics.get_agent_du_budget("agent-2") == pytest.approx(13.37)
+
+
+@pytest.mark.unit
+def test_get_agent_llm_latency_p95_prefers_samples(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        infra_metrics,
+        "_LATENCY_SAMPLES_PER_AGENT",
+        {"agent-3": deque([10.0, 20.0, 30.0], maxlen=100)},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        infra_metrics.prom_metrics,
+        "AGENT_LLM_LATENCY_P95_MS",
+        GaugeStub({("agent-3",): 99.0}),
+        raising=False,
+    )
+
+    assert infra_metrics.get_agent_llm_latency_p95("agent-3") == pytest.approx(20.0)
+
+
+@pytest.mark.unit
+def test_get_agent_llm_latency_p95_falls_back_to_gauge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        infra_metrics,
+        "_LATENCY_SAMPLES_PER_AGENT",
+        {},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        infra_metrics.prom_metrics,
+        "AGENT_LLM_LATENCY_P95_MS",
+        GaugeStub({("agent-4",): 55.5}),
+        raising=False,
+    )
+
+    assert infra_metrics.get_agent_llm_latency_p95("agent-4") == pytest.approx(55.5)


### PR DESCRIPTION
## Summary
- add a helper in `infra.metrics` that reads labeled Prometheus gauges safely and expose per-agent LLM latency p95 values
- update `/api/token_balances` to source latency metrics through the new helper instead of touching gauges directly
- extend integration and unit coverage to lock down the new metrics plumbing

## Testing
- ruff check --no-fix src
- pytest tests/unit/infra/test_metrics_helpers.py -q
- pytest tests/integration/interfaces/test_dashboard_backend_api.py::test_token_balances_includes_metrics -m "integration" -q

------
https://chatgpt.com/codex/tasks/task_e_68c990cbad888326bedc408804020e69