### PR TITLE
Include member answers in judge prompt and normalize judge scores

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from src.agents.council.fitness_store import CouncilFitnessStore, council_fitness_store
 from src.agents.council.stats_store import council_stats_store
@@ -34,6 +34,7 @@ from src.sim.resource_manager import get_resource_manager
 
 logger = logging.getLogger(__name__)
 LLM_MAX_ATTEMPTS = 2
+JUDGE_SCORE_CATEGORIES = ("correctness", "clarity", "usefulness", "safety")
 
 DEFAULT_MEMBER_PROMPT = (
     "You are participating in a council of AI personas. Provide a JSON object with keys: "
@@ -56,10 +57,11 @@ class CouncilVoteModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
     winning_member_id: str = Field(
-        alias="winning_member_id", validation_alias="winner"
+        validation_alias=AliasChoices("winner_id", "winner", "winning_member_id")
     )
-    scores: dict[str, float] = Field(default_factory=dict, alias="votes")
-    metrics: dict[str, float] = Field(default_factory=dict)
+    votes: dict[str, Any] = Field(default_factory=dict)
+    scores: dict[str, Any] = Field(default_factory=dict)
+    metrics: dict[str, Any] = Field(default_factory=dict)
     summary: str
     reasoning: str | None = None
     resolution: str | None = None
@@ -356,15 +358,124 @@ def _build_judge_prompt(
     *,
     extra_context: str | None = None,
     rag_docs: Sequence[str] | None = None,
-    ) -> str:
+) -> str:
     rag_section = _format_rag_docs(rag_docs or [])
     additional_context = extra_context or "(no extra context provided)"
