### PR TITLE
Restrict Discord control commands to admins

### DIFF
--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -105,6 +105,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "DISCORD_BOT_TOKEN": "",
     "DISCORD_CHANNEL_ID": None,
     "DISCORD_TOKENS_DB_URL": "",
+    "DISCORD_ALLOW_OPA_CONTROL_COMMANDS": False,
     "OPENAI_API_KEY": "",
     "ANTHROPIC_API_KEY": "",
     "DEFAULT_LOG_LEVEL": "INFO",

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -114,6 +114,7 @@ class ConfigSettings(BaseSettings):
     DISCORD_BOT_TOKEN: str = ""
     DISCORD_CHANNEL_ID: int | None = None
     DISCORD_TOKENS_DB_URL: str = ""
+    DISCORD_ALLOW_OPA_CONTROL_COMMANDS: bool = False
     OPENAI_API_KEY: str = ""
     ANTHROPIC_API_KEY: str = ""
     DEFAULT_LOG_LEVEL: str = "INFO"

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -377,6 +377,15 @@ class SimulationDiscordBot:
                         chan = getattr(interaction, "channel", None)
                         chan_id = getattr(chan, "id", None)
                         agent_id = self.channel_to_agent.get(chan_id)
+                        if not await _has_control_command_permission(
+                            getattr(interaction, "user", None),
+                            "start",
+                            agent_id=agent_id,
+                        ):
+                            await interaction.response.send_message(
+                                "unauthorized", ephemeral=True
+                            )
+                            return
                         try:
                             await start_simulation(self.context)
                         except Exception as exc:
@@ -405,6 +414,15 @@ class SimulationDiscordBot:
                         chan = getattr(interaction, "channel", None)
                         chan_id = getattr(chan, "id", None)
                         agent_id = self.channel_to_agent.get(chan_id)
+                        if not await _has_control_command_permission(
+                            getattr(interaction, "user", None),
+                            "stop",
+                            agent_id=agent_id,
+                        ):
+                            await interaction.response.send_message(
+                                "unauthorized", ephemeral=True
+                            )
+                            return
                         try:
                             await stop_simulation(self.context)
                         except Exception as exc:
@@ -431,6 +449,15 @@ class SimulationDiscordBot:
                 @moderation_rate_limit("spawn")
                 async def _tree_spawn(interaction: "discord.Interaction", agent_id: str) -> None:
                     with command_span("spawn", interaction, agent_id=agent_id) as span:
+                        if not await _has_control_command_permission(
+                            getattr(interaction, "user", None),
+                            "spawn",
+                            agent_id=agent_id,
+                        ):
+                            await interaction.response.send_message(
+                                "unauthorized", ephemeral=True
+                            )
+                            return
                         try:
                             await spawn_agent_command(agent_id, self.context)
                         except Exception as exc:
@@ -1094,6 +1121,50 @@ def has_admin_permission(user: Any) -> bool:
     return bool(perms)
 
 
