### PR TITLE
Auto-discover event logs for snapshot replay

### DIFF
--- a/docs/replay.md
+++ b/docs/replay.md
@@ -12,12 +12,14 @@ python -m src.app --seed 42
 
 ## Replaying from a snapshot
 
-To replay a previous run, pass the snapshot path to `--replay`. Optional `--replay-start` and `--replay-end` flags restrict which ticks from the event log are applied. Supplying the same `--seed` as the original run restores deterministic behaviour.
+To replay a previous run, pass the snapshot path to `--replay`. When `EVENT_LOG_PATH` is unset the application automatically looks for an `event_log.jsonl` (or similar) located next to the snapshot and uses it for replay. Optional `--replay-start` and `--replay-end` flags restrict which ticks from the event log are applied. Supplying the same `--seed` as the original run restores deterministic behaviour.
 
 ```bash
 python -m src.app --replay snapshots/snapshot_10.json --seed 42 \
     --replay-start 11 --replay-end 20
 ```
+
+If you need to point to a different log file, set `EVENT_LOG_PATH` before running `src.app` or pass `--events /path/to/log.jsonl` to `tools/replay_cli.py`.
 
 ## Slicing event logs
 

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -383,8 +384,14 @@ def main() -> None:
         log_suppressed=args.log_suppressed_warnings,
     )
 
+    events_path: Path | None = None
+    if args.replay:
+        events_path = event_log.resolve_replay_event_log(
+            Path(args.replay), os.getenv("EVENT_LOG_PATH")
+        )
+
     if args.seed is None and args.replay:
-        stored = event_log.get_seed()
+        stored = event_log.get_seed(events_path)
         if stored is not None:
             logging.info("Using seed %s from event log", stored)
             args.seed = stored
@@ -400,6 +407,8 @@ def main() -> None:
         }
         if args.seed is not None:
             replay_kwargs["seed"] = args.seed
