### PR TITLE
Fix signature demo summaries

### DIFF
--- a/scripts/run_signature_demo.py
+++ b/scripts/run_signature_demo.py
@@ -8,7 +8,7 @@ import json
 import os
 import shutil
 import statistics
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -182,9 +182,49 @@ def _summarize_targets(
     return summary
 
 
+def _summarize_success_metrics(
+    success_metrics: Mapping[str, object] | None,
+) -> dict[str, object]:
+    if not success_metrics:
+        return {}
+
+    def _sanitize(value: object) -> object:
+        if isinstance(value, Mapping):
+            return {str(key): _sanitize(inner) for key, inner in value.items()}
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            return [_sanitize(item) for item in value]
+        return value
+
+    return {str(metric): _sanitize(details) for metric, details in success_metrics.items()}
+
+
+def _append_guidance_details(
+    lines: list[str],
+    details: object,
+    indent: str = "  ",
+) -> None:
+    if isinstance(details, Mapping):
+        for key, value in details.items():
+            if isinstance(value, Mapping):
+                lines.append(f"{indent}- {key}:")
+                _append_guidance_details(lines, value, indent + "  ")
+            elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                lines.append(f"{indent}- {key}:")
+                for item in value:
+                    _append_guidance_details(lines, item, indent + "  ")
+            else:
+                lines.append(f"{indent}- {key}: {value}")
+    elif isinstance(details, Sequence) and not isinstance(details, (str, bytes, bytearray)):
+        for item in details:
+            _append_guidance_details(lines, item, indent)
+    else:
+        lines.append(f"{indent}- {details}")
+
+
 def _write_readme(
     entries: Iterable[tuple[str, Path]],
     target_summary: dict[str, dict[str, object]] | None = None,
+    success_guidance: Mapping[str, object] | None = None,
 ) -> None:
     lines = [
         "# Signature Demo Results",
@@ -228,6 +268,12 @@ def _write_readme(
             if isinstance(reason, str):
                 lines.append(f"  - Note: {reason}")
 
+    if success_guidance:
+        lines.extend(["", "## Success Metrics Guidance", ""])
+        for metric, details in success_guidance.items():
+            lines.append(f"- **{metric}**")
+            _append_guidance_details(lines, details)
+
     README_PATH.parent.mkdir(parents=True, exist_ok=True)
     README_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -266,12 +312,13 @@ async def main() -> None:
 
     metrics_path = RESULT_DIR / "metrics.json"
     metrics = export_traces.load_metrics(event_log_path)
-    target_summary = _summarize_targets(
-        metrics, data.get("evaluation_targets") if isinstance(data, dict) else None
-    )
+    target_summary = _summarize_targets(metrics, evaluation_targets)
+    success_guidance = _summarize_success_metrics(success_metrics)
     metrics_output: dict[str, object] = {key: value for key, value in metrics.items()}
     if target_summary:
         metrics_output["_target_summary"] = target_summary
+    if success_guidance:
+        metrics_output["_success_metrics_guidance"] = success_guidance
     with metrics_path.open("w", encoding="utf-8") as fh:
         json.dump(metrics_output, fh, indent=2)
 
@@ -307,7 +354,7 @@ async def main() -> None:
     ]
     for plot_path in sorted(plot_paths):
         artifact_entries.append((f"Plot: {plot_path.stem}", plot_path))
-    _write_readme(artifact_entries, target_summary)
+    _write_readme(artifact_entries, target_summary, success_guidance)
 
     print(f"Event log: {event_log_path}")
     print(f"Metrics: {metrics_path}")

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -194,6 +194,18 @@ async def test_run_signature_demo(
         entry = target_summary[key]
         assert isinstance(entry, dict)
         assert "status" in entry
+    success_guidance = metrics.get("_success_metrics_guidance")
+    assert isinstance(success_guidance, dict)
+    assert success_guidance.get("coalition_count", {}).get("target_max") == success_metrics[
+        "coalition_count"
+    ]["target_max"]
+    sentiment_guidance = success_guidance.get("sentiment_curve")
+    assert isinstance(sentiment_guidance, dict)
+    expected_trend = sentiment_guidance.get("expected_trend")
+    assert isinstance(expected_trend, dict)
+    assert expected_trend.get("proposal") == success_metrics["sentiment_curve"]["expected_trend"][
+        "proposal"
+    ]
 
     replay_files = sorted(snapshots_dir.glob("replay_*.jsonl"))
     assert replay_files, "Replay slice not created"
@@ -219,3 +231,6 @@ async def test_run_signature_demo(
 
     readme_text = (result_dir / "README.md").read_text(encoding="utf-8")
     assert "Evaluation Target Summary" in readme_text
+    assert "Success Metrics Guidance" in readme_text
+    assert "coalition_count" in readme_text
+    assert "variance_tolerance" in readme_text


### PR DESCRIPTION
## Summary
- ensure the signature demo reuses the loaded evaluation targets and emits success metric guidance alongside target summaries
- update the generated README to include success metric guidance and add the guidance to the metrics artifact
- extend the signature demo integration test to validate the enhanced summaries

## Testing
- pytest tests/integration/scenario/test_run_signature_demo.py -m integration

------
https://chatgpt.com/codex/tasks/task_e_68e3d1bc36c883268096ba07a64e499c