### PR TITLE
Propagate scenario evaluation configuration

### DIFF
--- a/scripts/run_signature_demo.py
+++ b/scripts/run_signature_demo.py
@@ -11,10 +11,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import yaml
-
 from scripts import export_traces
-from src.app import create_simulation
+from src.app import create_simulation, load_scenario
 from src.infra import event_log
 from src.infra.checkpoint import capture_rng_state
 from src.infra.snapshot import compute_trace_hash, save_snapshot
@@ -126,14 +124,17 @@ async def main() -> None:
     event_log_path = RESULT_DIR / "event_log.jsonl"
     os.environ["EVENT_LOG_PATH"] = str(event_log_path)
 
-    with SCENARIO_PATH.open("r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh)
-
-    scenario_desc = data.get("description", "")
-    steps = int(data.get("steps", 0) or 0)
-    num_agents = int(data.get("agents", 3) or 3)
-    beats = data.get("beats") or []
-    eval_hooks = data.get("evaluation_hooks") or []
+    (
+        scenario_desc,
+        steps_override,
+        agents_override,
+        beats,
+        evaluation_hooks,
+        evaluation_targets,
+        success_metrics,
+    ) = load_scenario(str(SCENARIO_PATH))
+    steps = steps_override or 0
+    num_agents = agents_override or 3
 
     sim = create_simulation(
         num_agents=num_agents,
@@ -141,9 +142,10 @@ async def main() -> None:
         scenario=scenario_desc,
         beats=beats,
         seed=42,
+        evaluation_hook_names=evaluation_hooks,
+        evaluation_targets=evaluation_targets,
+        success_metrics=success_metrics,
     )
-    if eval_hooks:
-        sim.register_named_evaluation_hooks(list(map(str, eval_hooks)))
 
     await sim.async_run(steps)
 

--- a/src/app.py
+++ b/src/app.py
@@ -74,8 +74,24 @@ def _simple_yaml(path: Path) -> dict[str, object]:
     return data
 
 
-def load_scenario(value: str) -> tuple[str, int | None, int | None, list[str]]:
-    """Return scenario description, overrides, and optional beats from a file."""
+def load_scenario(
+    value: str,
+) -> tuple[
+    str,
+    int | None,
+    int | None,
+    list[str],
+    list[str],
+    dict[str, object],
+    dict[str, object],
+]:
+    """Return scenario description and optional overrides from a file.
+
+    The returned tuple contains the scenario description, optional overrides for
+    ``steps`` and ``agents``, narrative beats, evaluation hook names, evaluation
+    target definitions, and success metric specifications. When ``value`` does
+    not reference a file the remaining items are empty defaults.
+    """
     path = Path(value)
     if path.is_file():
         try:  # Try full YAML parsing if PyYAML is available
@@ -91,16 +107,38 @@ def load_scenario(value: str) -> tuple[str, int | None, int | None, list[str]]:
             agents = content.get("agents")
             beats = content.get("beats")
             beat_list = [str(b) for b in beats] if isinstance(beats, list) else []
+            hook_values = content.get("evaluation_hooks")
+            if isinstance(hook_values, list):
+                evaluation_hooks = [str(h) for h in hook_values if h is not None]
+            elif hook_values is None:
+                evaluation_hooks = []
+            else:
+                evaluation_hooks = [str(hook_values)]
+            targets = content.get("evaluation_targets")
+            evaluation_targets = (
+                {str(key): value for key, value in targets.items()}
+                if isinstance(targets, dict)
+                else {}
+            )
+            success_defs = content.get("success_metrics")
+            success_metrics = (
+                {str(key): value for key, value in success_defs.items()}
+                if isinstance(success_defs, dict)
+                else {}
+            )
             return (
                 desc,
                 int(steps) if steps is not None else None,
                 int(agents) if agents is not None else None,
                 beat_list,
+                evaluation_hooks,
+                evaluation_targets,
+                success_metrics,
             )
         if isinstance(content, str):
-            return content, None, None, []
-        return str(content), None, None, []
-    return value, None, None, []
+            return content, None, None, [], [], {}, {}
+        return str(content), None, None, [], [], {}, {}
+    return value, None, None, [], [], {}, {}
 
 
 use_uvloop_if_available()
@@ -120,6 +158,9 @@ def create_simulation(
     steps: int = 10,
     scenario: str = DEFAULT_SCENARIO,
     beats: list[str] | None = None,
+    evaluation_hook_names: list[str] | None = None,
+    evaluation_targets: dict[str, object] | None = None,
+    success_metrics: dict[str, object] | None = None,
     use_discord: bool = False,
     use_vector_store: bool = False,
     vector_store_dir: str = "./chroma_db",
@@ -195,6 +236,9 @@ def create_simulation(
         beats=beats,
         discord_bot=discord_bot,
         seed=seed,
+        evaluation_hook_names=evaluation_hook_names,
+        evaluation_targets=evaluation_targets,
+        success_metrics=success_metrics,
     )
     if config.KNOWLEDGE_BOARD_BACKEND == "graph":
         sim.knowledge_board = GraphKnowledgeBoard()
@@ -313,7 +357,15 @@ def main() -> None:
     # Load optional plugins before argument parsing
     asyncio.run(load_plugins())
     args = parse_args()
-    desc, file_steps, file_agents, beats = load_scenario(args.scenario)
+    (
+        desc,
+        file_steps,
+        file_agents,
+        beats,
+        evaluation_hooks,
+        evaluation_targets,
+        success_metrics,
+    ) = load_scenario(args.scenario)
     if file_steps is not None:
         args.steps = file_steps
     if file_agents is not None:
@@ -384,6 +436,12 @@ def main() -> None:
             "semantic_user": args.semantic_user,
             "semantic_password": args.semantic_password,
         }
+        if evaluation_hooks:
+            sim_kwargs["evaluation_hook_names"] = evaluation_hooks
+        if evaluation_targets:
+            sim_kwargs["evaluation_targets"] = evaluation_targets
+        if success_metrics:
+            sim_kwargs["success_metrics"] = success_metrics
         if args.seed is not None:
             sim_kwargs["seed"] = args.seed
         sim = create_simulation(**sim_kwargs)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 import argparse
 import asyncio
+import copy
 import logging
 import random
 import threading
 import time
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, cast
 
 import numpy as np
 from opentelemetry import trace
@@ -78,6 +79,9 @@ class Simulation:
         beats: list[str] | None = None,
         discord_bot: Optional["SimulationDiscordBot"] = None,
         seed: int | None = None,
+        evaluation_hook_names: Sequence[str] | None = None,
+        evaluation_targets: Mapping[str, Any] | None = None,
+        success_metrics: Mapping[str, Any] | None = None,
     ) -> None:
         """
         Initializes the Simulation instance.
@@ -97,6 +101,12 @@ class Simulation:
             discord_bot (Optional[SimulationDiscordBot]): Discord bot for sending
                 simulation updates to Discord.
             seed (int | None): Seed for Python and NumPy random number generators.
+            evaluation_hook_names (Sequence[str] | None): Symbolic evaluation
+                hook names to register for metric collection.
+            evaluation_targets (Mapping[str, Any] | None): Scenario-provided
+                evaluation target thresholds for compliance checks.
+            success_metrics (Mapping[str, Any] | None): High-level success metric
+                definitions describing desired narrative outcomes.
         """
         # Reload configuration to pick up any environment overrides set in tests
         config.load_config(validate_required=False)
