### PR TITLE
Handle moderation events during replay

### DIFF
--- a/src/sim/resources.py
+++ b/src/sim/resources.py
@@ -11,50 +11,81 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 logger = logging.getLogger(__name__)
 
 
-async def mute_agent(sim: Simulation, agent_id: str) -> None:
-    """Mute ``agent_id`` and broadcast the action."""
+def mute_agent(sim: Simulation, agent_id: str) -> dict[str, object]:
+    """Mute ``agent_id`` and return the moderation event payload."""
+
     sim.muted_agents.add(agent_id)
-    event = {
+    return {
         "type": "moderation",
         "action": "mute",
         "agent_id": agent_id,
         "step": sim.current_step,
     }
-    await sim.event_kernel.emit_environment_event(event)
 
 
-async def reset_memory(sim: Simulation, agent_id: str) -> None:
-    """Reset the memory of ``agent_id`` and broadcast the action."""
+def unmute_agent(sim: Simulation, agent_id: str) -> dict[str, object]:
+    """Unmute ``agent_id`` and return the moderation event payload."""
+
+    sim.muted_agents.discard(agent_id)
+    return {
+        "type": "moderation",
+        "action": "unmute",
+        "agent_id": agent_id,
+        "step": sim.current_step,
+    }
+
+
+def reset_memory(sim: Simulation, agent_id: str) -> dict[str, object] | None:
+    """Reset the memory of ``agent_id`` and return the moderation event payload."""
+
     try:
         sim.memory_service.reset_agent(agent_id)
     except Exception:  # pragma: no cover - defensive
         logger.error("Failed to reset memory for %s", agent_id, exc_info=True)
-        return
-    event = {
+        return None
+    return {
         "type": "moderation",
         "action": "reset_memory",
         "agent_id": agent_id,
         "step": sim.current_step,
     }
-    await sim.event_kernel.emit_environment_event(event)
 
 
-async def apply_penalty(sim: Simulation, agent_id: str, ip: float = 0.0, du: float = 0.0) -> None:
-    """Apply an IP/DU penalty to ``agent_id`` and broadcast the action."""
+def apply_penalty(
+    sim: Simulation,
+    agent_id: str,
+    ip: float = 0.0,
+    du: float = 0.0,
+) -> dict[str, object] | None:
+    """Apply an IP/DU penalty to ``agent_id`` and return the moderation event payload."""
+
+    penalty_ip = abs(float(ip))
+    penalty_du = abs(float(du))
+
+    for agent in sim.agents:
+        if agent.agent_id == agent_id:
+            state = getattr(agent, "state", None)
+            if state is not None:
+                if hasattr(state, "ip"):
+                    state.ip = max(float(getattr(state, "ip", 0.0)) - penalty_ip, 0.0)
+                if hasattr(state, "du"):
+                    state.du = max(float(getattr(state, "du", 0.0)) - penalty_du, 0.0)
+            break
+
     try:
-        ledger.log_change(agent_id, -abs(ip), -abs(du), "moderation_penalty")
+        ledger.log_change(agent_id, -penalty_ip, -penalty_du, "moderation_penalty")
     except Exception:  # pragma: no cover - defensive
         logger.error("Failed to apply penalty to %s", agent_id, exc_info=True)
-        return
-    event = {
+        return None
+
+    return {
         "type": "moderation",
         "action": "penalty",
         "agent_id": agent_id,
-        "ip": ip,
-        "du": du,
+        "ip": float(ip),
+        "du": float(du),
         "step": sim.current_step,
     }
-    await sim.event_kernel.emit_environment_event(event)
 
 
-__all__ = ["apply_penalty", "mute_agent", "reset_memory"]
+__all__ = ["apply_penalty", "mute_agent", "reset_memory", "unmute_agent"]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -549,20 +549,35 @@ class Simulation:
                     )
                     _ = task
 
-    async def mute_agent(self: Self, agent_id: str) -> None:
+    async def mute_agent(self: Self, agent_id: str, *, emit_event: bool = True) -> None:
         from .resources import mute_agent as _mute_agent
 
-        await _mute_agent(self, agent_id)
+        event = _mute_agent(self, agent_id)
+        if emit_event:
+            await self.event_kernel.emit_environment_event(event)
 
-    async def reset_memory(self: Self, agent_id: str) -> None:
+    async def unmute_agent(self: Self, agent_id: str, *, emit_event: bool = True) -> None:
+        from .resources import unmute_agent as _unmute_agent
+
+        event = _unmute_agent(self, agent_id)
+        if emit_event:
+            await self.event_kernel.emit_environment_event(event)
+
+    async def reset_memory(self: Self, agent_id: str, *, emit_event: bool = True) -> None:
         from .resources import reset_memory as _reset_memory
 
-        await _reset_memory(self, agent_id)
+        event = _reset_memory(self, agent_id)
+        if emit_event and event:
+            await self.event_kernel.emit_environment_event(event)
 
-    async def apply_penalty(self: Self, agent_id: str, ip: float, du: float) -> None:
+    async def apply_penalty(
+        self: Self, agent_id: str, ip: float, du: float, *, emit_event: bool = True
+    ) -> None:
         from .resources import apply_penalty as _apply_penalty
 
-        await _apply_penalty(self, agent_id, ip, du)
+        event = _apply_penalty(self, agent_id, ip, du)
+        if emit_event and event:
+            await self.event_kernel.emit_environment_event(event)
 
     async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process moderation actions like muting or penalties."""
@@ -576,6 +591,11 @@ class Simulation:
         elif action == "reset_memory" and agent_id:
             await self.event_kernel.schedule_immediate(
                 lambda aid=str(agent_id): self.reset_memory(aid),
+                vector=self.vector,
+            )
+        elif action == "unmute" and agent_id:
+            await self.event_kernel.schedule_immediate(
+                lambda aid=str(agent_id): self.unmute_agent(aid),
                 vector=self.vector,
             )
         elif action == "penalty" and agent_id:
@@ -1566,6 +1586,42 @@ class Simulation:
                 from src.infra.checkpoint import restore_environment
 
                 restore_environment(env)
+        elif event.get("type") == "moderation":
+            action = event.get("action")
+            agent_id = event.get("agent_id")
+            if not isinstance(agent_id, str):
+                return
+            from .resources import (
+                apply_penalty as _apply_penalty,
+            )
+            from .resources import (
+                mute_agent as _mute_agent,
+            )
+            from .resources import (
+                reset_memory as _reset_memory,
+            )
+            from .resources import (
+                unmute_agent as _unmute_agent,
+            )
+
+            if action == "mute":
+                _mute_agent(self, agent_id)
+            elif action == "unmute":
+                _unmute_agent(self, agent_id)
+            elif action == "reset_memory":
+                _reset_memory(self, agent_id)
+            elif action == "penalty":
+                ip_val = event.get("ip", 0.0)
+                du_val = event.get("du", 0.0)
+                try:
+                    ip = float(ip_val)
+                except (TypeError, ValueError):
+                    ip = 0.0
+                try:
+                    du = float(du_val)
+                except (TypeError, ValueError):
+                    du = 0.0
+                _apply_penalty(self, agent_id, ip, du)
         elif event.get("type") == "tick":
             step = event.get("step")
             if isinstance(step, int) and step > self.current_step:

--- a/tests/integration/sim/test_moderation_replay.py
+++ b/tests/integration/sim/test_moderation_replay.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.infra import event_log
+from src.infra.ledger import Ledger
+from src.sim.simulation import Simulation
+
+
+@dataclass
+class ModeratedAgentState:
+    ip: float = 10.0
+    du: float = 5.0
+    short_term_memory: list[dict[str, Any]] = field(default_factory=list)
+    messages_sent_count: int = 0
+    last_message_step: int | None = None
+    collective_ip: float = 0.0
+    collective_du: float = 0.0
+    role: str = "tester"
+    current_role: str = "tester"
+    steps_in_current_role: int = 0
+    mood_level: float = 0.0
+    mood_value: float = 0.0
+    current_project_id: str | None = None
+    name: str = "Moderated Agent"
+    is_alive: bool = True
+    age: int = 0
+
+
+class ModeratedAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = ModeratedAgentState()
+
+    def get_id(self) -> str:  # pragma: no cover - scheduler compatibility
+        return self.agent_id
+
+    def update_state(self, state: ModeratedAgentState) -> None:  # pragma: no cover - simple setter
+        self.state = state
+
+    async def run_turn(  # pragma: no cover - not used in this test
+        self,
+        simulation_step: int,
+        environment_perception: dict[str, Any] | None = None,
+        vector_store_manager: Any | None = None,
+        knowledge_board: Any | None = None,
+        memory_service: Any | None = None,
+    ) -> dict[str, Any]:
+        return {}
+
+
+class RecordingMemoryService:
+    def __init__(self) -> None:
+        self.vector_store = SimpleNamespace()
+        self.semantic_manager = None
+        self.reset_calls: list[str] = []
+        self.contents: dict[str, list[str]] = {}
+
+    def reset_agent(self, agent_id: str) -> None:
+        self.reset_calls.append(agent_id)
+        self.contents[agent_id] = []
+
+    def close(self) -> None:  # pragma: no cover - compatibility stub
+        pass
+
+
+def _prepare_event_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    event_path = events_dir / "events.jsonl"
+    monkeypatch.setenv("EVENT_LOG_PATH", str(event_path))
+    monkeypatch.setenv("ENABLE_REDPANDA", "0")
+    monkeypatch.setattr(event_log, "_producer", None, raising=False)
+    monkeypatch.setattr(event_log, "_get_producer", lambda: None)
+    event_log._last_hash = None
+    event_log._seed = None
+    event_log._seed_cache = {}
+    event_log._header_written = set()
+    return event_path
+
+
+def _prepare_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Ledger:
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir()
+    ledger = Ledger(ledger_dir / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+    monkeypatch.setattr("src.sim.resources.ledger", ledger)
+    return ledger
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_moderation_events_replay_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    event_path = _prepare_event_log(tmp_path, monkeypatch)
+    ledger = _prepare_ledger(tmp_path, monkeypatch)
+
+    live_memory = RecordingMemoryService()
+    agent = ModeratedAgent("agent-moderated")
+    live_memory.contents[agent.agent_id] = ["keep"]
+    ledger.log_change(agent.agent_id, agent.state.ip, agent.state.du, "init")
+    sim = Simulation([agent], memory_service=live_memory, seed=321)
+
+    await sim.mute_agent(agent.agent_id)
+    sim.current_step += 1
+    await sim.apply_penalty(agent.agent_id, ip=2.0, du=1.0)
+    sim.current_step += 1
+    await sim.reset_memory(agent.agent_id)
+    sim.current_step += 1
+    await sim.unmute_agent(agent.agent_id)
+
+    expected_ip = agent.state.ip
+    expected_du = agent.state.du
+
+    await sim.stop_event_listener()
+    sim.close()
+
+    events = event_log.fetch_events(after_step=-1, path=event_path)
+    moderation_events = [ev for ev in events if ev.get("type") == "moderation"]
+    assert {ev.get("action") for ev in moderation_events} == {
+        "mute",
+        "penalty",
+        "reset_memory",
+        "unmute",
+    }
+
+    replay_tmp = tmp_path / "replay"
+    replay_tmp.mkdir()
+    replay_ledger = _prepare_ledger(replay_tmp, monkeypatch)
+
+    replay_memory = RecordingMemoryService()
+    replay_agent = ModeratedAgent(agent.agent_id)
+    replay_agent.state.ip = 10.0
+    replay_agent.state.du = 5.0
+    replay_memory.contents[replay_agent.agent_id] = ["stale"]
+    replay_ledger.log_change(
+        replay_agent.agent_id, replay_agent.state.ip, replay_agent.state.du, "init"
+    )
+    replay_sim = Simulation([replay_agent], memory_service=replay_memory, seed=321)
+
+    for event in moderation_events:
+        replay_sim.apply_event(event)
+
+    assert replay_agent.agent_id not in replay_sim.muted_agents
+    assert replay_agent.state.ip == pytest.approx(expected_ip)
+    assert replay_agent.state.du == pytest.approx(expected_du)
+    assert replay_memory.reset_calls == [replay_agent.agent_id]
+    assert replay_memory.contents[replay_agent.agent_id] == []
+
+    balance_ip, balance_du = replay_ledger.get_balance(replay_agent.agent_id)
+    assert balance_ip == pytest.approx(expected_ip)
+    assert balance_du == pytest.approx(expected_du)
+
+    await replay_sim.stop_event_listener()
+    replay_sim.close()


### PR DESCRIPTION
## Summary
- reuse the moderation resource helpers for both live moderation actions and replayed events so agent state, ledger, and mute state stay consistent
- add moderation replay handling in Simulation.apply_event to mirror live actions for mute, unmute, memory resets, and penalties
- add an integration test that records moderation events, replays them, and asserts mute state, memory resets, and penalties persist

## Testing
- `ruff check src/sim/resources.py src/sim/simulation.py tests/integration/sim/test_moderation_replay.py`
- `pytest -m "integration" tests/integration/sim/test_moderation_replay.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690a71e491748326a76bbaf0df54fea0)