### PR TITLE
Improve council orchestration resilience

### DIFF
--- a/src/agents/council/__init__.py
+++ b/src/agents/council/__init__.py
@@ -1,6 +1,7 @@
 """Council Mode data models."""
 
 from .fitness_store import CouncilFitnessStore
+from .stats_store import CouncilStatsStore
 from .orchestrator import CouncilOrchestrator
 from .graph_state import CouncilState, CouncilStateModel, council_outcome_node
 from .types import (
@@ -21,5 +22,6 @@ __all__ = [
     "CouncilOutcome",
     "CouncilQuestion",
     "MemberAnswer",
+    "CouncilStatsStore",
     "council_outcome_node",
 ]

--- a/src/agents/council/fitness_store.py
+++ b/src/agents/council/fitness_store.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from itertools import combinations
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
 
@@ -39,6 +38,76 @@ class CouncilFitnessStore:
         self._agreement_scores: list[float] = []
         self.agreement_threshold = float(agreement_threshold)
         self.min_samples = int(min_samples)
+
+    def reset(self) -> None:
+        """Clear tracked metrics so repeated tests start from a clean slate."""
+
+        self._wins.clear()
+        self._appearances.clear()
+        self._pair_counts.clear()
+        self._pair_agreements.clear()
+        self._agreement_scores.clear()
+
+    def update_from_vote(
+        self,
+        question: CouncilQuestion,
+        answers: Sequence[MemberAnswer],
+        vote: CouncilVoteModel,
+    ) -> dict[str, object]:
+        """Update aggregate metrics based on the latest council vote."""
+
+        top_score = max(vote.scores.values()) if vote.scores else 0.0
+        winners = {
+            member_id
+            for member_id, score in vote.scores.items()
+            if score >= top_score
+        }
+
+        for answer in answers:
+            member_id = answer.member_id
+            self._appearances[member_id] += 1
+            if member_id in winners:
+                self._wins[member_id] += 1
+
+        for idx, left in enumerate(answers):
+            for right in answers[idx + 1 :]:
+                member_a, member_b = sorted((left.member_id, right.member_id))
+                key = f"{member_a}|{member_b}"
+                self._pair_counts[key] += 1
+                if (left.answer or "").strip().lower() == (right.answer or "").strip().lower():
+                    self._pair_agreements[key] += 1
+
+        members_snapshot: dict[str, dict[str, float]] = {}
+        for member_id in self._appearances:
+            appearances = float(self._appearances[member_id])
+            wins = float(self._wins.get(member_id, 0))
+            members_snapshot[member_id] = {
+                "wins": wins,
+                "appearances": appearances,
+                "win_rate": wins / appearances if appearances else 0.0,
+            }
+
+        pairs_snapshot: dict[str, dict[str, float]] = {}
+        warnings: list[str] = []
+        for key, count in self._pair_counts.items():
+            agreements = float(self._pair_agreements.get(key, 0))
+            agreement_rate = agreements / count if count else 0.0
+            pairs_snapshot[key] = {
+                "questions_together": float(count),
+                "top_agreements": agreements,
+                "agreement_rate": agreement_rate,
+            }
+            if count >= self.min_samples and agreement_rate >= self.agreement_threshold:
+                warnings.append(
+                    f"Pair {key} showing high agreement {agreement_rate:.2f} over {count} questions"
+                )
+
+        return {
+            "question_id": question.question_id,
+            "members": members_snapshot,
+            "pairs": pairs_snapshot,
+            "warnings": warnings,
+        }
 
     def record(self, outcome: CouncilOutcome) -> None:
         """Record the results of a completed council round."""

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -13,7 +13,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.shared import llm_mocks
+from src.agents.council.fitness_store import CouncilFitnessStore, council_fitness_store
+from src.agents.council.stats_store import council_stats_store
 from src.agents.council.types import (
     CouncilConfig,
     CouncilMemberConfig,
@@ -21,11 +22,9 @@ from src.agents.council.types import (
     CouncilQuestion,
     MemberAnswer,
 )
-from src.agents.council.fitness_store import CouncilFitnessStore, council_fitness_store
 from src.agents.memory.multi_layer_retriever import MultiLayerRetriever
 from src.infra import llm_client
 from src.infra.config import get_config, load_council_config
-from src.infra import llm_client
 from src.infra.llm_client import (
     generate_structured_output,
     generate_text,
@@ -34,6 +33,7 @@ from src.infra.llm_client import (
 from src.sim.resource_manager import get_resource_manager
 
 logger = logging.getLogger(__name__)
+LLM_MAX_ATTEMPTS = 2
 
 DEFAULT_MEMBER_PROMPT = (
     "You are participating in a council of AI personas. Provide a JSON object with keys: "
@@ -263,41 +263,73 @@ def _ask_council_member(
     model_name = str((member.metadata or {}).get("model")) if member.metadata else None
     member_model = model_name or "mistral:latest"
     track_mock_usage = is_mock_mode_enabled()
-    if track_mock_usage:
-        response = llm_client.client.generate(prompt=prompt)
-        payload = json.loads(str(response.get("response", "{}")))
-        structured = MemberResponseModel.model_validate(payload)
-    else:
-        structured = generate_structured_output(
-            prompt,
-            response_model=MemberResponseModel,
-            model=member_model,
-            temperature=0.3,
-            agent_state=agent_state,
-        )
-        llm_client.client.generate(prompt=telemetry_prompt)
+    errors: list[str] = []
 
-    structured = generate_structured_output(
-        prompt,
-        response_model=MemberResponseModel,
-        model=member_model,
-        temperature=0.3,
-        agent_state=agent_state,
-    )
-
-    if structured is None:
-        fallback_text = (
-            generate_text(
-                prompt, model=member_model, temperature=0.3, agent_state=agent_state
+    structured: MemberResponseModel | None = None
+    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
+        try:
+            if track_mock_usage:
+                llm_client.client.generate(prompt=prompt)
+                structured = generate_structured_output(
+                    prompt,
+                    response_model=MemberResponseModel,
+                    model=member_model,
+                    temperature=0.3,
+                    agent_state=agent_state,
+                )
+            else:
+                structured = generate_structured_output(
+                    prompt,
+                    response_model=MemberResponseModel,
+                    model=member_model,
+                    temperature=0.3,
+                    agent_state=agent_state,
+                )
+            if structured is not None:
+                break
+        except Exception as exc:  # pragma: no cover - defensive
+            if isinstance(exc, RuntimeError) and "budget" in str(exc).lower():
+                raise
+            errors.append(str(exc))
+            logger.warning(
+                "Council member structured response failed",
+                extra={
+                    "event": "council.member.llm_error",
+                    "member_id": member.member_id,
+                    "attempt": attempt,
+                },
+                exc_info=True,
             )
-            or ""
-        )
+
+    fallback_text = ""
+    if structured is None:
+        try:
+            fallback_text = (
+                generate_text(
+                    prompt,
+                    model=member_model,
+                    temperature=0.3,
+                    agent_state=agent_state,
+                )
+                or ""
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(str(exc))
+            logger.error(
+                "Council member fallback text generation failed",
+                extra={
+                    "event": "council.member.fallback_error",
+                    "member_id": member.member_id,
+                },
+                exc_info=True,
+            )
         return MemberAnswer(
             member_id=member.member_id,
             answer=fallback_text,
             reasoning=None,
             confidence=None,
             citations=[],
+            metadata={"errors": errors, "fallback_used": True},
         )
 
     return MemberAnswer(
@@ -306,6 +338,7 @@ def _ask_council_member(
         reasoning=structured.reasoning,
         confidence=structured.confidence,
         citations=structured.citations,
+        metadata={"errors": errors, "fallback_used": False},
     )
 
 
@@ -339,17 +372,50 @@ def _judge_council_answers(
 
     track_mock_usage = is_mock_mode_enabled()
     prompt = _build_judge_prompt(question, answers, extra_context=extra_context, rag_docs=rag_docs)
-    if track_mock_usage:
-        response = llm_client.client.generate(prompt=prompt)
-        payload = json.loads(str(response.get("response", "{}")))
-        return CouncilVoteModel.model_validate(payload)
+    errors: list[str] = []
+    structured: CouncilVoteModel | None = None
+    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
+        try:
+            if track_mock_usage:
+                llm_client.client.generate(prompt=prompt)
+                structured = generate_structured_output(
+                    prompt,
+                    response_model=CouncilVoteModel,
+                    model=context.judge_model,
+                    temperature=0.1,
+                )
+            else:
+                structured = generate_structured_output(
+                    prompt,
+                    response_model=CouncilVoteModel,
+                    model=context.judge_model,
+                    temperature=0.1,
+                )
+            if structured is not None:
+                break
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(str(exc))
+            logger.warning(
+                "Council judge evaluation failed",
+                extra={
+                    "event": "council.judge.llm_error",
+                    "question_id": question.question_id,
+                    "attempt": attempt,
+                },
+                exc_info=True,
+            )
 
-    return generate_structured_output(
-        prompt,
-        response_model=CouncilVoteModel,
-        model=context.judge_model,
-        temperature=0.1,
-    )
+    if structured is None and errors:
+        logger.error(
+            "Council judge failed after retries",
+            extra={
+                "event": "council.judge.failure",
+                "question_id": question.question_id,
+                "errors": errors,
+            },
+        )
+
+    return structured
 
 
 class CouncilOrchestrator:
@@ -419,6 +485,13 @@ class CouncilOrchestrator:
         extra_context: str | None = None,
         rag_docs: Sequence[str] | None = None,
     ) -> CouncilOutcome:
+        logger.info(
+            "Starting council deliberation",
+            extra={
+                "event": "council.deliberation.start",
+                "question_id": question.question_id,
+            },
+        )
         rag_docs = await _populate_question_rag_documents(
             question,
             base_documents=rag_docs,
@@ -431,6 +504,23 @@ class CouncilOrchestrator:
             "du_budget_exhausted": False,
             "du_budget_per_member": self._resolve_du_budget(context.config),
         }
+        if not context.config.members:
+            metrics.update({"member_count": 0, "error": "no_active_members"})
+            logger.warning(
+                "No active council members available",
+                extra={
+                    "event": "council.no_members",
+                    "question_id": question.question_id,
+                },
+            )
+            return CouncilOutcome(
+                question=question,
+                answers=[],
+                resolution="No active council members available",
+                winning_member_ids=[],
+                summary=None,
+                metadata={"metrics": metrics},
+            )
         member_states = self._allocate_du_budgets(context.config, metrics)
 
         answers = await self._gather_member_answers(
@@ -474,8 +564,9 @@ class CouncilOrchestrator:
         base_metrics.setdefault(
             "du_budget_per_member", self._resolve_du_budget(context.config)
         )
-
-        return self._build_outcome(question, answers, vote, base_metrics)
+        outcome = self._build_outcome(question, answers, vote, base_metrics)
+        await self._record_outcome_metrics(outcome)
+        return outcome
 
     def _resolve_du_budget(self, config: CouncilConfig) -> float:
         if config.du_budget_per_question is not None:
@@ -519,6 +610,8 @@ class CouncilOrchestrator:
         semaphore = asyncio.Semaphore(
             max(1, context.config.max_concurrent_calls or self.max_concurrent_calls)
         )
+        metrics.setdefault("member_errors", {})
+        metrics.setdefault("member_fallbacks", 0)
 
         async def _call_member(member: CouncilMemberConfig) -> MemberAnswer | None:
             state = member_states.get(member.member_id)
@@ -540,6 +633,18 @@ class CouncilOrchestrator:
                     )
                 else:
                     logger.exception("Council member call failed: %s", exc)
+                metrics["member_errors"][member.member_id] = str(exc)
+                return None
+            except Exception as exc:  # pragma: no cover - defensive
+                metrics["member_errors"][member.member_id] = str(exc)
+                logger.exception(
+                    "Council member call encountered unexpected error",
+                    extra={
+                        "event": "council.member.failure",
+                        "member_id": member.member_id,
+                    },
+                    exc_info=True,
+                )
                 return None
 
         results = await asyncio.gather(
@@ -554,8 +659,15 @@ class CouncilOrchestrator:
                     metrics["du_budget_exhausted"] = True
                 else:
                     logger.exception("Unexpected error during council call", exc_info=result)
+                metrics["member_errors"][getattr(result, "member_id", "unknown")] = str(
+                    result
+                )
                 continue
             if result is not None:
+                if isinstance(result.metadata, Mapping) and result.metadata.get(
+                    "fallback_used"
+                ):
+                    metrics["member_fallbacks"] += 1
                 answers.append(result)
         return answers
 
@@ -596,6 +708,19 @@ class CouncilOrchestrator:
             summary=summary,
             metadata=metadata,
         )
+
+    async def _record_outcome_metrics(self, outcome: CouncilOutcome) -> None:
+        try:
+            await council_stats_store.record_outcome_async(outcome)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to persist council metrics",
+                extra={
+                    "event": "council.metrics.error",
+                    "question_id": outcome.question.question_id,
+                },
+                exc_info=True,
+            )
 
     def serialize_metrics(self) -> dict[str, list[dict[str, float]]]:
         """Return a snapshot of aggregated council metrics."""

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -14,6 +14,7 @@ from src.agents.council import (
     CouncilQuestion,
 )
 from src.agents.council.fitness_store import council_fitness_store
+from src.agents.council.stats_store import CouncilStatsStore
 from src.infra import llm_client
 from src.shared import llm_mocks
 


### PR DESCRIPTION
## Summary
- add guards and structured logging for council deliberations, including empty member sets
- wrap council LLM calls with retries, DU-aware error propagation, and metrics annotations
- extend council fitness metrics tracking and tests to persist pairwise outcomes reliably

## Testing
- ruff check src/agents/council/fitness_store.py src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py
- python -m pytest tests/unit/agents/council/test_council_orchestrator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942cb60951c8326bd855adc205a8747)