@@ -185,9 +195,18 @@ class Simulation:
         logger.info("Simulation initialized with collective IP/DU tracking.")
 
         # --- NEW: Evaluation hooks and metrics ---
+        self.evaluation_hook_names: list[str] = []
+        self.evaluation_targets: dict[str, Any] = (
+            copy.deepcopy(evaluation_targets) if evaluation_targets else {}
+        )
+        self.success_metrics: dict[str, Any] = (
+            copy.deepcopy(success_metrics) if success_metrics else {}
+        )
         self.evaluation_hooks: list[Callable[[Self, list[Any]], dict[str, Any] | None]] = []
         self.metrics: list[dict[str, Any]] = []
         self.add_evaluation_hook(self._collect_metrics)
+        if evaluation_hook_names:
+            self.register_named_evaluation_hooks(list(evaluation_hook_names))
 
         # --- Initialize memory service ---
         if memory_service is None:
@@ -1135,7 +1154,7 @@ class Simulation:
             "collective_du": self.collective_du,
         }
 
-    def register_named_evaluation_hooks(self: Self, hook_names: list[str]) -> None:
+    def register_named_evaluation_hooks(self: Self, hook_names: Sequence[str]) -> None:
         """Register evaluation hooks by symbolic ``hook_names``.
 
         Each name is looked up in :data:`EVALUATION_HOOKS`; unknown names are ignored
@@ -1143,13 +1162,22 @@ class Simulation:
         registering the provided hooks to avoid duplicate metric entries.
         """
 
+        requested = [str(name) for name in hook_names]
         self.evaluation_hooks = []
-        for name in hook_names:
+        self.evaluation_hook_names = []
+        for name in requested:
             hook = EVALUATION_HOOKS.get(name)
             if hook is None:
                 logger.warning("Unknown evaluation hook '%s'", name)
                 continue
+            self.evaluation_hook_names.append(name)
             self.add_evaluation_hook(hook)
