### PR TITLE
Add CLI overrides for signature demo script

### DIFF
--- a/scripts/run_signature_demo.py
+++ b/scripts/run_signature_demo.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import os
@@ -24,6 +25,28 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers
 RESULT_DIR = Path("results/signature_demo")
 SCENARIO_PATH = Path("scenarios/signature_demo.yaml")
 README_PATH = RESULT_DIR / "README.md"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Return CLI arguments for running the signature demo."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Seed value passed to the simulation and event log.",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        help="Number of steps to run the simulation.",
+    )
+    parser.add_argument(
+        "--agents",
+        type=int,
+        help="Number of agents participating in the simulation.",
+    )
+    return parser.parse_args(argv)
 
 
 def _clean_results_dir() -> None:
@@ -278,7 +301,9 @@ def _write_readme(
     README_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-async def main() -> None:
+async def main(
+    *, seed: int | None = None, steps: int | None = None, agents: int | None = None
+) -> None:
     """Execute the signature_demo scenario and save outputs."""
     _clean_results_dir()
     RESULT_DIR.mkdir(parents=True, exist_ok=True)
@@ -294,21 +319,24 @@ async def main() -> None:
         evaluation_targets,
         success_metrics,
     ) = load_scenario(str(SCENARIO_PATH))
-    steps = steps_override or 0
-    num_agents = agents_override or 3
+    steps_value = steps if steps is not None else steps_override or 0
+    num_agents = agents if agents is not None else agents_override or 3
+    seed_value = seed if seed is not None else 42
+
+    event_log.set_seed(seed_value)
 
     sim = create_simulation(
         num_agents=num_agents,
-        steps=steps,
+        steps=steps_value,
         scenario=scenario_desc,
         beats=beats,
-        seed=42,
+        seed=seed_value,
         evaluation_hook_names=evaluation_hooks,
         evaluation_targets=evaluation_targets,
         success_metrics=success_metrics,
     )
 
-    await sim.async_run(steps)
+    await sim.async_run(steps_value)
 
     metrics_path = RESULT_DIR / "metrics.json"
     metrics = export_traces.load_metrics(event_log_path)
@@ -366,4 +394,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    arguments = parse_args()
+    asyncio.run(
+        main(seed=arguments.seed, steps=arguments.steps, agents=arguments.agents)
+    )

