### PR TITLE
Fix event log header caching per path

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -28,7 +28,8 @@ _topic = os.getenv("REDPANDA_TOPIC", "culture.events")
 _producer: Any | None = None
 _last_hash: str | None = None
 _seed: int | None = None
-_header_written: bool = False
+_seed_cache: dict[Path, int] = {}
+_header_written: set[Path] = set()
 
 
 def set_seed(seed: int) -> None:
@@ -55,15 +56,21 @@ def get_log_header(path: str | Path | None = None) -> dict[str, Any]:
 
 def get_seed(path: str | Path | None = None) -> int | None:
     """Return the seed from the event log header if available."""
+
     global _seed
-    if _seed is not None:
-        return _seed
+    file = _log_file(path)
+    resolved = _resolved_path(file)
+    cached = _seed_cache.get(resolved)
+    if cached is not None:
+        return cached
+
     header = get_log_header(path)
     seed = header.get("seed") if isinstance(header, dict) else None
     if isinstance(seed, int):
+        _seed_cache[resolved] = seed
         _seed = seed
         return seed
-    return None
+    return _seed
 
 
 _consumer_conf = {
@@ -80,16 +87,44 @@ def _log_file(path: str | Path | None = None) -> Path:
     return Path(os.getenv("EVENT_LOG_PATH", "event_log.jsonl"))
 
 
+def _resolved_path(path: Path) -> Path:
+    """Return a stable cache key for ``path``."""
+
+    try:
+        return path.resolve()
+    except Exception:
+        return Path(os.path.abspath(path))
+
+
+def _get_or_create_seed(resolved: Path) -> int:
+    """Return the cached seed for ``resolved`` or generate a new one."""
+
+    global _seed
+    cached = _seed_cache.get(resolved)
+    if cached is not None:
+        return cached
+
+    if _seed is None:
+        try:
+            _seed = random.getstate()[1][0]
+        except Exception:  # pragma: no cover - fallback
+            _seed = 0
+
+    _seed_cache[resolved] = _seed
+    return _seed
+
+
 def _rehydrate_log_state(path: str | Path | None = None) -> None:
     """Populate cached state from the existing log file if available."""
 
     global _last_hash, _seed
     needs_hash = _last_hash is None
-    needs_seed = _seed is None
+    file = _log_file(path)
+    resolved = _resolved_path(file)
+    needs_seed = resolved not in _seed_cache
     if not needs_hash and not needs_seed:
         return
 
-    file = _log_file(path)
     if not file.exists():
         return
 
@@ -109,6 +144,7 @@ def _rehydrate_log_state(path: str | Path | None = None) -> None:
                 header_seed = header.get("seed")
                 if isinstance(header_seed, int):
                     _seed = header_seed
+                    _seed_cache[resolved] = header_seed
                     needs_seed = False
 
             last_event: dict[str, Any] | None = None
@@ -135,6 +171,7 @@ def _rehydrate_log_state(path: str | Path | None = None) -> None:
                 seed = last_event.get("seed")
                 if isinstance(seed, int):
                     _seed = seed
+                    _seed_cache[resolved] = seed
     except Exception:  # pragma: no cover - ignore
         pass
 
@@ -142,15 +179,13 @@ def _rehydrate_log_state(path: str | Path | None = None) -> None:
 def _ensure_header(path: str | Path | None = None) -> None:
     """Write the log header containing the simulation seed if missing."""
     global _header_written, _seed
-    if _header_written:
-        return
     file = _log_file(path)
-    if _seed is None:
-        try:
-            _seed = random.getstate()[1][0]
-        except Exception:  # pragma: no cover - fallback
-            _seed = 0
-    header = {"type": "header", "seed": _seed}
+    resolved = _resolved_path(file)
+    if resolved in _header_written:
+        return
+
+    seed_value = _get_or_create_seed(resolved)
+    header = {"type": "header", "seed": seed_value}
     try:  # pragma: no cover - best effort
         if file.exists():
             with file.open("r", encoding="utf-8") as fh:
@@ -162,16 +197,18 @@ def _ensure_header(path: str | Path | None = None) -> None:
             if existing.get("type") == "header" and "seed" in existing:
                 # Populate the cached seed from the existing header to ensure
                 # subsequent ``log_event`` calls embed the same seed value.
-                if _seed is None and isinstance(existing.get("seed"), int):
-                    _seed = existing["seed"]
-                _header_written = True
+                existing_seed = existing.get("seed")
+                if isinstance(existing_seed, int):
+                    _seed = existing_seed
+                    _seed_cache[resolved] = existing_seed
+                _header_written.add(resolved)
                 return
         file.parent.mkdir(parents=True, exist_ok=True)
         if not file.exists() or file.stat().st_size == 0:
             with file.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(header))
                 fh.write("\n")
