### PR TITLE
Consolidate DU budget metrics helper

### DIFF
--- a/src/infra/metrics.py
+++ b/src/infra/metrics.py
@@ -24,31 +24,6 @@ _LATENCY_SAMPLES_PER_AGENT: dict[str, deque[float]] = {}
 # Keep rolling windows for retrieval benchmark metrics
 _RETRIEVAL_LATENCY_SAMPLES: deque[float] = deque(maxlen=100)
 _RECALL_P5_SAMPLES: deque[float] = deque(maxlen=100)
-
-
-def record_du_budget(agent_id: str, value: float) -> None:
-    """Record the remaining DU budget for ``agent_id``."""
-
-    _agent_du_budget[agent_id] = float(value)
-
-    gauge = getattr(prom_metrics, "AGENT_REMAINING_DU", None)
-    if gauge is not None:
-        try:  # pragma: no cover - defensive update
-            if hasattr(gauge, "labels"):
-                gauge.labels(agent_id=agent_id).set(float(value))
-            else:
-                gauge.set(float(value))
-        except Exception:
-            pass
-
-    try:  # pragma: no cover - optional dependency
-        hook = getattr(ledger, "record_du_budget", None)
-        if callable(hook):
-            hook(agent_id, value)
-    except Exception:
-        pass
-
-
 def record_du_per_1k_tokens(agent_id: str, value: float) -> None:
     """Record DU cost per 1k tokens for the latest LLM call."""
     global _last_du_per_1k_tokens
@@ -148,25 +123,34 @@ def record_du_budget(agent_id: str, remaining: float) -> None:
 
     remaining = float(remaining)
     _agent_du_budget[agent_id] = remaining
+
     gauge = getattr(prom_metrics, "AGENT_REMAINING_DU", None)
     if gauge is not None:
+        updated = False
         if hasattr(gauge, "labels"):
             try:
-                gauge.labels(agent_id=agent_id).set(remaining)
+                child = gauge.labels(agent_id=agent_id)
             except Exception:
-                try:
-                    gauge.set(remaining)
-                except Exception:
-                    pass
-        else:
+                child = None
+            else:
+                if hasattr(child, "set"):
+                    try:
+                        child.set(remaining)
+                        updated = True
+                    except Exception:
+                        pass
+        if not updated and hasattr(gauge, "set"):
             try:
                 gauge.set(remaining)
             except Exception:
                 pass
-    try:  # pragma: no cover - optional dependency
-        ledger.record_du_budget(agent_id, remaining)
-    except Exception:
-        pass
+
+    hook = getattr(ledger, "record_du_budget", None)
+    if callable(hook):
+        try:  # pragma: no cover - optional dependency
+            hook(agent_id, remaining)
+        except Exception:
+            pass
 
 
 def record_llm_latency(agent_id: str, latency_ms: float) -> None:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -6,9 +6,9 @@ import logging
 import random
 import threading
 import time
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import numpy as np
 from opentelemetry import trace

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -18,11 +18,26 @@ def _ensure_record_du_budget_stub() -> None:
         return
 
     def record_du_budget(agent_id: str, value: float) -> None:
-        metrics_module._agent_du_budget[agent_id] = float(value)
+        remaining = float(value)
+        metrics_module._agent_du_budget[agent_id] = remaining
         gauge = getattr(metrics_module.prom_metrics, "AGENT_REMAINING_DU", None)
         if hasattr(gauge, "labels"):
             try:
-                gauge.labels(agent_id=agent_id).set(float(value))
+                gauge.labels(agent_id=agent_id).set(remaining)
+            except Exception:
+                try:
+                    gauge.set(remaining)
+                except Exception:
+                    pass
+        else:
+            try:
+                gauge.set(remaining)
+            except Exception:
+                pass
+        hook = getattr(metrics_module.ledger, "record_du_budget", None)
+        if callable(hook):
+            try:
+                hook(agent_id, remaining)
             except Exception:
                 pass
 

--- a/tests/unit/infra/test_metrics_helpers.py
+++ b/tests/unit/infra/test_metrics_helpers.py
@@ -1,10 +1,10 @@
-import pytest
-
 from collections import deque
 from types import SimpleNamespace
 
-from src.infra import metrics as infra_metrics
+import pytest
+
 import src.sim.resource_manager as resource_manager_mod
+from src.infra import metrics as infra_metrics
 
 
 class GaugeChildStub:
@@ -24,6 +24,49 @@ class GaugeStub:
         if key not in self._metrics:
             self._metrics[key] = GaugeChildStub(0.0)
         return self._metrics[key]
+
+
+@pytest.mark.unit
+def test_record_du_budget_updates_backends_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    child_calls: list[float] = []
+
+    class GaugeWithLabels:
+        def __init__(self) -> None:
+            self.label_calls: list[dict[str, str]] = []
+            self.set_calls: list[float] = []
+
+        def labels(self, **labels: str):
+            self.label_calls.append(labels)
+
+            class Child:
+                def set(self_inner, value: float) -> None:
+                    child_calls.append(value)
+
+            return Child()
+
+        def set(self, value: float) -> None:
+            self.set_calls.append(value)
+
+    gauge = GaugeWithLabels()
+    ledger_calls: list[tuple[str, float]] = []
+
+    def ledger_hook(agent_id: str, remaining: float) -> None:
+        ledger_calls.append((agent_id, remaining))
+
+    monkeypatch.setattr(infra_metrics, "_agent_du_budget", {}, raising=False)
+    monkeypatch.setattr(infra_metrics.prom_metrics, "AGENT_REMAINING_DU", gauge, raising=False)
+    monkeypatch.setattr(
+        infra_metrics,
+        "ledger",
+        SimpleNamespace(record_du_budget=ledger_hook),
+    )
+
+    infra_metrics.record_du_budget("agent-42", 12.5)
+
+    assert infra_metrics._agent_du_budget["agent-42"] == pytest.approx(12.5)
+    assert child_calls == [12.5]
+    assert gauge.set_calls == []
+    assert ledger_calls == [("agent-42", 12.5)]
 
 
 @pytest.mark.unit

--- a/tests/unit/interfaces/test_board_payload_embed.py
+++ b/tests/unit/interfaces/test_board_payload_embed.py
@@ -1,12 +1,7 @@
-import hashlib
-import json
-import sys
-from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
-from src.interfaces.dashboard_backend import board_payload_to_embed  # noqa: E402
+from src.interfaces.dashboard_backend import board_payload_to_embed
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- merge the duplicate `record_du_budget` implementations into a single helper that only updates gauges once and safely invokes the ledger hook
- align the signature demo stub with the consolidated helper behaviour and refresh linted imports
- add a focused unit test covering the DU budget helper while updating linted imports touched by the check

## Testing
- pytest tests/unit/infra/test_metrics_helpers.py
- ruff check src/ tests/


------
https://chatgpt.com/codex/tasks/task_e_68e3d1bd99f88326b96f75861508b9cd