### PR TITLE
Add council fitness store metrics tracking and tests

### DIFF
--- a/src/agents/council/__init__.py
+++ b/src/agents/council/__init__.py
@@ -1,5 +1,6 @@
 """Council Mode data models."""
 
+from .fitness_store import CouncilFitnessStore
 from .orchestrator import CouncilOrchestrator
 from .types import (
     CouncilConfig,
@@ -13,6 +14,7 @@ __all__ = [
     "CouncilConfig",
     "CouncilMemberConfig",
     "CouncilOrchestrator",
+    "CouncilFitnessStore",
     "CouncilOutcome",
     "CouncilQuestion",
     "MemberAnswer",

--- a/src/agents/council/fitness_store.py
+++ b/src/agents/council/fitness_store.py
@@ -1,0 +1,80 @@
+"""Fitness tracking for council outcomes."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Iterable
+
+from src.agents.council.types import CouncilOutcome
+
+
+@dataclass
+class MemberFitness:
+    """Aggregated performance metrics for a council member."""
+
+    wins: int = 0
+    appearances: int = 0
+    win_rate: float = 0.0
+    agreement_score: float = 0.0
+
+
+class CouncilFitnessStore:
+    """Store and update fitness metrics for council participants."""
+
+    def __init__(self) -> None:
+        self._wins: Counter[str] = Counter()
+        self._appearances: Counter[str] = Counter()
+        self._agreement_scores: list[float] = []
+
+    def record(self, outcome: CouncilOutcome) -> None:
+        """Record the results of a completed council round."""
+
+        winners = set(outcome.winning_member_ids)
+        agreement_score = self._extract_agreement(outcome.metadata)
+        if agreement_score is not None:
+            self._agreement_scores.append(agreement_score)
+
+        for member_id in self._iter_participants(outcome.answers):
+            self._appearances[member_id] += 1
+            if member_id in winners:
+                self._wins[member_id] += 1
+
+    @staticmethod
+    def _iter_participants(answers: Sequence) -> Iterable[str]:
+        for answer in answers:
+            member_id = getattr(answer, "member_id", None)
+            if member_id:
+                yield str(member_id)
+
+    @staticmethod
+    def _extract_agreement(metadata: Mapping[str, object] | None) -> float | None:
+        if not isinstance(metadata, Mapping):
+            return None
+        raw_score = metadata.get("agreement_score")
+        if isinstance(raw_score, (int, float)):
+            return float(raw_score)
+        return None
+
+    def get_member_fitness(self, member_id: str) -> MemberFitness:
+        """Return the fitness metrics for the provided member."""
+
+        appearances = self._appearances.get(member_id, 0)
+        wins = self._wins.get(member_id, 0)
+        win_rate = float(wins / appearances) if appearances else 0.0
+        return MemberFitness(
+            wins=wins,
+            appearances=appearances,
+            win_rate=win_rate,
+            agreement_score=self.average_agreement_score,
+        )
+
+    @property
+    def average_agreement_score(self) -> float:
+        """Average agreement score across recorded outcomes."""
+
+        if not self._agreement_scores:
+            return 0.0
+        return sum(self._agreement_scores) / len(self._agreement_scores)
+

--- a/tests/unit/agents/council/test_council_metrics.py
+++ b/tests/unit/agents/council/test_council_metrics.py
@@ -1,0 +1,84 @@
+"""Tests for council fitness metrics tracking."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agents.council import CouncilFitnessStore
+from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
+
+pytestmark = pytest.mark.unit
+
+
+def _make_outcome(
+    question_id: str,
+    winners: list[str],
+    agreement_score: float | None,
+) -> CouncilOutcome:
+    question = CouncilQuestion(question_id=question_id, prompt="Sample prompt")
+    answers = [
+        MemberAnswer(member_id="member-a", answer="Answer A"),
+        MemberAnswer(member_id="member-b", answer="Answer B"),
+        MemberAnswer(member_id="member-c", answer="Answer C"),
+    ]
+    metadata = {"agreement_score": agreement_score} if agreement_score is not None else None
+    return CouncilOutcome(
+        question=question,
+        answers=answers,
+        resolution="winner decided",
+        winning_member_ids=winners,
+        metadata=metadata,
+    )
+
+
+def test_council_fitness_store_tracks_wins_and_win_rate() -> None:
+    store = CouncilFitnessStore()
+
+    store.record(_make_outcome("q1", ["member-a"], agreement_score=0.5))
+
+    member_a = store.get_member_fitness("member-a")
+    member_b = store.get_member_fitness("member-b")
+    assert member_a.wins == 1
+    assert member_a.appearances == 1
+    assert member_a.win_rate == 1.0
+    assert member_b.wins == 0
+    assert member_b.appearances == 1
+    assert member_b.win_rate == 0.0
+    assert store.average_agreement_score == 0.5
+
+    store.record(_make_outcome("q2", ["member-b"], agreement_score=0.75))
+
+    member_a = store.get_member_fitness("member-a")
+    member_b = store.get_member_fitness("member-b")
+    assert member_a.wins == 1
+    assert member_a.appearances == 2
+    assert member_a.win_rate == 0.5
+    assert member_b.wins == 1
+    assert member_b.appearances == 2
+    assert member_b.win_rate == 0.5
+    assert store.average_agreement_score == 0.625
+
+
+def test_council_fitness_store_handles_multiple_winners() -> None:
+    store = CouncilFitnessStore()
+
+    store.record(_make_outcome("q1", ["member-a", "member-b"], agreement_score=0.9))
+    member_a = store.get_member_fitness("member-a")
+    member_b = store.get_member_fitness("member-b")
+    member_c = store.get_member_fitness("member-c")
+
+    assert member_a.wins == 1
+    assert member_b.wins == 1
+    assert member_c.wins == 0
+    assert member_a.win_rate == 1.0
+    assert member_b.win_rate == 1.0
+    assert member_c.win_rate == 0.0
+    assert store.average_agreement_score == 0.9
+
+    store.record(_make_outcome("q2", ["member-c"], agreement_score=0.3))
+    member_c = store.get_member_fitness("member-c")
+
+    assert member_c.wins == 1
+    assert member_c.appearances == 2
+    assert member_c.win_rate == 0.5
+    assert store.average_agreement_score == 0.6


### PR DESCRIPTION
## Summary
- add a council fitness store to track wins, appearances, and agreement averages
- expose the fitness store through the council package
- add unit coverage to confirm win counts, win rates, and agreement scores update predictably

## Testing
- pytest tests/unit/agents/council/test_council_metrics.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f4ba7dc83269239aac6e0ce4c95)