### PR TITLE
Check and short-circuit on DU budget exhaustion during council member calls

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1019,6 +1019,29 @@ class CouncilOrchestrator:
             max(1, context.config.max_concurrent_calls or self.max_concurrent_calls)
         )
         failures: list[str] = []
+        answers: list[MemberAnswer] = []
+
+        def _has_available_budget(
+            member: CouncilMemberConfig, state: SimpleNamespace | None
+        ) -> bool:
+            try:
+                resource_manager = get_resource_manager()
+            except Exception:
+                resource_manager = None
+
+            if resource_manager is not None:
+                try:
+                    if resource_manager.get_du_budget(member.member_id) <= 0:
+                        return False
+                except Exception:
+                    pass
+
+            if state is not None:
+                remaining = getattr(state, "du", None)
+                if remaining is not None and remaining <= 0:
+                    return False
+
+            return True
 
         async def _call_member(member: CouncilMemberConfig) -> MemberAnswer | None:
             state = member_states.get(member.member_id)
@@ -1043,32 +1066,45 @@ class CouncilOrchestrator:
                     failures.append(member.member_id)
                 return None
 
-        results = await asyncio.gather(
-            *[_call_member(member) for member in context.config.members],
-            return_exceptions=True,
-        )
-
-        answers: list[MemberAnswer] = []
-        for member, result in zip(context.config.members, results):
-            if isinstance(result, Exception):
-                if "budget" in str(result).lower():
+        for member in context.config.members:
+            if metrics.get("du_budget_exhausted"):
+                break
+            state = member_states.get(member.member_id)
+            if not _has_available_budget(member, state):
+                metrics["du_budget_exhausted"] = True
+                logger.warning(
+                    "DU budget exhausted before scheduling member %s", member.member_id
+                )
+                break
+            try:
+                result = await _call_member(member)
+            except Exception as exc:
+                if "budget" in str(exc).lower():
                     metrics["du_budget_exhausted"] = True
                 else:
-                    logger.exception("Unexpected error during council call", exc_info=result)
+                    logger.exception("Unexpected error during council call", exc_info=exc)
                     failures.append(member.member_id)
-                continue
+                result = None
+
             if result is None:
                 failures.append(member.member_id)
+                if metrics.get("du_budget_exhausted"):
+                    break
                 continue
 
             answers.append(result)
+            if metrics.get("du_budget_exhausted"):
+                break
 
         if failures:
             metrics["partial"] = True
             metrics["failed_members"] = sorted(set(failures))
 
-        if metrics.get("du_budget_exhausted") and answers:
-            metrics.setdefault("completed_members", [answer.member_id for answer in answers])
+        if metrics.get("du_budget_exhausted"):
+            if answers:
+                metrics.setdefault(
+                    "completed_members", [answer.member_id for answer in answers]
+                )
             metrics.setdefault("partial", True)
         return answers
 

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -248,6 +248,25 @@ def test_council_orchestrator_marks_du_exhaustion(monkeypatch: pytest.MonkeyPatc
     llm_mocks.set_mock_llm_du_budget(None)
 
 
+def test_council_orchestrator_stops_calls_after_du_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator(max_concurrency=3)
+    config = _build_council_config(num_members=4, voting_mode="judge_llm")
+    question = _build_question()
+
+    llm_mocks.mock_generate_stats.reset()
+    llm_mocks.set_mock_llm_du_budget(2)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert outcome.metadata is not None
+    assert outcome.metadata.get("du_exhausted") is True
+    assert llm_mocks.mock_generate_stats.call_count == 3
+
+    llm_mocks.set_mock_llm_du_budget(None)
+
+
 def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPatch) -> None:
     orchestrator = CouncilOrchestrator()
     config = _build_council_config(voting_mode="judge_llm")


### PR DESCRIPTION
### Motivation
- Ensure the orchestrator does not schedule additional council member LLM calls when a member's DU budget is exhausted to avoid unnecessary cost and errors.
- Surface a clear partial outcome when budget exhaustion prevents full council participation.

### Description
- Added an internal helper `_has_available_budget` and pre-checks in `src/agents/council/orchestrator.py` to verify DU availability before scheduling each member call.
- Replaced the previous `asyncio.gather`-based fire-and-forget approach with a sequential scheduling loop that short-circuits when budget is exhausted and logs a warning.
- Normalize metric handling by setting `du_budget_exhausted`, `partial`, and `completed_members` consistently when budget limits are hit.
- Added `test_council_orchestrator_stops_calls_after_du_exhaustion` in `tests/unit/agents/council/test_council_orchestrator.py` to assert no extra calls are made after DU exhaustion using the existing `mock_generate_stats` counters.

### Testing
- Ran `python -m pytest tests/unit/agents/council/test_council_orchestrator.py`, and the suite passed (`13 passed`).
- Ran `ruff check .`, which reported pre-existing lint issues in unrelated files (RUF/E402 and other warnings) and did not block this change.
- Unit test `test_council_orchestrator_stops_calls_after_du_exhaustion` verifies that `mock_generate_stats.call_count` matches the expected number of calls after budget exhaustion.
- No new integration or end-to-end tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948252c96208326b33462e8de94d3e4)