### PR TITLE
Log DU budget exceed events

### DIFF
--- a/src/sim/resource_manager.py
+++ b/src/sim/resource_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from src.infra import event_log
 from src.infra.metrics import record_du_budget
 
 
@@ -36,6 +37,17 @@ class ResourceManager:
         """Verify that the agent has at least ``amount`` DU available."""
         remaining = self._du_budgets.get(agent_id, 0.0)
         if amount > remaining:
+            try:
+                event_log.log_event(
+                    {
+                        "type": "du_budget_exceeded",
+                        "agent": agent_id,
+                        "required": float(amount),
+                        "remaining": float(remaining),
+                    }
+                )
+            except Exception:  # pragma: no cover - best effort
+                pass
             try:
                 from src.interfaces.discord_bot import notify_budget_exceeded
 

--- a/tests/integration/event_log/test_du_budget_logging.py
+++ b/tests/integration/event_log/test_du_budget_logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.mark.integration
+def test_du_budget_exceeded_event_logged(monkeypatch, tmp_path) -> None:
+    log_path = tmp_path / "event_log.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_path))
+
+    import src.infra.event_log as event_log_module
+
+    importlib.reload(event_log_module)
+
+    import src.sim.resource_manager as resource_manager_module
+
+    importlib.reload(resource_manager_module)
+
+    rm = resource_manager_module.ResourceManager(5.0, 5.0)
+    rm.set_du_budget("agent-1", 0.1)
+
+    with pytest.raises(RuntimeError):
+        rm.ensure_du_budget("agent-1", 0.5)
+
+    assert log_path.exists()
+
+    with log_path.open("r", encoding="utf-8") as fh:
+        events = [json.loads(line) for line in fh if line.strip()]
+
+    du_events = [event for event in events if event.get("type") == "du_budget_exceeded"]
+    assert du_events, "Expected a du_budget_exceeded event to be logged"
+
+    event = du_events[-1]
+    assert event["agent"] == "agent-1"
+    assert event["required"] == pytest.approx(0.5)
+    assert event["remaining"] == pytest.approx(0.1)
+    assert isinstance(event.get("seed"), int)


### PR DESCRIPTION
## Summary
- log a `du_budget_exceeded` event before raising when DU budgets are exceeded
- add an integration test to ensure the event log captures DU budget violations with metadata

## Testing
- pytest tests/unit/sim/test_du_budget.py tests/integration/event_log/test_du_budget_logging.py
- ruff check src/sim/resource_manager.py tests/integration/event_log/test_du_budget_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68dd28729d288326a85b7bb5c31a4490