--- a/tests/integration/scenario/test_run_signature_demo.py
+++ b/tests/integration/scenario/test_run_signature_demo.py
@@ -121,8 +121,8 @@ async def test_run_signature_demo(
     # Build deterministic agent outputs tied to the scenario beats.
     (
         _,
-        _,
-        _,
+        scenario_steps_override,
+        scenario_agents_override,
         beats,
         hook_names,
         evaluation_targets,
@@ -146,8 +146,10 @@ async def test_run_signature_demo(
         )
 
     created_sims: list = []
+    create_kwargs: list[dict[str, object]] = []
 
     def create_simulation_stub(**kwargs):
+        create_kwargs.append(dict(kwargs))
         sim = create_simulation(**kwargs)
         created_sims.append(sim)
         return sim
@@ -164,88 +166,122 @@ async def test_run_signature_demo(
             "src.infra.llm_client.async_generate_structured_output",
             AsyncMock(side_effect=lambda *a, **k: next_structured_output()),
         )
+
         await run_signature_demo.main()
 
-    assert created_sims, "Simulation was not constructed"
-    sim = created_sims[0]
-    assert sim.evaluation_hook_names == hook_names
-    assert sim.evaluation_targets == evaluation_targets
-    assert sim.success_metrics == success_metrics
+        assert created_sims, "Simulation was not constructed"
+        default_sim = created_sims[0]
+        default_kwargs = create_kwargs[0]
+        expected_agents = scenario_agents_override or 3
+        expected_steps = scenario_steps_override or 0
 
-    event_log_path = result_dir / "event_log.jsonl"
-    metrics_path = result_dir / "metrics.json"
-    traces_path = result_dir / "traces.jsonl"
-    bundle_path = result_dir / "signature_demo_bundle.zip"
-    snapshots_dir = result_dir / "snapshots"
+        assert default_kwargs["seed"] == 42
+        assert default_kwargs["num_agents"] == expected_agents
+        assert default_kwargs["steps"] == expected_steps
+        assert default_sim.evaluation_hook_names == hook_names
+        assert default_sim.evaluation_targets == evaluation_targets
+        assert default_sim.success_metrics == success_metrics
 
-    assert event_log_path.exists(), "Event log was not generated"
-    assert metrics_path.exists(), "Metrics JSON was not generated"
-    assert traces_path.exists(), "Trace dataset was not generated"
-    assert bundle_path.exists(), "Bundle archive was not generated"
-    assert snapshots_dir.is_dir(), "Snapshot directory missing"
+        event_log_path = result_dir / "event_log.jsonl"
+        metrics_path = result_dir / "metrics.json"
+        traces_path = result_dir / "traces.jsonl"
+        bundle_path = result_dir / "signature_demo_bundle.zip"
+        snapshots_dir = result_dir / "snapshots"
 
-    log_lines = event_log_path.read_text(encoding="utf-8").splitlines()
-    assert log_lines, "Event log is empty"
-    header = json.loads(log_lines[0])
-    assert header["type"] == "header"
-    assert header["seed"] == 42
+        assert event_log_path.exists(), "Event log was not generated"
+        assert metrics_path.exists(), "Metrics JSON was not generated"
+        assert traces_path.exists(), "Trace dataset was not generated"
+        assert bundle_path.exists(), "Bundle archive was not generated"
+        assert snapshots_dir.is_dir(), "Snapshot directory missing"
 
-    events = [json.loads(line) for line in log_lines[1:] if line.strip()]
-    assert events, "Event log contains no events"
-    max_step = max(ev.get("step", 0) for ev in events)
-    assert max_step > 0
+        default_log_lines = event_log_path.read_text(encoding="utf-8").splitlines()
+        assert default_log_lines, "Event log is empty"
+        header = json.loads(default_log_lines[0])
+        assert header["type"] == "header"
+        assert header["seed"] == 42
 
-    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
-    for key in ("coalitions", "sentiment", "collective_du", "collective_ip"):
-        assert key in metrics
-        assert metrics[key], f"Metric '{key}' has no data points"
-        step, value = metrics[key][0]
-        assert isinstance(step, int)
-        assert isinstance(value, float)
-    target_summary = metrics.get("_target_summary")
-    assert isinstance(target_summary, dict)
-    for key in ("coalitions", "sentiment", "collective_du", "collective_ip"):
-        assert key in target_summary
-        entry = target_summary[key]
-        assert isinstance(entry, dict)
-        assert "status" in entry
-    success_guidance = metrics.get("_success_metrics_guidance")
-    assert isinstance(success_guidance, dict)
-    assert success_guidance.get("coalition_count", {}).get("target_max") == success_metrics[
-        "coalition_count"
-    ]["target_max"]
-    sentiment_guidance = success_guidance.get("sentiment_curve")
-    assert isinstance(sentiment_guidance, dict)
-    expected_trend = sentiment_guidance.get("expected_trend")
-    assert isinstance(expected_trend, dict)
-    assert expected_trend.get("proposal") == success_metrics["sentiment_curve"]["expected_trend"][
-        "proposal"
-    ]
+        events = [json.loads(line) for line in default_log_lines[1:] if line.strip()]
+        assert events, "Event log contains no events"
+        max_step = max(ev.get("step", 0) for ev in events)
+        assert max_step > 0
 
-    replay_files = sorted(snapshots_dir.glob("replay_*.jsonl"))
-    assert replay_files, "Replay slice not created"
-    replay_path = replay_files[0]
-    replay_lines = replay_path.read_text(encoding="utf-8").splitlines()
-    assert replay_lines, "Replay slice is empty"
-    replay_header = json.loads(replay_lines[0])
-    assert replay_header["type"] == "header"
-    assert replay_header["seed"] == 42
-    assert replay_path.name.endswith(f"_{max_step}.jsonl")
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+        for key in ("coalitions", "sentiment", "collective_du", "collective_ip"):
+            assert key in metrics
+            assert metrics[key], f"Metric '{key}' has no data points"
+            step, value = metrics[key][0]
+            assert isinstance(step, int)
+            assert isinstance(value, float)
+        target_summary = metrics.get("_target_summary")
+        assert isinstance(target_summary, dict)
+        for key in ("coalitions", "sentiment", "collective_du", "collective_ip"):
+            assert key in target_summary
+            entry = target_summary[key]
+            assert isinstance(entry, dict)
+            assert "status" in entry
+        success_guidance = metrics.get("_success_metrics_guidance")
+        assert isinstance(success_guidance, dict)
+        assert success_guidance.get("coalition_count", {}).get("target_max") == success_metrics[
+            "coalition_count"
+        ]["target_max"]
+        sentiment_guidance = success_guidance.get("sentiment_curve")
+        assert isinstance(sentiment_guidance, dict)
+        expected_trend = sentiment_guidance.get("expected_trend")
+        assert isinstance(expected_trend, dict)
+        assert expected_trend.get("proposal") == success_metrics["sentiment_curve"]["expected_trend"][
+            "proposal"
+        ]
 
-    snapshot_files = sorted(p for p in snapshots_dir.glob("snapshot_*.json"))
-    assert snapshot_files, "Snapshot JSON not written"
-    snapshot = json.loads(snapshot_files[-1].read_text(encoding="utf-8"))
-    assert snapshot.get("seed") == 42
-    assert snapshot.get("trace_hash")
+        replay_files = sorted(snapshots_dir.glob("replay_*.jsonl"))
+        assert replay_files, "Replay slice not created"
+        replay_path = replay_files[0]
+        replay_lines = replay_path.read_text(encoding="utf-8").splitlines()
+        assert replay_lines, "Replay slice is empty"
+        replay_header = json.loads(replay_lines[0])
+        assert replay_header["type"] == "header"
+        assert replay_header["seed"] == 42
+        assert replay_path.name.endswith(f"_{max_step}.jsonl")
 
-    with zipfile.ZipFile(bundle_path) as zf:
-        names = set(zf.namelist())
-        assert "traces.jsonl" in names
-        assert "metrics.json" in names
-        assert any(name.startswith("snapshots/") for name in names)
+        snapshot_files = sorted(p for p in snapshots_dir.glob("snapshot_*.json"))
+        assert snapshot_files, "Snapshot JSON not written"
+        snapshot = json.loads(snapshot_files[-1].read_text(encoding="utf-8"))
+        assert snapshot.get("seed") == 42
+        assert snapshot.get("trace_hash")
 
-    readme_text = (result_dir / "README.md").read_text(encoding="utf-8")
-    assert "Evaluation Target Summary" in readme_text
-    assert "Success Metrics Guidance" in readme_text
-    assert "coalition_count" in readme_text
-    assert "variance_tolerance" in readme_text
+        with zipfile.ZipFile(bundle_path) as zf:
+            names = set(zf.namelist())
+            assert "traces.jsonl" in names
+            assert "metrics.json" in names
+            assert any(name.startswith("snapshots/") for name in names)
+
+        readme_text = (result_dir / "README.md").read_text(encoding="utf-8")
+        assert "Evaluation Target Summary" in readme_text
+        assert "Success Metrics Guidance" in readme_text
+        assert "coalition_count" in readme_text
+        assert "variance_tolerance" in readme_text
+
+        # Run the script again using explicit CLI parameters to verify overrides.
+        event_log_module._seed_cache.clear()
+        event_log_module._header_written.clear()
+        event_log_module._last_hash = None
+        event_log_module._seed = None
+
+        cli_seed = 99
+        cli_steps = 5
+        cli_agents = 4
+
+        await run_signature_demo.main(
+            seed=cli_seed, steps=cli_steps, agents=cli_agents
+        )
+
+        assert len(created_sims) >= 2, "Second simulation was not constructed"
+        cli_kwargs = create_kwargs[-1]
+        assert cli_kwargs["seed"] == cli_seed
+        assert cli_kwargs["steps"] == cli_steps
+        assert cli_kwargs["num_agents"] == cli_agents
+
+        cli_log_lines = event_log_path.read_text(encoding="utf-8").splitlines()
+        assert cli_log_lines, "Event log is empty after CLI invocation"
+        cli_header = json.loads(cli_log_lines[0])
+        assert cli_header["type"] == "header"
+        assert cli_header["seed"] == cli_seed


### PR DESCRIPTION
## Summary
- add an argparse-based CLI to `scripts/run_signature_demo.py` so the seed, steps, and agent count can be overridden while preserving existing defaults
- wire the parsed arguments into the simulation setup and event log seed handling
- update the signature demo integration test to exercise the new CLI parameters and confirm the default seed/agent values

## Testing
- pytest -m integration tests/integration/scenario/test_run_signature_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68f649296dc883269c8304b78b0a1a5e