### PR TITLE
Add council make target and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,21 @@ OUTPUT ?= data/traces.jsonl
 .PHONY: local-slice
 local-slice:
 	@if [ -f "$(ACTIVATE)" ]; then \
-	    source "$(ACTIVATE)"; \
-	    if [ ! -f ".venv/.deps_installed" ]; then \
-	        pip install -r requirements.txt -r requirements-dev.txt; \
-	        touch .venv/.deps_installed; \
-	    fi; \
+		source "$(ACTIVATE)"; \
+		if [ ! -f ".venv/.deps_installed" ]; then \
+			pip install -r requirements.txt -r requirements-dev.txt; \
+			touch .venv/.deps_installed; \
+		fi; \
 	fi; \
-        $(VERTICAL_SLICE)
+	$(VERTICAL_SLICE)
 
 .PHONY: dataset
 dataset:
-       python - <<EOF
-from scripts.export_traces import export_latest
-export_latest(directory="$(SNAPSHOTS)", output="$(OUTPUT)")
-EOF
+	python - <<-EOF
+	from scripts.export_traces import export_latest
+	export_latest(directory="$(SNAPSHOTS)", output="$(OUTPUT)")
+	EOF
+
+.PHONY: council
+council:
+	python -m scripts.council_cli --question "$(Q)"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ The "Culture: An AI Genesis Engine" project has established a robust foundationa
 
 Culture ships with an opt-in, experimental **Council Mode** where you can temporarily promote a panel of specialized agents to debate, critique, or ratify pivotal simulation actions before they execute. Because this workflow is still evolving, it is disabled by default—enable it only when you are ready to iterate on council prompts and guardrails. Refer to the [Council Mode design doc](docs/council_mode_design.md) for the latest setup instructions, capabilities, and caveats.
 
+To pose a one-off question to the council without running a full simulation, use the Makefile helper and provide your prompt via `Q`:
+
+```bash
+make council Q="Should we prioritize the supply-chain audit?"
+```
+
 ## Technology Stack
 
 * **Core Language:** Python 3.11+


### PR DESCRIPTION
## Summary
- add a Makefile target to run the council CLI with a provided question
- document how to invoke the new council target via the README

## Testing
- python -m pytest tests/test_pytest_sanity.py
- python -m ruff check scripts src tests/test_pytest_sanity.py *(fails: existing lint issues in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941685f31bc83268fe0740deea07b52)