### PR TITLE
Summarize signature demo evaluation target compliance

### DIFF
--- a/docs/scenario_hooks.md
+++ b/docs/scenario_hooks.md
@@ -2,7 +2,8 @@
 
 Scenario files may register evaluation hooks that gather metrics during a
 simulation run. Add the desired hooks under the `evaluation_hooks` key in the
-scenario YAML:
+scenario YAML and, optionally, describe the intended outcomes in
+`success_metrics` and `evaluation_targets`:
 
 ```yaml
 name: signature_demo
@@ -11,6 +12,15 @@ beats:
   - introduction
   - collaboration
   - resolution
+success_metrics:
+  coalition_count:
+    target_max: 1
+    explanation: Keep the group aligned on a single coalition.
+  sentiment_curve:
+    expected_trend:
+      introduction: 0.05
+      collaboration: 0.00
+      resolution: 0.10
 evaluation_hooks:
   - coalitions
   - sentiment
@@ -35,7 +45,8 @@ The following built-in hooks are available:
 ## Evaluation targets
 
 Use the optional `evaluation_targets` block to declare bounds for each metric. These
-targets help flag runs that deviate from expected group dynamics.
+targets help flag runs that deviate from expected group dynamics. The values are
+interpreted alongside the telemetry emitted by the corresponding evaluation hook.
 
 | Hook       | Target field    | Description |
 |------------|-----------------|-------------|
@@ -44,7 +55,30 @@ targets help flag runs that deviate from expected group dynamics.
 
 Results from each hook are recorded in the metrics registry and written to the
 simulation event log at the end of every beat, enabling downstream analysis or
-plotting.
+plotting. The `success_metrics` block offers narrative guidance for scenario
+authors and operators reviewing a run, while `evaluation_targets` provides
+machine-readable thresholds.
+
+### How the CLI uses success metrics and targets
+
+Running the simulator through `python src/app.py --scenario <path>` loads the
+scenario YAML, including its beats and descriptive blocks. While the CLI does not
+enforce pass/fail outcomes automatically, any registered evaluation hooks write
+their numeric outputs to the event log. Downstream tooling—or a quick Python
+script—can compare those recorded values to the declared `success_metrics` or
+`evaluation_targets` to decide whether a run stayed within the expected bounds.
+
+### How the signature demo script surfaces compliance
+
+`scripts/run_signature_demo.py` orchestrates `scenarios/signature_demo.yaml` end
+to end. After the run finishes, the script now inspects the scenario's
+`evaluation_targets`, compares them against the collected metrics, and records a
+pass/fail summary in two places:
+
+- The generated `metrics.json` contains the raw metric time series plus a
+  `_target_summary` object summarizing compliance.
+- The accompanying `README.md` lists the produced artifacts and adds an
+  "Evaluation Target Summary" section with per-metric pass/fail notes.
 
 ## Running and replaying `signature_demo`
 
@@ -54,8 +88,8 @@ Run the demo and automatically export its event log and metrics:
 python scripts/run_signature_demo.py
 ```
 
-The script writes `event_log.jsonl` and `metrics.json` to
-`results/signature_demo/`.
+The script writes `event_log.jsonl`, `metrics.json`, and a human-readable
+summary to `results/signature_demo/`.
 
 1. Run the scenario and generate snapshots and an event log (default
    `event_log.jsonl`):

--- a/scripts/run_signature_demo.py
+++ b/scripts/run_signature_demo.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import os
 import shutil
+import statistics
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -101,7 +102,92 @@ def _create_snapshot(sim: Simulation, directory: Path) -> Path:
     return directory / f"snapshot_{sim.current_step}.json"
 
 
