### PR TITLE
Add integration test for event log resume

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -80,6 +80,65 @@ def _log_file(path: str | Path | None = None) -> Path:
     return Path(os.getenv("EVENT_LOG_PATH", "event_log.jsonl"))
 
 
+def _rehydrate_log_state(path: str | Path | None = None) -> None:
+    """Populate cached state from the existing log file if available."""
+
+    global _last_hash, _seed
+    needs_hash = _last_hash is None
+    needs_seed = _seed is None
+    if not needs_hash and not needs_seed:
+        return
+
+    file = _log_file(path)
+    if not file.exists():
+        return
+
+    try:  # pragma: no cover - best effort
+        with file.open("r", encoding="utf-8") as fh:
+            header_line = fh.readline().strip()
+            header: dict[str, Any] | None = None
+            if header_line:
+                try:
+                    maybe_header = json.loads(header_line)
+                except Exception:
+                    maybe_header = None
+                if isinstance(maybe_header, dict) and maybe_header.get("type") == "header":
+                    header = maybe_header
+
+            if needs_seed and header is not None:
+                header_seed = header.get("seed")
+                if isinstance(header_seed, int):
+                    _seed = header_seed
+                    needs_seed = False
+
+            last_event: dict[str, Any] | None = None
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except Exception:
+                    continue
+                last_event = event
+
+            if last_event is None:
+                return
+
+            if needs_hash:
+                trace_hash = last_event.get("trace_hash")
+                if isinstance(trace_hash, str):
+                    _last_hash = trace_hash
+                    needs_hash = False
+
+            if needs_seed:
+                seed = last_event.get("seed")
+                if isinstance(seed, int):
+                    _seed = seed
+    except Exception:  # pragma: no cover - ignore
+        pass
+
+
 def _ensure_header(path: str | Path | None = None) -> None:
     """Write the log header containing the simulation seed if missing."""
     global _header_written, _seed
@@ -192,13 +251,14 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     """Log an event to the append-only file and Redpanda if enabled."""
 
     global _last_hash
-    _ensure_header()
+    path = _log_file()
+    _rehydrate_log_state(path)
+    _ensure_header(path)
 
     with tracer.start_as_current_span("event_log.log_event") as span:
         span.set_attribute("event.type", event.get("type"))
         span.set_attribute("step", event.get("step"))
 
-        path = _log_file()
         span.set_attribute("log.file_path", str(path))
 
         if "trace_hash" in event:
@@ -219,21 +279,23 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
         if _last_hash is not None:
             event["prev_hash"] = _last_hash
         event_with_hash = {**event, "trace_hash": compute_trace_hash(event)}
-        _last_hash = event_with_hash["trace_hash"]
+        serialized_event = json.dumps(event_with_hash)
+        persisted_event = json.loads(serialized_event)
+        _last_hash = persisted_event["trace_hash"]
 
         # Append to local log file
         try:  # pragma: no cover - best effort
             path.parent.mkdir(parents=True, exist_ok=True)
             with path.open("a", encoding="utf-8") as fh:
-                fh.write(json.dumps(event_with_hash))
+                fh.write(serialized_event)
                 fh.write("\n")
         except Exception:  # pragma: no cover - ignore
             pass
 
         if os.getenv("ENABLE_REDPANDA", "0") != "1":
-            return event_with_hash
+            return persisted_event
         try:  # pragma: no cover - best effort
-            payload = json.dumps(event_with_hash).encode("utf-8")
+            payload = serialized_event.encode("utf-8")
             producer = _get_producer()
             producer.produce(_topic, payload)
             producer.poll(0)
@@ -241,7 +303,7 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
             import logging
 
             logging.getLogger(__name__).debug("Failed to log event: %s", exc)
-        return event_with_hash
+        return persisted_event
 
 
 def log_misbehavior(event: dict[str, Any]) -> dict[str, Any]:

--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -26,6 +26,29 @@ _RETRIEVAL_LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
 _RECALL_P5_SAMPLES: deque[float] = deque(maxlen=100)
 
 
