### PR TITLE
Add fixture and integration test for replay CLI

### DIFF
--- a/tests/integration/tools/test_replay_cli_integration.py
+++ b/tests/integration/tools/test_replay_cli_integration.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from src.sim.simulation import Simulation
+from tests.utils.replay_cli_fixture import (
+    ReplayFixtureAgent,
+    ReplayFixtureState,
+    create_replay_cli_artifacts,
+)
+from tools import replay_cli
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_replay_cli_replays_fixture(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    artifacts = await create_replay_cli_artifacts(tmp_path, monkeypatch)
+
+    captured: list[Simulation] = []
+    original = Simulation.replay_from_snapshot.__func__
+
+    def fake_from_snapshot(
+        cls: type[Simulation], snapshot: dict, *, seed: int | None = None
+    ) -> Simulation:
+        agents: list[ReplayFixtureAgent] = []
+        agents_data = snapshot.get("agents", [])
+        if not agents_data:
+            agents_data = [{"agent_id": "agent-1"}]
+        for idx, data in enumerate(agents_data):
+            agent_id = data.get("agent_id", f"agent-{idx}")
+            agent = ReplayFixtureAgent(agent_id)
+            state = ReplayFixtureState()
+            state.ip = float(data.get("ip", 0.0))
+            state.du = float(data.get("du", 0.0))
+            agent.state = state
+            agents.append(agent)
+
+        sim = Simulation(agents=agents)
+        sim.current_step = int(snapshot.get("step", 0))
+        sim.collective_ip = float(snapshot.get("collective_ip", 0.0))
+        sim.collective_du = float(snapshot.get("collective_du", 0.0))
+
+        kb = snapshot.get("knowledge_board", {})
+        entries = kb.get("entries", [])
+        sim.knowledge_board.entries.clear()
+        sim.knowledge_board.entries.extend(entries)
+
+        world_map = snapshot.get("world_map", {})
+        if isinstance(world_map, dict):
+            sim.world_map.width = int(world_map.get("width", sim.world_map.width))
+            sim.world_map.height = int(world_map.get("height", sim.world_map.height))
+            agents_positions = world_map.get("agents", {})
+            sim.world_map.agent_positions = {
+                key: tuple(value) if isinstance(value, (list, tuple)) else value
+                for key, value in agents_positions.items()
+            }
+        return sim
+
+    monkeypatch.setattr(
+        replay_cli.Simulation, "from_snapshot", classmethod(fake_from_snapshot)
+    )
+
+    def capture_replay(
+        cls: type[Simulation],
+        snapshot,
+        *,
+        start_step=None,
+        end_step=None,
+        seed=None,
+        events_path=None,
+    ) -> Simulation:
+        sim = original(
+            cls,
+            snapshot,
+            start_step=start_step,
+            end_step=end_step,
+            seed=seed,
+            events_path=events_path,
+        )
+        captured.append(sim)
+        return sim
+
+    monkeypatch.setattr(
+        replay_cli.Simulation, "replay_from_snapshot", classmethod(capture_replay)
+    )
+
+    exit_code = replay_cli.main(
+        [
+            str(artifacts.snapshot_path),
+            "--from",
+            str(artifacts.start_step),
+            "--to",
+            str(artifacts.end_step),
+            "--events",
+            str(artifacts.replay_slice_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured, "expected the replay CLI to invoke Simulation.replay_from_snapshot"
+
+    replayed = captured[-1]
+    try:
+        assert replayed.current_step == artifacts.expected_step
+        assert (
+            replayed.knowledge_board.to_dict().get("entries", [])
+            == artifacts.expected_knowledge_entries
+        )
+    finally:
+        replayed.close()

--- a/tests/utils/replay_cli_fixture.py
+++ b/tests/utils/replay_cli_fixture.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from src.infra import event_log
+from src.infra.snapshot import compute_trace_hash, save_snapshot
+from src.sim.simulation import Simulation
+
+__all__ = [
+    "ReplayCLIArtifacts",
+    "ReplayFixtureAgent",
+    "ReplayFixtureState",
+    "create_replay_cli_artifacts",
+]
+
+
+@dataclass(slots=True)
+class ReplayCLIArtifacts:
+    """Artifacts produced by the replay CLI fixture."""
+
+    snapshot_path: Path
+    events_path: Path
+    replay_slice_path: Path
+    start_step: int
+    end_step: int
+    expected_step: int
+    expected_knowledge_entries: list[dict]
+
+
+class ReplayFixtureState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    role: str = "dummy"
+    steps_in_current_role: int = 0
+    mood_level: float = 0.0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:  # pragma: no cover - stub
+        return None
+
+
+class ReplayFixtureAgent:
+    def __init__(self, agent_id: str = "agent-1") -> None:
+        self.agent_id = agent_id
+        self.state = ReplayFixtureState()
+        self._added = False
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, new_state: ReplayFixtureState) -> None:
+        self.state = new_state
+
+    async def run_turn(  # pragma: no cover - executed via simulation
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        memory_service: object | None = None,
+        vector_store_manager: object | None = None,
+        knowledge_board: object | None = None,
+        **_: object,
+    ) -> dict:
+        if not self._added and knowledge_board is not None:
+            knowledge_board.add_entry("fixture-entry", self.agent_id, simulation_step)
+            self._added = True
+        return {}
+
+
+def _snapshot_from_sim(sim: Simulation) -> dict:
+    snapshot = {
+        "step": sim.current_step,
+        "collective_ip": sim.collective_ip,
+        "collective_du": sim.collective_du,
+        "knowledge_board": sim.knowledge_board.to_dict(),
+        "world_map": sim.world_map.to_dict(),
+        "agents": [
+            {
+                "agent_id": agent.agent_id,
+                "ip": agent.state.ip,
+                "du": agent.state.du,
+            }
+            for agent in sim.agents
+        ],
+    }
+    snapshot_no_vector = {
+        **{k: v for k, v in snapshot.items() if k != "trace_hash"},
+        "knowledge_board": {
+            k: v for k, v in snapshot["knowledge_board"].items() if k != "vector"
+        },
+        "world_map": {k: v for k, v in snapshot["world_map"].items() if k != "vector"},
+    }
+    snapshot["trace_hash"] = compute_trace_hash(snapshot_no_vector)
+    return snapshot
+
+
+async def create_replay_cli_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> ReplayCLIArtifacts:
+    """Generate snapshot and replay slice suitable for exercising the replay CLI."""
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ENABLE_REDPANDA", "0")
+    monkeypatch.setenv("SNAPSHOT_INTERVAL_STEPS", "1")
+    events_path = tmp_path / "event_log.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(events_path))
+    monkeypatch.setattr(event_log, "_header_written", set(), raising=False)
+    monkeypatch.setattr(event_log, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log, "_seed", None, raising=False)
+    monkeypatch.setattr(event_log, "_last_hash", None, raising=False)
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+    monkeypatch.setattr("src.sim.simulation.upload_snapshot", lambda *_, **__: None)
+
+    def _save(step: int, data: dict, directory: Path = tmp_path) -> None:
+        save_snapshot(step, data, directory=directory)
+
+    monkeypatch.setattr("src.sim.simulation.save_snapshot", _save)
+
+    agent = ReplayFixtureAgent()
+    sim = Simulation(agents=[agent])
+    sim.evaluation_hooks = []
+
+    base_snapshot = _snapshot_from_sim(sim)
+    save_snapshot(0, base_snapshot, directory=tmp_path)
+    snapshot_path = tmp_path / "snapshot_0.json"
+
+    await sim.run_step()
+    end_step = sim.current_step
+    expected_entries = list(sim.knowledge_board.to_dict().get("entries", []))
+
+    replay_slice_path = event_log.store_replay_slice(1, end_step, directory=tmp_path)
+
+    sim.close()
+
+    return ReplayCLIArtifacts(
+        snapshot_path=snapshot_path,
+        events_path=events_path,
+        replay_slice_path=replay_slice_path,
+        start_step=1,
+        end_step=end_step,
+        expected_step=end_step,
+        expected_knowledge_entries=expected_entries,
+    )


### PR DESCRIPTION
## Summary
- add a reusable replay CLI fixture that captures a snapshot and replay slice from a minimal simulation run
- add an integration test that replays the generated slice through `tools.replay_cli` and validates the simulation state

## Testing
- pytest -m "integration" tests/integration/tools/test_replay_cli_integration.py
- ruff check tests/utils/replay_cli_fixture.py tests/integration/tools/test_replay_cli_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68f251b25c6c8326a65f9a8f105ca562