### PR TITLE
Add tracing spans for event dispatch

### DIFF
--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
+from opentelemetry import trace
 from typing_extensions import Self
 
 from src.infra.event_log import log_event
@@ -19,6 +20,8 @@ from src.interfaces.dashboard_backend import (
 
 from .event_bus import get_event_bus
 from .version_vector import VersionVector
+
+tracer = trace.get_tracer(__name__)
 
 
 @dataclass(order=True)
@@ -214,7 +217,16 @@ class EventKernel:
                 continue
             self.current_step = event.step
             self.vector.merge(event.vector)
-            await event.callback()
+            queue_depth_before_callback = len(self._queue)
+            with tracer.start_as_current_span("event.kernel.dispatch") as span:
+                if span.is_recording():
+                    span.set_attribute("event.agent_id", event.agent_id or "")
+                    span.set_attribute("event.step", event.step)
+                    span.set_attribute("event.token_burn", event.tokens)
+                    span.set_attribute(
+                        "event.queue_depth_before_callback", queue_depth_before_callback
+                    )
+                await event.callback()
             executed.append(event)
         return executed
 

--- a/tests/unit/sim/test_event_kernel_tracing.py
+++ b/tests/unit/sim/test_event_kernel_tracing.py
@@ -1,0 +1,71 @@
+import pytest
+
+from src.sim.event_kernel import EventKernel
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingSpan:
+    def __init__(self, tracer: "RecordingTracer", name: str) -> None:
+        self._tracer = tracer
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def __enter__(self) -> "RecordingSpan":
+        self._tracer.spans.append(self)
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        pass
+
+    def is_recording(self) -> bool:
+        return True
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[RecordingSpan] = []
+
+    def start_as_current_span(self, name: str) -> RecordingSpan:
+        return RecordingSpan(self, name)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_records_span_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = RecordingTracer()
+    monkeypatch.setattr("src.sim.event_kernel.tracer", tracer)
+
+    kernel = EventKernel()
+    kernel.set_budget("agent-1", 10)
+    kernel.set_budget("agent-2", 10)
+    called: list[str] = []
+
+    async def cb(label: str) -> None:
+        called.append(label)
+
+    kernel.schedule_immediate_nowait(lambda: cb("first"), agent_id="agent-1", tokens=3)
+    kernel.schedule_in_nowait(0, lambda: cb("second"), agent_id="agent-2", tokens=1)
+
+    await kernel.dispatch(2)
+
+    assert called == ["first", "second"]
+    assert len(tracer.spans) == 2
+
+    first_span, second_span = tracer.spans
+    assert first_span.name == "event.kernel.dispatch"
+    assert first_span.attributes == {
+        "event.agent_id": "agent-1",
+        "event.step": 0,
+        "event.token_burn": 3,
+        "event.queue_depth_before_callback": 1,
+    }
+    assert second_span.attributes == {
+        "event.agent_id": "agent-2",
+        "event.step": 0,
+        "event.token_burn": 1,
+        "event.queue_depth_before_callback": 0,
+    }
+


### PR DESCRIPTION
## Summary
- instrument the event kernel dispatcher with OpenTelemetry spans that capture key metadata
- add a unit test that verifies span attributes during dispatch

## Testing
- pytest tests/unit/sim/test_event_kernel_tracing.py
- ruff check src/sim/event_kernel.py tests/unit/sim/test_event_kernel_tracing.py

------
https://chatgpt.com/codex/tasks/task_e_68f24928fbc08326ad76e9c55a2ca9a4