### PR TITLE
Add Council Mode documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Signature Demo](#signature-demo)
 - [culture-ui Frontend](#culture-ui-frontend)
 - [Extensions and Plug-ins](#extensions-and-plug-ins)
+- [Council Mode (Experimental)](#council-mode-experimental)
 - [Roadmap](#roadmap)
 - [Exporting Simulation Traces](#exporting-simulation-traces)
 
@@ -109,6 +110,10 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
 * **Agent Lifecycle & Legacy:**
     * Agent Legacy & Artifacts on the Knowledge Board.
     * Mechanisms for agent "death" or succession.
+
+## Council Mode (Experimental)
+
+Culture ships with an opt-in, experimental **Council Mode** where you can temporarily promote a panel of specialized agents to debate, critique, or ratify pivotal simulation actions before they execute. Because this workflow is still evolving, it is disabled by default—enable it only when you are ready to iterate on council prompts and guardrails. Refer to the [Council Mode design doc](docs/council_mode_design.md) for the latest setup instructions, capabilities, and caveats.
 
 ## Technology Stack
 

--- a/docs/council_mode_design.md
+++ b/docs/council_mode_design.md
@@ -1,0 +1,13 @@
+# Council Mode Design Notes
+
+Council Mode is an opt-in orchestration pattern where multiple specialized agents debate or critique a proposal before the simulation executes it. The goal is to increase robustness for high-stakes actions while keeping the feature experimental and easy to disable.
+
+## Current Status
+- **Experimental:** Disabled by default. Enable only when iterating on council prompts and evaluation workflows.
+- **Pluggable:** Implemented as a higher-level protocol that wraps existing LangGraph flows.
+- **Guardrailed:** Each councilor must operate within strict budgets to avoid runaway token usage.
+
+## Next Steps
+1. Add scenario templates that showcase council deliberation loops.
+2. Capture telemetry for the entire council session to simplify debugging.
+3. Harden failure recovery so the main simulation can proceed if the council deadlocks.


### PR DESCRIPTION
## Summary
- add a Council Mode entry to the README summary and describe the opt-in, experimental feature with a link to the design notes
- create docs/council_mode_design.md to give the design status, guardrails, and next steps for the feature

## Testing
- python scripts/check_markdown_links.py README.md docs/council_mode_design.md

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd5f43c3483269595b5aa3d3fb2fd)