### PR TITLE
Rehydrate event log hash chain after restart

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -124,6 +124,59 @@ def _ensure_header(path: str | Path | None = None) -> None:
         pass
 
 
+def _rehydrate_last_hash(path: Path) -> None:
+    """Populate ``_last_hash`` from the most recent event on disk."""
+
+    global _last_hash
+    if _last_hash is not None or not path.exists():
+        return
+    try:  # pragma: no cover - best effort
+        with path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            pos = fh.tell()
+            if pos <= 0:
+                return
+            buffer = bytearray()
+            while pos > 0:
+                pos -= 1
+                fh.seek(pos)
+                char = fh.read(1)
+                if char == b"\n":
+                    if not buffer:
+                        continue
+                    line_bytes = bytes(reversed(buffer)).strip()
+                    buffer.clear()
+                    if not line_bytes:
+                        continue
+                    try:
+                        line = line_bytes.decode("utf-8")
+                        event = json.loads(line)
+                    except Exception:
+                        continue
+                    if isinstance(event, dict) and event.get("type") != "header":
+                        last_hash = event.get("trace_hash")
+                        if isinstance(last_hash, str):
+                            _last_hash = last_hash
+                        return
+                    continue
+                buffer.append(char[0])
+            if buffer:
+                line_bytes = bytes(reversed(buffer)).strip()
+                if not line_bytes:
+                    return
+                try:
+                    line = line_bytes.decode("utf-8")
+                    event = json.loads(line)
+                except Exception:
+                    return
+                if isinstance(event, dict) and event.get("type") != "header":
+                    last_hash = event.get("trace_hash")
+                    if isinstance(last_hash, str):
+                        _last_hash = last_hash
+    except Exception:
+        pass
+
+
 def _is_valid_event(event: dict[str, Any], last_step: int, last_hash: str | None) -> bool:
     """Check ``event`` ordering and integrity."""
     step = event.get("step", 0)
@@ -200,6 +253,7 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
 
         path = _log_file()
         span.set_attribute("log.file_path", str(path))
+        _rehydrate_last_hash(path)
 
         if "trace_hash" in event:
             event = {**event}

--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -120,6 +120,31 @@ def get_agent_du_budget(agent_id: str) -> float:
     return 0.0
 
 
+def record_du_budget(agent_id: str, remaining: float) -> None:
+    """Record remaining DU budget for ``agent_id`` to metrics backends."""
+
+    remaining = float(remaining)
+    _agent_du_budget[agent_id] = remaining
+    gauge = getattr(prom_metrics, "AGENT_REMAINING_DU", None)
+    if gauge is not None:
+        if hasattr(gauge, "labels"):
+            try:
+                gauge.labels(agent_id=agent_id).set(remaining)
+            except Exception:
+                try:
+                    gauge.set(remaining)
+                except Exception:
+                    pass
+        else:
+            try:
+                gauge.set(remaining)
+            except Exception:
+                pass
+    try:  # pragma: no cover - optional dependency
+        ledger.record_du_budget(agent_id, remaining)
+    except Exception:
+        pass
+
 
 def record_llm_latency(agent_id: str, latency_ms: float) -> None:
     """Record latency for an LLM call and update p95 statistics."""


### PR DESCRIPTION
## Summary
- hydrate the cached event log hash from the latest on-disk entry before appending new events so prev_hash links survive restarts
- invoke the new hydration step during event logging to keep the hash chain intact for subsequent writes
- add the missing metrics.record_du_budget helper used by the resource manager so imports succeed during tests

## Testing
- pytest tests/integration/event_log/test_replay_slice_determinism.py tests/integration/test_seed_replay.py *(2 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68d147d9ec0c83269ed122a783a3f20a