### PR TITLE
Add helper for unmuting moderated agents

### DIFF
--- a/src/sim/resources.py
+++ b/src/sim/resources.py
@@ -23,6 +23,18 @@ async def mute_agent(sim: Simulation, agent_id: str) -> None:
     await sim.event_kernel.emit_environment_event(event)
 
 
+async def unmute_agent(sim: Simulation, agent_id: str) -> None:
+    """Unmute ``agent_id`` and broadcast the action."""
+    sim.muted_agents.discard(agent_id)
+    event = {
+        "type": "moderation",
+        "action": "unmute",
+        "agent_id": agent_id,
+        "step": sim.current_step,
+    }
+    await sim.event_kernel.emit_environment_event(event)
+
+
 async def reset_memory(sim: Simulation, agent_id: str) -> None:
     """Reset the memory of ``agent_id`` and broadcast the action."""
     try:
@@ -57,4 +69,4 @@ async def apply_penalty(sim: Simulation, agent_id: str, ip: float = 0.0, du: flo
     await sim.event_kernel.emit_environment_event(event)
 
 
-__all__ = ["apply_penalty", "mute_agent", "reset_memory"]
+__all__ = ["apply_penalty", "mute_agent", "reset_memory", "unmute_agent"]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -554,6 +554,11 @@ class Simulation:
 
         await _mute_agent(self, agent_id)
 
+    async def unmute_agent(self: Self, agent_id: str) -> None:
+        from .resources import unmute_agent as _unmute_agent
+
+        await _unmute_agent(self, agent_id)
+
     async def reset_memory(self: Self, agent_id: str) -> None:
         from .resources import reset_memory as _reset_memory
 
@@ -571,6 +576,11 @@ class Simulation:
         if action == "mute" and agent_id:
             await self.event_kernel.schedule_immediate(
                 lambda aid=str(agent_id): self.mute_agent(aid),
+                vector=self.vector,
+            )
+        elif action == "unmute" and agent_id:
+            await self.event_kernel.schedule_immediate(
+                lambda aid=str(agent_id): self.unmute_agent(aid),
                 vector=self.vector,
             )
         elif action == "reset_memory" and agent_id:


### PR DESCRIPTION
## Summary
- add an `unmute_agent` helper in the shared moderation resources that clears mute state and emits telemetry
- expose the helper via `__all__` and wire Simulation methods to use it
- route Simulation moderation commands for `unmute` through the event kernel like other actions

## Testing
- `ruff check`
- `pytest` *(fails: event log spans tests expect Redpanda integration but `confluent_kafka` is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690a71e4665083268c5f1ce941ddcded)