### PR TITLE
Improve council config defaults

### DIFF
--- a/config/council.yml
+++ b/config/council.yml
@@ -1,5 +1,7 @@
-# Sample council roster used in local development
-# Each member uses the default local model placeholder by default.
+# Sample council roster used in local development.
+# All members default to the local model placeholder defined in your settings.
+max_concurrent_calls: 3
+du_budget_per_question: 5.0
 members:
   - name: Innovator
     role: Innovator

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -349,7 +349,7 @@ def load_council_config(*, path: str | None = None, reload: bool = False) -> dic
 
     if yaml is None:
         logger.debug("pyyaml is unavailable; using default council config")
-        result = {"members": default_members}
+        result = deepcopy(default_config)
         if cacheable:
             _COUNCIL_CONFIG = result
         return deepcopy(result)
@@ -370,23 +370,23 @@ def load_council_config(*, path: str | None = None, reload: bool = False) -> dic
     else:
         logger.debug("Council config not found at %s; falling back to defaults", config_path)
 
+    merged_config: dict[str, Any] = {**default_config, **(loaded_data or {})}
+
     members: list[dict[str, Any]] = []
-    if loaded_data is not None:
-        raw_members = loaded_data.get("members")
-        if isinstance(raw_members, list):
-            default_model = default_members[0].get("model") if default_members else None
-            for entry in raw_members:
-                if isinstance(entry, dict):
-                    normalized = dict(entry)
-                    if default_model and not normalized.get("model"):
-                        normalized["model"] = default_model
-                    members.append(normalized)
+    raw_members = merged_config.get("members")
+    if isinstance(raw_members, list):
+        default_model = default_members[0].get("model") if default_members else None
+        for entry in raw_members:
+            if isinstance(entry, dict):
+                normalized = dict(entry)
+                if default_model and not normalized.get("model"):
+                    normalized["model"] = default_model
+                members.append(normalized)
 
     if not members:
         members = default_members
 
-    source_config = loaded_data or default_config
-    result = {k: v for k, v in source_config.items() if k != "members"}
+    result = {k: v for k, v in merged_config.items() if k != "members"}
     result["members"] = members
     if cacheable:
         _COUNCIL_CONFIG = result

--- a/tests/unit/infra/test_council_config.py
+++ b/tests/unit/infra/test_council_config.py
@@ -29,6 +29,10 @@ def test_load_council_config_returns_defaults_when_missing(
 
     assert result["members"], "Expected default members when YAML file is missing"
     assert result["members"][0]["name"] == "Innovator"
+    assert (
+        result["max_concurrent_calls"] == infra_config.settings.COUNCIL_MAX_CONCURRENT_CALLS
+    )
+    assert result["du_budget_per_question"] == infra_config.settings.DU_BUDGET_PER_QUESTION
 
 
 def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -48,3 +52,23 @@ def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert result["members"][0]["name"] == "Strategist"
     assert result["members"][0]["model"] == "local/mistral"
     assert result["members"][1]["model"], "Missing model should default to base model"
+
+
+def test_load_council_config_merges_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _reset_cache(monkeypatch)
+    path = tmp_path / "council.yml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "members": [{"name": "Strategist", "role": "Planner"}],
+                "max_concurrent_calls": 5,
+            }
+        )
+    )
+    monkeypatch.setattr(infra_config.settings, "COUNCIL_CONFIG_PATH", str(path), raising=False)
+
+    result = infra_config.load_council_config(reload=True)
+
+    assert result["max_concurrent_calls"] == 5
+    assert result["du_budget_per_question"] == infra_config.settings.DU_BUDGET_PER_QUESTION
+    assert result["members"][0]["model"], "Missing model should default to base model"


### PR DESCRIPTION
## Summary
- add a sample council configuration file with the default roster and budgets
- ensure the council configuration loader always merges defaults when YAML is missing or partial
- expand council configuration tests to cover default budgets and merge behavior

## Testing
- ruff check src/infra/config.py tests/unit/infra/test_council_config.py
- python -m pytest tests/unit/infra/test_council_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404e680f4c8326bb03d9d913bbc6e8)