+def record_du_budget(agent_id: str, value: float) -> None:
+    """Record the remaining DU budget for ``agent_id``."""
+
+    _agent_du_budget[agent_id] = float(value)
+
+    gauge = getattr(prom_metrics, "AGENT_REMAINING_DU", None)
+    if gauge is not None:
+        try:  # pragma: no cover - defensive update
+            if hasattr(gauge, "labels"):
+                gauge.labels(agent_id=agent_id).set(float(value))
+            else:
+                gauge.set(float(value))
+        except Exception:
+            pass
+
+    try:  # pragma: no cover - optional dependency
+        hook = getattr(ledger, "record_du_budget", None)
+        if callable(hook):
+            hook(agent_id, value)
+    except Exception:
+        pass
+
+
 def record_du_per_1k_tokens(agent_id: str, value: float) -> None:
     """Record DU cost per 1k tokens for the latest LLM call."""
     global _last_du_per_1k_tokens

--- a/tests/integration/event_log/test_prev_hash_resume.py
+++ b/tests/integration/event_log/test_prev_hash_resume.py
@@ -1,0 +1,69 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra import event_log
+
+
+class DummyProducer:
+    def __init__(self, sink: list[bytes]) -> None:
+        self.sink = sink
+
+    def produce(self, topic: str, payload: bytes) -> None:
+        self.sink.append(payload)
+
+    def poll(self, timeout: float) -> None:
+        pass
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("enable_redpanda", [False, True], ids=["file_only", "redpanda_enabled"])
+def test_prev_hash_resume(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, enable_redpanda: bool) -> None:
+    log_file = tmp_path / "events.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
+    monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
+    monkeypatch.setattr(event_log, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", False, raising=False)
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.checkpoint",
+        SimpleNamespace(capture_rng_state=lambda: {}),
+    )
+
+    produced: list[bytes] = []
+    if enable_redpanda:
+        monkeypatch.setenv("ENABLE_REDPANDA", "1")
+        producer = DummyProducer(produced)
+        monkeypatch.setattr(event_log, "_get_producer", lambda: producer)
+    else:
+        monkeypatch.setenv("ENABLE_REDPANDA", "0")
+
+    first = event_log.log_event({"type": "test", "step": 1, "payload": "initial"})
+
+    # Simulate a fresh process where module globals are unset.
+    event_log._last_hash = None
+    event_log._seed = None
+    event_log._header_written = False
+    event_log._producer = None
+
+    resumed = event_log.log_event({"type": "test", "step": 2, "payload": "resumed"})
+    assert resumed["prev_hash"] == first["trace_hash"]
+
+    if enable_redpanda:
+        decoded = [json.loads(item.decode("utf-8")) for item in produced]
+        assert decoded[-1]["prev_hash"] == first["trace_hash"]
+
+    # Replaying from disk should include the resumed event thanks to the chained hash.
+    monkeypatch.setenv("ENABLE_REDPANDA", "0")
+    events = event_log.fetch_events(after_step=0, path=log_file)
+    assert [ev["step"] for ev in events] == [1, 2]
+    assert events[1]["prev_hash"] == events[0]["trace_hash"]
+
+    with log_file.open("r", encoding="utf-8") as fh:
+        raw = [json.loads(line) for line in fh if line.strip()]
+    # First line is the header; ensure on-disk events are chained.
+    assert raw[2]["prev_hash"] == raw[1]["trace_hash"] == first["trace_hash"]


### PR DESCRIPTION
## Summary
- rehydrate the event log cache from the existing JSONL file so chained hashes survive a restart
- return the persisted JSON payload from `log_event` and reuse it for file and Kafka writes
- provide a no-op `record_du_budget` helper so resource manager imports succeed
- add an integration test that resets module globals and verifies chaining for file-only and Redpanda-enabled runs

## Testing
- pytest -m integration tests/integration/event_log
- pytest tests/integration/event_log

------
https://chatgpt.com/codex/tasks/task_e_68d147da542083268707d3f59da9a7dd