### PR TITLE
Add event log option to replay CLI

### DIFF
--- a/docs/scenario_hooks.md
+++ b/docs/scenario_hooks.md
@@ -116,3 +116,13 @@ summary to `results/signature_demo/`.
    ```
 
    Adjust `--replay-start` and `--replay-end` to slice the run if desired.
+
+   For an ad-hoc inspection without booting the full app CLI, use the replay
+   helper instead. The tool accepts an optional `--events` flag but will also
+   look for `event_log.jsonl` next to the snapshot bundle automatically:
+
+   ```bash
+   python -m tools.replay_cli demo_run/snapshots/snapshot_0.json --from 1 --to 50
+   python -m tools.replay_cli demo_run/snapshots/snapshot_0.json --from 51 --to 100 \
+       --events demo_run/event_log.jsonl
+   ```

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -1373,6 +1373,7 @@ class Simulation:
         start_step: int | None = None,
         end_step: int | None = None,
         seed: int | None = None,
+        event_log_path: str | Path | None = None,
     ) -> Self:
         """Load a snapshot and replay events from the event log."""
         snap = load_snapshot(snapshot_path)
@@ -1383,12 +1384,10 @@ class Simulation:
         if start_step is not None:
             after_step = max(after_step, start_step - 1)
 
-        for event in event_log.stream_events(after_step=after_step):
+        for event in event_log.stream_events(after_step=after_step, end_step=end_step, path=event_log_path):
             step = int(event.get("step", 0))
             if start_step is not None and step < start_step:
                 continue
-            if end_step is not None and step > end_step:
-                break
             sim.apply_event(event)
         return sim
 

--- a/tests/unit/tools/test_replay_cli.py
+++ b/tests/unit/tools/test_replay_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from tools import replay_cli
@@ -7,8 +9,10 @@ from tools import replay_cli
 def test_replay_cli_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     called: dict[str, object] = {}
 
-    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None):
-        called.update(snapshot=snapshot, start=start_step, end=end_step, seed=seed)
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None, event_log_path=None):
+        called.update(
+            snapshot=snapshot, start=start_step, end=end_step, seed=seed, events=event_log_path
+        )
 
     monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
 
@@ -20,6 +24,7 @@ def test_replay_cli_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
         "start": 2,
         "end": 4,
         "seed": 99,
+        "events": None,
     }
 
 
@@ -27,11 +32,76 @@ def test_replay_cli_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_replay_cli_tick_range_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
     called: dict[str, object] = {}
 
-    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None):
-        called.update(start=start_step, end=end_step)
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None, event_log_path=None):
+        called.update(start=start_step, end=end_step, events=event_log_path)
 
     monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
 
     replay_cli.main(["snap.json", "--from-tick", "5", "--to-tick", "7"])
     assert called["start"] == 5
     assert called["end"] == 7
+    assert called["events"] is None
+
+
+@pytest.mark.unit
+def test_replay_cli_discovers_event_log(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events = tmp_path / "event_log.jsonl"
+    events.write_text("{\"type\": \"header\", \"seed\": 123}\n", encoding="utf-8")
+    snapshot_dir = tmp_path / "snapshots"
+    snapshot_dir.mkdir()
+    snapshot = snapshot_dir / "snapshot_0.json"
+    snapshot.write_text("{}", encoding="utf-8")
+
+    captured_seed: dict[str, object] = {}
+
+    def fake_get_seed(path=None):
+        captured_seed["path"] = path
+        return 321
+
+    called: dict[str, object] = {}
+
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None, event_log_path=None):
+        called.update(seed=seed, events=event_log_path)
+
+    monkeypatch.setattr(replay_cli.event_log, "get_seed", fake_get_seed)
+    monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
+
+    replay_cli.main([str(snapshot), "--from", "1", "--to", "2"])
+
+    assert captured_seed["path"] == events
+    assert called == {"seed": 321, "events": events}
+
+
+@pytest.mark.unit
+def test_replay_cli_events_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events = tmp_path / "custom.jsonl"
+    events.write_text("{\"type\": \"header\", \"seed\": 555}\n", encoding="utf-8")
+    snapshot = tmp_path / "snapshot_0.json"
+    snapshot.write_text("{}", encoding="utf-8")
+
+    captured_seed: dict[str, object] = {}
+
+    def fake_get_seed(path=None):
+        captured_seed["path"] = path
+        return 555
+
+    called: dict[str, object] = {}
+
+    def mock_replay(snapshot: str, start_step=None, end_step=None, seed=None, event_log_path=None):
+        called.update(snapshot=snapshot, events=event_log_path, seed=seed)
+
+    monkeypatch.setattr(replay_cli.event_log, "get_seed", fake_get_seed)
+    monkeypatch.setattr(replay_cli.Simulation, "replay_from_snapshot", mock_replay)
+
+    replay_cli.main([
+        str(snapshot),
+        "--from",
+        "3",
+        "--to",
+        "4",
+        "--events",
+        str(events),
+    ])
+
+    assert captured_seed["path"] == events
+    assert called == {"snapshot": str(snapshot), "events": events, "seed": 555}

--- a/tools/replay_cli.py
+++ b/tools/replay_cli.py
@@ -4,9 +4,21 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from src.infra import event_log
 from src.sim.simulation import Simulation
+
+
+def _discover_event_log(snapshot_path: str | Path) -> Path | None:
+    """Infer the event log location from the snapshot hierarchy."""
+
+    path = Path(snapshot_path)
+    for directory in path.parents:
+        candidate = directory / "event_log.jsonl"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -33,14 +45,31 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         help="Override RNG seed (defaults to seed from event log)",
     )
+    parser.add_argument(
+        "--events",
+        type=Path,
+        help="Path to the event log (auto-detected relative to the snapshot if omitted)",
+    )
     args = parser.parse_args(argv)
+
+    event_log_path: Path | None
+    if args.events is not None:
+        if not args.events.is_file():
+            parser.error(f"Event log not found: {args.events}")
+        event_log_path = args.events
+    else:
+        event_log_path = _discover_event_log(args.snapshot)
 
     seed = args.seed
     if seed is None:
-        seed = event_log.get_seed()
+        seed = event_log.get_seed(path=event_log_path)
 
     Simulation.replay_from_snapshot(
-        args.snapshot, start_step=args.start, end_step=args.end, seed=seed
+        args.snapshot,
+        start_step=args.start,
+        end_step=args.end,
+        seed=seed,
+        event_log_path=event_log_path,
     )
     return 0
 


### PR DESCRIPTION
## Summary
- add an optional `--events` flag to `tools/replay_cli.py` with auto-discovery for nearby event logs
- allow `Simulation.replay_from_snapshot` to accept an event log path so the CLI no longer depends on global environment
- document the new workflow and extend replay CLI unit tests for the discovery and flag behaviours

## Testing
- python -m tools.replay_cli --help
- pytest tests/unit/tools/test_replay_cli.py tests/integration/event_log/test_replay.py tests/integration/event_log/test_replay_slice.py tests/integration/sim/test_snapshot_replay.py


------
https://chatgpt.com/codex/tasks/task_e_68dd1239de3c83268a3c0dace8a4b276