### PR TITLE
Normalize council schema: add aliases, role/voting Literals, and question fields

### DIFF
--- a/config/council.yml
+++ b/config/council.yml
@@ -4,24 +4,24 @@ max_concurrent_calls: 3
 du_budget_per_question: 5.0
 voting_mode: single_winner
 members:
-  - member_id: innovator
-    display_name: Innovator
+  - id: innovator
+    name: Innovator
     role: Innovator
     persona: Creates bold ideas and alternatives.
     model: mistral:latest
     temperature: 0.4
     max_tokens: 256
     is_active: true
-  - member_id: analyzer
-    display_name: Analyzer
+  - id: analyzer
+    name: Analyzer
     role: Analyzer
     persona: Evaluates risks and feasibility.
     model: mistral:latest
     temperature: 0.2
     max_tokens: 256
     is_active: true
-  - member_id: red-team
-    display_name: Red Team
+  - id: red-team
+    name: Red Team
     role: Red Team
     persona: Challenges assumptions and stress tests decisions.
     model: mistral:latest

--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -2,10 +2,49 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+CouncilRole = Literal["Facilitator", "Innovator", "Analyzer", "Red Team", "Generalist"]
+CouncilVotingMode = Literal["single_winner", "consensus"]
+
+_ROLE_ALIASES = {
+    "facilitator": "Facilitator",
+    "moderator": "Facilitator",
+    "innovator": "Innovator",
+    "analyzer": "Analyzer",
+    "red team": "Red Team",
+    "redteam": "Red Team",
+    "generalist": "Generalist",
+}
+_VOTING_MODE_ALIASES = {
+    "single_winner": "single_winner",
+    "singlewinner": "single_winner",
+    "consensus": "consensus",
+}
+
+
+def _normalize_role(value: Any) -> str:
+    if value is None:
+        return "Generalist"
+    text = str(value).strip()
+    if not text:
+        return "Generalist"
+    key = re.sub(r"[\s_-]+", " ", text).strip().lower()
+    return _ROLE_ALIASES.get(key, text)
+
+
+def _normalize_voting_mode(value: Any) -> str:
+    if value is None:
+        return "single_winner"
+    text = str(value).strip()
+    if not text:
+        return "single_winner"
+    key = re.sub(r"[\s-]+", "_", text).strip().lower()
+    return _VOTING_MODE_ALIASES.get(key, text)
 
 
 class CouncilMemberConfig(BaseModel):
@@ -19,7 +58,7 @@ class CouncilMemberConfig(BaseModel):
     model: str = Field(min_length=1)
     temperature: float = Field(ge=0.0, le=2.0)
     max_tokens: int = Field(ge=1, validation_alias=AliasChoices("max_tokens", "max_turn_tokens"))
-    role: str = Field(min_length=1)
+    role: CouncilRole = Field(min_length=1)
     is_active: bool = True
     system_prompt: str = ""
     description: str = ""
@@ -37,8 +76,8 @@ class CouncilMemberConfig(BaseModel):
         normalized.setdefault(
             "display_name", normalized.get("name") or normalized.get("member_id") or "member"
         )
-        role = normalized.get("role") or "Generalist"
-        normalized.setdefault("role", role)
+        role = _normalize_role(normalized.get("role") or "Generalist")
+        normalized["role"] = role
 
         persona = (
             normalized.get("persona")
@@ -77,7 +116,7 @@ class CouncilConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="ignore")
 
     enabled: bool = True
-    voting_mode: str = "single_winner"
+    voting_mode: CouncilVotingMode = "single_winner"
     members: list[CouncilMemberConfig] = Field(default_factory=list)
     quorum: int | None = None
     consensus_threshold: float = 0.67
@@ -96,16 +135,34 @@ class CouncilConfig(BaseModel):
             raise ValueError("At least one council member must be active")
         return value
 
+    @field_validator("voting_mode", mode="before")
+    @classmethod
+    def _normalize_voting_mode(cls, value: Any) -> Any:
+        return _normalize_voting_mode(value)
+
 
 class CouncilQuestion(BaseModel):
     """Represents a structured question posed to the council."""
 
-    question_id: str
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    question_id: str = Field(validation_alias=AliasChoices("question_id", "id", "name"))
     prompt: str
-    context: str | None = None
+    user_id: str | None = Field(default=None, validation_alias=AliasChoices("user_id", "userId"))
+    extra_context: str | None = Field(
+        default=None, validation_alias=AliasChoices("extra_context", "context")
+    )
     rag_documents: list[str] = Field(default_factory=list)
     metadata: Mapping[str, Any] | None = None
     metrics: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def context(self) -> str | None:
