### PR TITLE
Add council CLI and tests

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Command-line interface for running council deliberations."""
+
+from __future__ import annotations
+
+import typer
+
+from src.agents.council.orchestrator import run_council
+from src.agents.council.types import CouncilQuestion
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    prompt: str = typer.Argument(..., help="Question to pose to the council"),
+    context: str | None = typer.Option(None, "--context", "-c", help="Optional context"),
+    rag_doc: list[str] | None = typer.Option(
+        None,
+        "--rag-doc",
+        "--rag-docs",
+        help="Additional RAG documents to supply to the council",
+    ),
+    question_id: str = typer.Option(
+        "cli-question",
+        "--question-id",
+        "-q",
+        help="Identifier for the question posed to the council",
+    ),
+) -> None:
+    """Run the council with the provided ``prompt`` and display the outcome."""
+
+    rag_docs = list(rag_doc or [])
+    question = CouncilQuestion(
+        question_id=question_id,
+        prompt=prompt,
+        context=context,
+        rag_documents=rag_docs,
+    )
+
+    outcome = run_council(question, extra_context=context, rag_docs=rag_docs)
+
+    typer.echo(f"Question: {outcome.question.prompt}")
+    if outcome.question.context:
+        typer.echo(f"Context: {outcome.question.context}")
+    if outcome.question.rag_documents:
+        typer.echo("RAG Docs:")
+        for doc in outcome.question.rag_documents:
+            typer.echo(f"- {doc}")
+
+    typer.echo(f"Resolution: {outcome.resolution}")
+
+    if outcome.summary:
+        typer.echo(f"Summary: {outcome.summary}")
+
+    if outcome.winning_member_ids:
+        winners = ", ".join(outcome.winning_member_ids)
+        typer.echo(f"Winners: {winners}")
+
+    if outcome.answers:
+        typer.echo("Answers:")
+        for answer in outcome.answers:
+            typer.echo(f"- {answer.member_id}: {answer.answer}")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual tool
+    app()

--- a/src/agents/council/fitness_store.py
+++ b/src/agents/council/fitness_store.py
@@ -78,3 +78,8 @@ class CouncilFitnessStore:
             return 0.0
         return sum(self._agreement_scores) / len(self._agreement_scores)
 
+
+
+council_fitness_store = CouncilFitnessStore()
+
+__all__ = ["CouncilFitnessStore", "council_fitness_store"]

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -1,0 +1,65 @@
+import pytest
+from typer.testing import CliRunner
+
+from scripts import council_cli
+from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
+
+pytestmark = pytest.mark.unit
+
+
+def test_council_cli_reports_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    recorded_calls: list[tuple[CouncilQuestion, str | None, list[str] | None]] = []
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+    ) -> CouncilOutcome:
+        recorded_calls.append((question, extra_context, rag_docs))
+        return CouncilOutcome(
+            question=CouncilQuestion(
+                question_id="q-123",
+                prompt="Mocked prompt",
+                context="Mock context",
+                rag_documents=rag_docs or [],
+            ),
+            answers=[MemberAnswer(member_id="alpha", answer="Alpha answer")],
+            resolution="Mock resolution",
+            winning_member_ids=["alpha"],
+            summary="Mock summary",
+            metadata={"fitness": {"scores": []}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(
+        council_cli.app,
+        [
+            "What should we do?",
+            "--context",
+            "Extra context",
+            "--rag-doc",
+            "doc-a",
+            "--rag-doc",
+            "doc-b",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Question: Mocked prompt" in result.output
+    assert "Context: Mock context" in result.output
+    assert "RAG Docs:" in result.output
+    assert "- doc-a" in result.output
+    assert "- doc-b" in result.output
+    assert "Resolution: Mock resolution" in result.output
+    assert "Summary: Mock summary" in result.output
+    assert "Winners: alpha" in result.output
+    assert "- alpha: Alpha answer" in result.output
+
+    question, extra_context, rag_docs = recorded_calls[0]
+    assert question.prompt == "What should we do?"
+    assert question.context == "Extra context"
+    assert rag_docs == ["doc-a", "doc-b"]
+    assert extra_context == "Extra context"


### PR DESCRIPTION
## Summary
- add a Typer-based council CLI that formats deliberation output
- expose a reusable council fitness store instance
- add a unit test that mocks council execution and asserts CLI output

## Testing
- pytest tests/unit/scripts/test_council_cli.py
- ruff check scripts/council_cli.py tests/unit/scripts/test_council_cli.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941685e95488326b7abcf1f104399d0)