### PR TITLE
Use DEFAULT_LLM_MODEL for council model defaults

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -164,7 +164,7 @@ def _build_council_context() -> CouncilContext:
     """Load the council configuration and normalize member metadata."""
 
     raw_config = load_council_config()
-    default_model = str(get_config("DEFAULT_LLM_MODEL") or "mistral:latest")
+    default_model = _resolve_default_model()
     judge_model = str(raw_config.get("judge_model") or default_model)
     voting_mode = str(raw_config.get("voting_mode") or "single_winner")
     max_concurrent_calls = raw_config.get("max_concurrent_calls")
@@ -236,6 +236,13 @@ def _build_council_context() -> CouncilContext:
     return CouncilContext(config=council_config, judge_model=judge_model, member_model=default_model)
 
 
+def _resolve_default_model() -> str:
+    default_model = get_config("DEFAULT_LLM_MODEL")
+    if not default_model or str(default_model).strip() == "":
+        raise RuntimeError("DEFAULT_LLM_MODEL must be configured for council orchestration.")
+    return str(default_model)
+
+
 def _format_rag_docs(rag_docs: Sequence[str]) -> str:
     if not rag_docs:
         return "- (no retrieved documents; placeholder RAG list)"
@@ -270,8 +277,10 @@ def _ask_council_member(
     agent_state: Any | None = None,
 ) -> MemberAnswer:
     prompt = _build_member_prompt(member, question, extra_context=extra_context, rag_docs=rag_docs)
-    model_name = str((member.metadata or {}).get("model")) if member.metadata else None
-    member_model = model_name or "mistral:latest"
+    model_name = (member.metadata or {}).get("model") if member.metadata else None
+    member_model = str(model_name).strip() if model_name else ""
+    if not member_model:
+        member_model = _resolve_default_model()
     track_mock_usage = is_mock_mode_enabled()
     errors: list[str] = []
 

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -338,3 +338,39 @@ def test_council_orchestrator_requires_members(monkeypatch: pytest.MonkeyPatch) 
 
     with pytest.raises(ValidationError, match="at least one member"):
         CouncilConfig(enabled=True, members=[])
+
+
+def test_build_council_context_uses_config_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_get_config(key: str | None = None) -> str | None:
+        if key == "DEFAULT_LLM_MODEL":
+            return "configured-model"
+        return None
+
+    monkeypatch.setattr(council_orchestrator, "get_config", fake_get_config)
+    monkeypatch.setattr(
+        council_orchestrator,
+        "load_council_config",
+        lambda: {"members": [{"member_id": "member-1", "max_tokens": 128}]},
+    )
+
+    context = council_orchestrator._build_council_context()
+
+    assert context.member_model == "configured-model"
+    assert context.judge_model == "configured-model"
+    assert context.config.members[0].model == "configured-model"
+
+
+def test_build_council_context_requires_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(council_orchestrator, "get_config", lambda *_: None)
+    monkeypatch.setattr(
+        council_orchestrator,
+        "load_council_config",
+        lambda: {"members": [{"member_id": "member-1", "max_tokens": 128}]},
+    )
+
+    with pytest.raises(RuntimeError, match="DEFAULT_LLM_MODEL must be configured"):
+        council_orchestrator._build_council_context()


### PR DESCRIPTION
### Motivation

- Remove hard-coded LLM model fallbacks (e.g., `"mistral:latest"`) from council orchestration and enforce using configured defaults.
- Ensure council judge/member models are derived from `DEFAULT_LLM_MODEL` when available and fail fast with a clear error when it is not configured.

### Description

- Add helper ` _resolve_default_model()` which reads `DEFAULT_LLM_MODEL` via `get_config` and raises a `RuntimeError` when missing.
- Replace hard-coded fallbacks in `_build_council_context()` and `_ask_council_member()` to use the new resolver so members/judge use the configured default.
- Update member model resolution to prefer explicit `member.metadata['model']` and fall back to the configured default.
- Add unit tests in `tests/unit/agents/council/test_council_orchestrator.py` asserting config-derived default usage and required default-model error behavior.

### Testing

- Ran `ruff check .` which reported existing repository lint violations (not introduced by this change).
- Ran `ruff format --check .` which reported files that would be reformatted (existing repo formatting required).
- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py tests/unit/infra/test_council_config.py` and the updated tests passed (`13 passed`, `0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948207cd3b88326a75a4b59f586ad93)