+        return self.extra_context
+
+    @context.setter
+    def context(self, value: str | None) -> None:
+        self.extra_context = value
 
 
 class MemberAnswer(BaseModel):

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -82,7 +82,7 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
         CouncilMemberConfig(
             member_id="facilitator",
             display_name="Facilitator",
-            role="Moderator",
+            role="Facilitator",
             description="Ensures everyone is heard",
             system_prompt="Lead with clarity",
             decision_weight=1.0,
@@ -95,7 +95,7 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
         CouncilMemberConfig(
             member_id="innovator",
             display_name="Innovator",
-            role="Idea generator",
+            role="Innovator",
             description="Pushes creative thinking",
             system_prompt="Bring new ideas",
             decision_weight=1.0,
@@ -108,7 +108,7 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
         CouncilMemberConfig(
             member_id="analyst",
             display_name="Analyst",
-            role="Evaluator",
+            role="Analyzer",
             description="Stress-tests ideas",
             system_prompt="Look for gaps",
             decision_weight=1.0,
@@ -126,7 +126,7 @@ def _build_council_config(num_members: int = 3) -> CouncilConfig:
             CouncilMemberConfig(
                 member_id=f"member-{idx}",
                 display_name=f"Member {idx}",
-                role="Specialist",
+                role="Generalist",
                 description="Brings domain expertise",
                 system_prompt="Share focused insight",
                 decision_weight=1.0,
@@ -164,7 +164,9 @@ class DummyRetriever:
         ]
 
 
-def test_council_orchestrator_invokes_all_members_and_aggregates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_council_orchestrator_invokes_all_members_and_aggregates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     orchestrator = CouncilOrchestrator()
     config = _build_council_config()
     question = _build_question()
@@ -246,9 +248,7 @@ def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPat
     member_prompts: list[str] = []
     judge_prompts: list[str] = []
 
-    monkeypatch.setattr(
-        "src.agents.council.orchestrator._format_rag_docs", lambda _: rag_marker
-    )
+    monkeypatch.setattr("src.agents.council.orchestrator._format_rag_docs", lambda _: rag_marker)
 
     original_generate = llm_client.client.generate
 
@@ -282,9 +282,7 @@ def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPat
 def test_council_orchestrator_persists_metrics(
     monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
-    store = CouncilStatsStore(
-        db_path=tmp_path_factory.mktemp("council-metrics") / "stats.sqlite3"
-    )
+    store = CouncilStatsStore(db_path=tmp_path_factory.mktemp("council-metrics") / "stats.sqlite3")
     monkeypatch.setattr(council_orchestrator, "council_stats_store", store)
 
     orchestrator = CouncilOrchestrator()
@@ -294,9 +292,7 @@ def test_council_orchestrator_persists_metrics(
     outcome = orchestrator.deliberate(config, question)
 
     snapshot = store.serialize_metrics()
-    facilitator_stats = next(
-        m for m in snapshot["members"] if m["member_id"] == "facilitator"
-    )
+    facilitator_stats = next(m for m in snapshot["members"] if m["member_id"] == "facilitator")
     assert facilitator_stats["wins"] == 1
     assert facilitator_stats["participations"] == 1
     assert len(snapshot["members"]) == len(config.members)

--- a/tests/unit/agents/council/test_council_types.py
+++ b/tests/unit/agents/council/test_council_types.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 from pydantic import TypeAdapter, ValidationError
 
-from src.agents.council.types import CouncilConfig
+from src.agents.council.types import CouncilConfig, CouncilQuestion
 
 pytestmark = pytest.mark.unit
 
@@ -22,8 +22,8 @@ def sample_yaml_path(tmp_path: Path) -> Path:
     enabled: true
     voting_mode: single_winner
     members:
-      - member_id: facilitator
-        display_name: Facilitator
+      - id: facilitator
+        name: Facilitator
         role: Moderator
         persona: Guides the conversation and keeps members on track.
         model: mistral:latest
@@ -50,21 +50,20 @@ def test_sample_yaml_loads_successfully(
     member = config.members[0]
     assert member.member_id == "facilitator"
     assert member.display_name == "Facilitator"
+    assert member.role == "Facilitator"
     assert member.persona == "Guides the conversation and keeps members on track."
     assert member.temperature == pytest.approx(0.2)
     assert member.max_tokens == 256
     assert member.model == "mistral:latest"
 
 
-def test_load_fails_with_empty_members(
-    council_config_adapter: TypeAdapter[CouncilConfig]
-) -> None:
+def test_load_fails_with_empty_members(council_config_adapter: TypeAdapter[CouncilConfig]) -> None:
     with pytest.raises(ValidationError):
         council_config_adapter.validate_python({"enabled": True, "members": []})
 
 
 def test_load_fails_with_misconfigured_member(
-    council_config_adapter: TypeAdapter[CouncilConfig]
+    council_config_adapter: TypeAdapter[CouncilConfig],
 ) -> None:
     invalid_yaml = {
         "enabled": True,
@@ -87,7 +86,7 @@ def test_load_fails_with_misconfigured_member(
 
 
 def test_load_fails_without_active_members(
-    council_config_adapter: TypeAdapter[CouncilConfig]
+    council_config_adapter: TypeAdapter[CouncilConfig],
 ) -> None:
     with pytest.raises(ValidationError):
         council_config_adapter.validate_python(
@@ -107,3 +106,19 @@ def test_load_fails_without_active_members(
                 ],
             }
         )
+
+
+def test_council_question_aliases() -> None:
+    question = CouncilQuestion.model_validate(
+        {
+            "id": "question-1",
+            "prompt": "What should we do next?",
+            "user_id": "user-123",
+            "extra_context": "Focus on the roadmap.",
+        }
+    )
+
+    assert question.question_id == "question-1"
+    assert question.user_id == "user-123"
+    assert question.extra_context == "Focus on the roadmap."
+    assert question.context == "Focus on the roadmap."

--- a/tests/unit/infra/test_council_config.py
+++ b/tests/unit/infra/test_council_config.py
@@ -21,18 +21,14 @@ def test_load_council_config_returns_defaults_when_missing(
 ) -> None:
     _reset_cache(monkeypatch)
     missing = tmp_path / "council.yml"
-    monkeypatch.setattr(
-        infra_config.settings, "COUNCIL_CONFIG_PATH", str(missing), raising=False
-    )
+    monkeypatch.setattr(infra_config.settings, "COUNCIL_CONFIG_PATH", str(missing), raising=False)
 
     result = infra_config.load_council_config(reload=True)
 
     assert result["members"], "Expected default members when YAML file is missing"
     assert result["members"][0]["display_name"] == "Innovator"
     assert result["members"][0]["member_id"] == "innovator"
-    assert (
-        result["max_concurrent_calls"] == infra_config.settings.COUNCIL_MAX_CONCURRENT_CALLS
-    )
+    assert result["max_concurrent_calls"] == infra_config.settings.COUNCIL_MAX_CONCURRENT_CALLS
     assert result["du_budget_per_question"] == infra_config.settings.DU_BUDGET_PER_QUESTION
     assert result["voting_mode"] == "single_winner"
     assert result["members"][0]["is_active"] is True
@@ -44,8 +40,13 @@ def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_pat
     path = tmp_path / "council.yml"
     roster = {
         "members": [
-            {"name": "Strategist", "role": "Planner", "model": "local/mistral"},
-            {"name": "Scout", "role": "Observer"},
+            {
+                "id": "strategist",
+                "name": "Strategist",
+                "role": "Innovator",
+                "model": "local/mistral",
+            },
+            {"id": "scout", "name": "Scout", "role": "Analyzer"},
         ]
     }
     path.write_text(yaml.safe_dump(roster))
@@ -61,13 +62,15 @@ def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert all("temperature" in member for member in result["members"])
 
 
-def test_load_council_config_merges_defaults(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_load_council_config_merges_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     _reset_cache(monkeypatch)
     path = tmp_path / "council.yml"
     path.write_text(
         yaml.safe_dump(
             {
-                "members": [{"name": "Strategist", "role": "Planner"}],
+                "members": [{"id": "strategist", "name": "Strategist", "role": "Innovator"}],
                 "max_concurrent_calls": 5,
             }
         )


### PR DESCRIPTION
### Motivation

- Support the canonical spec field names for council configs and questions while preserving backward-compatible aliases.
- Constrain allowed values for member `role` and `voting_mode` to a known set to reduce runtime errors.
- Add structured fields (`user_id`, `extra_context`) to `CouncilQuestion` and accept legacy keys like `id`/`name`/`context`.
- Update sample config and tests to reflect the canonical schema and validate alias behavior.

### Description

- Introduced `CouncilRole` and `CouncilVotingMode` `Literal` types and added normalization helpers `_normalize_role` and `_normalize_voting_mode` to accept common aliases.
- Changed `CouncilMemberConfig.role` to `CouncilRole` and `CouncilConfig.voting_mode` to `CouncilVotingMode` and added a validator to normalize incoming values.
- Extended `CouncilQuestion` to accept aliased keys via `AliasChoices` for `question_id` (`id`/`name`), added `user_id` and `extra_context`, and provided a `context` property mapping to `extra_context`.
- Updated `config/council.yml` to canonical `id`/`name` keys and adjusted unit tests in `tests/unit/agents/council/*` and `tests/unit/infra/test_council_config.py` to cover the new/aliased fields and normalized roles.

### Testing

- Ran linter/formatter: `ruff format` and `ruff check` on the modified files and resolved one autofix; `ruff` checks passed.
- Ran unit tests: `pytest tests/unit/agents/council/test_council_types.py tests/unit/infra/test_council_config.py tests/unit/agents/council/test_council_orchestrator.py` and all executed tests passed (16 passed, 1 pytest warning about config).
- Verified that the changes are backward-compatible with legacy keys like `member_id`/`display_name`/`context` via the normalization and aliasing logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948193c3f3883268ebdcbd6fd7baa1d)