### PR TITLE
Add PewDiePie-flavored council personas

### DIFF
--- a/config/council.yml
+++ b/config/council.yml
@@ -4,27 +4,36 @@ max_concurrent_calls: 3
 du_budget_per_question: 5.0
 voting_mode: judge_llm
 members:
-  - member_id: innovator
-    display_name: Innovator
+  - member_id: bro-host
+    display_name: Hype Bro
     role: Innovator
-    persona: Creates bold ideas and alternatives.
+    persona: Energetic PewDiePie-style host who hypes up ideas with playful gaming banter and upbeat encouragement.
+    system_prompt: >-
+      Channel a high-energy PewDiePie vibe—riff with playful "bro" humor, quick reactions, and hype-heavy positivity while still delivering grounded suggestions.
+      Keep answers concise but animated.
     model: mistral:latest
-    temperature: 0.4
+    temperature: 0.45
     max_tokens: 256
     is_active: true
-  - member_id: analyzer
-    display_name: Analyzer
-    role: Analyzer
-    persona: Evaluates risks and feasibility.
-    model: mistral:latest
-    temperature: 0.2
-    max_tokens: 256
-    is_active: true
-  - member_id: red-team
-    display_name: Red Team
+  - member_id: savage-critic
+    display_name: Savage Critic
     role: Red Team
-    persona: Challenges assumptions and stress tests decisions.
+    persona: Sarcastic PewDiePie-esque critic who roasts weak spots, drops witty side-eye, and keeps solutions honest without getting mean.
+    system_prompt: >-
+      Speak like a sarcastic PewDiePie-style commentator: roast flaws with sharp wit, toss in playful jabs, and push for stronger answers.
+      Stay concise and constructive even when you tease.
     model: mistral:latest
-    temperature: 0.3
+    temperature: 0.35
+    max_tokens: 256
+    is_active: true
+  - member_id: wholesome-bro
+    display_name: Wholesome Bro
+    role: Analyzer
+    persona: Warm, wholesome counterbalance who channels PewDiePie's softer side—supportive, empathetic, and focused on keeping things helpful.
+    system_prompt: >-
+      Respond like a gentle, upbeat PewDiePie-style friend: encourage the team, smooth over tension, and ground advice in care and clarity.
+      Keep it concise, kind, and reassuring.
+    model: mistral:latest
+    temperature: 0.25
     max_tokens: 256
     is_active: true

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -37,8 +37,8 @@ LLM_MAX_ATTEMPTS = 2
 JUDGE_SCORE_CATEGORIES = ("correctness", "clarity", "usefulness", "safety")
 
 DEFAULT_MEMBER_PROMPT = (
-    "You are participating in a council of AI personas. Provide a JSON object with keys: "
-    "answer (string), reasoning (string), confidence (0-1 float), citations (list of strings)."
+    "You are participating in a council of AI personas. Stay fully in character and keep your unique voice. "
+    "Provide a JSON object with keys: answer (string), reasoning (string), confidence (0-1 float), citations (list of strings)."
 )
 
 
@@ -209,7 +209,10 @@ def _build_council_context() -> CouncilContext:
         )
         system_prompt = str(
             entry.get("system_prompt")
-            or f"You are {display_name}, a {role}. Offer concise, grounded answers."
+            or (
+                f"You are {display_name} ({role}). Embrace this persona: {persona}. "
+                "Stay in-character while keeping answers concise and grounded."
+            )
         )
         metadata = dict(entry.get("metadata") or {})
         model_name = str(entry.get("model") or metadata.get("model") or default_model)

--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -112,8 +112,10 @@ class CouncilMemberConfig(BaseModel):
 
         if not normalized.get("system_prompt"):
             role = normalized.get("role") or "Generalist"
+            persona_summary = normalized.get("persona") or normalized.get("description")
             normalized["system_prompt"] = (
-                f"You are {normalized['display_name']}, a {role}. Offer concise, grounded answers."
+                f"You are {normalized['display_name']} ({role}). Embrace this persona: {persona_summary}. "
+                "Stay in-character while keeping answers concise and grounded."
             )
 
         return normalized


### PR DESCRIPTION
## Summary
- add PewDiePie-inspired council member personas to the sample configuration with explicit prompts
- update council prompt scaffolding so persona voice is preserved when defaults are used
- strengthen default system prompt generation to keep members in-character

## Testing
- python -m ruff check src tests *(fails: existing lints unrelated to this change)*
- python -m pytest tests/unit/agents/council/test_council_orchestrator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953df820278832696f409664cf549c1)