### PR TITLE
Add `--question` alias and `--show-all` output to council CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ dataset:
 
 .PHONY: council
 council:
-	python -m scripts.council_cli --question "$(Q)"
+	python -m scripts.council_cli --question "$(Q)" $(if $(SHOW_ALL),--show-all)

--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -13,13 +13,25 @@ app = typer.Typer(add_completion=False)
 
 @app.command()
 def main(
-    prompt: str = typer.Argument(..., help="Question to pose to the council"),
+    prompt: str | None = typer.Argument(
+        None, help="Question to pose to the council"
+    ),
+    question: str | None = typer.Option(
+        None,
+        "--question",
+        help="Question to pose to the council (alias for the prompt argument)",
+    ),
     context: str | None = typer.Option(None, "--context", "-c", help="Optional context"),
     rag_doc: list[str] | None = typer.Option(
         None,
         "--rag-doc",
         "--rag-docs",
         help="Additional RAG documents to supply to the council",
+    ),
+    show_all: bool = typer.Option(
+        False,
+        "--show-all",
+        help="Print answers from all members instead of only winners",
     ),
     question_id: str = typer.Option(
         "cli-question",
@@ -30,10 +42,21 @@ def main(
 ) -> None:
     """Run the council with the provided ``prompt`` and display the outcome."""
 
+    if prompt and question and prompt != question:
+        raise typer.BadParameter(
+            "Provide the question either as the prompt argument or via --question, not both."
+        )
+
+    resolved_prompt = question or prompt
+    if not resolved_prompt:
+        raise typer.BadParameter(
+            "A question is required. Provide the prompt argument or --question."
+        )
+
     rag_docs = list(rag_doc or [])
     question = CouncilQuestion(
         question_id=question_id,
-        prompt=prompt,
+        prompt=resolved_prompt,
         context=context,
         rag_documents=rag_docs,
     )
@@ -58,9 +81,17 @@ def main(
         typer.echo(f"Winners: {winners}")
 
     if outcome.answers:
-        typer.echo("Answers:")
-        for answer in outcome.answers:
-            typer.echo(f"- {answer.member_id}: {answer.answer}")
+        answers = outcome.answers
+        if not show_all and outcome.winning_member_ids:
+            winner_ids = set(outcome.winning_member_ids)
+            answers = [
+                answer for answer in outcome.answers if answer.member_id in winner_ids
+            ]
+
+        if answers:
+            typer.echo("Answers:")
+            for answer in answers:
+                typer.echo(f"- {answer.member_id}: {answer.answer}")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual tool

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -63,3 +63,70 @@ def test_council_cli_reports_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
     assert question.context == "Extra context"
     assert rag_docs == ["doc-a", "doc-b"]
     assert extra_context == "Extra context"
+
+
+def test_council_cli_accepts_question_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    recorded_calls: list[tuple[CouncilQuestion, str | None, list[str] | None]] = []
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+    ) -> CouncilOutcome:
+        recorded_calls.append((question, extra_context, rag_docs))
+        return CouncilOutcome(
+            question=question,
+            answers=[],
+            resolution="Mock resolution",
+            winning_member_ids=[],
+            summary=None,
+            metadata={"fitness": {"scores": []}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(council_cli.app, ["--question", "What now?"])
+
+    assert result.exit_code == 0
+    question, extra_context, rag_docs = recorded_calls[0]
+    assert question.prompt == "What now?"
+    assert extra_context is None
+    assert rag_docs == []
+
+
+def test_council_cli_show_all_answers(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+    ) -> CouncilOutcome:
+        return CouncilOutcome(
+            question=question,
+            answers=[
+                MemberAnswer(member_id="alpha", answer="Alpha answer"),
+                MemberAnswer(member_id="bravo", answer="Bravo answer"),
+            ],
+            resolution="Mock resolution",
+            winning_member_ids=["alpha"],
+            summary=None,
+            metadata={"fitness": {"scores": []}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(council_cli.app, ["Prompt"])
+
+    assert result.exit_code == 0
+    assert "- alpha: Alpha answer" in result.output
+    assert "- bravo: Bravo answer" not in result.output
+
+    result = runner.invoke(council_cli.app, ["Prompt", "--show-all"])
+
+    assert result.exit_code == 0
+    assert "- alpha: Alpha answer" in result.output
+    assert "- bravo: Bravo answer" in result.output


### PR DESCRIPTION
### Motivation
- Allow providing the question either as a positional prompt or via a `--question` option and prevent ambiguous usage.
- Give users control over whether to print all member answers or only winning members via a `--show-all` flag.
- Ensure the Makefile `council` helper can forward the `--show-all` flag.
- Improve unit test coverage for the new CLI behaviors.

### Description
- Updated `scripts/council_cli.py` to make the positional `prompt` optional, add a `--question` option as an alias, validate mutual exclusivity between them, add a `--show-all` boolean option, and filter printed answers to winners by default.
- Updated the `Makefile` `council` target to forward `--show-all` when `SHOW_ALL` is set (`python -m scripts.council_cli --question "$(Q)" $(if $(SHOW_ALL),--show-all)`).
- Extended `tests/unit/scripts/test_council_cli.py` with `test_council_cli_accepts_question_option` and `test_council_cli_show_all_answers` to cover the new flags and answer-filtering behavior.

### Testing
- Ran `ruff check scripts/council_cli.py tests/unit/scripts/test_council_cli.py` and the linter checks passed.
- Ran `pytest tests/unit/scripts/test_council_cli.py` and all tests passed (`3 passed`).
- Pytest emitted a `PytestConfigWarning: Unknown config option: asyncio_mode` warning but it did not affect test success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948193d070083268bfe8c73cc94cd72)