-        _header_written = True
+        _header_written.add(resolved)
         if os.getenv("ENABLE_REDPANDA", "0") == "1":
             try:
                 producer = _get_producer()
@@ -305,6 +342,7 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
 
     global _last_hash
     path = _log_file()
+    resolved = _resolved_path(path)
     _rehydrate_log_state(path)
     _ensure_header(path)
 
@@ -320,14 +358,9 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
             event.pop("trace_hash", None)
         from src.infra.checkpoint import capture_rng_state
 
-        global _seed
-        if _seed is None:
-            try:
-                _seed = random.getstate()[1][0]
-            except Exception:  # pragma: no cover - fallback
-                _seed = 0
+        seed_value = _get_or_create_seed(resolved)
 
-        event = {**event, "rng_state": capture_rng_state(), "seed": _seed}
+        event = {**event, "rng_state": capture_rng_state(), "seed": seed_value}
         if "step" in event and "tick" not in event:
             event["tick"] = event["step"]
         if _last_hash is not None:

--- a/tests/integration/event_log/test_event_log_path_switch.py
+++ b/tests/integration/event_log/test_event_log_path_switch.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.infra import event_log
+
+
+@pytest.mark.integration
+def test_switching_event_log_path_writes_new_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(first))
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
+    monkeypatch.setattr(event_log, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", set(), raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.infra.checkpoint",
+        SimpleNamespace(capture_rng_state=lambda: {}),
+    )
+    event_log.set_seed(4321)
+
+    event_log.log_event({"type": "first", "step": 1})
+
+    monkeypatch.setenv("EVENT_LOG_PATH", str(second))
+
+    logged = event_log.log_event({"type": "second", "step": 2})
+
+    contents = second.read_text(encoding="utf-8").splitlines()
+    assert contents, "new event log should not be empty"
+    header = json.loads(contents[0])
+    assert header["type"] == "header"
+    assert header.get("seed") == logged["seed"]

