### PR TITLE
Add council graph state and outcome node

### DIFF
--- a/src/agents/council/__init__.py
+++ b/src/agents/council/__init__.py
@@ -2,6 +2,7 @@
 
 from .fitness_store import CouncilFitnessStore
 from .orchestrator import CouncilOrchestrator
+from .graph_state import CouncilState, CouncilStateModel, council_outcome_node
 from .types import (
     CouncilConfig,
     CouncilMemberConfig,
@@ -15,7 +16,10 @@ __all__ = [
     "CouncilMemberConfig",
     "CouncilOrchestrator",
     "CouncilFitnessStore",
+    "CouncilState",
+    "CouncilStateModel",
     "CouncilOutcome",
     "CouncilQuestion",
     "MemberAnswer",
+    "council_outcome_node",
 ]

--- a/src/agents/council/graph_state.py
+++ b/src/agents/council/graph_state.py
@@ -1,0 +1,59 @@
+"""State and helpers for council-focused LangGraph flows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TypedDict
+
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import NotRequired
+
+from src.agents.council.orchestrator import run_council
+from src.agents.council.types import CouncilOutcome, CouncilQuestion
+
+logger = logging.getLogger(__name__)
+
+
+class CouncilState(TypedDict):
+    """State shared between council graph nodes."""
+
+    question: str
+    messages: list[str]
+    council_outcome: NotRequired[CouncilOutcome | None]
+    final_answer: NotRequired[str | None]
+
+
+class CouncilStateModel(BaseModel):
+    """Pydantic representation of :class:`CouncilState`."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    question: str
+    messages: list[str] = Field(default_factory=list)
+    council_outcome: CouncilOutcome | None = None
+    final_answer: str | None = None
+
+
+async def council_outcome_node(state: CouncilState) -> dict[str, CouncilOutcome | str | None]:
+    """Resolve a council question and store the result in the graph state."""
+
+    rag_docs = [str(message) for message in state.get("messages", [])]
+    question = CouncilQuestion(
+        question_id="council-question",
+        prompt=state.get("question", ""),
+        context="\n".join(rag_docs) if rag_docs else None,
+        rag_documents=rag_docs,
+    )
+
+    try:
+        outcome: CouncilOutcome = await asyncio.to_thread(
+            run_council, question, extra_context=question.context, rag_docs=rag_docs
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging only
+        logger.error("Council deliberation failed: %s", exc, exc_info=True)
+        return {"council_outcome": None, "final_answer": None}
+
+    final_answer = outcome.resolution or outcome.summary or ""
+    return {"council_outcome": outcome, "final_answer": final_answer}
+


### PR DESCRIPTION
## Summary
- add a typed state and Pydantic model for council graph data
- implement a council outcome node that populates deliberation results and final answer
- expose the new state helpers and node from the council package

## Testing
- python -m ruff check src/agents/council/graph_state.py
- python -m pytest *(fails: interrupted after long runtime with existing test failures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c7c67a0c8326ad0def4db160b91b)