### PR TITLE
Add validation tests for council config

### DIFF
--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableSequence, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import Field
 
 
 @dataclass(slots=True)
@@ -21,12 +23,15 @@ class CouncilMemberConfig:
     metadata: Mapping[str, Any] | None = None
 
 
+CouncilMembers = Annotated[Sequence[CouncilMemberConfig], Field(min_length=1)]
+
+
 @dataclass(slots=True)
 class CouncilConfig:
     """Top-level configuration for enabling Council Mode in a scenario."""
 
     enabled: bool
-    members: Sequence[CouncilMemberConfig]
+    members: CouncilMembers
     quorum: int | None = None
     consensus_threshold: float = 0.67
     max_rounds: int = 1

--- a/tests/unit/agents/council/test_council_types.py
+++ b/tests/unit/agents/council/test_council_types.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import TypeAdapter, ValidationError
+
+from src.agents.council.types import CouncilConfig
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def council_config_adapter() -> TypeAdapter[CouncilConfig]:
+    return TypeAdapter(CouncilConfig)
+
+
+@pytest.fixture
+def sample_yaml(tmp_path: Path) -> str:
+    content = """
+    enabled: true
+    members:
+      - member_id: facilitator
+        display_name: Facilitator
+        role: Moderator
+        description: Guides the conversation and keeps members on track.
+        system_prompt: Maintain order and summarize the discussion.
+        decision_weight: 1.5
+        max_turn_tokens: 256
+    """
+    path = tmp_path / "council" / "sample.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path.read_text()
+
+
+def test_sample_yaml_loads_successfully(
+    council_config_adapter: TypeAdapter[CouncilConfig], sample_yaml: str
+) -> None:
+    parsed = yaml.safe_load(sample_yaml)
+
+    config = council_config_adapter.validate_python(parsed)
+
+    assert config.enabled is True
+    assert len(config.members) == 1
+    member = config.members[0]
+    assert member.member_id == "facilitator"
+    assert member.display_name == "Facilitator"
+    assert member.decision_weight == pytest.approx(1.5)
+    assert member.max_turn_tokens == 256
+
+
+def test_load_fails_with_empty_members(
+    council_config_adapter: TypeAdapter[CouncilConfig]
+) -> None:
+    with pytest.raises(ValidationError):
+        council_config_adapter.validate_python({"enabled": True, "members": []})
+
+
+def test_load_fails_with_misconfigured_member(
+    council_config_adapter: TypeAdapter[CouncilConfig]
+) -> None:
+    invalid_yaml = {
+        "enabled": True,
+        "members": [
+            {
+                "member_id": "facilitator",
+                "display_name": "Facilitator",
+                "description": "Missing required role and system prompt",
+            }
+        ],
+    }
+
+    with pytest.raises(ValidationError):
+        council_config_adapter.validate_python(invalid_yaml)


### PR DESCRIPTION
## Summary
- enforce a minimum council member count using a pydantic field constraint
- add council type unit tests covering valid sample YAML and invalid member configurations

## Testing
- pytest tests/unit/agents/council/test_council_types.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692476e35c9c832699324d38c6da8bb9)