### PR TITLE
Tighten Council config schema, defaults and validation

### DIFF
--- a/config/council.yml
+++ b/config/council.yml
@@ -4,21 +4,24 @@ max_concurrent_calls: 3
 du_budget_per_question: 5.0
 voting_mode: single_winner
 members:
-  - name: Innovator
+  - member_id: innovator
+    display_name: Innovator
     role: Innovator
     persona: Creates bold ideas and alternatives.
     model: mistral:latest
     temperature: 0.4
     max_tokens: 256
     is_active: true
-  - name: Analyzer
+  - member_id: analyzer
+    display_name: Analyzer
     role: Analyzer
     persona: Evaluates risks and feasibility.
     model: mistral:latest
     temperature: 0.2
     max_tokens: 256
     is_active: true
-  - name: Red Team
+  - member_id: red-team
+    display_name: Red Team
     role: Red Team
     persona: Challenges assumptions and stress tests decisions.
     model: mistral:latest

--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -15,13 +15,11 @@ class CouncilMemberConfig(BaseModel):
 
     member_id: str = Field(validation_alias=AliasChoices("member_id", "id"))
     display_name: str = Field(validation_alias=AliasChoices("display_name", "name"))
-    persona: str = ""
-    role: str = "Generalist"
-    model: str | None = None
-    temperature: float = Field(default=0.3, ge=0.0, le=2.0)
-    max_tokens: int | None = Field(
-        default=None, validation_alias=AliasChoices("max_tokens", "max_turn_tokens")
-    )
+    persona: str = Field(min_length=1)
+    model: str = Field(min_length=1)
+    temperature: float = Field(ge=0.0, le=2.0)
+    max_tokens: int = Field(ge=1, validation_alias=AliasChoices("max_tokens", "max_turn_tokens"))
+    role: str = Field(min_length=1)
     is_active: bool = True
     system_prompt: str = ""
     description: str = ""
@@ -39,14 +37,30 @@ class CouncilMemberConfig(BaseModel):
         normalized.setdefault(
             "display_name", normalized.get("name") or normalized.get("member_id") or "member"
         )
-        persona = normalized.get("persona") or normalized.get("description")
-        normalized.setdefault("persona", persona or "")
-        normalized.setdefault("description", persona or "")
-        normalized.setdefault("metadata", normalized.get("metadata") or {})
+        role = normalized.get("role") or "Generalist"
+        normalized.setdefault("role", role)
+
+        persona = (
+            normalized.get("persona")
+            or normalized.get("description")
+            or f"{normalized['display_name']} focuses on the {role} perspective."
+        )
+        normalized.setdefault("persona", persona)
+        normalized.setdefault("description", normalized.get("description") or persona)
+
+        metadata = normalized.get("metadata") or {}
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        normalized.setdefault("metadata", metadata)
+        if "model" not in normalized and metadata.get("model"):
+            normalized["model"] = metadata.get("model")
 
         max_turn_tokens = normalized.get("max_turn_tokens")
         if max_turn_tokens is not None and "max_tokens" not in normalized:
             normalized["max_tokens"] = max_turn_tokens
+        normalized.setdefault("max_tokens", 256)
+        normalized.setdefault("temperature", 0.3)
+        normalized.setdefault("is_active", True)
 
         if not normalized.get("system_prompt"):
             role = normalized.get("role") or "Generalist"
@@ -64,7 +78,7 @@ class CouncilConfig(BaseModel):
 
     enabled: bool = True
     voting_mode: str = "single_winner"
-    members: list[CouncilMemberConfig]
+    members: list[CouncilMemberConfig] = Field(default_factory=list)
     quorum: int | None = None
     consensus_threshold: float = 0.67
     max_rounds: int = 1
@@ -78,10 +92,9 @@ class CouncilConfig(BaseModel):
     def _validate_members(cls, value: list[CouncilMemberConfig]) -> list[CouncilMemberConfig]:
         if not value:
             raise ValueError("Council configuration must include at least one member")
-        active_members = [member for member in value if member.is_active]
-        if not active_members:
+        if not any(member.is_active for member in value):
             raise ValueError("At least one council member must be active")
