### PR TITLE
Handle compressed snapshot event log resolution in replay CLI

### DIFF
--- a/tests/unit/tools/test_replay_cli.py
+++ b/tests/unit/tools/test_replay_cli.py
@@ -61,3 +61,15 @@ def test_replay_cli_tick_range_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
     assert called["start"] == 5
     assert called["end"] == 7
     assert called["events"] is None
+
+
+@pytest.mark.unit
+def test_resolve_event_log_handles_compressed_snapshot(tmp_path: Path) -> None:
+    snapshot = tmp_path / "sim.json.zst"
+    snapshot.touch()
+    expected = tmp_path / "sim.jsonl"
+    expected.touch()
+
+    resolved = replay_cli._resolve_event_log(snapshot, explicit=None)
+
+    assert resolved == expected

--- a/tools/replay_cli.py
+++ b/tools/replay_cli.py
@@ -4,9 +4,8 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
-
 
 from src.infra import event_log
 from src.sim.simulation import Simulation
@@ -16,7 +15,13 @@ def _candidate_event_logs(snapshot: Path) -> Iterable[Path]:
     """Yield plausible event log paths relative to ``snapshot``."""
 
     directory = snapshot.parent
-    stem = snapshot.stem
+
+    compression_suffixes = {".zst", ".gz", ".bz2", ".xz"}
+    uncompressed_snapshot = snapshot
+    while uncompressed_snapshot.suffix in compression_suffixes:
+        uncompressed_snapshot = uncompressed_snapshot.with_suffix("")
+
+    stem = uncompressed_snapshot.stem
     if stem.endswith(".json"):
         stem = stem[:-5]
     candidates = [
@@ -24,7 +29,7 @@ def _candidate_event_logs(snapshot: Path) -> Iterable[Path]:
         directory / "event_log.jsonl",
         directory / f"{stem}.events.jsonl",
         directory / f"{stem}.event_log.jsonl",
-        snapshot.with_suffix(".jsonl"),
+        uncompressed_snapshot.with_suffix(".jsonl"),
     ]
     seen: set[Path] = set()
     for candidate in candidates:


### PR DESCRIPTION
## Summary
- ensure the replay CLI strips compression suffixes before composing event log candidates
- add a unit test to confirm compressed snapshots resolve to the expected .jsonl log

## Testing
- pytest tests/unit/tools/test_replay_cli.py
- ruff check tools/replay_cli.py tests/unit/tools/test_replay_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68de8c9d9eb08326b79f2d08d7b4dfc5