+        if events_path is not None:
+            replay_kwargs["events_path"] = events_path
         Simulation.replay_from_snapshot(
             args.replay,
             **replay_kwargs,
@@ -408,7 +417,9 @@ def main() -> None:
             out_path = Path(args.export_dataset)
             with out_path.open("w", encoding="utf-8") as fh:
                 after = (args.replay_start or 0) - 1
-                for ev in event_log.stream_events(after_step=after, end_step=args.replay_end):
+                for ev in event_log.stream_events(
+                    after_step=after, end_step=args.replay_end, path=events_path
+                ):
                     step = int(ev.get("step", 0))
                     if args.replay_start is not None and step < args.replay_start:
                         continue

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -30,6 +30,50 @@ except ImportError:  # pragma: no cover - fallback when tests stub snapshot
 
 compute_trace_hash = _compute_trace_hash
 
+
+def candidate_event_logs_for_snapshot(snapshot: str | Path) -> Iterable[Path]:
+    """Yield plausible event log paths relative to ``snapshot``."""
+
+    snapshot_path = Path(snapshot)
+    directory = snapshot_path.parent
+
+    compression_suffixes = {".zst", ".gz", ".bz2", ".xz"}
+    uncompressed_snapshot = snapshot_path
+    while uncompressed_snapshot.suffix in compression_suffixes:
+        uncompressed_snapshot = uncompressed_snapshot.with_suffix("")
+
+    stem = uncompressed_snapshot.stem
+    if stem.endswith(".json"):
+        stem = stem[:-5]
+    candidates = [
+        directory / "events.jsonl",
+        directory / "event_log.jsonl",
+        directory / f"{stem}.events.jsonl",
+        directory / f"{stem}.event_log.jsonl",
+        uncompressed_snapshot.with_suffix(".jsonl"),
+    ]
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        yield candidate
+
+
+def resolve_replay_event_log(
+    snapshot: str | Path, explicit: str | Path | None = None
+) -> Path | None:
+    """Determine which event log file should be used for replay."""
+
+    if explicit:
+        return Path(explicit)
+    for candidate in candidate_event_logs_for_snapshot(snapshot):
+        if candidate.exists():
+            return candidate
+    return None
+
 tracer = trace.get_tracer(__name__)
 
 _broker = os.getenv("REDPANDA_BROKER", "localhost:9092")

--- a/tests/unit/app/test_replay_event_log_detection.py
+++ b/tests/unit/app/test_replay_event_log_detection.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from src import app
+
+
+@pytest.mark.unit
+def test_replay_detects_adjacent_event_log(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text("{}", encoding="utf-8")
+    event_log_path = tmp_path / "event_log.jsonl"
+    event_log_path.write_text('{"type": "header", "seed": 17}\n', encoding="utf-8")
+
+    monkeypatch.delenv("EVENT_LOG_PATH", raising=False)
+
+    args = argparse.Namespace(
+        version=False,
+        scenario="Sample scenario",
+        agents=3,
+        steps=10,
+        seed=None,
+        discord=False,
+        vector_store=False,
+        vector_dir="./chroma_db",
+        semantic_memory=False,
+        semantic_db="bolt://localhost:7687",
+        semantic_user="neo4j",
+        semantic_password="test",
+        no_warning_filters=False,
+        log_suppressed_warnings=False,
+        checkpoint=None,
+        replay=str(snapshot),
+        replay_start=None,
+        replay_end=None,
+        proposal=None,
+        proposer_id="agent_1",
+        export_dataset=None,
+    )
+
+    monkeypatch.setattr(app, "parse_args", lambda: args)
+    monkeypatch.setattr(app, "setup_logging", lambda: None)
+
+    async def _noop_load_plugins() -> None:
+        return None
+
+    monkeypatch.setattr(app, "load_plugins", _noop_load_plugins)
+    monkeypatch.setattr(app, "configure_warning_filters", lambda *_, **__: None)
+    monkeypatch.setattr(
+        app,
+        "load_scenario",
+        lambda _: ("Sample scenario", None, None, [], [], {}, {}),
+    )
+
+    seed_calls: dict[str, Path | None] = {}
+
+    def _fake_get_seed(path: Path | None = None) -> int:
+        seed_calls["path"] = path
+        return 42
+
+    monkeypatch.setattr(app.event_log, "get_seed", _fake_get_seed)
+    monkeypatch.setattr(app.event_log, "set_seed", lambda *_: None)
+
+    replay_calls: dict[str, object] = {}
+
+    def _fake_replay(snapshot_path: Path, **kwargs: object) -> None:
+        replay_calls["snapshot"] = snapshot_path
+        replay_calls["kwargs"] = kwargs
+
+    monkeypatch.setattr(app.Simulation, "replay_from_snapshot", _fake_replay)
+
+    app.main()
+
+    assert seed_calls["path"] == event_log_path
+    assert Path(replay_calls["snapshot"]) == Path(args.replay)
+    assert replay_calls["kwargs"]["events_path"] == event_log_path
+    assert replay_calls["kwargs"]["seed"] == 42

--- a/tools/replay_cli.py
+++ b/tools/replay_cli.py
@@ -4,53 +4,13 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Iterable
 from pathlib import Path
 
 from src.infra import event_log
+from src.infra.event_log import (
+    resolve_replay_event_log as _resolve_event_log,
+)
 from src.sim.simulation import Simulation
-
-
-def _candidate_event_logs(snapshot: Path) -> Iterable[Path]:
-    """Yield plausible event log paths relative to ``snapshot``."""
-
-    directory = snapshot.parent
-
-    compression_suffixes = {".zst", ".gz", ".bz2", ".xz"}
-    uncompressed_snapshot = snapshot
-    while uncompressed_snapshot.suffix in compression_suffixes:
-        uncompressed_snapshot = uncompressed_snapshot.with_suffix("")
-
-    stem = uncompressed_snapshot.stem
-    if stem.endswith(".json"):
-        stem = stem[:-5]
-    candidates = [
-        directory / "events.jsonl",
-        directory / "event_log.jsonl",
-        directory / f"{stem}.events.jsonl",
-        directory / f"{stem}.event_log.jsonl",
-        uncompressed_snapshot.with_suffix(".jsonl"),
-    ]
-    seen: set[Path] = set()
-    for candidate in candidates:
-        if not candidate:
-            continue
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        yield candidate
-
-
-def _resolve_event_log(snapshot: Path, explicit: str | None) -> Path | None:
-    """Determine which event log file should be used for replay."""
-
-    if explicit:
-        return Path(explicit)
-    for candidate in _candidate_event_logs(snapshot):
-        if candidate.exists():
-
-            return candidate
-    return None
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary
- share replay log discovery helpers from `src.infra.event_log` and reuse them in the CLI
- ensure `src.app` replays use the resolved log for seed loading, playback, and dataset export
- document the auto-discovery behaviour and cover it with a unit test

## Testing
- ruff check src/app.py src/infra/event_log/__init__.py tools/replay_cli.py tests/unit/app/test_replay_event_log_detection.py
- pytest tests/unit/app/test_replay_event_log_detection.py tests/unit/tools/test_replay_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ee65859d908326a6eb50751c8b9bc1