--- a/tests/integration/event_log/test_prev_hash_resume.py
+++ b/tests/integration/event_log/test_prev_hash_resume.py
@@ -26,7 +26,8 @@ def test_prev_hash_resume(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, enabl
     monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
     monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
     monkeypatch.setattr(event_log, "_seed", None, raising=False)
-    monkeypatch.setattr(event_log, "_header_written", False, raising=False)
+    monkeypatch.setattr(event_log, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", set(), raising=False)
     monkeypatch.setattr(event_log, "_producer", None, raising=False)
     monkeypatch.setitem(
         sys.modules,
@@ -47,7 +48,8 @@ def test_prev_hash_resume(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, enabl
     # Simulate a fresh process where module globals are unset.
     event_log._last_hash = None
     event_log._seed = None
-    event_log._header_written = False
+    event_log._seed_cache = {}
+    event_log._header_written = set()
     event_log._producer = None
 
     resumed = event_log.log_event({"type": "test", "step": 2, "payload": "resumed"})

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -98,7 +98,9 @@ async def test_run_signature_demo(
     monkeypatch.setattr(event_log_module, "_get_producer", lambda: None)
     monkeypatch.setattr(event_log_module, "_producer", None, raising=False)
     monkeypatch.setattr(event_log_module, "_last_hash", None, raising=False)
-    monkeypatch.setattr(event_log_module, "_header_written", False, raising=False)
+    monkeypatch.setattr(event_log_module, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log_module, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log_module, "_header_written", set(), raising=False)
     event_log_module.set_seed(42)
 
     # Build deterministic agent outputs tied to the scenario beats.

--- a/tests/integration/scenario/test_signature_demo.py
+++ b/tests/integration/scenario/test_signature_demo.py
@@ -22,7 +22,9 @@ async def test_signature_demo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(event_log, "_get_producer", lambda: None)
     monkeypatch.setattr(event_log, "_producer", None, raising=False)
     monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
-    monkeypatch.setattr(event_log, "_header_written", False, raising=False)
+    monkeypatch.setattr(event_log, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", set(), raising=False)
     event_log.set_seed(42)
     monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda *a, **k: None)
 

--- a/tests/integration/scenario/test_signature_metrics.py
+++ b/tests/integration/scenario/test_signature_metrics.py
@@ -23,7 +23,9 @@ async def test_signature_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(event_log, "_get_producer", lambda: None)
     monkeypatch.setattr(event_log, "_producer", None, raising=False)
     monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
-    monkeypatch.setattr(event_log, "_header_written", False, raising=False)
+    monkeypatch.setattr(event_log, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log, "_header_written", set(), raising=False)
     event_log.set_seed(42)
     monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda *a, **k: None)
 

--- a/tests/integration/sim/test_snapshot_rng_state.py
+++ b/tests/integration/sim/test_snapshot_rng_state.py
@@ -56,6 +56,7 @@ async def test_snapshot_rng_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 
     event_log._last_hash = None
     event_log._seed = None
+    event_log._seed_cache = {}
     seed = 1234
     random.seed(seed)
     event_log.set_seed(seed)
@@ -72,6 +73,7 @@ async def test_snapshot_rng_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     # Replay from snapshot_2 using the stored seed and event log
     event_log._last_hash = None
     event_log._seed = None
+    event_log._seed_cache = {}
     stored = event_log.get_seed(str(tmp_path / "events.jsonl")) or seed
     replay = Simulation.replay_from_snapshot(
         snap_path, start_step=3, end_step=3, seed=stored

--- a/tests/integration/test_seed_replay.py
+++ b/tests/integration/test_seed_replay.py
@@ -26,6 +26,7 @@ async def test_seed_replay(monkeypatch: pytest.MonkeyPatch) -> None:
             np.random.seed(1234)
         event_log._last_hash = None
         event_log._seed = None
+        event_log._seed_cache = {}
         events: list[dict[str, Any]] = []
         real_log_event = event_log.log_event
 

--- a/tests/unit/infra/test_event_log_misbehavior.py
+++ b/tests/unit/infra/test_event_log_misbehavior.py
@@ -40,7 +40,8 @@ def test_log_misbehavior_and_fetch(monkeypatch, tmp_path):
     monkeypatch.setenv("EVENT_LOG_PATH", str(log_file))
     monkeypatch.setattr("src.infra.event_log._last_hash", None, raising=False)
     monkeypatch.setattr("src.infra.event_log._seed", None, raising=False)
-    monkeypatch.setattr("src.infra.event_log._header_written", False, raising=False)
+    monkeypatch.setattr("src.infra.event_log._seed_cache", {}, raising=False)
+    monkeypatch.setattr("src.infra.event_log._header_written", set(), raising=False)
     monkeypatch.setitem(
         sys.modules,
         "src.infra.checkpoint",


### PR DESCRIPTION
## Summary
- cache event log headers and seeds per resolved log path to avoid leaking state across files
- update event log hydration to record seeds per path when replaying existing logs
- add integration coverage for switching EVENT_LOG_PATH mid-run and adjust existing tests for the per-path cache

## Testing
- pytest -m "unit" tests/unit/infra/test_event_log_misbehavior.py
- pytest -m "integration" tests/integration/event_log/test_event_log_path_switch.py tests/integration/event_log/test_prev_hash_resume.py tests/integration/test_seed_replay.py tests/integration/sim/test_snapshot_rng_state.py

------
https://chatgpt.com/codex/tasks/task_e_68dd287167b88326b7feedb971731722