-        return active_members
+        return value
 
 
 class CouncilQuestion(BaseModel):

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -167,7 +167,8 @@ def _build_default_council_config() -> dict[str, Any]:
     return {
         "members": [
             {
-                "name": "Innovator",
+                "member_id": "innovator",
+                "display_name": "Innovator",
                 "role": "Innovator",
                 "persona": "Creates bold ideas and alternatives.",
                 "model": model_name,
@@ -176,7 +177,8 @@ def _build_default_council_config() -> dict[str, Any]:
                 "is_active": True,
             },
             {
-                "name": "Analyzer",
+                "member_id": "analyzer",
+                "display_name": "Analyzer",
                 "role": "Analyzer",
                 "persona": "Evaluates risks and feasibility.",
                 "model": model_name,
@@ -185,7 +187,8 @@ def _build_default_council_config() -> dict[str, Any]:
                 "is_active": True,
             },
             {
-                "name": "Red Team",
+                "member_id": "red-team",
+                "display_name": "Red Team",
                 "role": "Red Team",
                 "persona": "Challenges assumptions and stress tests decisions.",
                 "model": model_name,
@@ -401,14 +404,35 @@ def load_council_config(*, path: str | None = None, reload: bool = False) -> dic
     raw_members = merged_config.get("members")
     if isinstance(raw_members, list):
         default_model = default_members[0].get("model") if default_members else None
+        default_max_tokens = default_members[0].get("max_tokens") if default_members else None
+        default_temperature = default_members[0].get("temperature") if default_members else None
         for entry in raw_members:
             if isinstance(entry, dict):
                 normalized = dict(entry)
+                display_name = (
+                    normalized.get("display_name")
+                    or normalized.get("name")
+                    or normalized.get("member_id")
+                    or normalized.get("id")
+                )
+                if display_name:
+                    normalized.setdefault("display_name", display_name)
+                if not normalized.get("member_id") and display_name:
+                    normalized["member_id"] = str(display_name)
                 if default_model and not normalized.get("model"):
                     normalized["model"] = default_model
+                if default_max_tokens and not normalized.get("max_tokens"):
+                    normalized["max_tokens"] = default_max_tokens
+                if default_temperature is not None and "temperature" not in normalized:
+                    normalized["temperature"] = default_temperature
+                normalized.setdefault("role", "Generalist")
+                persona = normalized.get("persona") or normalized.get("description")
+                if not persona and display_name:
+                    persona = f"{display_name} offers a {normalized['role']} perspective."
+                if persona:
+                    normalized.setdefault("persona", persona)
                 if "max_turn_tokens" in normalized and "max_tokens" not in normalized:
                     normalized["max_tokens"] = normalized.get("max_turn_tokens")
-                normalized.setdefault("temperature", 0.3)
                 normalized.setdefault("is_active", True)
                 members.append(normalized)
 

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -68,7 +68,10 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
             system_prompt="Lead with clarity",
             decision_weight=1.0,
             persona="Guides the conversation",
+            model="mistral:latest",
             temperature=0.2,
+            max_tokens=256,
+            is_active=True,
         ),
         CouncilMemberConfig(
             member_id="innovator",
@@ -78,7 +81,10 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
             system_prompt="Bring new ideas",
             decision_weight=1.0,
             persona="Explores creative options",
+            model="mistral:latest",
             temperature=0.3,
+            max_tokens=256,
+            is_active=True,
         ),
         CouncilMemberConfig(
             member_id="analyst",
@@ -88,7 +94,10 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
             system_prompt="Look for gaps",
             decision_weight=1.0,
             persona="Evaluates trade-offs",
+            model="mistral:latest",
             temperature=0.25,
+            max_tokens=256,
+            is_active=True,
         ),
     ]
 
@@ -103,6 +112,10 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
                 system_prompt="Share focused insight",
                 decision_weight=1.0,
                 persona="Subject matter expert",
+                model="mistral:latest",
+                temperature=0.3,
+                max_tokens=256,
+                is_active=True,
             )
         )
 

--- a/tests/unit/agents/council/test_council_types.py
+++ b/tests/unit/agents/council/test_council_types.py
@@ -26,6 +26,7 @@ def sample_yaml_path(tmp_path: Path) -> Path:
         display_name: Facilitator
         role: Moderator
         persona: Guides the conversation and keeps members on track.
+        model: mistral:latest
         system_prompt: Maintain order and summarize the discussion.
         temperature: 0.2
         max_tokens: 256
