### PR TITLE
Document Redpanda topic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,7 @@ See [docs/testing.md](docs/testing.md) for full instructions, marker definitions
   - `OTEL_EXPORTER_ENDPOINT` to override the OTLP log endpoint
   - `ENABLE_REDPANDA=1` to log events to Redpanda
   - `REDPANDA_BROKER` (e.g., localhost:9092) address of the Redpanda broker
+  - `REDPANDA_TOPIC` to override the default `culture.events` topic name
   - `SNAPSHOT_COMPRESS=1` to compress simulation snapshots
 
 
@@ -944,7 +945,7 @@ You can install Redpanda quickly with:
 curl -1s https://raw.githubusercontent.com/redpanda-data/redpanda/master/install.sh | bash
 docker compose -f docker-compose.redpanda.yml up -d
 ```
-Events are written to the `culture-events` topic and can be consumed using the `rpk` CLI.
+Events are written to the `culture.events` topic by default and can be consumed using the `rpk` CLI. Override the topic name with the `REDPANDA_TOPIC` environment variable if desired.
 
 ### Prometheus Metrics
 The simulation exposes Prometheus metrics on port 8000 when `src.interfaces.metrics` is imported.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -210,9 +210,10 @@ Set the following variables in your `.env`:
 ```env
 ENABLE_REDPANDA=1
 REDPANDA_BROKER=localhost:9092
+REDPANDA_TOPIC=culture.events  # optional override of the topic name
 ```
 
-Events will be written to the `culture-events` topic. You can inspect them with the `rpk` CLI or any Kafka-compatible consumer.
+Events will be written to the `culture.events` topic by default. You can inspect them with the `rpk` CLI or any Kafka-compatible consumer, or override the destination by setting `REDPANDA_TOPIC`.
 
 ## 9. Metrics Reference
 


### PR DESCRIPTION
## Summary
- document the default Redpanda topic name as `culture.events`
- explain how to override the topic via the `REDPANDA_TOPIC` environment variable in README and observability docs

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163988541c83269436414a9b068c89)