+_TRUE_BOOL_VALUES = {"1", "true", "yes", "on"}
+_FALSE_BOOL_VALUES = {"0", "false", "no", "off"}
+
+
+def _coerce_to_bool(value: object) -> bool:
+    """Normalize truthy and falsy values retrieved from configuration."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUE_BOOL_VALUES:
+            return True
+        if lowered in _FALSE_BOOL_VALUES:
+            return False
+    return bool(value)
+
+
+def _allow_control_via_opa() -> bool:
+    """Return True when control commands may defer authorization to OPA."""
+    value = config.CONFIG_OVERRIDES.get("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
+    if value is None:
+        value = config.get_config("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
+    return _coerce_to_bool(value)
+
+
+async def _has_control_command_permission(
+    user: Any, command: str, *, agent_id: str | None = None
+) -> bool:
+    """Return True when the user may execute privileged control commands."""
+
+    if has_admin_permission(user):
+        return True
+    if not _allow_control_via_opa():
+        return False
+    payload = {
+        "command": command,
+        "user_id": str(getattr(user, "id", "")),
+    }
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    allowed, _ = await evaluate_with_opa(json.dumps(payload))
+    return bool(allowed)
+
+
 async def check_command_rate_limit(user: Any) -> bool:
     """Increment and check the rate limit for the given user."""
     user_id = str(getattr(user, "id", ""))
@@ -1301,6 +1372,13 @@ async def slash_start(interaction: Any) -> None:
         agent_id = None
         if bot_instance is not None:
             agent_id = bot_instance.channel_to_agent.get(chan_id)
+        if not await _has_control_command_permission(
+            getattr(interaction, "user", None),
+            "start",
+            agent_id=agent_id,
+        ):
+            await send_interaction_response(interaction, "unauthorized", ephemeral=True)
+            return
         try:
             await start_simulation(ctx)
         except Exception as exc:
@@ -1343,6 +1421,13 @@ async def slash_stop(interaction: Any) -> None:
         agent_id = None
         if bot_instance is not None:
             agent_id = bot_instance.channel_to_agent.get(chan_id)
+        if not await _has_control_command_permission(
+            getattr(interaction, "user", None),
+            "stop",
+            agent_id=agent_id,
+        ):
+            await send_interaction_response(interaction, "unauthorized", ephemeral=True)
+            return
         try:
             await stop_simulation(ctx)
         except Exception as exc:
@@ -1380,6 +1465,13 @@ async def slash_spawn(interaction: Any, agent_id: str) -> None:
     with command_span("spawn", interaction, agent_id=agent_id) as span:
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        if not await _has_control_command_permission(
+            getattr(interaction, "user", None),
+            "spawn",
+            agent_id=agent_id,
+        ):
+            await send_interaction_response(interaction, "unauthorized", ephemeral=True)
+            return
         try:
             await spawn_agent_command(agent_id, ctx)
         except Exception as exc:

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import typing
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -9,7 +10,14 @@ import pytest
 pytest.importorskip("discord")
 from src.interfaces import metrics
 from src.interfaces.dashboard_backend import AgentMessage, SimulationEvent
-from src.interfaces.discord_bot import SimulationDiscordBot, say, stats
+from src.interfaces.discord_bot import (
+    SimulationDiscordBot,
+    say,
+    slash_spawn,
+    slash_start,
+    slash_stop,
+    stats,
+)
 from src.sim.context import SimulationContext
 
 sent_by_token: list[str] = []
@@ -197,6 +205,33 @@ async def test_on_message_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
         assert bot.client.channel.sent
 
         await bot.stop_bot()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_commands_require_admin_without_opa(
+    simulation_bot: SimulationDiscordBot,
+) -> None:
+    class Perms:
+        administrator = False
+
+    user = SimpleNamespace(id="user0", guild_permissions=Perms())
+
+    async def _assert_unauthorized(
+        command: typing.Callable[..., typing.Awaitable[None]], *args: object
+    ) -> None:
+        response = SimpleNamespace(send_message=AsyncMock())
+        interaction = SimpleNamespace(
+            user=user,
+            response=response,
+            channel=SimpleNamespace(id=simulation_bot.channel_id),
+        )
+        await command(interaction, *args)
+        response.send_message.assert_awaited_once_with("unauthorized", ephemeral=True)
+
+    await _assert_unauthorized(slash_start)
+    await _assert_unauthorized(slash_stop)
+    await _assert_unauthorized(slash_spawn, "agent-1")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- gate the Discord start/stop/spawn commands behind administrator privileges with an optional OPA fallback toggle
- add a configuration flag to control whether OPA may authorize privileged Discord commands
- extend the Discord bot integration tests to ensure non-admin users receive unauthorized responses by default

## Testing
- ruff check src/infra/config.py src/infra/settings.py src/interfaces/discord_bot.py tests/integration/interfaces/test_discord_bot.py
- pytest tests/integration/interfaces/test_discord_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68de81420bec832694211351f4267cd4