### PR TITLE
Respect agent post-turn memory policies

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -78,6 +78,22 @@ def _generate_default_genes() -> dict[str, float]:
     return {f"g{i}": random.random() for i in range(3)}
 
 
+def _coerce_policy_bool(value: Any, default: bool = True) -> bool:
+    """Best-effort coercion of policy values to boolean."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
 class AgentActionIntent(str, Enum):
     IDLE = "idle"
     CONTINUE_COLLABORATION = "continue_collaboration"
@@ -172,6 +188,7 @@ class AgentStateData(BaseModel):
     memory_retriever_token_cap: int = Field(
         default_factory=lambda: int(str(get_config("MEMORY_RETRIEVER_TOKEN_LIMIT") or "1000"))
     )
+    post_turn_memory_policy: Any = Field(default_factory=lambda: {"write": True})
 
     def __init__(self, **data: Any) -> None:
         """Initialize and conditionally call ``model_post_init`` for Pydantic v1."""
@@ -344,6 +361,49 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             if isinstance(first_goal, dict) and "description" in first_goal:
                 return str(first_goal["description"])
         return "Contribute to the simulation as effectively as possible."
+
+    def should_write_post_turn_memory(
+        self: Self,
+        *,
+        event_type: str,
+        memory_type: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Return whether post-turn memories should be written to persistent storage."""
+
+        policy = getattr(self, "post_turn_memory_policy", None)
+        default = True
+
+        if callable(policy):
+            try:
+                result = policy(
+                    self,
+                    event_type=event_type,
+                    memory_type=memory_type,
+                    metadata=metadata,
+                )
+            except TypeError:
+                try:
+                    result = policy(
+                        event_type=event_type,
+                        memory_type=memory_type,
+                        metadata=metadata,
+                    )
+                except TypeError:
+                    result = policy(event_type, memory_type, metadata)
+            return _coerce_policy_bool(result, default)
+
+        if isinstance(policy, dict):
+            if memory_type and memory_type in policy:
+                return _coerce_policy_bool(policy[memory_type], default)
+            if event_type in policy:
+                return _coerce_policy_bool(policy[event_type], default)
+            for key in ("write", "allow", "enabled"):
+                if key in policy:
+                    return _coerce_policy_bool(policy[key], default)
+            return default
+
+        return _coerce_policy_bool(policy, default)
 
     # ------------------------------------------------------------------
     # Role embedding utilities

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -172,6 +172,52 @@ def _set_current_role(agent_state: AgentState, role: str) -> None:
         setattr(agent_state, "role", role)
 
 
