### PR TITLE
Add tracing spans to dashboard event emissions

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Callable, Final, cast
 
 from pydantic import BaseModel
 
+from opentelemetry import trace
+
 from src.governance.law_board import law_board
 from src.governance.service import governance
 from src.infra import event_log
@@ -26,6 +28,7 @@ from .widget_registry import WidgetRegistry
 SNAPSHOT_DIR = Path(__file__).resolve().parents[2] / "snapshots"
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # JSON response body for semantic summary retrieval errors
 SEMANTIC_SUMMARIES_ERROR: Final[dict[str, str]] = {"error": "summary retrieval failed"}
@@ -969,21 +972,66 @@ except AttributeError:  # pragma: no cover - stub app may lack decorators
     pass
 
 
+def _coerce_tags(value: Any) -> list[str] | None:
+    """Normalize tag values into a list for span attributes."""
+
+    if value is None:
+        return None
+    if isinstance(value, (list, set, tuple)):
+        return [str(tag) for tag in value]
+    return [str(value)]
+
+
+async def _publish_with_span(
+    bus: Any,
+    event: SimulationEvent,
+    span_name: str,
+    breakpoint_tags: set[str],
+) -> None:
+    """Publish ``event`` on ``bus`` while recording tracing metadata."""
+
+    with tracer.start_as_current_span(span_name) as span:
+        span.set_attribute("event.type", event.type)
+
+        data = event.data or {}
+        step = data.get("step") if isinstance(data, dict) else None
+        if step is not None:
+            span.set_attribute("event.step", step)
+
+        tags_attr = None
+        if isinstance(data, dict):
+            tags_attr = _coerce_tags(data.get("tags"))
+        if tags_attr is not None:
+            span.set_attribute("event.tags", tags_attr)
+
+        span.set_attribute(
+            "event.breakpoint_tags", sorted(breakpoint_tags) if breakpoint_tags else []
+        )
+
+        await bus.publish(event)
+
+
 async def emit_event(event: SimulationEvent) -> None:
     """Emit a simulation event and check for breakpoints."""
     bus = get_event_bus()
-    await bus.publish(event)
     tags = set(event.data.get("tags", [])) if event.data else set()
-    if tags & BREAKPOINT_TAGS:
+    breakpoint_tags = tags & BREAKPOINT_TAGS
+
+    await _publish_with_span(bus, event, "dashboard.emit_event", breakpoint_tags)
+
+    if breakpoint_tags:
         DEFAULT_CONTEXT.sim_state["paused"] = True
-        await bus.publish(
+        await _publish_with_span(
+            bus,
             SimulationEvent(
                 type="breakpoint_hit",
                 data={
-                    "tags": list(tags & BREAKPOINT_TAGS),
+                    "tags": list(breakpoint_tags),
                     "step": event.data.get("step") if event.data else None,
                 },
-            )
+            ),
+            "dashboard.emit_event.breakpoint",
+            breakpoint_tags,
         )
 
 

--- a/tests/integration/interfaces/test_dashboard_backend.py
+++ b/tests/integration/interfaces/test_dashboard_backend.py
@@ -8,6 +8,31 @@ from src import http_app
 from src.interfaces import dashboard_backend as db
 
 
+class RecordingSpan:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def __enter__(self) -> "RecordingSpan":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial
+        return False
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[RecordingSpan] = []
+
+    def start_as_current_span(self, name: str) -> RecordingSpan:
+        span = RecordingSpan(name)
+        self.spans.append(span)
+        return span
+
+
 class FailingManager:
     def get_semantic_summaries(self, agent_id: str, limit: int = 3) -> list[str]:
         raise RuntimeError("boom")
@@ -23,3 +48,61 @@ async def test_semantic_summaries_error_response(monkeypatch: pytest.MonkeyPatch
     assert resp.status_code == 500
     data = resp.json()
     assert data["error"] == "summary retrieval failed"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_emit_event_tracing_records_attributes_for_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracer = RecordingTracer()
+    monkeypatch.setattr(db, "tracer", tracer)
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "paused", False)
+
+    await db.emit_event(db.SimulationEvent(type="evaluation"))
+    await db.emit_event(db.SimulationEvent(type="evaluation", data={"step": 3}))
+
+    assert [span.name for span in tracer.spans] == [
+        "dashboard.emit_event",
+        "dashboard.emit_event",
+    ]
+    empty_span, step_span = tracer.spans
+
+    assert empty_span.attributes["event.type"] == "evaluation"
+    assert empty_span.attributes["event.breakpoint_tags"] == []
+    assert "event.step" not in empty_span.attributes
+
+    assert step_span.attributes["event.type"] == "evaluation"
+    assert step_span.attributes["event.step"] == 3
+    assert step_span.attributes["event.breakpoint_tags"] == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_emit_event_tracing_records_breakpoint_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracer = RecordingTracer()
+    monkeypatch.setattr(db, "tracer", tracer)
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "paused", False)
+
+    await db.emit_event(
+        db.SimulationEvent(type="evaluation", data={"step": 5, "tags": ["nsfw", "other"]})
+    )
+
+    assert [span.name for span in tracer.spans] == [
+        "dashboard.emit_event",
+        "dashboard.emit_event.breakpoint",
+    ]
+
+    original_span, breakpoint_span = tracer.spans
+    assert original_span.attributes["event.type"] == "evaluation"
+    assert original_span.attributes["event.step"] == 5
+    assert original_span.attributes["event.breakpoint_tags"] == ["nsfw"]
+
+    assert breakpoint_span.attributes["event.type"] == "breakpoint_hit"
+    assert breakpoint_span.attributes["event.step"] == 5
+    assert breakpoint_span.attributes["event.breakpoint_tags"] == ["nsfw"]
+
+    assert db.DEFAULT_CONTEXT.sim_state["paused"] is True
+    db.DEFAULT_CONTEXT.sim_state["paused"] = False


### PR DESCRIPTION
## Summary
- wrap dashboard event bus publishes in OpenTelemetry spans that capture event type, step, and breakpoint metadata
- ensure breakpoint emissions pause the simulation while recording tracing data even when events lack payloads
- add integration tests that patch the dashboard tracer to verify span names and attributes for evaluation and breakpoint events

## Testing
- pytest tests/integration/interfaces/test_dashboard_backend.py::test_emit_event_tracing_records_attributes_for_evaluation -m integration
- pytest tests/integration/interfaces/test_dashboard_backend.py::test_emit_event_tracing_records_breakpoint_event -m integration

------
https://chatgpt.com/codex/tasks/task_e_68f640ec6034832686d86bec3505f65d