### PR TITLE
Extend observability metrics payload

### DIFF
--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -80,8 +80,17 @@ export async function registerWidgetBackend(widget: WidgetRegistration): Promise
 export interface ObservabilityMetrics {
   du_per_1k_tokens: number
   llm_latency_p95_ms: number
-  agent_du_per_1k_tokens: Record<string, number>
-  agent_llm_latency_p95_ms: Record<string, number>
+  coalition_count: number
+  average_sentiment: number
+  rag_hit_rate: number
+  memory_retrievals_total: number
+  memory_retrieval_errors_total: number
+  memory_retrieval_success_rate: number
+  memory_retrieval_error_rate: number
+  llm_errors_total: number
+  llm_error_rate: number
+  agent_du_per_1k_tokens?: Record<string, number>
+  agent_llm_latency_p95_ms?: Record<string, number>
 }
 
 export async function fetchObservabilityMetrics(): Promise<ObservabilityMetrics> {
@@ -93,6 +102,15 @@ export async function displayObservabilityMetrics(): Promise<void> {
   const metrics = await fetchObservabilityMetrics()
   console.log('DU/1k tokens:', metrics.du_per_1k_tokens)
   console.log('p95 latency (ms):', metrics.llm_latency_p95_ms)
+  console.log('Coalitions:', metrics.coalition_count)
+  console.log('Average sentiment:', metrics.average_sentiment)
+  console.log('RAG hit rate:', metrics.rag_hit_rate)
+  console.log('Memory retrievals (total):', metrics.memory_retrievals_total)
+  console.log('Memory retrieval errors (total):', metrics.memory_retrieval_errors_total)
+  console.log('Memory retrieval success rate:', metrics.memory_retrieval_success_rate)
+  console.log('Memory retrieval error rate:', metrics.memory_retrieval_error_rate)
+  console.log('LLM errors (total):', metrics.llm_errors_total)
+  console.log('LLM error rate:', metrics.llm_error_rate)
   console.log('Agent DU/1k tokens:', metrics.agent_du_per_1k_tokens)
   console.log('Agent p95 latency (ms):', metrics.agent_llm_latency_p95_ms)
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,12 +73,38 @@ to alert when budgets run low or spike unexpectedly.
 ### Dashboard Cost Metrics Endpoint
 
 The dashboard backend provides `/api/observability_metrics` for quick visibility into
-LLM usage. The endpoint returns:
+LLM usage, coalition dynamics, and retrieval health. Example response:
+
+```json
+{
+  "du_per_1k_tokens": 1.8,
+  "llm_latency_p95_ms": 450.0,
+  "coalition_count": 4,
+  "average_sentiment": 0.37,
+  "rag_hit_rate": 0.82,
+  "memory_retrievals_total": 120,
+  "memory_retrieval_errors_total": 6,
+  "memory_retrieval_success_rate": 0.95,
+  "memory_retrieval_error_rate": 0.05,
+  "llm_errors_total": 3,
+  "llm_error_rate": 0.02
+}
+```
 
 - `du_per_1k_tokens` – average digital units spent per 1,000 tokens. Lower values
   indicate more efficient usage of the DU budget.
 - `llm_latency_p95_ms` – 95th percentile latency of recent LLM calls in milliseconds,
   useful for spotting tail latency issues.
+- `coalition_count` – number of active coalitions discovered in the simulation.
+- `average_sentiment` – current aggregate sentiment across agents.
+- `rag_hit_rate` – most recent hit rate for Retrieval Augmented Generation (RAG)
+  lookups.
+- `memory_retrievals_total` and `memory_retrieval_errors_total` – cumulative counts of
+  successful and failed memory retrievals, respectively.
+- `memory_retrieval_success_rate` and `memory_retrieval_error_rate` – derived ratios of
+  successful and failed retrievals.
+- `llm_errors_total` – total failed LLM calls captured by the monitoring decorator.
+- `llm_error_rate` – share of failed LLM calls relative to total LLM traffic.
 
 These metrics can be fetched directly by the UI or external monitoring systems.
 

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -465,9 +465,7 @@ async def api_agent_stats() -> Response:
             du_per_1k = infra_metrics.get_agent_du_per_1k_tokens(ag.agent_id)
             try:
                 llm_latency_p95 = float(
-                    metrics.AGENT_LLM_LATENCY_P95_MS.labels(
-                        agent_id=ag.agent_id
-                    )._value.get()  # type: ignore[attr-defined]
+                    metrics.AGENT_LLM_LATENCY_P95_MS.labels(agent_id=ag.agent_id)._value.get()  # type: ignore[attr-defined]
                 )
             except Exception:  # pragma: no cover - defensive
                 llm_latency_p95 = 0.0
@@ -693,21 +691,42 @@ async def api_token_balances() -> Response:
             agent["tokens"][token] = int(amount)
         for agent_id, agent in balances.items():
             agent["remaining_du_budget"] = infra_metrics.get_agent_du_budget(agent_id)
-            agent["llm_latency_p95_ms"] = infra_metrics.get_agent_llm_latency_p95(
-                agent_id
-            )
+            agent["llm_latency_p95_ms"] = infra_metrics.get_agent_llm_latency_p95(agent_id)
         return balances
 
     agents = await asyncio.to_thread(_load)
     return JSONResponse({"agents": agents})
 
 
-def _cost_metrics_data() -> dict[str, float]:
-    """Collect DU cost and latency metrics."""
+def _cost_metrics_data() -> dict[str, float | int]:
+    """Collect DU cost, sentiment, and reliability metrics for dashboards."""
+
+    memory_retrievals = metrics.get_memory_retrievals()
+    memory_retrieval_errors = metrics.get_memory_retrieval_errors()
+    memory_retrieval_attempts = memory_retrievals + memory_retrieval_errors
+    memory_success_rate = (
+        memory_retrievals / memory_retrieval_attempts if memory_retrieval_attempts else 0.0
+    )
+    memory_error_rate = (
+        memory_retrieval_errors / memory_retrieval_attempts if memory_retrieval_attempts else 0.0
+    )
+
+    llm_errors_total = metrics.get_llm_errors_total()
+    llm_calls_total = metrics.get_llm_calls_total()
+    llm_error_rate = llm_errors_total / llm_calls_total if llm_calls_total else 0.0
 
     return {
         "du_per_1k_tokens": metrics.get_du_per_1k_tokens(),
         "llm_latency_p95_ms": metrics.get_llm_latency_p95(),
+        "coalition_count": metrics.get_coalition_count(),
+        "average_sentiment": metrics.get_average_sentiment(),
+        "rag_hit_rate": metrics.get_rag_hit_rate(),
+        "memory_retrievals_total": memory_retrievals,
+        "memory_retrieval_errors_total": memory_retrieval_errors,
+        "memory_retrieval_success_rate": memory_success_rate,
+        "memory_retrieval_error_rate": memory_error_rate,
+        "llm_errors_total": llm_errors_total,
+        "llm_error_rate": llm_error_rate,
     }
 
 

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -116,6 +116,16 @@ def get_llm_latency_p95() -> float:
     return float(LLM_LATENCY_P95_MS._value.get())
 
 
+def get_llm_calls_total() -> int:
+    """Return the total number of LLM calls recorded."""
+    return int(LLM_CALLS_TOTAL._value.get())
+
+
+def get_llm_errors_total() -> int:
+    """Return the total number of failed LLM calls."""
+    return int(LLM_ERRORS_TOTAL._value.get())
+
+
 def get_kb_size() -> int:
     """Return the current Knowledge Board size."""
     return int(KNOWLEDGE_BOARD_SIZE._value.get())
@@ -223,6 +233,8 @@ __all__ = [
     "get_gas_price_per_token",
     "get_human_messages",
     "get_kb_size",
+    "get_llm_calls_total",
+    "get_llm_errors_total",
     "get_llm_latency",
     "get_llm_latency_p95",
     "get_memory_retrieval_errors",

--- a/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
+++ b/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
@@ -1,0 +1,80 @@
+import json
+import sys
+import types
+
+import pytest
+
+from tests.unit.interfaces.test_dashboard_backend_control import load_dashboard_backend
+
+
+def _prepare_dashboard_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    if "src.sim.resource_manager" not in sys.modules:
+        resource_manager = types.ModuleType("src.sim.resource_manager")
+        resource_manager.get_resource_manager = lambda: None
+        monkeypatch.setitem(sys.modules, "src.sim.resource_manager", resource_manager)
+
+
+def _patch_metrics(db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db.metrics, "get_du_per_1k_tokens", lambda: 1.5)
+    monkeypatch.setattr(db.metrics, "get_llm_latency_p95", lambda: 450.0)
+    monkeypatch.setattr(db.metrics, "get_coalition_count", lambda: 3)
+    monkeypatch.setattr(db.metrics, "get_average_sentiment", lambda: 0.42)
+    monkeypatch.setattr(db.metrics, "get_rag_hit_rate", lambda: 0.85)
+    monkeypatch.setattr(db.metrics, "get_memory_retrievals", lambda: 80)
+    monkeypatch.setattr(db.metrics, "get_memory_retrieval_errors", lambda: 20)
+    monkeypatch.setattr(db.metrics, "get_llm_errors_total", lambda: 5)
+    monkeypatch.setattr(db.metrics, "get_llm_calls_total", lambda: 50)
+
+
+@pytest.mark.unit
+def test_cost_metrics_data_includes_observability_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_dashboard_backend(monkeypatch)
+    db = load_dashboard_backend()
+    _patch_metrics(db, monkeypatch)
+
+    payload = db._cost_metrics_data()
+
+    assert payload["du_per_1k_tokens"] == 1.5
+    assert payload["llm_latency_p95_ms"] == 450.0
+    assert payload["coalition_count"] == 3
+    assert payload["average_sentiment"] == 0.42
+    assert payload["rag_hit_rate"] == 0.85
+    assert payload["memory_retrievals_total"] == 80
+    assert payload["memory_retrieval_errors_total"] == 20
+    assert pytest.approx(payload["memory_retrieval_success_rate"]) == 0.8
+    assert pytest.approx(payload["memory_retrieval_error_rate"]) == 0.2
+    assert payload["llm_errors_total"] == 5
+    assert pytest.approx(payload["llm_error_rate"]) == 0.1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_observability_metrics_serializes_extended_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_dashboard_backend(monkeypatch)
+    db = load_dashboard_backend()
+    _patch_metrics(db, monkeypatch)
+
+    resp = await db.api_observability_metrics()
+    payload = json.loads(resp.body)
+
+    expected_keys = {
+        "du_per_1k_tokens",
+        "llm_latency_p95_ms",
+        "coalition_count",
+        "average_sentiment",
+        "rag_hit_rate",
+        "memory_retrievals_total",
+        "memory_retrieval_errors_total",
+        "memory_retrieval_success_rate",
+        "memory_retrieval_error_rate",
+        "llm_errors_total",
+        "llm_error_rate",
+    }
+
+    assert expected_keys.issubset(payload.keys())
+    assert payload["memory_retrieval_errors_total"] == 20
+    assert payload["llm_errors_total"] == 5


### PR DESCRIPTION
## Summary
- add sentiment, coalition, retrieval, and error metrics to the dashboard observability payload
- expose new helpers for LLM counters, update UI typings/logging, and refresh documentation
- add unit tests that validate the enriched observability response

## Testing
- pytest tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
- ruff check --no-fix src/interfaces/dashboard_backend.py src/interfaces/metrics.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cd650f727c8326a9d558d8046b1f33