### PR TITLE
Refactor Discord moderation command registration

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -410,6 +410,11 @@ class SimulationDiscordBot:
             if tree is not None:
                 self.command_trees[_token] = tree
 
+                register_moderation_commands(
+                    tree,
+                    resolve_context=lambda self=self: (self.context, self.event_queue),
+                )
+
                 @tree.command(name="start")
                 @moderation_rate_limit("start")
                 async def _tree_start(interaction: "discord.Interaction") -> None:
@@ -565,82 +570,6 @@ class SimulationDiscordBot:
                             )
                         )
                         await interaction.response.send_message("killed", ephemeral=True)
-
-                @tree.command(name="reset_memory")
-                @app_commands.describe(agent_id="ID of the agent to reset")
-                @moderation_rate_limit("reset_memory")
-                async def _tree_reset_memory(
-                    interaction: "discord.Interaction", agent_id: str
-                ) -> None:
-                    with command_span("reset_memory", interaction, agent_id=agent_id) as span:
-                        if not has_admin_permission(getattr(interaction, "user", None)):
-                            await interaction.response.send_message("unauthorized", ephemeral=True)
-                            return
-                        await self.event_queue.put(
-                            SimulationEvent(
-                                type="moderation",
-                                data={"command": "reset_memory", "agent_id": agent_id},
-                            )
-                        )
-                        await send_interaction_response(
-                            interaction, "memory reset", ephemeral=True
-                        )
-
-                @tree.command(name="penalty")
-                @app_commands.describe(
-                    agent_id="ID of the agent to penalize",
-                    ip="Influence points to deduct",
-                    du="Decision units to deduct",
-                )
-                @moderation_rate_limit("penalty")
-                async def _tree_penalty(
-                    interaction: "discord.Interaction",
-                    agent_id: str,
-                    ip: float = 0.0,
-                    du: float = 0.0,
-                ) -> None:
-                    with command_span("penalty", interaction, agent_id=agent_id) as span:
-                        if not has_admin_permission(getattr(interaction, "user", None)):
-                            await interaction.response.send_message("unauthorized", ephemeral=True)
-                            return
-                        await self.event_queue.put(
-                            SimulationEvent(
-                                type="moderation",
-                                data={
-                                    "command": "penalty",
-                                    "agent_id": agent_id,
-                                    "ip": ip,
-                                    "du": du,
-                                },
-                            )
-                        )
-                        await send_interaction_response(
-                            interaction, "penalty applied", ephemeral=True
-                        )
-
-                @tree.command(name="mute")
-                @app_commands.describe(agent_id="ID of the agent to mute")
-                async def _tree_mute(interaction: "discord.Interaction", agent_id: str) -> None:
-                    with command_span("mute", interaction, agent_id=agent_id) as span:
-                        await self.event_queue.put(
-                            SimulationEvent(
-                                type="moderation",
-                                data={"command": "mute", "agent_id": agent_id},
-                            )
-                        )
-                        await interaction.response.send_message("muted", ephemeral=True)
-
-                @tree.command(name="unmute")
-                @app_commands.describe(agent_id="ID of the agent to unmute")
-                async def _tree_unmute(interaction: "discord.Interaction", agent_id: str) -> None:
-                    with command_span("unmute", interaction, agent_id=agent_id) as span:
-                        await self.event_queue.put(
-                            SimulationEvent(
-                                type="moderation",
-                                data={"command": "unmute", "agent_id": agent_id},
-                            )
-                        )
-                        await interaction.response.send_message("unmuted", ephemeral=True)
 
                 @tree.command(name="nudge")
                 @app_commands.describe(prompt="Prompt to nudge the simulation")
@@ -1325,7 +1254,10 @@ async def record_misbehavior(interaction: Any, agent_id: str, reason: str) -> No
     await send_interaction_response(interaction, "misbehavior recorded", ephemeral=True)
 
 