-    member_section = " ".join(f"member_id={answer.member_id}" for answer in answers)
-    return (
-        "[council-judgement] "
-        f"question={question.prompt} context={question.context or ''} "
-        f"extra_context={additional_context} rag_docs={rag_section} {member_section}"
+    member_blocks = []
+    for answer in answers:
+        member_blocks.append(
+            "\n".join(
+                [
+                    f"- id: {answer.member_id}",
+                    f"  answer: {answer.answer}",
+                    f"  reasoning: {answer.reasoning or '(no reasoning provided)'}",
+                ]
+            )
+        )
+    member_section = "\n".join(member_blocks) or "(no member answers)"
+    score_categories = ", ".join(JUDGE_SCORE_CATEGORIES)
+    return "\n".join(
+        [
+            "[council-judgement]",
+            f"Question: {question.prompt}",
+            f"Context: {question.context or ''}",
+            f"Extra context: {additional_context}",
+            f"RAG docs: {rag_section}",
+            "Members:",
+            member_section,
+            "",
+            "Scoring guidance:",
+            f"- Score each member from 0.0 to 1.0 for: {score_categories}.",
+            "- Compute a total score as the average of the category scores.",
+            "- Choose the winner with the highest total score (break ties by clarity).",
+            "",
+            "Return ONLY valid JSON matching this schema:",
+            "{",
+            '  "winner_id": "<member_id>",',
+            '  "votes": {"<member_id>": 0.0},',
+            '  "scores": {"<member_id>": {"correctness": 0.0, "clarity": 0.0, "usefulness": 0.0, "safety": 0.0}},',
+            '  "metrics": {"cohesion": 0.0, "coverage": 0.0, "member_scores": {"<member_id>": {"correctness": 0.0, "clarity": 0.0, "usefulness": 0.0, "safety": 0.0, "total": 0.0}}},',
+            '  "summary": "<concise summary>",',
+            '  "reasoning": "<why the winner was selected>",',
+            '  "resolution": "<final resolution or selected answer>"',
+            "}",
+        ]
     )
+
+
+def _coerce_score(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _extract_category_scores(raw: Mapping[str, Any]) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for category in JUDGE_SCORE_CATEGORIES:
+        value = _coerce_score(raw.get(category))
+        if value is not None:
+            scores[category] = value
+    return scores
+
+
+def _normalize_vote_metrics(
+    structured: CouncilVoteModel, answers: Sequence[MemberAnswer]
+) -> CouncilVoteModel:
+    totals: dict[str, float] = {}
+    breakdown: dict[str, dict[str, float]] = {}
+
+    for member_id, score_map in structured.scores.items():
+        if isinstance(score_map, Mapping):
+            category_scores = _extract_category_scores(score_map)
+            if category_scores:
+                breakdown[member_id] = category_scores
+
+    for member_id, value in structured.votes.items():
+        if isinstance(value, Mapping):
+            category_scores = _extract_category_scores(value)
+            if category_scores:
+                breakdown.setdefault(member_id, category_scores)
+        else:
+            score_value = _coerce_score(value)
+            if score_value is not None:
+                totals[member_id] = score_value
+
+    for member_id, category_scores in breakdown.items():
+        if category_scores:
+            totals.setdefault(member_id, sum(category_scores.values()) / len(category_scores))
+
+    if not totals and breakdown:
+        totals = {
+            member_id: sum(scores.values()) / len(scores) for member_id, scores in breakdown.items()
+        }
+
+    member_ids = {answer.member_id for answer in answers}
+    for member_id, total in totals.items():
+        if member_id in member_ids:
+            breakdown.setdefault(member_id, {})
+            breakdown[member_id]["total"] = total
+
+    structured.votes = totals
+    if breakdown:
+        structured.scores = {
+            member_id: {
+                category: score
+                for category, score in scores.items()
+                if category in JUDGE_SCORE_CATEGORIES
+            }
+            for member_id, scores in breakdown.items()
+        }
+        structured.metrics = {
+            **structured.metrics,
+            "member_scores": breakdown,
+            "score_categories": list(JUDGE_SCORE_CATEGORIES),
+        }
+    return structured
 
 
 def _judge_council_answers(
@@ -422,6 +533,9 @@ def _judge_council_answers(
                 "errors": errors,
             },
         )
+
+    if structured is not None:
+        structured = _normalize_vote_metrics(structured, answers)
 
     return structured
 
@@ -693,9 +807,9 @@ class CouncilOrchestrator:
 
         if vote is not None:
             winning_member_ids = [vote.winning_member_id]
-            votes = dict(vote.scores)
+            votes = dict(vote.votes)
             outcome_metrics.update(vote.metrics)
-            metadata.update({"scores": votes, "judge_reasoning": vote.reasoning})
+            metadata.update({"scores": vote.scores or votes, "judge_reasoning": vote.reasoning})
             summary = vote.summary
             answer_lookup = {answer.member_id: answer.answer for answer in answers}
             resolution = vote.resolution or answer_lookup.get(

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -29,10 +29,29 @@ def patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
         True,
         {
             "CouncilVoteModel": {
+                "winner_id": "facilitator",
                 "winning_member_id": "facilitator",
-                "winner": "facilitator",
-                "votes": {"facilitator": 1, "innovator": 1, "analyst": 1},
-                "scores": {"facilitator": 1.0, "innovator": 1.0, "analyst": 1.0},
+                "votes": {},
+                "scores": {
+                    "facilitator": {
+                        "correctness": 0.9,
+                        "clarity": 0.8,
+                        "usefulness": 0.7,
+                        "safety": 0.95,
+                    },
+                    "innovator": {
+                        "correctness": 0.6,
+                        "clarity": 0.7,
+                        "usefulness": 0.8,
+                        "safety": 0.9,
+                    },
+                    "analyst": {
+                        "correctness": 0.7,
+                        "clarity": 0.6,
+                        "usefulness": 0.85,
+                        "safety": 0.9,
+                    },
+                },
                 "metrics": {"cohesion": 0.91, "coverage": 0.77},
                 "summary": "Deterministic council summary",
                 "reasoning": "deterministic reasoning",
@@ -158,11 +177,15 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(monkeypatch: py
     assert observed_member_ids == expected_member_ids
 
     assert outcome.winning_member_ids == ["facilitator"]
+    assert outcome.winner_id == "facilitator"
     assert outcome.resolution == "facilitator proposal selected"
+    assert outcome.votes["facilitator"] == pytest.approx(0.8375)
     assert outcome.metadata is not None
     metrics = outcome.metadata.get("metrics", {})
     assert metrics.get("du_budget_exhausted") is False
     assert metrics.get("du_budget_per_member") == pytest.approx(5.0)
+    assert "member_scores" in metrics
+    assert outcome.metrics["member_scores"]["facilitator"]["total"] == pytest.approx(0.8375)
     assert outcome.summary == "Deterministic council summary"
 
     serialized = json.loads(json.dumps(outcome.metadata))
@@ -253,6 +276,7 @@ def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPat
     assert all(rag_marker in prompt for prompt in judge_prompts)
     assert all(extra_context in prompt for prompt in member_prompts)
     assert all(extra_context in prompt for prompt in judge_prompts)
+    assert all("facilitator proposal selected" in prompt for prompt in judge_prompts)
 
 
 def test_council_orchestrator_persists_metrics(


### PR DESCRIPTION
### Motivation

- Make the judge prompt richer and unambiguous by embedding each council member's answer, reasoning and ID so the judge has full context when evaluating proposals.
- Provide explicit scoring guidance (categories: `correctness`, `clarity`, `usefulness`, `safety`) and a JSON return schema so judge outputs are deterministic and machine-parseable.
- Convert judge outputs (votes/scores) into structured metrics to populate `CouncilOutcome` fields (`winner_id`, `votes`, `metrics`) for downstream analytics and fitness updates.

### Description

- Rewrote `_build_judge_prompt` to include per-member blocks with `id`, `answer`, and `reasoning`, plus scoring guidance and an explicit JSON schema to return.
- Added `JUDGE_SCORE_CATEGORIES` and helper functions: `_coerce_score`, `_extract_category_scores`, and `_normalize_vote_metrics` to parse category-level scores and compute per-member totals and a `member_scores` metrics block.
- Updated `CouncilVoteModel` shape (aliases handling via `AliasChoices`) and relaxed `votes/scores/metrics` types so judge JSON with nested category scores is accepted and normalized.
- Integrated normalization in `_judge_council_answers` and propagated normalized `votes`, `scores`, and `metrics` into the `CouncilOutcome` via `_build_outcome` (ensuring `winner_id`, `votes`, `metrics` and `metadata` reflect judge output).
- Extended unit tests in `tests/unit/agents/council/test_council_orchestrator.py` to expect the judge prompt to include answer text and to assert that the mocked judge JSON drives the selected winner and populates vote/metric structures (including `member_scores` and computed totals).

### Testing

- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py` — 8 tests passed (after changes).
- Ran `python -m black --check src tests` — check reports files that would be reformatted (repo-wide formatting changes not part of this PR); black reported multiple files would be reformatted.
- Ran `python -m ruff check src tests` — ruff reported existing repo lint issues (many warnings/errors unrelated to the council changes).
- Attempted `mypy` (type checking) but it was long-running/interrupted in this environment; no new mypy-specific failures tied to the council changes were observed during unit test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a7e8dc7883268cfd9387aff46612)