@@ -52,6 +53,7 @@ def test_sample_yaml_loads_successfully(
     assert member.persona == "Guides the conversation and keeps members on track."
     assert member.temperature == pytest.approx(0.2)
     assert member.max_tokens == 256
+    assert member.model == "mistral:latest"
 
 
 def test_load_fails_with_empty_members(
@@ -70,8 +72,12 @@ def test_load_fails_with_misconfigured_member(
             {
                 "member_id": "facilitator",
                 "display_name": "Facilitator",
-                "description": "Missing required role and system prompt",
-                "is_active": False,
+                "role": "Moderator",
+                "persona": "Guides the discussion",
+                "model": "",
+                "temperature": 0.2,
+                "max_tokens": 256,
+                "is_active": True,
             }
         ],
     }
@@ -93,6 +99,9 @@ def test_load_fails_without_active_members(
                         "display_name": "Facilitator",
                         "role": "Moderator",
                         "persona": "Inactive member",
+                        "model": "mistral:latest",
+                        "temperature": 0.2,
+                        "max_tokens": 256,
                         "is_active": False,
                     }
                 ],

--- a/tests/unit/infra/test_council_config.py
+++ b/tests/unit/infra/test_council_config.py
@@ -28,7 +28,8 @@ def test_load_council_config_returns_defaults_when_missing(
     result = infra_config.load_council_config(reload=True)
 
     assert result["members"], "Expected default members when YAML file is missing"
-    assert result["members"][0]["name"] == "Innovator"
+    assert result["members"][0]["display_name"] == "Innovator"
+    assert result["members"][0]["member_id"] == "innovator"
     assert (
         result["max_concurrent_calls"] == infra_config.settings.COUNCIL_MAX_CONCURRENT_CALLS
     )
@@ -52,9 +53,10 @@ def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     result = infra_config.load_council_config(reload=True)
 
-    assert result["members"][0]["name"] == "Strategist"
+    assert result["members"][0]["display_name"] == "Strategist"
     assert result["members"][0]["model"] == "local/mistral"
     assert result["members"][1]["model"], "Missing model should default to base model"
+    assert result["members"][1]["persona"], "Missing persona should be derived"
     assert all(member.get("is_active") for member in result["members"])
     assert all("temperature" in member for member in result["members"])
 


### PR DESCRIPTION
### Motivation

- Ensure council roster and member configuration are validated strictly and normalized so downstream orchestration can rely on consistent fields (ids, display names, model, temperature, token limits, persona, role, activity).
- Provide sensible defaults and normalization when loading YAML so older/simple configs continue to work.
- Surface schema errors early by using Pydantic validation and update tests to reflect the required fields.

### Description

- Updated `src/agents/council/types.py`:
  - Strengthened `CouncilMemberConfig` fields (`persona`, `model`, `temperature`, `max_tokens`, `role`) with validation and sensible defaults in the pre-validator normalization.
  - Ensured `system_prompt`, `description`, `metadata`, `is_active` and other derived fields are normalized when parsing raw mappings.
  - Made `CouncilConfig.members` use a `default_factory` and adjusted member validation to require at least one active member while returning the original member list.
- Updated YAML defaults in `config/council.yml` to include `member_id` and `display_name` (and model/token entries) for the sample roster.
- Enhanced loader and defaults in `src/infra/config.py` to populate `member_id`, `display_name`, `model`, `max_tokens`, `temperature`, `role`, and derived `persona` when merging file-provided roster entries with defaults.
- Updated unit tests to reflect the new required/normalized fields:
  - `tests/unit/agents/council/test_council_types.py`
  - `tests/unit/agents/council/test_council_orchestrator.py`
  - `tests/unit/infra/test_council_config.py`

### Testing

- Ran linter: `ruff check .` — the run reported many existing lint issues across the repository (RUF007/RUF059/E402 etc.). These are pre-existing and not caused by this change.
- Ran the test suite: `pytest` — overall run encountered unrelated failures (5 failing tests in infra/llm and event_log spans), likely due to missing optional dependencies / environment differences. The council-related unit tests that were modified or exercise the new schema passed (council types and orchestrator tests exercised by the changes succeeded).

If you want, I can split the normalization/validation work into smaller PRs or address the unrelated failing infra tests and lint warnings in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a034d7f88326a466b3e5c2cc8810)