+def _coerce_truthy(value: Any, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _should_write_post_turn_memory(
+    agent_state: AgentState | Any,
+    *,
+    event_type: str,
+    memory_type: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    policy_fn = getattr(agent_state, "should_write_post_turn_memory", None)
+    if callable(policy_fn):
+        try:
+            result = policy_fn(
+                event_type=event_type,
+                memory_type=memory_type,
+                metadata=metadata,
+            )
+        except TypeError:
+            result = policy_fn(event_type, memory_type, metadata)
+        return _coerce_truthy(result)
+
+    policy = getattr(agent_state, "post_turn_memory_policy", None)
+    if isinstance(policy, dict):
+        if memory_type and memory_type in policy:
+            return _coerce_truthy(policy[memory_type])
+        if event_type in policy:
+            return _coerce_truthy(policy[event_type])
+        for key in ("write", "allow", "enabled"):
+            if key in policy:
+                return _coerce_truthy(policy[key])
+        return True
+    return _coerce_truthy(policy)
+
+
 def _embedding_similarity(vec1: list[float], vec2: list[float]) -> float:
     """Return cosine similarity between two vectors."""
     if not vec1 or not vec2:
@@ -304,14 +350,21 @@ def update_state_node(state: AgentTurnState) -> dict[str, Any]:
                     memory_summary,
                     {"step": sim_step, "type": "consolidated_summary"},
                 )
-                service = state.get("memory_service")
-                if service and hasattr(service, "add_memory"):
-                    cast(MemoryService, service).add_memory(
+                service = cast(MemoryService | None, state.get("memory_service"))
+                if service and hasattr(service, "store_post_turn_memory"):
+                    should_write = _should_write_post_turn_memory(
+                        agent_state_obj,
+                        event_type="consolidated_summary",
+                        memory_type="consolidated_summary",
+                        metadata={"step": sim_step},
+                    )
+                    service.store_post_turn_memory(
                         agent_id,
                         sim_step,
                         "consolidated_summary",
                         memory_summary,
-                        "consolidated_summary",
+                        write=should_write,
+                        memory_type="consolidated_summary",
                     )
                 logger.info(f"Agent {agent_id}: Generated L1 memory summary.")
         except Exception as e:

--- a/tests/unit/graphs/test_basic_agent_graph_utils.py
+++ b/tests/unit/graphs/test_basic_agent_graph_utils.py
@@ -1,4 +1,5 @@
 import random
+from collections import deque
 from types import SimpleNamespace
 
 import pytest
@@ -33,6 +34,7 @@ def make_agent_state() -> SimpleNamespace:
         du=0.0,
         role_embedding=ROLE_EMBEDDINGS.role_vectors[roles.ROLE_INNOVATOR],
         role_reputation={},
+        post_turn_memory_policy={"write": True},
     )
 
 
@@ -138,3 +140,88 @@ def test_compile_agent_graph(monkeypatch: pytest.MonkeyPatch) -> None:
     compiled = "compiled"
     monkeypatch.setattr(bag, "build_graph", lambda: compiled)
     assert bag.compile_agent_graph() == compiled
+
+
+class DummyMemoryService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def store_post_turn_memory(
+        self,
+        agent_id: str,
+        step: int,
+        event_type: str,
+        content: str,
+        *,
+        write: bool,
+        memory_type: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "agent_id": agent_id,
+                "step": step,
+                "event_type": event_type,
+                "content": content,
+                "write": write,
+                "memory_type": memory_type,
+                "metadata": metadata,
+            }
+        )
+        return "stored" if write else ""
+
+
+class DummySummary:
+    def __init__(self, summary: str) -> None:
+        self.summary = summary
+
+
+class DummyL1Generator:
+    def __init__(self, summary_text: str = "summary") -> None:
+        self._summary_text = summary_text
+
+    def generate_summary(self, *args: object, **kwargs: object) -> DummySummary:
+        return DummySummary(self._summary_text)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("policy_config,expected", [(True, True), (False, False), ({"write": False}, False)])
+def test_update_state_node_respects_post_turn_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    policy_config: object,
+    expected: bool,
+) -> None:
+    agent_state = make_agent_state()
+    agent_state.short_term_memory = deque(
+        [
+            {"content": "m1"},
+            {"content": "m2"},
+            {"content": "m3"},
+        ]
+    )
+    agent_state.llm_client = object()
+    agent_state.mood_value = 0.0
+
+    if isinstance(policy_config, bool):
+        agent_state.should_write_post_turn_memory = lambda **_: policy_config
+    else:
+        agent_state.post_turn_memory_policy = policy_config
+
+    controller = DummyController(agent_state)
+    monkeypatch.setattr(bag, "AgentController", lambda s: controller)
+    monkeypatch.setattr(bag, "L1SummaryGenerator", lambda: DummyL1Generator("generated"))
+
+    service = DummyMemoryService()
+
+    state = {
+        "agent_id": "agent_1",
+        "simulation_step": 4,
+        "structured_output": SimpleNamespace(action_intent="idle", requested_role_change=None),
+        "state": agent_state,
+        "memory_service": service,
+    }
+
+    bag.update_state_node(state)
+
+    assert service.calls, "Memory service should be invoked for summaries"
+    assert service.calls[0]["write"] is expected

--- a/tests/unit/memory/test_post_turn_policy.py
+++ b/tests/unit/memory/test_post_turn_policy.py
@@ -21,6 +21,12 @@ def test_post_turn_write_policy(chroma_test_dir: Path) -> None:
 
     mem_id = service.store_post_turn_memory("agent", 1, "thought", "hello", write=True)
     assert mem_id
+    stored = vector.collection.get(include=["ids", "documents"])
+    assert stored
+    assert stored.get("documents") == ["hello"]
 
     no_mem = service.store_post_turn_memory("agent", 2, "thought", "skip", write=False)
     assert no_mem == ""
+    stored_after = vector.collection.get(include=["ids", "documents"])
+    assert stored_after
+    assert stored_after.get("documents") == ["hello"]


### PR DESCRIPTION
## Summary
- add post-turn memory policy support on AgentState and helper utilities for coercing policy results
- route BasicAgentGraph summary writes through MemoryService.store_post_turn_memory with explicit policy-based flags
- extend unit coverage for policy-aware writes and MemoryService skip behavior

## Testing
- pytest tests/unit/memory/test_post_turn_policy.py
- pytest tests/unit/graphs/test_basic_agent_graph_utils.py
- pytest tests/integration/memory


------
https://chatgpt.com/codex/tasks/task_e_68e3d7d2389083269119dfd213fac66c