### PR TITLE
Add concurrency tracking to council orchestrator mock LLM

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+import asyncio
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -16,8 +18,10 @@ from src.agents.council.types import (
     CouncilQuestion,
     MemberAnswer,
 )
+from src.infra import llm_client
 from src.infra.config import get_config, load_council_config
 from src.infra.llm_client import generate_structured_output, generate_text
+from src.shared import llm_mocks
 
 DEFAULT_MEMBER_PROMPT = (
     "You are participating in a council of AI personas. Provide a JSON object with keys: "
@@ -279,3 +283,151 @@ def run_council(
         summary=summary,
         metadata=metadata,
     )
+
+
+class CouncilOrchestrator:
+    """Coordinate concurrent council member calls with optional resource limits."""
+
+    def __init__(self: "CouncilOrchestrator", *, max_concurrency: int = 3) -> None:
+        self.max_concurrency = max(1, max_concurrency)
+        self._semaphore = asyncio.Semaphore(self.max_concurrency)
+
+    @staticmethod
+    def _build_member_prompt(member: CouncilMemberConfig, question: CouncilQuestion) -> str:
+        return (
+            "[council-member-answer] "
+            f"member_id={member.member_id} question={question.prompt} context={question.context or ''}"
+        )
+
+    @staticmethod
+    def _build_judge_prompt(question: CouncilQuestion, answers: Sequence[MemberAnswer]) -> str:
+        member_section = " ".join(f"member_id={answer.member_id}" for answer in answers)
+        return (
+            "[council-judgement] "
+            f"question={question.prompt} context={question.context or ''} {member_section}"
+        )
+
+    @staticmethod
+    def _parse_member_response(member: CouncilMemberConfig, raw: dict[str, Any]) -> MemberAnswer:
+        return MemberAnswer(
+            member_id=member.member_id,
+            answer=str(raw.get("answer", "")),
+            reasoning=raw.get("reasoning"),
+            confidence=float(raw.get("confidence", 0.0)) if raw.get("confidence") is not None else None,
+            citations=list(raw.get("citations", []) or []),
+        )
+
+    async def _ask_member_async(
+        self: "CouncilOrchestrator",
+        member: CouncilMemberConfig,
+        question: CouncilQuestion,
+    ) -> MemberAnswer:
+        prompt = self._build_member_prompt(member, question)
+        async with self._semaphore:
+            response = await asyncio.to_thread(llm_client.client.generate, prompt=prompt)
+        payload = json.loads(str(response.get("response", "{}")))
+        return self._parse_member_response(member, payload)
+
+    async def _judge_answers_async(
+        self: "CouncilOrchestrator",
+        question: CouncilQuestion,
+        answers: Sequence[MemberAnswer],
+    ) -> CouncilOutcome:
+        prompt = self._build_judge_prompt(question, answers)
+        response = await asyncio.to_thread(llm_client.client.generate, prompt=prompt)
+        payload = json.loads(str(response.get("response", "{}")))
+
+        winner = str(payload.get("winner") or "")
+        votes = payload.get("votes") or {}
+        metrics = payload.get("metrics") or {}
+
+        return CouncilOutcome(
+            question=question,
+            answers=answers,
+            resolution=str(payload.get("resolution") or "No consensus reached."),
+            winning_member_ids=[winner] if winner else [],
+            summary=payload.get("summary"),
+            metadata={"votes": votes, "metrics": metrics},
+        )
+
+    async def _gather_answers(
+        self: "CouncilOrchestrator",
+        config: CouncilConfig,
+        question: CouncilQuestion,
+    ) -> tuple[list[MemberAnswer], bool]:
+        tasks = {
+            asyncio.create_task(self._ask_member_async(member, question)): index
+            for index, member in enumerate(config.members)
+        }
+        answers: list[tuple[int, MemberAnswer]] = []
+        budget_exhausted = False
+        try:
+            pending_tasks = set(tasks.keys())
+            while pending_tasks:
+                done, pending_tasks = await asyncio.wait(
+                    pending_tasks, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    try:
+                        answer = task.result()
+                    except RuntimeError as exc:
+                        if "budget" in str(exc).lower():
+                            budget_exhausted = True
+                            continue
+                        raise
+                    else:
+                        answers.append((tasks[task], answer))
+                if budget_exhausted:
+                    pending_tasks = set()
+                    break
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+        ordered_answers = [
+            answer for _, answer in sorted(answers, key=lambda pair: pair[0])
+        ]
+        return ordered_answers, budget_exhausted
+
+    async def _deliberate_async(
+        self: "CouncilOrchestrator",
+        config: CouncilConfig,
+        question: CouncilQuestion,
+    ) -> CouncilOutcome:
+        answers, budget_exhausted = await self._gather_answers(config, question)
+
+        if budget_exhausted:
+            return CouncilOutcome(
+                question=question,
+                answers=answers,
+                resolution="Insufficient DU budget; partial council outcome",
+                winning_member_ids=[],
+                summary=None,
+                metadata={
+                    "du_exhausted": True,
+                    "partial": True,
+                    "completed_members": [a.member_id for a in answers],
+                },
+            )
+
+        if not answers:
+            return CouncilOutcome(
+                question=question,
+                answers=[],
+                resolution="No answers produced.",
+                winning_member_ids=[],
+                summary=None,
+                metadata=None,
+            )
+
+        return await self._judge_answers_async(question, answers)
+
+    def deliberate(
+        self: "CouncilOrchestrator",
+        config: CouncilConfig,
+        question: CouncilQuestion,
+    ) -> CouncilOutcome:
+        """Synchronously orchestrate the council deliberation."""
+
+        return asyncio.run(self._deliberate_async(config, question))

--- a/src/shared/llm_mocks.py
+++ b/src/shared/llm_mocks.py
@@ -8,6 +8,7 @@ import logging
 import re
 import socket
 from typing import Any
+import threading
 from unittest.mock import MagicMock
 
 from typing_extensions import Self
@@ -53,6 +54,56 @@ logger = logging.getLogger(__name__)
 # Module-level mock responses for broader access
 mock_text_global = "This is a mock generated text (global)"
 mock_summary_global = "This is a mock memory summary (global)"
+
+
+class MockLLMGenerateStats:
+    """Track aggregate metrics for the mocked LLM generate calls."""
+
+    def __init__(self: Self) -> None:
+        self._lock = threading.Lock()
+        self.reset()
+
+    def reset(self: Self) -> None:
+        """Reset all tracking counters."""
+
+        with self._lock:
+            self.active_calls = 0
+            self.peak_concurrent_calls = 0
+            self.call_count = 0
+            self.du_budget: float | None = None
+
+    def set_du_budget(self: Self, budget: float | None) -> None:
+        """Set the remaining DU budget for the mock generator."""
+
+        with self._lock:
+            self.du_budget = float(budget) if budget is not None else None
+
+    def _consume_du(self: Self) -> None:
+        with self._lock:
+            if self.du_budget is None:
+                return
+            self.du_budget -= 1.0
+            if self.du_budget < 0:
+                raise RuntimeError("Mock DU budget exhausted")
+
+    def start_call(self: Self) -> None:
+        """Register the beginning of a generate call."""
+
+        with self._lock:
+            self.active_calls += 1
+            self.call_count += 1
+            self.peak_concurrent_calls = max(
+                self.peak_concurrent_calls, self.active_calls
+            )
+
+    def finish_call(self: Self) -> None:
+        """Register the completion of a generate call."""
+
+        with self._lock:
+            self.active_calls = max(0, self.active_calls - 1)
+
+
+mock_generate_stats = MockLLMGenerateStats()
 
 
 def is_ollama_running() -> bool:
@@ -150,125 +201,128 @@ def create_mock_ollama_client() -> MagicMock:
     # as ollama.Client.generate does.
 
     def mock_generate(*args: Any, **kwargs: Any) -> OllamaGenerateResponse:
-        prompt_content = str(kwargs.get("prompt", ""))  # Ensure prompt_content is a string
-        logger.debug(f"MOCK_GENERATE_PROMPT_CONTENT_DEBUG: '''{prompt_content}'''")
+        mock_generate_stats.start_call()
+        try:
+            mock_generate_stats._consume_du()
 
-        if "[council-member-answer]" in prompt_content:
-            member_match = re.search(r"member_id[=:]\s*([\w-]+)", prompt_content)
-            member_id = member_match.group(1) if member_match else "member"
-            logger.debug("Mock generate producing deterministic council member answer for %s", member_id)
-            response_json_str = json.dumps(
-                {
-                    "answer": f"Deterministic answer from {member_id}",
-                    "reasoning": f"Deterministic reasoning from {member_id}",
-                    "confidence": 0.82,
-                    "citations": [f"citation-{member_id}"],
+            prompt_content = str(kwargs.get("prompt", ""))  # Ensure prompt_content is a string
+            logger.debug(f"MOCK_GENERATE_PROMPT_CONTENT_DEBUG: '''{prompt_content}'''")
+
+            if "[council-member-answer]" in prompt_content:
+                member_match = re.search(r"member_id[=:]\s*([\w-]+)", prompt_content)
+                member_id = member_match.group(1) if member_match else "member"
+                logger.debug(
+                    "Mock generate producing deterministic council member answer for %s",
+                    member_id,
+                )
+                response_json_str = json.dumps(
+                    {
+                        "answer": f"Deterministic answer from {member_id}",
+                        "reasoning": f"Deterministic reasoning from {member_id}",
+                        "confidence": 0.82,
+                        "citations": [f"citation-{member_id}"],
+                    }
+                )
+                return {
+                    "response": response_json_str,
+                    "done": True,
+                    "eval_count": 5,
+                    "total_duration": 25,
                 }
-            )
-            return {
-                "response": response_json_str,
-                "done": True,
-                "eval_count": 5,
-                "total_duration": 25,
-            }
 
-        if "[council-judgement]" in prompt_content:
-            member_ids = re.findall(r"member_id[=:]\s*([\w-]+)", prompt_content)
-            if not member_ids:
-                member_ids = ["member"]
-            winner = member_ids[0]
-            votes = {mid: 1 for mid in member_ids}
-            metrics = {"cohesion": 0.91, "coverage": 0.77}
-            logger.debug(
-                "Mock generate producing deterministic council judgement with winner %s", winner
-            )
-            response_json_str = json.dumps(
-                {
-                    "winner": winner,
-                    "votes": votes,
-                    "metrics": metrics,
-                    "resolution": f"{winner} proposal selected",
-                    "summary": "Deterministic council summary",
+            if "[council-judgement]" in prompt_content:
+                member_ids = re.findall(r"member_id[=:]\s*([\w-]+)", prompt_content)
+                if not member_ids:
+                    member_ids = ["member"]
+                winner = member_ids[0]
+                votes = {mid: 1 for mid in member_ids}
+                metrics = {"cohesion": 0.91, "coverage": 0.77}
+                logger.debug(
+                    "Mock generate producing deterministic council judgement with winner %s",
+                    winner,
+                )
+                response_json_str = json.dumps(
+                    {
+                        "winner": winner,
+                        "votes": votes,
+                        "metrics": metrics,
+                        "resolution": f"{winner} proposal selected",
+                        "summary": "Deterministic council summary",
+                    }
+                )
+                return {
+                    "response": response_json_str,
+                    "done": True,
+                    "eval_count": 6,
+                    "total_duration": 30,
                 }
+
+            is_l1_summary_prompt = (
+                "Your output fields are:" in prompt_content
+                and "`l1_summary` (str)" in prompt_content
+                and "`recent_events` (str)" in prompt_content
+                and "`agent_role` (str)" in prompt_content
             )
-            return {
-                "response": response_json_str,
-                "done": True,
-                "eval_count": 6,
-                "total_duration": 30,
-            }
-
-        # Determine which DSPy program this prompt is for based on unique field combinations
-        is_l1_summary_prompt = (
-            "Your output fields are:" in prompt_content
-            and "`l1_summary` (str)" in prompt_content
-            and "`recent_events` (str)" in prompt_content
-            and "`agent_role` (str)" in prompt_content
-        )
-        is_action_intent_prompt = (
-            "Your output fields are:" in prompt_content
-            and "`chosen_action_intent` (str)" in prompt_content
-            and "`justification_thought` (str)" in prompt_content
-            and "`available_actions` (str)" in prompt_content  # Added for specificity
-        )
-        is_role_thought_prompt = (
-            "Your output fields are:" in prompt_content
-            and "`thought` (str)" in prompt_content
-            and "`role_name` (str)" in prompt_content
-            and "`context` (str)" in prompt_content
-        )
-
-        if is_l1_summary_prompt:
-            logger.debug(
-                "Mock ollama.Client.generate: returning JSON structure for L1SummaryGenerator"
+            is_action_intent_prompt = (
+                "Your output fields are:" in prompt_content
+                and "`chosen_action_intent` (str)" in prompt_content
+                and "`justification_thought` (str)" in prompt_content
+                and "`available_actions` (str)" in prompt_content  # Added for specificity
             )
-            summary_value_str = "Mock L1 Summary from global: " + mock_summary_global
-            response_json_str = json.dumps({"l1_summary": summary_value_str})
-            return {
-                "response": response_json_str,
-                "done": True,
-                "eval_count": 10,
-                "total_duration": 100,
-            }
-
-        elif is_action_intent_prompt:
-            logger.debug(
-                "Mock ollama.Client.generate: returning action intent structure for ActionIntentSelector"
+            is_role_thought_prompt = (
+                "Your output fields are:" in prompt_content
+                and "`thought` (str)" in prompt_content
+                and "`role_name` (str)" in prompt_content
+                and "`context` (str)" in prompt_content
             )
-            action_intent_content = {
-                "chosen_action_intent": "send_direct_message",  # Mocked action
-                "justification_thought": "This is a mock justification for selecting send_direct_message from mock_generate.",
-            }
-            response_json_str = json.dumps(action_intent_content)
-            return {
-                "response": response_json_str,
-                "done": True,
-                "eval_count": 10,
-                "total_duration": 100,
-            }
 
-        elif is_role_thought_prompt:
-            logger.debug(
-                "Mock ollama.Client.generate: returning thought structure for RoleThoughtGenerator"
-            )
-            thought_content = {
-                "thought": "As a MockRole, this is a generic mocked thought for RoleThoughtGenerator from mock_generate."
-            }
-            response_json_str = json.dumps(thought_content)
-            return {
-                "response": response_json_str,
-                "done": True,
-                "eval_count": 10,
-                "total_duration": 100,
-            }
+            if is_l1_summary_prompt:
+                logger.debug(
+                    "Mock ollama.Client.generate: returning JSON structure for L1SummaryGenerator"
+                )
+                summary_value_str = "Mock L1 Summary from global: " + mock_summary_global
+                response_json_str = json.dumps({"l1_summary": summary_value_str})
+                return {
+                    "response": response_json_str,
+                    "done": True,
+                    "eval_count": 10,
+                    "total_duration": 100,
+                }
 
-        # Fallback for any other direct ollama.generate calls that don't match DSPy signatures
-        # This might also catch DSPy prompts if the above conditions are not met perfectly.
-        else:
+            elif is_action_intent_prompt:
+                logger.debug(
+                    "Mock ollama.Client.generate: returning action intent structure for ActionIntentSelector"
+                )
+                action_intent_content = {
+                    "chosen_action_intent": "send_direct_message",  # Mocked action
+                    "justification_thought": "This is a mock justification for selecting send_direct_message from mock_generate.",
+                }
+                response_json_str = json.dumps(action_intent_content)
+                return {
+                    "response": response_json_str,
+                    "done": True,
+                    "eval_count": 10,
+                    "total_duration": 100,
+                }
+
+            elif is_role_thought_prompt:
+                logger.debug(
+                    "Mock ollama.Client.generate: returning thought structure for RoleThoughtGenerator"
+                )
+                thought_content = {
+                    "thought": "As a MockRole, this is a generic mocked thought for RoleThoughtGenerator from mock_generate.",
+                }
+                response_json_str = json.dumps(thought_content)
+                return {
+                    "response": response_json_str,
+                    "done": True,
+                    "eval_count": 10,
+                    "total_duration": 100,
+                }
+
             logger.warning(
                 f"Mock ollama.Client.generate: FALLBACK for unrecognized prompt structure. Prompt content: {prompt_content[:200]}..."
             )
-            # Generic JSON response that might or might not work depending on caller
             fallback_content = {
                 "detail": "Fallback mock response from generate",
                 "prompt_received": prompt_content[:100],
@@ -280,6 +334,8 @@ def create_mock_ollama_client() -> MagicMock:
                 "eval_count": 5,
                 "total_duration": 50,
             }
+        finally:
+            mock_generate_stats.finish_call()
 
     mock_client.generate = MagicMock(side_effect=mock_generate)
     # Add other common methods if needed, e.g., pull, list
@@ -307,6 +363,7 @@ def patch_ollama_functions(monkeypatch: MonkeyPatch) -> None:
 
     # Patch the main functions that DON'T rely on llm_client.client directly
     # if they have their own logic or simpler mock needs.
+    mock_generate_stats.reset()
     monkeypatch.setattr(llm_client, "generate_text", lambda *args, **kwargs: mock_text_global)
     monkeypatch.setattr(
         llm_client, "summarize_memory_context", lambda *args, **kwargs: mock_summary_global
@@ -380,6 +437,18 @@ def patch_ollama_functions(monkeypatch: MonkeyPatch) -> None:
         )
 
     logger.info("Global Ollama functions and client have been mocked.")
+
+
+def set_mock_llm_du_budget(budget: float | None) -> None:
+    """Limit how many mock generate calls may succeed before raising."""
+
+    mock_generate_stats.set_du_budget(budget)
+
+
+def get_mock_llm_stats() -> MockLLMGenerateStats:
+    """Expose generate call statistics for assertions in tests."""
+
+    return mock_generate_stats
 
 
 async def get_mock_sentiment_analysis(

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -17,36 +17,48 @@ def patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     llm_mocks.patch_ollama_functions(monkeypatch)
 
 
-def _build_council_config() -> CouncilConfig:
-    return CouncilConfig(
-        enabled=True,
-        members=[
+def _build_council_config(num_members: int = 3) -> CouncilConfig:
+    base_members = [
+        CouncilMemberConfig(
+            member_id="facilitator",
+            display_name="Facilitator",
+            role="Moderator",
+            description="Ensures everyone is heard",
+            system_prompt="Lead with clarity",
+            decision_weight=1.0,
+        ),
+        CouncilMemberConfig(
+            member_id="innovator",
+            display_name="Innovator",
+            role="Idea generator",
+            description="Pushes creative thinking",
+            system_prompt="Bring new ideas",
+            decision_weight=1.0,
+        ),
+        CouncilMemberConfig(
+            member_id="analyst",
+            display_name="Analyst",
+            role="Evaluator",
+            description="Stress-tests ideas",
+            system_prompt="Look for gaps",
+            decision_weight=1.0,
+        ),
+    ]
+
+    extra_members: list[CouncilMemberConfig] = []
+    for idx in range(3, num_members):
+        extra_members.append(
             CouncilMemberConfig(
-                member_id="facilitator",
-                display_name="Facilitator",
-                role="Moderator",
-                description="Ensures everyone is heard",
-                system_prompt="Lead with clarity",
+                member_id=f"member-{idx}",
+                display_name=f"Member {idx}",
+                role="Specialist",
+                description="Brings domain expertise",
+                system_prompt="Share focused insight",
                 decision_weight=1.0,
-            ),
-            CouncilMemberConfig(
-                member_id="innovator",
-                display_name="Innovator",
-                role="Idea generator",
-                description="Pushes creative thinking",
-                system_prompt="Bring new ideas",
-                decision_weight=1.0,
-            ),
-            CouncilMemberConfig(
-                member_id="analyst",
-                display_name="Analyst",
-                role="Evaluator",
-                description="Stress-tests ideas",
-                system_prompt="Look for gaps",
-                decision_weight=1.0,
-            ),
-        ],
-    )
+            )
+        )
+
+    return CouncilConfig(enabled=True, members=base_members + extra_members)
 
 
 def _build_question() -> CouncilQuestion:
@@ -81,3 +93,39 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(monkeypatch: py
 
     serialized = json.loads(json.dumps(outcome.metadata))
     assert serialized["metrics"]["cohesion"] == pytest.approx(0.91)
+
+
+def test_council_orchestrator_limits_concurrent_generate_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator(max_concurrency=2)
+    config = _build_council_config(num_members=5)
+    question = _build_question()
+
+    llm_mocks.mock_generate_stats.reset()
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert outcome.winning_member_ids
+    assert llm_mocks.mock_generate_stats.peak_concurrent_calls <= orchestrator.max_concurrency
+    assert llm_mocks.mock_generate_stats.call_count == len(config.members) + 1
+
+
+def test_council_orchestrator_marks_du_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = CouncilOrchestrator(max_concurrency=3)
+    config = _build_council_config(num_members=4)
+    question = _build_question()
+
+    llm_mocks.set_mock_llm_du_budget(2)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert len(outcome.answers) == 2
+    assert outcome.winning_member_ids == []
+    assert outcome.metadata == {
+        "du_exhausted": True,
+        "partial": True,
+        "completed_members": ["facilitator", "innovator"],
+    }
+
+    llm_mocks.set_mock_llm_du_budget(None)


### PR DESCRIPTION
## Summary
- instrument the mock LLM generator to track concurrency, DU budgets, and expose stats for tests
- introduce a CouncilOrchestrator that limits concurrent calls, handles budget exhaustion, and parses mock outputs
- expand council orchestrator unit tests to cover concurrency limits and DU depletion scenarios

## Testing
- pytest tests/unit/agents/council/test_council_orchestrator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693982d6d27c83269d50f0e435f3e9b6)