### PR TITLE
Handle budget notifications when no asyncio loop is running

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -264,9 +264,17 @@ def notify_budget_exceeded(agent_id: str, required: float, remaining: float) -> 
     bot_instance = get_active_bot()
     if bot_instance is not None:
         try:
-            asyncio.create_task(bot_instance.send_simulation_update(embed=embed))  # noqa: RUF006
-        except Exception:  # pragma: no cover - best effort
-            logger.exception("Failed to send budget exceeded embed")
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                asyncio.run(bot_instance.send_simulation_update(embed=embed))
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("Failed to send budget exceeded embed")
+        else:
+            try:
+                loop.create_task(bot_instance.send_simulation_update(embed=embed))  # noqa: RUF006
+            except Exception:  # pragma: no cover - best effort
+                logger.exception("Failed to send budget exceeded embed")
 
 
 class SimulationDiscordBot:

--- a/tests/unit/interfaces/test_discord_bot.py
+++ b/tests/unit/interfaces/test_discord_bot.py
@@ -193,6 +193,46 @@ def test_embed_creators(discord_module: object, monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.unit
+def test_notify_budget_exceeded_without_running_loop(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured_payloads: list[object] = []
+
+    class DummyBot:
+        def __init__(self) -> None:
+            self.embeds: list[dict[str, object] | None] = []
+
+        async def send_simulation_update(self, *, embed: dict[str, object] | None = None) -> None:
+            self.embeds.append(embed)
+
+    dummy_bot = DummyBot()
+
+    monkeypatch.setattr(discord_module, "message_sse_queue", SimpleNamespace(put_nowait=captured_payloads.append))
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda: dummy_bot)
+    monkeypatch.setattr(
+        discord_module, "metrics", SimpleNamespace(get_llm_latency_p95=lambda: 42.0)
+    )
+    monkeypatch.setattr(
+        discord_module.ledger, "get_balance", lambda agent_id: (1.0, 2.0), raising=False
+    )
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        discord_module.notify_budget_exceeded("agent-123", required=10.0, remaining=-1.0)
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+    assert captured_payloads, "SSE queue should receive at least one payload"
+    payload = captured_payloads[0]
+    assert getattr(payload, "agent_id", None) == "agent-123"
+    assert getattr(payload, "extra", {}).get("required") == 10.0
+    assert getattr(payload, "extra", {}).get("remaining") == -1.0
+    assert dummy_bot.embeds, "Fallback path should dispatch embed synchronously"
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_forward_agent_messages_embed(
     discord_module: object, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
- ensure `notify_budget_exceeded` gracefully delivers alerts when no asyncio loop is running
- keep SSE notifications intact and schedule work on a running loop when available
- add a regression test covering the no-loop scenario for Discord budget notifications

## Testing
- `pytest tests/unit/interfaces/test_discord_bot.py -k "notify_budget_exceeded_without_running_loop or notify_budget_exceeded"`
- `ruff check src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68f640ed2b888326ba40ccf986957460