### PR TITLE
Add council graph node test

### DIFF
--- a/src/agents/graphs/council_graph.py
+++ b/src/agents/graphs/council_graph.py
@@ -1,0 +1,56 @@
+"""LangGraph wrapper for running council deliberations."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, TypedDict, cast
+
+from langgraph.graph import END, StateGraph
+
+from src.agents.council.orchestrator import run_council
+from src.agents.council.types import CouncilOutcome, CouncilQuestion
+
+
+class CouncilGraphState(TypedDict, total=False):
+    """State tracked through the council graph."""
+
+    question: str
+    question_id: str
+    context: str | None
+    rag_documents: list[str]
+    council_outcome: CouncilOutcome
+    final_answer: str
+
+
+async def council_node(state: CouncilGraphState) -> dict[str, Any]:
+    """Run the council and persist its outcome in the graph state."""
+
+    question = CouncilQuestion(
+        question_id=cast(str, state.get("question_id", "council-question")),
+        prompt=cast(str, state.get("question", "")),
+        context=state.get("context"),
+        rag_documents=state.get("rag_documents", []),
+    )
+
+    outcome = await asyncio.to_thread(
+        run_council,
+        question,
+        extra_context=state.get("context"),
+        rag_docs=state.get("rag_documents"),
+    )
+
+    final_answer = outcome.summary or outcome.resolution
+    return {"council_outcome": outcome, "final_answer": final_answer}
+
+
+def build_graph() -> Any:
+    """Compile the council graph and return its executor."""
+
+    graph_builder = StateGraph(CouncilGraphState)
+    graph_builder.add_node("council", council_node)
+    graph_builder.set_entry_point("council")
+    graph_builder.add_edge("council", END)
+    return graph_builder.compile()
+
+
+__all__ = ["CouncilGraphState", "build_graph", "council_node"]

--- a/tests/unit/agents/graphs/test_council_node.py
+++ b/tests/unit/agents/graphs/test_council_node.py
@@ -1,0 +1,50 @@
+import pytest
+
+pytest.importorskip("langgraph")
+pytestmark = pytest.mark.unit
+
+from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
+from src.agents.graphs import council_graph
+from src.agents.graphs.council_graph import CouncilGraphState, build_graph
+
+
+@pytest.mark.asyncio
+async def test_council_node_sets_outcome_and_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+    dummy_outcome = CouncilOutcome(
+        question=CouncilQuestion(question_id="q-123", prompt="What now?"),
+        answers=[MemberAnswer(member_id="alpha", answer="Proceed")],
+        resolution="Resolution text",
+        winning_member_ids=["alpha"],
+        summary="Summary text",
+        metadata={},
+    )
+
+    def fake_run_council(
+        question: CouncilQuestion, *, extra_context: str | None, rag_docs: list[str] | None
+    ) -> CouncilOutcome:
+        recorded["question"] = question
+        recorded["extra_context"] = extra_context
+        recorded["rag_docs"] = rag_docs
+        return dummy_outcome
+
+    monkeypatch.setattr(council_graph, "run_council", fake_run_council)
+
+    graph = build_graph()
+    starting_state: CouncilGraphState = {
+        "question": "How should we proceed?",
+        "question_id": "q-001",
+        "context": "Use prior research",
+        "rag_documents": ["doc-a", "doc-b"],
+    }
+
+    result = await graph.ainvoke(starting_state)
+
+    assert result["council_outcome"] == dummy_outcome
+    assert result["final_answer"] == dummy_outcome.summary
+    assert isinstance(recorded["question"], CouncilQuestion)
+    assert recorded["question"].prompt == starting_state["question"]
+    assert recorded["extra_context"] == starting_state["context"]
+    assert recorded["rag_docs"] == starting_state["rag_documents"]


### PR DESCRIPTION
## Summary
- add a council graph wrapper that runs the council node and stores its output
- add a unit test to ensure the council node fills in both the council outcome and final answer

## Testing
- pytest tests/unit/agents/graphs/test_council_node.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c2ae5be0832684f84ca74d79eeb8)