-from src.interfaces.discord_moderation import moderation_rate_limit  # noqa: E402
+from src.interfaces.discord_moderation import (  # noqa: E402
+    moderation_rate_limit,
+    register_moderation_commands,
+)
 
 
 @bot.command(name="say")

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -2,6 +2,7 @@
 
 import time
 from functools import wraps
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable
 
 from src.infra.ledger import log_penalty
@@ -15,6 +16,8 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 bot = getattr(discord_bot, "bot")
 get_active_bot = discord_bot.get_active_bot
 has_admin_permission = discord_bot.has_admin_permission
+
+_APP_COMMANDS = getattr(discord_bot, "app_commands", SimpleNamespace(describe=lambda *a, **k: (lambda f: f)))
 
 _ACTION_COUNTS: dict[str, int] = {}
 _COOLDOWNS: dict[str, float] = {}
@@ -97,62 +100,124 @@ def moderation_rate_limit(action: str) -> Callable[[Callable[..., Any]], Callabl
     return decorator
 
 
-@bot.tree.command(name="mute")
-@moderation_rate_limit("mute")
-async def slash_mute(interaction: Any, agent_id: str) -> None:
-    """Mute an agent in the simulation."""
-    bot_instance = get_active_bot()
-    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(type="moderation", data={"command": "mute", "agent_id": agent_id})
-    )
-    await interaction.response.send_message("muted", ephemeral=True)
+def _context_description(**kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Return an ``app_commands.describe`` decorator when available."""
+
+    describe = getattr(_APP_COMMANDS, "describe", None)
+    if describe is None:
+        def _noop(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        return _noop
+
+    return describe(**kwargs)
 
 
-@bot.tree.command(name="reset_memory")
-@moderation_rate_limit("reset_memory")
-async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
-    """Reset the memory of an agent."""
-    bot_instance = get_active_bot()
-    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    if not has_admin_permission(getattr(interaction, "user", None)):
-        await interaction.response.send_message("unauthorized", ephemeral=True)
-        return
-    await ctx.get_event_queue().put(
-        SimulationEvent(type="moderation", data={"command": "reset_memory", "agent_id": agent_id})
-    )
-    await interaction.response.send_message("memory reset", ephemeral=True)
+def register_moderation_commands(
+    tree: Any,
+    *,
+    resolve_context: Callable[[], tuple[Any, Any]],
+) -> dict[str, Callable[..., Any]]:
+    """Register moderation commands on the provided command tree."""
 
+    commands: dict[str, Callable[..., Any]] = {}
 
-@bot.tree.command(name="penalty")
-@moderation_rate_limit("penalty")
-async def slash_penalty(interaction: Any, agent_id: str, ip: float = 0.0, du: float = 0.0) -> None:
-    """Apply an IP/DU penalty to an agent."""
-    bot_instance = get_active_bot()
-    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(
-            type="moderation",
-            data={"command": "penalty", "agent_id": agent_id, "ip": ip, "du": du},
+    @tree.command(name="reset_memory")
+    @_context_description(agent_id="ID of the agent to reset")
+    @moderation_rate_limit("reset_memory")
+    async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
+        ctx, event_queue = resolve_context()
+        if not has_admin_permission(getattr(interaction, "user", None)):
+            await interaction.response.send_message("unauthorized", ephemeral=True)
+            return
+        await event_queue.put(
+            SimulationEvent(type="moderation", data={"command": "reset_memory", "agent_id": agent_id})
         )
+        await discord_bot.send_interaction_response(interaction, "memory reset", ephemeral=True)
+
+    commands["reset_memory"] = slash_reset_memory
+
+    @tree.command(name="penalty")
+    @_context_description(
+        agent_id="ID of the agent to penalize",
+        ip="Influence points to deduct",
+        du="Decision units to deduct",
     )
-    try:  # pragma: no cover - best effort
-        log_penalty(agent_id, abs(ip), abs(du), "moderation_penalty")
-    except Exception:
-        pass
-    await interaction.response.send_message("penalty applied", ephemeral=True)
+    @moderation_rate_limit("penalty")
+    async def slash_penalty(
+        interaction: Any,
+        agent_id: str,
+        ip: float = 0.0,
+        du: float = 0.0,
+    ) -> None:
+        ctx, event_queue = resolve_context()
+        if not has_admin_permission(getattr(interaction, "user", None)):
+            await interaction.response.send_message("unauthorized", ephemeral=True)
+            return
+        await event_queue.put(
+            SimulationEvent(
+                type="moderation",
+                data={"command": "penalty", "agent_id": agent_id, "ip": ip, "du": du},
+            )
+        )
+        try:  # pragma: no cover - best effort
+            log_penalty(agent_id, abs(ip), abs(du), "moderation_penalty")
+        except Exception:
+            pass
+        await discord_bot.send_interaction_response(interaction, "penalty applied", ephemeral=True)
+
+    commands["penalty"] = slash_penalty
+
+    @tree.command(name="mute")
+    @_context_description(agent_id="ID of the agent to mute")
+    @moderation_rate_limit("mute")
+    async def slash_mute(interaction: Any, agent_id: str) -> None:
+        ctx, event_queue = resolve_context()
+        await event_queue.put(
+            SimulationEvent(type="moderation", data={"command": "mute", "agent_id": agent_id})
+        )
+        await discord_bot.send_interaction_response(interaction, "muted", ephemeral=True)
+
+    commands["mute"] = slash_mute
+
+    @tree.command(name="unmute")
+    @_context_description(agent_id="ID of the agent to unmute")
+    @moderation_rate_limit("unmute")
+    async def slash_unmute(interaction: Any, agent_id: str) -> None:
+        ctx, event_queue = resolve_context()
+        await event_queue.put(
+            SimulationEvent(type="moderation", data={"command": "unmute", "agent_id": agent_id})
+        )
+        await discord_bot.send_interaction_response(interaction, "unmuted", ephemeral=True)
+
+    commands["unmute"] = slash_unmute
+
+    return commands
 
 
-@bot.tree.command(name="unmute")
-@moderation_rate_limit("unmute")
-async def slash_unmute(interaction: Any, agent_id: str) -> None:
-    """Unmute an agent in the simulation."""
+def _global_context_resolver() -> tuple[Any, Any]:
     bot_instance = get_active_bot()
-    ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-    await ctx.get_event_queue().put(
-        SimulationEvent(type="moderation", data={"command": "unmute", "agent_id": agent_id})
-    )
-    await interaction.response.send_message("unmuted", ephemeral=True)
+    if bot_instance is not None:
+        return bot_instance.context, bot_instance.event_queue
+    ctx = DEFAULT_CONTEXT
+    return ctx, ctx.get_event_queue()
 
 
-__all__ = ["slash_mute", "slash_penalty", "slash_reset_memory", "slash_unmute"]
+_REGISTERED_COMMANDS = register_moderation_commands(
+    getattr(bot, "tree"), resolve_context=_global_context_resolver
+)
+
+slash_reset_memory = _REGISTERED_COMMANDS["reset_memory"]
+slash_penalty = _REGISTERED_COMMANDS["penalty"]
+slash_mute = _REGISTERED_COMMANDS["mute"]
+slash_unmute = _REGISTERED_COMMANDS["unmute"]
+
+
+__all__ = [
+    "moderation_rate_limit",
+    "register_moderation_commands",
+    "slash_mute",
+    "slash_penalty",
+    "slash_reset_memory",
+    "slash_unmute",
+]

--- a/tests/unit/interfaces/test_discord_bot_moderation_commands.py
+++ b/tests/unit/interfaces/test_discord_bot_moderation_commands.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib
 import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -127,13 +127,18 @@ def reload_module(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setitem(sys.modules, "src.sim.context", SimpleNamespace(SimulationContext=DummyContext))
     monkeypatch.setitem(sys.modules, "src.utils.policy", dummy_policy)
 
-    module = importlib.reload(importlib.import_module("src.interfaces.discord_bot"))
+    sys.modules.pop("src.interfaces.discord_moderation", None)
+    sys.modules.pop("src.interfaces.discord_bot", None)
+    module = importlib.import_module("src.interfaces.discord_bot")
     return module
 
 
 @pytest.fixture()
 def discord_module(monkeypatch: pytest.MonkeyPatch):
     module = reload_module(monkeypatch)
+    module.DEFAULT_CONTEXT.sim_state = {}
+    module.DEFAULT_CONTEXT._event_queue = asyncio.Queue()
+    module.DEFAULT_CONTEXT.message_queue = asyncio.Queue()
     yield module
     importlib.reload(module)
 
@@ -151,17 +156,18 @@ class DummyInteraction:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_command_tree_registers_moderation_commands(discord_module: object) -> None:
-    context = DummyContext()
+    context = discord_module.DEFAULT_CONTEXT
     bot = discord_module.SimulationDiscordBot("token", 123, context=context)
     tree = next(iter(bot.command_trees.values()))
-    assert "reset_memory" in tree.commands
-    assert "penalty" in tree.commands
+    for name in {"reset_memory", "penalty", "mute", "unmute"}:
+        assert name in tree.commands
+        assert hasattr(tree.commands[name], "__wrapped__")
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_reset_memory_and_penalty_commands_require_admin(discord_module: object) -> None:
-    context = DummyContext()
+    context = discord_module.DEFAULT_CONTEXT
     bot = discord_module.SimulationDiscordBot("token", 123, context=context)
     tree = next(iter(bot.command_trees.values()))
 
@@ -201,3 +207,50 @@ async def test_reset_memory_and_penalty_commands_require_admin(discord_module: o
     authorized_penalty.response.send_message.assert_awaited_once_with(
         "penalty applied", ephemeral=True
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mute_command_respects_rate_limiting(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    context = discord_module.DEFAULT_CONTEXT
+    bot = discord_module.SimulationDiscordBot("token", 123, context=context)
+    tree = next(iter(bot.command_trees.values()))
+    mute_cmd = tree.commands["mute"]
+    queue = context.get_event_queue()
+    assert queue is bot.event_queue
+    assert context.get_event_queue() is queue
+    queue_put = AsyncMock()
+    monkeypatch.setattr(queue, "put", queue_put)
+
+    moderation_module = importlib.import_module("src.interfaces.discord_moderation")
+    moderation_module._ACTION_COUNTS.clear()
+    moderation_module._COOLDOWNS.clear()
+    penalty_logger = Mock()
+    monkeypatch.setattr(moderation_module, "log_penalty", penalty_logger)
+
+    allowed = DummyInteraction(admin=False, user_id="user-mute-allowed")
+    await mute_cmd(allowed, "agent-allowed")
+    assert queue_put.await_count == 1
+    allowed_event = queue_put.await_args_list[0].args[0]
+    assert allowed_event.type == "moderation"
+    assert allowed_event.data == {"command": "mute", "agent_id": "agent-allowed"}
+    allowed.response.send_message.assert_awaited_once_with("muted", ephemeral=True)
+    queue_put.reset_mock()
+
+    assert discord_module.get_active_bot() is bot
+
+    rate_limited = DummyInteraction(admin=False, user_id="user-mute-rate")
+    monkeypatch.setattr(
+        moderation_module,
+        "evaluate_with_opa",
+        AsyncMock(return_value=(False, None)),
+    )
+    await mute_cmd(rate_limited, "agent-rate")
+    rate_limited.response.send_message.assert_awaited_once_with(
+        "rate limited", ephemeral=True
+    )
+    assert moderation_module._ACTION_COUNTS["user-mute-rate:mute"] == 1
+    assert queue_put.await_count == 0
+    penalty_logger.assert_called_once()


### PR DESCRIPTION
## Summary
- reuse a shared registration helper so per-token command trees install the same moderation handlers
- centralize moderation command definitions in `discord_moderation.py`, exporting the helper for global setup
- expand moderation command tests to assert shared registration, permission checks, and rate limiting behaviour

## Testing
- pytest tests/unit/interfaces/test_discord_bot_moderation_commands.py
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68f64927ecf88326b64e2462a0d9c49d