### PR TITLE
Add council mode note to architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,10 @@ graph TD
     DEC --> INT[Interfaces]
 ```
 
+### Council Mode (Experimental, Opt-In)
+
+Culture.ai includes an **opt-in, experimental Council Mode** that temporarily promotes a panel of specialized agents to debate or ratify pivotal actions before they execute. Because this feature is still evolving, it remains disabled by default. See [docs/council_mode_design.md](./council_mode_design.md) for setup guidance, workflows, and limitations.
+
 ### Key Architectural Principles
 
 1. **Modularity**: Components are designed with clear boundaries and responsibilities


### PR DESCRIPTION
## Summary
- add an architecture section describing the opt-in, experimental Council Mode
- link readers to the Council Mode design document for setup details

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403de0051c8326afe408d23be980bd)