### PR TITLE
Add active agent count metric to simulation metrics

### DIFF
--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -84,6 +84,9 @@ HUMAN_MESSAGES_TOTAL = Counter(
 COALITION_COUNT = Gauge("coalition_count", "Number of active coalitions")
 AVERAGE_SENTIMENT = Gauge("average_sentiment", "Average sentiment across all agents")
 PROPOSAL_THROUGHPUT = Gauge("proposal_throughput", "Proposals processed per minute")
+ACTIVE_AGENT_COUNT = Gauge(
+    "active_agent_count", "Number of active agents participating in the simulation"
+)
 
 # Gas price metrics updated by ``Ledger.calculate_gas_price``
 GAS_PRICE_PER_CALL = Gauge("gas_price_per_call", "Current gas price charged per LLM call")

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -38,6 +38,7 @@ from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
 )
+from src.interfaces.metrics import ACTIVE_AGENT_COUNT
 from src.shared.telemetry import trace_agent_action
 from src.shared.typing import SimulationMessage
 from src.sim.event_kernel import EventKernel
@@ -120,6 +121,7 @@ class Simulation:
         self.seed = seed
 
         self.agents: list[Agent] = agents
+        ACTIVE_AGENT_COUNT.set(len(self.agents))
         self.current_step: int = 0
         self.current_agent_index: int = 0
         self.last_completed_agent_index: int | None = None
@@ -317,6 +319,7 @@ class Simulation:
 
         self.collective_ip = total_ip
         self.collective_du = total_du
+        ACTIVE_AGENT_COUNT.set(len(self.agents))
 
         if self.track_collective_metrics:
             current_collective_ip = sum(agent.state.ip for agent in self.agents)
@@ -516,6 +519,7 @@ class Simulation:
                         self.agents.remove(agent)
                     except ValueError:  # pragma: no cover - defensive
                         pass
+                    self._update_collective_metrics()
         elif action == "set_speed":
             try:
                 self.speed = float(cmd.get("value", 1))
@@ -654,6 +658,7 @@ class Simulation:
         self.agents.append(agent)
         await self.world_map.add_agent(agent.agent_id, x=len(self.agents) - 1, y=0)
         self._update_collective_metrics()
+        ACTIVE_AGENT_COUNT.set(len(self.agents))
 
     async def retire_agent(self: Self, agent: "Agent") -> None:
         """Retire an agent and compute inheritance."""

--- a/tests/unit/sim/test_simulation_agent_count.py
+++ b/tests/unit/sim/test_simulation_agent_count.py
@@ -1,0 +1,66 @@
+import sys
+
+import pytest
+
+from src.interfaces.metrics import ACTIVE_AGENT_COUNT
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+        self.is_alive = True
+        self.inheritance = 0.0
+        self.parent_id: str | None = None
+        self.genes: dict[str, float] = {}
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyAgentState:
+        return self._state
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self._state = state
+
+
+@pytest.mark.asyncio
+async def test_active_agent_count_gauge_updates() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    agent_a = DummyAgent("A")
+    sim = Simulation([agent_a])
+
+    assert ACTIVE_AGENT_COUNT._value.get() == 1
+
+    agent_b = DummyAgent("B")
+    await sim.spawn_agent(agent_b)
+    assert ACTIVE_AGENT_COUNT._value.get() == 2
+
+    await sim.handle_control_command({"command": "kill_agent", "agent_id": "A"})
+    assert ACTIVE_AGENT_COUNT._value.get() == 1
+
+    await sim.handle_control_command({"command": "kill_agent", "agent_id": "B"})
+    assert ACTIVE_AGENT_COUNT._value.get() == 0
+
+    sim.close()


### PR DESCRIPTION
## Summary
- add an `ACTIVE_AGENT_COUNT` gauge alongside existing simulation metrics
- update the simulation lifecycle to keep the active agent count gauge in sync during initialization, spawns, and removals
- add a unit test ensuring the gauge reflects agent additions and removals

## Testing
- pytest tests/unit/sim -k agent_count
- ruff check src tests *(fails: repository contains existing unused-variable warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916398fd17c8326a4161e768be13357)