### PR TITLE
Instrument MultiLayerRetriever latency metrics

### DIFF
--- a/src/agents/memory/multi_layer_retriever.py
+++ b/src/agents/memory/multi_layer_retriever.py
@@ -9,6 +9,7 @@ import tiktoken
 from opentelemetry import trace
 from typing_extensions import Self
 
+from src.infra import metrics as infra_metrics
 from src.interfaces import metrics
 
 from .semantic_memory_manager import SemanticMemoryManager
@@ -124,9 +125,15 @@ class MultiLayerRetriever:
                 metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
                 raise
             finally:
-                span.set_attribute(
-                    "memory.latency_ms", (time.perf_counter() - start_total) * 1000
-                )
+                latency_ms = (time.perf_counter() - start_total) * 1000
+                span.set_attribute("memory.latency_ms", latency_ms)
+                infra_metrics.record_retrieval_latency(latency_ms)
+                record_recall = getattr(infra_metrics, "record_recall_p5", None)
+                if callable(record_recall):
+                    try:
+                        record_recall(latency_ms)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
 
     async def retrieve_and_update_semantic(
         self: Self, agent_id: str, query: str = "", k: int = 5
@@ -170,9 +177,15 @@ class MultiLayerRetriever:
                 metrics.MEMORY_RETRIEVAL_ERRORS_TOTAL.inc()
                 raise
             finally:
-                span.set_attribute(
-                    "memory.latency_ms", (time.perf_counter() - start_total) * 1000
-                )
+                latency_ms = (time.perf_counter() - start_total) * 1000
+                span.set_attribute("memory.latency_ms", latency_ms)
+                infra_metrics.record_retrieval_latency(latency_ms)
+                record_recall = getattr(infra_metrics, "record_recall_p5", None)
+                if callable(record_recall):
+                    try:
+                        record_recall(latency_ms)
+                    except Exception:  # pragma: no cover - defensive
+                        pass
 
     def get_recent_semantic_summaries(self: Self, agent_id: str, limit: int = 3) -> list[str]:
         if not self.semantic_manager:

--- a/tests/unit/memory/test_multi_layer_retriever_spans.py
+++ b/tests/unit/memory/test_multi_layer_retriever_spans.py
@@ -56,3 +56,34 @@ async def test_retrieve_tracing(monkeypatch):
         if span.name != "memory.retrieve":
             assert span.attributes["llm.tokens.prompt"] == 0
             assert span.attributes["llm.tokens.completion"] == 0
+
+
+@pytest.mark.asyncio
+async def test_retrieve_records_latency_metric(monkeypatch):
+    times = iter([1.0, 2.0, 3.0, 4.0])
+
+    def fake_perf_counter():
+        return next(times)
+
+    monkeypatch.setattr(
+        "src.agents.memory.multi_layer_retriever.time.perf_counter", fake_perf_counter
+    )
+
+    recorded = {}
+
+    def fake_record_latency(value):
+        recorded["latency"] = value
+
+    monkeypatch.setattr(
+        "src.infra.metrics.record_retrieval_latency", fake_record_latency
+    )
+
+    class DummyVectorStore:
+        async def aretrieve_relevant_memories(self, agent_id, query, k):
+            return [{"relevance_score": 0.5}]
+
+    retriever = MultiLayerRetriever(DummyVectorStore(), None)
+    result = await retriever.retrieve("agent", "query", 1)
+
+    assert result
+    assert recorded["latency"] == pytest.approx(3000.0)


### PR DESCRIPTION
## Summary
- record retrieval latency metrics during multi-layer retrieval operations
- guard and invoke optional recall metric hooks alongside latency tracking
- add unit coverage ensuring latency metrics are recorded with measured timings

## Testing
- pytest tests/unit/memory/test_multi_layer_retriever_spans.py
- ruff check src/agents/memory/multi_layer_retriever.py tests/unit/memory/test_multi_layer_retriever_spans.py

------
https://chatgpt.com/codex/tasks/task_e_68f243af489883269c7797e8ed79d940