### PR TITLE
Log and replay human command events

### DIFF
--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -283,10 +283,14 @@ def _rehydrate_last_hash(path: Path) -> None:
         pass
 
 
+_STEP_EQ_ALLOWED_TYPES = {"human_command"}
+
+
 def _is_valid_event(event: dict[str, Any], last_step: int, last_hash: str | None) -> bool:
     """Check ``event`` ordering and integrity."""
     step = event.get("step", 0)
-    if step <= last_step:
+    event_type = event.get("type")
+    if step <= last_step and event_type not in _STEP_EQ_ALLOWED_TYPES:
         return False
     event_copy = {**event}
     trace_hash = event_copy.pop("trace_hash", None)
@@ -306,7 +310,8 @@ def _filter_events(
     valid: list[dict[str, Any]] = []
     for ev in events:
         if _is_valid_event(ev, last_step, last_hash):
-            last_step = ev.get("step", last_step)
+            if ev.get("type") not in _STEP_EQ_ALLOWED_TYPES:
+                last_step = ev.get("step", last_step)
             last_hash = ev.get("trace_hash")
             valid.append(ev)
     return valid

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -450,6 +450,21 @@ class Simulation:
             self.pending_messages_for_next_round.extend(msgs)
             self.messages_to_perceive_this_round.extend(msgs)
 
+        log_event(
+            {
+                "type": "human_command",
+                "step": self.current_step,
+                "tick": self.current_step + 1,
+                "sender_id": "human",
+                "target_agent_id": target.agent_id,
+                "broadcast": broadcast,
+                "text": text,
+                "ip_cost": ip_cost,
+                "du_cost": du_cost,
+                "messages": [dict(msg) for msg in msgs],
+            }
+        )
+
         if self.discord_bot and self.discord_bot.last_channel_id is not None:
             chan = self.discord_bot.last_channel_id
             aid = target.agent_id
@@ -1520,6 +1535,80 @@ class Simulation:
                 self.collective_ip = float(event["ip"])
             if "du" in event:
                 self.collective_du = float(event["du"])
+        elif event.get("type") == "human_command":
+            step = event.get("step")
+            if isinstance(step, int) and step > self.current_step:
+                self.current_step = step
+            sender = str(event.get("sender_id", "human"))
+            default_step = int(step) if isinstance(step, int) else self.current_step
+            raw_messages = event.get("messages", [])
+            reconstructed: list[SimulationMessage] = []
+            if isinstance(raw_messages, list):
+                for msg in raw_messages:
+                    if not isinstance(msg, Mapping):
+                        continue
+                    msg_step = msg.get("step", default_step)
+                    try:
+                        msg_step_int = int(msg_step)
+                    except (TypeError, ValueError):
+                        msg_step_int = default_step
+                    reconstructed.append(
+                        cast(
+                            SimulationMessage,
+                            {
+                                "step": msg_step_int,
+                                "sender_id": str(msg.get("sender_id", sender)),
+                                "recipient_id": msg.get("recipient_id"),
+                                "content": str(msg.get("content", "")),
+                                "action_intent": msg.get(
+                                    "action_intent",
+                                    AgentActionIntent.SEND_DIRECT_MESSAGE.value,
+                                ),
+                                "sentiment_score": msg.get("sentiment_score"),
+                            },
+                        )
+                    )
+            if not reconstructed:
+                text = str(event.get("text", ""))
+                target = event.get("target_agent_id")
+                recipients: list[str | None]
+                if event.get("broadcast"):
+                    recipients = [agent.agent_id for agent in self.agents]
+                elif isinstance(target, str):
+                    recipients = [target]
+                else:
+                    recipients = [None]
+                reconstructed = [
+                    cast(
+                        SimulationMessage,
+                        {
+                            "step": default_step,
+                            "sender_id": sender,
+                            "recipient_id": recipient,
+                            "content": text,
+                            "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
+                            "sentiment_score": None,
+                        },
+                    )
+                    for recipient in recipients
+                ]
+            target_id = event.get("target_agent_id")
+            try:
+                ip_cost = float(event.get("ip_cost", 0.0))
+            except (TypeError, ValueError):
+                ip_cost = 0.0
+            try:
+                du_cost = float(event.get("du_cost", 0.0))
+            except (TypeError, ValueError):
+                du_cost = 0.0
+            if isinstance(target_id, str):
+                for agent in self.agents:
+                    if agent.agent_id == target_id:
+                        agent.state.ip -= ip_cost
+                        agent.state.du -= du_cost
+                        break
+            self.pending_messages_for_next_round.extend(reconstructed)
+            self.messages_to_perceive_this_round.extend(reconstructed)
         elif event.get("type") == "snapshot":
             step = event.get("step")
             if isinstance(step, int):

--- a/tests/integration/sim/test_human_command_replay.py
+++ b/tests/integration/sim/test_human_command_replay.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.infra import event_log
+from src.infra.ledger import Ledger
+from src.sim.simulation import Simulation
+
+
+@dataclass
+class RecordingState:
+    ip: float = 5.0
+    du: float = 5.0
+    short_term_memory: list[dict[str, Any]] = field(default_factory=list)
+    messages_sent_count: int = 0
+    last_message_step: int | None = None
+    collective_ip: float = 0.0
+    collective_du: float = 0.0
+    role: str = "tester"
+    current_role: str = "tester"
+    steps_in_current_role: int = 0
+    mood_level: float = 0.0
+    mood_value: float = 0.0
+    current_project_id: str | None = None
+    name: str = "Recorder"
+    is_alive: bool = True
+    age: int = 0
+
+
+class RecordingAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = RecordingState()
+        self.perceptions: list[list[dict[str, Any]]] = []
+
+    def get_id(self) -> str:  # pragma: no cover - used by scheduler
+        return self.agent_id
+
+    def update_state(self, state: RecordingState) -> None:  # pragma: no cover - simple setter
+        self.state = state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict[str, Any] | None = None,
+        vector_store_manager: Any | None = None,
+        knowledge_board: Any | None = None,
+        memory_service: Any | None = None,
+    ) -> dict[str, Any]:
+        perceived = environment_perception.get("perceived_messages", []) if environment_perception else []
+        self.perceptions.append([dict(msg) for msg in perceived])
+        return {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_human_command_event_replays_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir()
+    ledger = Ledger(ledger_dir / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    event_path = events_dir / "events.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(event_path))
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+    event_log._last_hash = None
+    event_log._seed = None
+    event_log._seed_cache = {}
+
+    agent = RecordingAgent("agent-1")
+    ledger.log_change(agent.agent_id, agent.state.ip, agent.state.du, "init")
+    sim = Simulation([agent], seed=123)
+
+    await sim._handle_human_command("hello there")
+    await sim.run_step()
+    original_messages = agent.perceptions[-1]
+
+    await sim.stop_event_listener()
+    sim.close()
+
+    events = event_log.fetch_events(after_step=0, path=event_path)
+    assert any(ev.get("type") == "human_command" for ev in events)
+
+    replay_agent = RecordingAgent("agent-1")
+    replay_sim = Simulation([replay_agent], seed=123)
+    for ev in events:
+        replay_sim.apply_event(ev)
+
+    await replay_sim.run_step()
+    replayed_messages = replay_agent.perceptions[-1]
+
+    await replay_sim.stop_event_listener()
+    replay_sim.close()
+
+    assert replayed_messages == original_messages


### PR DESCRIPTION
## Summary
- log human-issued commands with structured payloads that include delivery metadata and costs
- allow event replays to enqueue logged human messages and deduct the recorded resources
- add an integration test that verifies a replayed simulation delivers the same human message to the agent

## Testing
- pytest -m "integration" tests/integration/sim/test_human_command_replay.py
- ruff check src/sim/simulation.py src/infra/event_log/__init__.py tests/integration/sim/test_human_command_replay.py

------
https://chatgpt.com/codex/tasks/task_e_68e91a3fcf6883268188a9717c2a79f6