### PR TITLE
Route agent decision flow through council node when enabled

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -30,10 +30,13 @@ else:
                 return None
 
 
+from src.infra import config
+
 from .basic_agent_graph import _maybe_consolidate_memories
 from .basic_agent_types import AgentTurnState
 from .graph_nodes import (
     analyze_perception_sentiment_node,
+    council_decision_node,
     finalize_message_agent_node,
     generate_thought_and_message_node,
     prepare_relationship_prompt_node,
@@ -60,12 +63,17 @@ def route_action_intent(state: AgentTurnState) -> str:
 
 
 def build_graph() -> Any:
+    use_council_mode = bool(config.get_config("USE_COUNCIL_MODE"))
+
     graph_builder = StateGraph(AgentTurnState)
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
     graph_builder.add_node("prepare_relationship_prompt", prepare_relationship_prompt_node)
     graph_builder.add_node("retrieve_memories", retriever_node)
     graph_builder.add_node("retrieve_and_summarize_memories", retrieve_and_summarize_memories_node)
     graph_builder.add_node("generate_thought_and_message", generate_thought_and_message_node)
+
+    if use_council_mode:
+        graph_builder.add_node("council_decision", council_decision_node)
 
     graph_builder.add_node("handle_propose_idea", handle_propose_idea_node)
     graph_builder.add_node("handle_ask_clarification", handle_ask_clarification_node)
@@ -89,8 +97,13 @@ def build_graph() -> Any:
     graph_builder.add_edge("retrieve_memories", "retrieve_and_summarize_memories")
     graph_builder.add_edge("retrieve_and_summarize_memories", "generate_thought_and_message")
 
+    branch_source = "generate_thought_and_message"
+    if use_council_mode:
+        graph_builder.add_edge("generate_thought_and_message", "council_decision")
+        branch_source = "council_decision"
+
     graph_builder.add_conditional_edges(
-        "generate_thought_and_message",
+        branch_source,
         route_action_intent,
         {
             "propose_idea": "handle_propose_idea",

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, Protocol, cast
 
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.base_agent import Agent
+from src.agents.council.orchestrator import run_council
+from src.agents.council.types import CouncilOutcome, CouncilQuestion
 from src.agents.memory.memory_service import MemoryService
 from src.infra.llm_client import (
     analyze_sentiment,
@@ -231,6 +233,60 @@ async def generate_thought_and_message_node(
         )
 
     return {"structured_output": cast(AgentActionOutput | None, structured)}
+
+
+async def council_decision_node(state: AgentTurnState) -> dict[str, AgentActionOutput | None]:
+    """Run the agent's proposed action through a council for feedback."""
+
+    output = cast(AgentActionOutput | None, state.get("structured_output"))
+    if output is None:
+        return {"structured_output": None}
+
+    question = CouncilQuestion(
+        question_id=f"{state.get('agent_id', 'agent')}-{state.get('simulation_step', 0)}",
+        prompt=(
+            "Given the agent context and proposed action below, propose the best response. "
+            "Return a concise resolution summarizing the recommended action."
+            f"\n\nGoal: {state.get('agent_goal', '')}"
+            f"\nRole: {state.get('current_role', '')}"
+            f"\nScenario: {state.get('scenario_description', '')}"
+            f"\nPerception: {state.get('environment_perception', {})}"
+            f"\nProposed intent: {getattr(output, 'action_intent', 'idle')}"
+            f"\nThought: {getattr(output, 'thought', '')}"
+            f"\nMessage: {getattr(output, 'message_content', '') or '(no message)'}"
+        ),
+        metadata={
+            "agent_id": state.get("agent_id"),
+            "simulation_step": state.get("simulation_step"),
+        },
+    )
+
+    rag_docs: list[str] = []
+    for key in ("memory_context", "rag_summary"):
+        docs = state.get(key)
+        if isinstance(docs, str):
+            rag_docs.append(docs)
+        elif isinstance(docs, list):
+            rag_docs.extend(str(item) for item in docs)
+
+    try:
+        outcome: CouncilOutcome = await asyncio.to_thread(
+            run_council,
+            question,
+            extra_context=state.get("prompt_modifier"),
+            rag_docs=rag_docs,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Council decision failed: %s", exc, exc_info=True)
+        return {"structured_output": output}
+
+    resolution = outcome.resolution or ""
+    updated = output.model_copy()
+    updated.justification = outcome.summary or resolution or output.justification
+    if resolution:
+        updated.thought = f"{output.thought}\n\nCouncil resolution: {resolution}".strip()
+
+    return {"structured_output": updated}
 
 
 async def finalize_message_agent_node(state: AgentTurnState) -> dict[str, Any]:

--- a/tests/unit/agents/graphs/test_agent_graph_builder.py
+++ b/tests/unit/agents/graphs/test_agent_graph_builder.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.graphs import agent_graph_builder
+from src.infra import config
+
+pytestmark = pytest.mark.unit
+
+
+def _patch_graph_nodes(monkeypatch: pytest.MonkeyPatch, *, include_council: bool, calls: list[str]) -> None:
+    def make_node(name: str, *, set_output: bool = False):  # type: ignore[type-arg]
+        async def _node(state: dict) -> dict:
+            calls.append(name)
+            if set_output:
+                state["structured_output"] = SimpleNamespace(action_intent="propose_idea")
+                return {"structured_output": state["structured_output"]}
+            return {}
+
+        return _node
+
+    for node_name in [
+        "analyze_perception_sentiment_node",
+        "prepare_relationship_prompt_node",
+        "retriever_node",
+        "retrieve_and_summarize_memories_node",
+        "handle_propose_idea_node",
+        "handle_ask_clarification_node",
+        "handle_continue_collaboration_node",
+        "handle_idle_node",
+        "handle_deep_analysis_node",
+        "handle_create_project_node",
+        "handle_join_project_node",
+        "handle_leave_project_node",
+        "handle_send_direct_message_node",
+        "finalize_message_agent_node",
+        "_maybe_consolidate_memories",
+    ]:
+        monkeypatch.setattr(agent_graph_builder, node_name, make_node(node_name))
+
+    monkeypatch.setattr(
+        agent_graph_builder,
+        "generate_thought_and_message_node",
+        make_node("generate_thought_and_message_node", set_output=True),
+    )
+
+    if include_council:
+        monkeypatch.setattr(
+            agent_graph_builder,
+            "council_decision_node",
+            make_node("council_decision_node"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_graph_skips_council_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": False})
+    _patch_graph_nodes(monkeypatch, include_council=False, calls=calls)
+
+    executor = agent_graph_builder.build_graph()
+    await executor.ainvoke({})
+
+    assert "council_decision_node" not in calls
+    assert "generate_thought_and_message_node" in calls
+
+
+@pytest.mark.asyncio
+async def test_graph_routes_to_council_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+    _patch_graph_nodes(monkeypatch, include_council=True, calls=calls)
+
+    executor = agent_graph_builder.build_graph()
+    await executor.ainvoke({})
+
+    assert "council_decision_node" in calls
+    # Ensure decision handlers still run after council
+    assert any(call.startswith("handle_") for call in calls)


### PR DESCRIPTION
## Summary
- add a council decision node that asks the council to review proposed actions and annotates the resulting structured output
- gate the agent graph through the council node when USE_COUNCIL_MODE is enabled while keeping the default path unchanged otherwise
- add unit coverage to confirm the graph uses the council path only when configured

## Testing
- pytest tests/unit/agents/graphs/test_agent_graph_builder.py
- ruff check src/agents/graphs tests/unit/agents/graphs/test_agent_graph_builder.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c2add0808326bd4dc844bceaa561)