### PR TITLE
Handle compressed snapshot suffixes in export traces

### DIFF
--- a/scripts/export_traces.py
+++ b/scripts/export_traces.py
@@ -17,6 +17,21 @@ from src.infra import event_log
 from src.infra.snapshot import load_snapshot
 
 
+def _snapshot_step(path: Path) -> int:
+    """Return the snapshot step number extracted from ``path``."""
+
+    name = path.name
+    prefix = "snapshot_"
+    if not name.startswith(prefix):
+        raise ValueError(f"Unexpected snapshot filename: {name}")
+    step_part = name[len(prefix) :]
+    for suffix in (".json.zst", ".json"):
+        if step_part.endswith(suffix):
+            step_part = step_part[: -len(suffix)]
+            break
+    return int(step_part)
+
+
 def export_latest(
     directory: str | Path = "snapshots", output: str | Path = "data/traces.jsonl"
 ) -> Path:
@@ -27,14 +42,14 @@ def export_latest(
     """
 
     path = Path(directory)
-    files = sorted(path.glob("snapshot_*.json*"), key=lambda p: int(p.stem.split("_")[1]))
+    files = sorted(path.glob("snapshot_*.json*"), key=_snapshot_step)
     if not files:
         raise FileNotFoundError(f"No snapshots found in {directory}")
 
     out_path = Path(output)
     with out_path.open("w", encoding="utf-8") as out:
         for file in files:
-            step = int(file.stem.split("_")[1])
+            step = _snapshot_step(file)
             compress = file.suffix == ".zst"
             snap = load_snapshot(step, directory=directory, compress=compress)
             out.write(json.dumps(snap))
@@ -46,9 +61,9 @@ def export_latest(
 def iter_snapshots(directory: str | Path) -> Iterable[dict[str, Any]]:
     """Yield snapshots from ``directory`` in step order."""
     path = Path(directory)
-    files = sorted(path.glob("snapshot_*.json*"), key=lambda p: int(p.stem.split("_")[1]))
+    files = sorted(path.glob("snapshot_*.json*"), key=_snapshot_step)
     for file in files:
-        step = int(file.stem.split("_")[1])
+        step = _snapshot_step(file)
         compress = file.suffix == ".zst"
         yield load_snapshot(step, directory=directory, compress=compress)
 

--- a/tests/unit/scripts/test_export_traces.py
+++ b/tests/unit/scripts/test_export_traces.py
@@ -70,6 +70,31 @@ def test_export_latest(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_export_latest_mixed_suffixes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "snapshot_1.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "snapshot_2.json.zst").write_text("", encoding="utf-8")
+    (tmp_path / "snapshot_10.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "snapshot_3.json.zst").write_text("", encoding="utf-8")
+
+    calls: list[tuple[int, bool]] = []
+
+    def fake_load_snapshot(step: int, *, directory: Path | str, compress: bool) -> dict[str, int]:
+        calls.append((step, compress))
+        return {"step": step}
+
+    monkeypatch.setattr(et, "load_snapshot", fake_load_snapshot)
+
+    out = tmp_path / "out.jsonl"
+    et.export_latest(directory=tmp_path, output=out)
+
+    lines = out.read_text().splitlines()
+    assert [json.loads(line)["step"] for line in lines] == [1, 2, 3, 10]
+    assert calls == [(1, False), (2, True), (3, True), (10, False)]
+
+
+@pytest.mark.unit
 def test_export_traces_no_snapshots(tmp_path: Path) -> None:
     out = tmp_path / "out.jsonl"
     ret = et.main(["--snapshots", str(tmp_path), "-o", str(out)])


### PR DESCRIPTION
## Summary
- normalize snapshot step detection to handle both `.json` and `.json.zst` files when exporting traces
- add a unit test covering mixed snapshot suffixes to ensure ordering remains correct

## Testing
- pytest tests/unit/scripts/test_export_traces.py
- ruff check scripts/export_traces.py tests/unit/scripts/test_export_traces.py

------
https://chatgpt.com/codex/tasks/task_e_68de8c9caad88326ac6830b664a818a8