### PR TITLE
Add deterministic council orchestrator flow

### DIFF
--- a/src/agents/council/__init__.py
+++ b/src/agents/council/__init__.py
@@ -7,6 +7,7 @@ from .types import (
     CouncilQuestion,
     MemberAnswer,
 )
+from .orchestrator import CouncilOrchestrator
 
 __all__ = [
     "CouncilConfig",
@@ -14,4 +15,5 @@ __all__ = [
     "CouncilOutcome",
     "CouncilQuestion",
     "MemberAnswer",
+    "CouncilOrchestrator",
 ]

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1,0 +1,113 @@
+"""Lightweight orchestration utilities for Council Mode simulations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from pydantic import BaseModel, Field
+
+from src.agents.council.types import (
+    CouncilConfig,
+    CouncilOutcome,
+    CouncilQuestion,
+    MemberAnswer,
+)
+from src.infra import llm_client
+
+
+class CouncilJudgeResponse(BaseModel):
+    """Structured output produced by the judge step."""
+
+    winner: str = Field(description="Member ID that produced the winning answer")
+    votes: dict[str, int] = Field(default_factory=dict)
+    metrics: dict[str, float] = Field(default_factory=dict)
+    resolution: str
+    summary: str | None = None
+
+
+class CouncilMemberResponse(BaseModel):
+    """Structured output produced for each council member."""
+
+    answer: str
+    reasoning: str
+    confidence: float | None = None
+    citations: list[str] = Field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CouncilOrchestrator:
+    """Coordinate member calls and adjudication for Council Mode."""
+
+    model: str = "mistral:latest"
+
+    def _member_prompt(self, question: CouncilQuestion, member_id: str) -> str:
+        return (
+            "[council-member-answer]\n"
+            f"member_id={member_id}\n"
+            f"question={question.prompt}\n"
+            f"context={question.context or ''}"
+        )
+
+    def _judge_prompt(
+        self, question: CouncilQuestion, answers: Sequence[MemberAnswer]
+    ) -> str:
+        rendered_answers = "\n".join(
+            f"member_id={answer.member_id} :: answer={answer.answer}"
+            for answer in answers
+        )
+        return (
+            "[council-judgement]\n"
+            f"question={question.prompt}\n"
+            f"context={question.context or ''}\n"
+            f"answers=\n{rendered_answers}"
+        )
+
+    def _parse_member_response(
+        self, payload: dict[str, object], member_id: str
+    ) -> MemberAnswer:
+        parsed = CouncilMemberResponse(**payload)
+        return MemberAnswer(
+            member_id=member_id,
+            answer=parsed.answer,
+            confidence=parsed.confidence,
+            reasoning=parsed.reasoning,
+            citations=list(parsed.citations),
+        )
+
+    def _collect_member_answers(
+        self, question: CouncilQuestion, members: Iterable[str]
+    ) -> list[MemberAnswer]:
+        answers: list[MemberAnswer] = []
+        for member_id in members:
+            prompt = self._member_prompt(question, member_id)
+            raw_response = llm_client.client.generate(prompt=prompt, model=self.model)
+            payload = json.loads(str(raw_response.get("response", "{}")))
+            answers.append(self._parse_member_response(payload, member_id))
+        return answers
+
+    def _adjudicate(self, question: CouncilQuestion, answers: Sequence[MemberAnswer]) -> CouncilJudgeResponse:
+        prompt = self._judge_prompt(question, answers)
+        raw_response = llm_client.client.generate(prompt=prompt, model=self.model)
+        payload = json.loads(str(raw_response.get("response", "{}")))
+        return CouncilJudgeResponse(**payload)
+
+    def deliberate(self, config: CouncilConfig, question: CouncilQuestion) -> CouncilOutcome:
+        if not config.enabled:
+            raise ValueError("Council is disabled in the provided configuration")
+
+        active_members = [member.member_id for member in config.members if member.decision_weight > 0]
+        member_answers = self._collect_member_answers(question, active_members)
+        judgement = self._adjudicate(question, member_answers)
+
+        metadata = {"votes": judgement.votes, "metrics": judgement.metrics}
+        return CouncilOutcome(
+            question=question,
+            answers=member_answers,
+            resolution=judgement.resolution,
+            winning_member_ids=[judgement.winner],
+            summary=judgement.summary,
+            metadata=metadata,
+        )
+

--- a/src/shared/llm_mocks.py
+++ b/src/shared/llm_mocks.py
@@ -5,6 +5,7 @@ Provides mock helpers for LLM-dependent tests.
 
 import json
 import logging
+import re
 import socket
 from typing import Any
 from unittest.mock import MagicMock
@@ -151,6 +152,51 @@ def create_mock_ollama_client() -> MagicMock:
     def mock_generate(*args: Any, **kwargs: Any) -> OllamaGenerateResponse:
         prompt_content = str(kwargs.get("prompt", ""))  # Ensure prompt_content is a string
         logger.debug(f"MOCK_GENERATE_PROMPT_CONTENT_DEBUG: '''{prompt_content}'''")
+
+        if "[council-member-answer]" in prompt_content:
+            member_match = re.search(r"member_id[=:]\s*([\w-]+)", prompt_content)
+            member_id = member_match.group(1) if member_match else "member"
+            logger.debug("Mock generate producing deterministic council member answer for %s", member_id)
+            response_json_str = json.dumps(
+                {
+                    "answer": f"Deterministic answer from {member_id}",
+                    "reasoning": f"Deterministic reasoning from {member_id}",
+                    "confidence": 0.82,
+                    "citations": [f"citation-{member_id}"],
+                }
+            )
+            return {
+                "response": response_json_str,
+                "done": True,
+                "eval_count": 5,
+                "total_duration": 25,
+            }
+
+        if "[council-judgement]" in prompt_content:
+            member_ids = re.findall(r"member_id[=:]\s*([\w-]+)", prompt_content)
+            if not member_ids:
+                member_ids = ["member"]
+            winner = member_ids[0]
+            votes = {mid: 1 for mid in member_ids}
+            metrics = {"cohesion": 0.91, "coverage": 0.77}
+            logger.debug(
+                "Mock generate producing deterministic council judgement with winner %s", winner
+            )
+            response_json_str = json.dumps(
+                {
+                    "winner": winner,
+                    "votes": votes,
+                    "metrics": metrics,
+                    "resolution": f"{winner} proposal selected",
+                    "summary": "Deterministic council summary",
+                }
+            )
+            return {
+                "response": response_json_str,
+                "done": True,
+                "eval_count": 6,
+                "total_duration": 30,
+            }
 
         # Determine which DSPy program this prompt is for based on unique field combinations
         is_l1_summary_prompt = (

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.agents.council import CouncilConfig, CouncilMemberConfig, CouncilOrchestrator, CouncilQuestion
+from src.infra import llm_client
+from src.shared import llm_mocks
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    llm_mocks.patch_ollama_functions(monkeypatch)
+
+
+def _build_council_config() -> CouncilConfig:
+    return CouncilConfig(
+        enabled=True,
+        members=[
+            CouncilMemberConfig(
+                member_id="facilitator",
+                display_name="Facilitator",
+                role="Moderator",
+                description="Ensures everyone is heard",
+                system_prompt="Lead with clarity",
+                decision_weight=1.0,
+            ),
+            CouncilMemberConfig(
+                member_id="innovator",
+                display_name="Innovator",
+                role="Idea generator",
+                description="Pushes creative thinking",
+                system_prompt="Bring new ideas",
+                decision_weight=1.0,
+            ),
+            CouncilMemberConfig(
+                member_id="analyst",
+                display_name="Analyst",
+                role="Evaluator",
+                description="Stress-tests ideas",
+                system_prompt="Look for gaps",
+                decision_weight=1.0,
+            ),
+        ],
+    )
+
+
+def _build_question() -> CouncilQuestion:
+    return CouncilQuestion(
+        question_id="q-1",
+        prompt="Which project should we fund first?",
+        context="We have budget for only one initiative this quarter.",
+    )
+
+
+def test_council_orchestrator_invokes_all_members_and_aggregates(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config()
+    question = _build_question()
+
+    outcome = orchestrator.deliberate(config, question)
+
+    expected_member_ids = {member.member_id for member in config.members}
+    observed_member_ids = {answer.member_id for answer in outcome.answers}
+
+    assert observed_member_ids == expected_member_ids
+
+    assert llm_client.client.generate.call_count == len(config.members) + 1
+
+    assert outcome.winning_member_ids == ["facilitator"]
+    assert outcome.resolution == "facilitator proposal selected"
+    assert outcome.metadata == {
+        "votes": {"facilitator": 1, "innovator": 1, "analyst": 1},
+        "metrics": {"cohesion": 0.91, "coverage": 0.77},
+    }
+    assert outcome.summary == "Deterministic council summary"
+
+    serialized = json.loads(json.dumps(outcome.metadata))
+    assert serialized["metrics"]["cohesion"] == pytest.approx(0.91)


### PR DESCRIPTION
## Summary
- add a council orchestrator that collects member answers and aggregates judged outcomes
- extend the LLM mocks to return deterministic council member and judgement JSON payloads
- add unit coverage to ensure every active council member is invoked and outcomes aggregate votes/metrics

## Testing
- pytest tests/unit/agents/council/test_council_orchestrator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829de4e60832686d384494244a453)