### PR TITLE
Add explain-why payload logging for agent actions

### DIFF
--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -7,7 +7,7 @@ import asyncio
 import copy
 import logging
 import uuid
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from math import sqrt
 
 # LangGraph imports
@@ -100,6 +100,18 @@ from src.agents.dspy_programs.role_thought_generator import get_role_thought_gen
 AgentMessage = DashboardAgentMessage
 
 logger = logging.getLogger(__name__)
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Recursively convert ``value`` to JSON-serializable primitives."""
+
+    if isinstance(value, Mapping):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
 
 
 class Agent:
@@ -453,6 +465,44 @@ class Agent:
         logger.debug(
             f"  Retrieved knowledge board content (entries: {len(knowledge_board_content)})"
         )
+        base_kb_entries = (
+            [str(entry) for entry in knowledge_board_content]
+            if isinstance(knowledge_board_content, list)
+            else ([str(knowledge_board_content)] if knowledge_board_content else [])
+        )
+
+        def _build_explain_payload(state: AgentTurnState | None = None) -> dict[str, Any]:
+            memories: list[Any] = []
+            kb_entries = list(base_kb_entries)
+            tool_calls: list[Any] = []
+            rag_summary: str | None = None
+
+            if state:
+                raw_memories = state.get("memory_history_list")
+                if isinstance(raw_memories, list):
+                    memories = [_to_jsonable(mem) for mem in raw_memories]
+
+                raw_kb = state.get("knowledge_board_content")
+                if isinstance(raw_kb, list) and raw_kb:
+                    kb_entries = [str(entry) for entry in raw_kb]
+
+                raw_tool_calls = state.get("tool_calls")
+                if isinstance(raw_tool_calls, list):
+                    tool_calls = [_to_jsonable(call) for call in raw_tool_calls]
+
+                raw_summary = state.get("rag_summary")
+                if isinstance(raw_summary, str):
+                    rag_summary = raw_summary
+                elif raw_summary is not None:
+                    rag_summary = str(raw_summary)
+
+            return {
+                "memories": memories,
+                "knowledge_board_entries": kb_entries,
+                "tool_calls": tool_calls,
+                "rag_summary": rag_summary,
+            }
+
         # --- End Extract Knowledge Board ---
 
         # --- Extract Simulation Scenario ---
@@ -546,6 +596,7 @@ class Agent:
                 "message_recipient_id": None,
                 "action_intent": "idle",
                 "structured_output": None,
+                "explain_why": _build_explain_payload(),
             }
 
         # The cast below was to object, which is too generic.
@@ -557,6 +608,7 @@ class Agent:
             Callable[[AgentTurnState], Awaitable[AgentTurnState]], self.graph.ainvoke
         )
 
+        final_result_state: AgentTurnState | None = None
         try:
             # Invoke the graph asynchronously for the turn
             logger.debug(
@@ -565,7 +617,7 @@ class Agent:
             logger.debug(
                 f"Agent {self.agent_id} initial_turn_state before invoke: {initial_turn_state.keys()}"
             )
-            final_result_state: AgentTurnState = await graph_ainvoke_callable(initial_turn_state)
+            final_result_state = await graph_ainvoke_callable(initial_turn_state)
 
             # Add debug logging to inspect the graph.ainvoke result
             logger.debug(
@@ -580,6 +632,7 @@ class Agent:
                     "message_content": None,
                     "message_recipient_id": None,
                     "action_intent": "idle",
+                    "explain_why": _build_explain_payload(),
                 }
 
             # Log dictionary keys to help debug
@@ -658,6 +711,7 @@ class Agent:
                     "message_recipient_id": message_recipient_id,
                     "action_intent": action_intent,
                     "trace_hash": trace_hash,
+                    "explain_why": _build_explain_payload(final_result_state),
                 }
                 logger.debug(f"Agent {self.agent_id} run_turn returning: {turn_output}")
 
@@ -693,6 +747,7 @@ class Agent:
                     "message_content": None,
                     "message_recipient_id": None,
                     "action_intent": "idle",
+                    "explain_why": _build_explain_payload(final_result_state),
                 }
 
         except Exception as e:
@@ -700,7 +755,12 @@ class Agent:
                 f"Error running turn for agent {self.agent_id} at step {simulation_step}: {e}",
                 exc_info=True,
             )
-            return {"message_content": None, "message_recipient_id": None, "action_intent": "idle"}
+            return {
+                "message_content": None,
+                "message_recipient_id": None,
+                "action_intent": "idle",
+                "explain_why": _build_explain_payload(final_result_state),
+            }
 
     def __str__(self: Self) -> str:
         """Returns a string representation of the agent."""

--- a/src/infra/event_log/__init__.py
+++ b/src/infra/event_log/__init__.py
@@ -7,7 +7,7 @@ import json
 import os
 import random
 import time
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +29,62 @@ except ImportError:  # pragma: no cover - fallback when tests stub snapshot
 
 
 compute_trace_hash = _compute_trace_hash
+
+
+_AGENT_ACTION_EXPLAIN_DEFAULT: dict[str, Any] = {
+    "memories": [],
+    "knowledge_board_entries": [],
+    "tool_calls": [],
+    "rag_summary": None,
+}
+
+def _jsonify(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(k): _jsonify(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, (tuple, set)):
+        return [_jsonify(item) for item in value]
+    if value is None:
+        return []
+    return [_jsonify(value)]
+
+
+def _sanitize_agent_action(event: dict[str, Any]) -> dict[str, Any]:
+    raw_explain = event.get("explain_why")
+    sanitized = dict(_AGENT_ACTION_EXPLAIN_DEFAULT)
+
+    if isinstance(raw_explain, Mapping):
+        if "memories" in raw_explain:
+            sanitized["memories"] = _ensure_list(raw_explain.get("memories"))
+        if "knowledge_board_entries" in raw_explain:
+            sanitized["knowledge_board_entries"] = [
+                str(item) for item in _ensure_list(raw_explain.get("knowledge_board_entries"))
+            ]
+        if "tool_calls" in raw_explain:
+            sanitized["tool_calls"] = _ensure_list(raw_explain.get("tool_calls"))
+        if "rag_summary" in raw_explain:
+            summary = raw_explain.get("rag_summary")
+            if summary is None or isinstance(summary, str):
+                sanitized["rag_summary"] = summary
+            else:
+                sanitized["rag_summary"] = str(summary)
+
+    return {**event, "explain_why": sanitized}
+
+
+def _sanitize_event_payload(event: dict[str, Any]) -> dict[str, Any]:
+    if event.get("type") == "agent_action":
+        return _sanitize_agent_action(event)
+    return event
 
 
 def candidate_event_logs_for_snapshot(snapshot: str | Path) -> Iterable[Path]:
@@ -404,6 +460,8 @@ def log_event(event: dict[str, Any]) -> dict[str, Any]:
     resolved = _resolved_path(path)
     _rehydrate_log_state(path)
     _ensure_header(path)
+
+    event = _sanitize_event_payload(event)
 
     with tracer.start_as_current_span("event_log.log_event") as span:
         span.set_attribute("event.type", event.get("type"))

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -806,6 +806,47 @@ async def api_memory_snapshot(step: int) -> Response:
     return resp
 
 
+@app.get("/api/agent_actions/explain_why")
+async def api_agent_action_explain_why(
+    after_step: int = 0, limit: int = 20
+) -> Response:
+    """Expose explain-why payloads for recent agent actions."""
+
+    def _load_events() -> list[dict[str, Any]]:
+        return event_log.fetch_events(after_step=after_step, event_type="agent_action")
+
+    events = await asyncio.to_thread(_load_events)
+    if limit > 0:
+        events = events[-limit:]
+
+    agent_events: list[dict[str, Any]] = []
+    for evt in events:
+        explain = evt.get("explain_why")
+        if not isinstance(explain, dict):
+            explain = {}
+        kb_entries = explain.get("knowledge_board_entries", [])
+        if not isinstance(kb_entries, list):
+            kb_entries = [kb_entries] if kb_entries else []
+        agent_events.append(
+            {
+                "agent_id": str(evt.get("agent_id", "")),
+                "step": int(evt.get("step", evt.get("tick", 0) or 0)),
+                "action_intent": evt.get("action_intent"),
+                "explain_why": {
+                    "memories": explain.get("memories", []),
+                    "knowledge_board_entries": [str(entry) for entry in kb_entries],
+                    "tool_calls": explain.get("tool_calls", []),
+                    "rag_summary": explain.get("rag_summary"),
+                },
+            }
+        )
+
+    resp = JSONResponse({"events": agent_events})
+    if not hasattr(resp, "status_code"):
+        resp.status_code = 200
+    return resp
+
+
 @app.get("/api/flagged_messages")
 async def api_flagged_messages(limit: int = 20) -> Response:
     """Return flagged messages with snapshot references."""

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -775,6 +775,22 @@ class Simulation:
         action_intent_str = agent_output.get("action_intent", "idle")
         map_action = agent_output.get("map_action")
 
+        explain_why_payload = (
+            {**agent_output.get("explain_why", {})}
+            if isinstance(agent_output.get("explain_why"), dict)
+            else {}
+        )
+        kb_excerpt = perception_data.get("knowledge_board_content", [])
+        if not isinstance(kb_excerpt, list):
+            kb_excerpt = [kb_excerpt] if kb_excerpt else []
+        explain_why_payload.setdefault(
+            "knowledge_board_entries", [str(entry) for entry in kb_excerpt]
+        )
+        explain_why_payload.setdefault("memories", [])
+        explain_why_payload.setdefault("tool_calls", [])
+        if "rag_summary" not in explain_why_payload:
+            explain_why_payload["rag_summary"] = None
+
         allowed = await evaluate_policy(action_intent_str)
         if not allowed:
             action_intent_str = AgentActionIntent.IDLE.value
@@ -885,6 +901,7 @@ class Simulation:
                     "du": current_agent_state.du,
                     "knowledge_board": kb_state,
                     "world_map": wm_state,
+                    "explain_why": explain_why_payload,
                 }
                 event = log_event(payload)
                 if event is None:

--- a/tests/integration/sim/test_agent_action_explain_why.py
+++ b/tests/integration/sim/test_agent_action_explain_why.py
@@ -1,0 +1,97 @@
+import json
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+
+from src.app import create_simulation
+from src.interfaces import dashboard_backend as db
+from src.sim.simulation import Simulation
+from tests.utils.mock_llm import MockLLM
+
+
+class ReplayState(SimpleNamespace):
+    ip: float = 0.0
+    du: float = 0.0
+    short_term_memory: ClassVar[list[Any]] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict[str, Any]] = {}
+    steps_in_current_role: int = 0
+    mood_level: float = 0.0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:  # pragma: no cover - noop
+        self.ip = ip
+        self.du = du
+
+
+class ReplayAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = ReplayState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, new_state: ReplayState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_agent_action_explain_why_logged_and_served(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: str
+) -> None:
+    from src.infra import event_log as event_log_module
+
+    log_path = tmp_path / "event_log.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(log_path))
+    monkeypatch.setattr(event_log_module, "_last_hash", None, raising=False)
+    monkeypatch.setattr(event_log_module, "_seed_cache", {}, raising=False)
+    monkeypatch.setattr(event_log_module, "_header_written", set(), raising=False)
+
+    captured_events: list[dict[str, Any]] = []
+    real_log_event = event_log_module.log_event
+
+    def capture(event: dict[str, Any]) -> dict[str, Any]:
+        persisted = real_log_event(event)
+        captured_events.append(persisted)
+        return persisted
+
+    monkeypatch.setattr("src.sim.simulation.log_event", capture)
+
+    with MockLLM():
+        sim = create_simulation(num_agents=1, steps=1, scenario="explain why")
+        sim.knowledge_board.add_entry(
+            "Shared context", sim.agents[0].agent_id, 0, sim.vector.to_dict()
+        )
+        await sim.run_step(max_turns=1)
+        await sim.stop_event_listener()
+
+    agent_events = [evt for evt in captured_events if evt.get("type") == "agent_action"]
+    assert agent_events, "Expected at least one agent_action event"
+    event = agent_events[0]
+
+    explain = event.get("explain_why")
+    assert isinstance(explain, dict)
+    assert isinstance(explain.get("memories"), list)
+    assert isinstance(explain.get("tool_calls"), list)
+    kb_entries = explain.get("knowledge_board_entries", [])
+    assert isinstance(kb_entries, list)
+    assert any("Shared context" in entry for entry in kb_entries)
+
+    replay_sim = Simulation(agents=[ReplayAgent(str(event.get("agent_id", "")))])  # type: ignore[list-item]
+    replay_sim.apply_event(event)
+
+    monkeypatch.setattr(db.event_log, "fetch_events", lambda *a, **k: [event])
+
+    resp = await db.api_agent_action_explain_why(limit=5)
+    body = resp.body.decode("utf-8") if isinstance(resp.body, (bytes, bytearray)) else resp.body
+    data = json.loads(body)
+
+    returned = data.get("events", [])
+    assert returned, "Expected agent action data in dashboard response"
+    explain_resp = returned[0]["explain_why"]
+    assert any("Shared context" in entry for entry in explain_resp["knowledge_board_entries"])
+    assert isinstance(explain_resp["memories"], list)
+    assert isinstance(explain_resp["tool_calls"], list)


### PR DESCRIPTION
## Summary
- capture retrieved memories and knowledge board excerpts during agent turns and include them in agent_action events
- sanitize explain-why fields in the event log and expose them through a new dashboard endpoint
- add an integration test covering explain-why data availability during event replay

## Testing
- pytest -m integration tests/integration/sim/test_agent_action_explain_why.py

------
https://chatgpt.com/codex/tasks/task_e_68f8defadeac8326a5b4c5fb6085d18e