+        if not self.evaluation_hook_names:
+            if requested:
+                logger.warning(
+                    "No valid evaluation hooks configured; using default metrics collector"
+                )
+            self.add_evaluation_hook(self._collect_metrics)
 
     async def run_step(self: Self, max_turns: int = 1) -> int:
         """Dispatch up to ``max_turns`` events via the kernel."""

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -102,7 +102,15 @@ async def test_run_signature_demo(
     event_log_module.set_seed(42)
 
     # Build deterministic agent outputs tied to the scenario beats.
-    _, _, _, beats = load_scenario(str(scenario_path))
+    (
+        _,
+        _,
+        _,
+        beats,
+        hook_names,
+        evaluation_targets,
+        success_metrics,
+    ) = load_scenario(str(scenario_path))
     beat_cycle = cycle(beats or ["default"])
     message_counter = count(1)
 
@@ -142,6 +150,10 @@ async def test_run_signature_demo(
         await run_signature_demo.main()
 
     assert created_sims, "Simulation was not constructed"
+    sim = created_sims[0]
+    assert sim.evaluation_hook_names == hook_names
+    assert sim.evaluation_targets == evaluation_targets
+    assert sim.success_metrics == success_metrics
 
     event_log_path = result_dir / "event_log.jsonl"
     metrics_path = result_dir / "metrics.json"

--- a/tests/integration/scenario/test_signature_demo.py
+++ b/tests/integration/scenario/test_signature_demo.py
@@ -10,7 +10,6 @@ from src.agents.graphs.basic_agent_types import AgentActionOutput
 from src.app import create_simulation, load_scenario
 from src.infra import event_log
 from src.infra import snapshot as snap
-from src.sim.simulation import Simulation
 from tests.utils.mock_llm import MockLLM
 
 
@@ -44,7 +43,15 @@ async def test_signature_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(snap, "load_snapshot", load_no_verify)
     monkeypatch.setattr(export_traces, "load_snapshot", load_no_verify)
 
-    scenario_desc, _, _, beats = load_scenario("scenarios/signature_demo.yaml")
+    (
+        scenario_desc,
+        _,
+        _,
+        beats,
+        hook_names,
+        evaluation_targets,
+        success_metrics,
+    ) = load_scenario("scenarios/signature_demo.yaml")
     beat_cycle = cycle(beats)
 
     def next_structured_output() -> AgentActionOutput:
@@ -76,9 +83,14 @@ async def test_signature_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
             scenario=scenario_desc,
             seed=42,
             beats=beats,
+            evaluation_hook_names=hook_names,
+            evaluation_targets=evaluation_targets,
+            success_metrics=success_metrics,
         )
         sim._beat_interval = max(1, sim.steps_to_run // len(beats))
-        sim.evaluation_hooks = [Simulation._collect_metrics]
+        assert sim.evaluation_hook_names == hook_names
+        assert sim.evaluation_targets == evaluation_targets
+        assert sim.success_metrics == success_metrics
         for _ in range(30):
             await sim.run_step()
 

--- a/tests/integration/scenario/test_signature_metrics.py
+++ b/tests/integration/scenario/test_signature_metrics.py
@@ -10,7 +10,6 @@ from src.agents.graphs.basic_agent_types import AgentActionOutput
 from src.app import create_simulation, load_scenario
 from src.infra import event_log
 from src.infra import snapshot as snap
-from src.sim.simulation import Simulation
 from tests.utils.mock_llm import MockLLM
 
 
@@ -45,7 +44,15 @@ async def test_signature_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(snap, "load_snapshot", load_no_verify)
     monkeypatch.setattr(export_traces, "load_snapshot", load_no_verify)
 
-    scenario_desc, _, _, beats = load_scenario("scenarios/signature_demo.yaml")
+    (
+        scenario_desc,
+        _,
+        _,
+        beats,
+        hook_names,
+        evaluation_targets,
+        success_metrics,
+    ) = load_scenario("scenarios/signature_demo.yaml")
     beat_cycle = cycle(beats)
 
     def next_structured_output() -> AgentActionOutput:
@@ -77,9 +84,14 @@ async def test_signature_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
             scenario=scenario_desc,
             seed=42,
             beats=beats,
+            evaluation_hook_names=hook_names,
+            evaluation_targets=evaluation_targets,
+            success_metrics=success_metrics,
         )
         sim._beat_interval = max(1, sim.steps_to_run // len(beats))
-        sim.evaluation_hooks = [Simulation._collect_metrics]
+        assert sim.evaluation_hook_names == hook_names
+        assert sim.evaluation_targets == evaluation_targets
+        assert sim.success_metrics == success_metrics
         for _ in range(30):
             await sim.run_step()
 

--- a/tests/unit/test_app_cli.py
+++ b/tests/unit/test_app_cli.py
@@ -80,12 +80,17 @@ def test_load_scenario_from_file(tmp_path) -> None:
     path = tmp_path / "demo.yaml"
     path.write_text("""description: Test scenario\nsteps: 7\nagents: 4\n""")
 
-    desc, steps, agents, beats = app.load_scenario(str(path))
+    desc, steps, agents, beats, hooks, targets, success_metrics = app.load_scenario(
+        str(path)
+    )
 
     assert desc == "Test scenario"
     assert steps == 7
     assert agents == 4
     assert beats == []
+    assert hooks == []
+    assert targets == {}
+    assert success_metrics == {}
 
 
 def test_main_uses_scenario_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- extend scenario loading so evaluation hooks, targets, and success metrics from YAML flow into `create_simulation`
- teach `Simulation` to cache evaluation metadata, auto-register named hooks, and expose success metric definitions
- update the signature demo runner and integration tests to cover the new evaluation metadata plumbing

## Testing
- pytest -m integration tests/integration/scenario/test_signature_demo.py tests/integration/scenario/test_signature_metrics.py tests/integration/scenario/test_run_signature_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68d29fdcf5b08326b23aa72c52720fc7