-def _write_readme(entries: Iterable[tuple[str, Path]]) -> None:
+def _summarize_targets(
+    metrics: dict[str, list[tuple[int, float]]],
+    evaluation_targets: dict[str, dict[str, float | int | str]] | None,
+) -> dict[str, dict[str, object]]:
+    summary: dict[str, dict[str, object]] = {}
+    if not evaluation_targets:
+        return summary
+
+    for metric, target in evaluation_targets.items():
+        if not isinstance(target, dict):
+            continue
+        values = [float(value) for _, value in metrics.get(metric, [])]
+        if not values:
+            summary[metric] = {
+                "status": "missing",
+                "reason": "No samples recorded for this metric.",
+            }
+            continue
+
+        checks: dict[str, dict[str, object]] = {}
+        status: str = "pass"
+        for field, raw_threshold in target.items():
+            if not isinstance(raw_threshold, (int, float)):
+                checks[field] = {
+                    "threshold": raw_threshold,
+                    "passed": None,
+                    "reason": "Non-numeric threshold is not evaluated.",
+                }
+                if status == "pass":
+                    status = "unknown"
+                continue
+
+            threshold = float(raw_threshold)
+            observed: float
+            passed: bool | None
+
+            if field == "max_count":
+                observed = max(values)
+                passed = observed <= threshold
+            elif field == "max_value":
+                observed = max(values)
+                passed = observed <= threshold
+            elif field == "min_value":
+                observed = min(values)
+                passed = observed >= threshold
+            elif field == "max_delta":
+                deltas = [abs(curr - prev) for prev, curr in zip(values[:-1], values[1:])]
+                observed = max(deltas) if deltas else 0.0
+                passed = observed <= threshold
+            elif field == "max_variance":
+                observed = statistics.pvariance(values) if len(values) > 1 else 0.0
+                passed = observed <= threshold
+            else:
+                checks[field] = {
+                    "threshold": threshold,
+                    "passed": None,
+                    "reason": "Unsupported target field.",
+                }
+                if status == "pass":
+                    status = "unknown"
+                continue
+
+            checks[field] = {
+                "threshold": threshold,
+                "observed": observed,
+                "passed": passed,
+            }
+            if not passed:
+                status = "fail"
+
+        if not checks:
+            summary[metric] = {
+                "status": "unknown",
+                "reason": "No recognized target fields for evaluation.",
+            }
+            continue
+
+        summary[metric] = {"status": status, "checks": checks}
+
+    return summary
+
+
+def _write_readme(
+    entries: Iterable[tuple[str, Path]],
+    target_summary: dict[str, dict[str, object]] | None = None,
+) -> None:
     lines = [
         "# Signature Demo Results",
         "",
@@ -115,6 +201,35 @@ def _write_readme(entries: Iterable[tuple[str, Path]]) -> None:
             rel = path
         suffix = "/" if path.is_dir() else ""
         lines.append(f"- **{label}**: `{rel}{suffix}`")
+    if target_summary:
+        lines.extend(["", "## Evaluation Target Summary", ""])
+        for metric, details in target_summary.items():
+            status = str(details.get("status", "unknown")).upper()
+            lines.append(f"- **{metric}**: {status}")
+            checks = details.get("checks")
+            if isinstance(checks, dict):
+                for field, check_details in checks.items():
+                    if not isinstance(check_details, dict):
+                        continue
+                    observed = check_details.get("observed")
+                    threshold = check_details.get("threshold")
+                    passed = check_details.get("passed")
+                    note_parts: list[str] = []
+                    if isinstance(observed, (int, float)):
+                        note_parts.append(f"observed={observed:.3f}")
+                    if isinstance(threshold, (int, float)):
+                        note_parts.append(f"target={threshold:.3f}")
+                    if isinstance(passed, bool):
+                        note_parts.append("pass" if passed else "fail")
+                    reason = check_details.get("reason")
+                    if isinstance(reason, str):
+                        note_parts.append(reason)
+                    summary_line = ", ".join(note_parts) if note_parts else "no details"
+                    lines.append(f"  - {field}: {summary_line}")
+            reason = details.get("reason")
+            if isinstance(reason, str):
+                lines.append(f"  - Note: {reason}")
+
     README_PATH.parent.mkdir(parents=True, exist_ok=True)
     README_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -149,8 +264,14 @@ async def main() -> None:
 
     metrics_path = RESULT_DIR / "metrics.json"
     metrics = export_traces.load_metrics(event_log_path)
+    target_summary = _summarize_targets(
+        metrics, data.get("evaluation_targets") if isinstance(data, dict) else None
+    )
+    metrics_output: dict[str, object] = {key: value for key, value in metrics.items()}
+    if target_summary:
+        metrics_output["_target_summary"] = target_summary
     with metrics_path.open("w", encoding="utf-8") as fh:
-        json.dump(metrics, fh, indent=2)
+        json.dump(metrics_output, fh, indent=2)
 
     snapshots_dir = RESULT_DIR / "snapshots"
     snapshot_path = _create_snapshot(sim, snapshots_dir)
@@ -184,7 +305,7 @@ async def main() -> None:
     ]
     for plot_path in sorted(plot_paths):
         artifact_entries.append((f"Plot: {plot_path.stem}", plot_path))
-    _write_readme(artifact_entries)
+    _write_readme(artifact_entries, target_summary)
 
     print(f"Event log: {event_log_path}")
     print(f"Metrics: {metrics_path}")

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -173,6 +173,13 @@ async def test_run_signature_demo(
         step, value = metrics[key][0]
         assert isinstance(step, int)
         assert isinstance(value, float)
+    target_summary = metrics.get("_target_summary")
+    assert isinstance(target_summary, dict)
+    for key in ("coalitions", "sentiment", "collective_du", "collective_ip"):
+        assert key in target_summary
+        entry = target_summary[key]
+        assert isinstance(entry, dict)
+        assert "status" in entry
 
     replay_files = sorted(snapshots_dir.glob("replay_*.jsonl"))
     assert replay_files, "Replay slice not created"
@@ -195,3 +202,6 @@ async def test_run_signature_demo(
         assert "traces.jsonl" in names
         assert "metrics.json" in names
         assert any(name.startswith("snapshots/") for name in names)
+
+    readme_text = (result_dir / "README.md").read_text(encoding="utf-8")
+    assert "Evaluation Target Summary" in readme_text


### PR DESCRIPTION
## Summary
- add evaluation target summarization to `scripts/run_signature_demo.py`, writing pass/fail output into the metrics bundle and README
- refresh `docs/scenario_hooks.md` to clarify how success metrics and targets are surfaced by the CLI and signature demo
- extend the signature demo integration test to cover the new target summary metadata

## Testing
- pytest -m "integration" tests/integration/scenario/test_run_signature_demo.py


------
https://chatgpt.com/codex/tasks/task_e_68d29fdd9af88326a8b0e2137d6828b7