### PR TITLE
Add council CLI metrics and vote display options

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+
 import typer
 
 from src.agents.council.orchestrator import run_council
@@ -32,6 +34,16 @@ def main(
         False,
         "--show-all",
         help="Print answers from all members instead of only winners",
+    ),
+    show_votes: bool = typer.Option(
+        False,
+        "--show-votes",
+        help="Display per-member votes and judge score summaries",
+    ),
+    show_metrics: bool = typer.Option(
+        False,
+        "--show-metrics",
+        help="Display fitness or collusion metrics from the council outcome",
     ),
     question_id: str = typer.Option(
         "cli-question",
@@ -92,6 +104,26 @@ def main(
             typer.echo("Answers:")
             for answer in answers:
                 typer.echo(f"- {answer.member_id}: {answer.answer}")
+
+    if show_votes:
+        if outcome.votes:
+            typer.echo("Judge Scores:")
+            for member_id, score in outcome.votes.items():
+                typer.echo(f"- {member_id}: {score}")
+
+        votes_to_display = [
+            (answer.member_id, answer.votes) for answer in outcome.answers if answer.votes
+        ]
+        if votes_to_display:
+            typer.echo("Votes:")
+            for member_id, votes in votes_to_display:
+                typer.echo(f"- {member_id}:")
+                for target_member, score in votes.items():
+                    typer.echo(f"  - {target_member}: {score}")
+
+    if show_metrics and outcome.metrics:
+        typer.echo("Metrics:")
+        typer.echo(json.dumps(outcome.metrics, indent=2))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual tool

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -130,3 +130,77 @@ def test_council_cli_show_all_answers(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result.exit_code == 0
     assert "- alpha: Alpha answer" in result.output
     assert "- bravo: Bravo answer" in result.output
+
+
+def test_council_cli_show_votes(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+    ) -> CouncilOutcome:
+        return CouncilOutcome(
+            question=question,
+            answers=[
+                MemberAnswer(member_id="alpha", answer="Alpha answer", votes={"bravo": 0.6}),
+                MemberAnswer(member_id="bravo", answer="Bravo answer", votes={"alpha": 0.4}),
+            ],
+            resolution="Mock resolution",
+            winning_member_ids=["alpha"],
+            votes={"alpha": 0.55, "bravo": 0.45},
+            summary=None,
+            metrics={"fitness": {"score": 0.95}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(council_cli.app, ["Prompt", "--show-votes", "--show-all"])
+
+    assert result.exit_code == 0
+    assert "Judge Scores:" in result.output
+    assert "- alpha: 0.55" in result.output
+    assert "- bravo: 0.45" in result.output
+    assert "Votes:" in result.output
+    assert "- alpha:" in result.output
+    assert "  - bravo: 0.6" in result.output
+    assert "- bravo:" in result.output
+    assert "  - alpha: 0.4" in result.output
+
+    result_default = runner.invoke(council_cli.app, ["Prompt"])
+
+    assert "Judge Scores:" not in result_default.output
+    assert "Votes:" not in result_default.output
+
+
+def test_council_cli_show_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+    ) -> CouncilOutcome:
+        return CouncilOutcome(
+            question=question,
+            answers=[MemberAnswer(member_id="alpha", answer="Alpha answer")],
+            resolution="Mock resolution",
+            winning_member_ids=["alpha"],
+            summary=None,
+            metrics={"fitness": {"score": 0.87}, "collusion": {"flagged": False}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(council_cli.app, ["Prompt", "--show-metrics"])
+
+    assert result.exit_code == 0
+    assert "Metrics:" in result.output
+    assert '"fitness"' in result.output
+    assert '"collusion"' in result.output
+
+    result_default = runner.invoke(council_cli.app, ["Prompt"])
+
+    assert "Metrics:" not in result_default.output


### PR DESCRIPTION
## Summary
- add CLI flags to display council vote details and metrics
- render judge scores, per-member votes, and metrics in council CLI output when requested
- expand council CLI unit tests to cover the new flags

## Testing
- ruff check scripts/council_cli.py tests/unit/scripts/test_council_cli.py
- pytest tests/unit/scripts/test_council_cli.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ea60b3d8832681edbd368e1a8b26)