### PR TITLE
Allow council CLI bypass env guard

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -45,6 +45,14 @@ def main(
         "--show-metrics",
         help="Display fitness or collusion metrics from the council outcome",
     ),
+    bypass_env_guard: bool = typer.Option(
+        True,
+        "--bypass-env-guard/--enforce-env-guard",
+        help=(
+            "Allow the council to run even when USE_COUNCIL_MODE is false. Disable to "
+            "respect the environment guard."
+        ),
+    ),
     question_id: str = typer.Option(
         "cli-question",
         "--question-id",
@@ -73,7 +81,12 @@ def main(
         rag_documents=rag_docs,
     )
 
-    outcome = run_council(question, extra_context=context, rag_docs=rag_docs)
+    outcome = run_council(
+        question,
+        extra_context=context,
+        rag_docs=rag_docs,
+        allow_disabled_mode=bypass_env_guard,
+    )
 
     typer.echo(f"Question: {outcome.question.prompt}")
     if outcome.question.context:

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -970,12 +970,19 @@ class CouncilOrchestrator:
         *,
         extra_context: str | None = None,
         rag_docs: Sequence[str] | None = None,
+        allow_disabled_mode: bool = False,
     ) -> CouncilOutcome:
         """Synchronously deliberate by awaiting the async implementation."""
 
         context = self._resolve_context(config)
         return asyncio.run(
-            self.adeliberate(context, question, extra_context=extra_context, rag_docs=rag_docs)
+            self.adeliberate(
+                context,
+                question,
+                extra_context=extra_context,
+                rag_docs=rag_docs,
+                allow_disabled_mode=allow_disabled_mode,
+            )
         )
 
     async def adeliberate(
@@ -985,11 +992,16 @@ class CouncilOrchestrator:
         *,
         extra_context: str | None = None,
         rag_docs: Sequence[str] | None = None,
+        allow_disabled_mode: bool = False,
     ) -> CouncilOutcome:
-        if not bool(get_config("USE_COUNCIL_MODE")) or not context.config.enabled:
+        council_enabled = bool(get_config("USE_COUNCIL_MODE"))
+        if not allow_disabled_mode and not council_enabled:
             raise RuntimeError(
                 "Council mode is disabled; set USE_COUNCIL_MODE=true to enable it."
             )
+
+        if not context.config.enabled:
+            raise RuntimeError("Council mode is disabled in the council configuration.")
 
         if not context.config.members:
             raise ValueError("Council configuration must include at least one member")
@@ -1395,6 +1407,7 @@ def run_council(
     *,
     extra_context: str | None = None,
     rag_docs: Sequence[str] | None = None,
+    allow_disabled_mode: bool = False,
 ) -> CouncilOutcome:
     """Gather answers from council members and select a winner using a judge model."""
 
@@ -1404,4 +1417,5 @@ def run_council(
         question,
         extra_context=extra_context,
         rag_docs=rag_docs,
+        allow_disabled_mode=allow_disabled_mode,
     )

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -160,6 +160,25 @@ def _build_question(metadata: Mapping[str, Any] | None = None) -> CouncilQuestio
     )
 
 
+def test_council_orchestrator_can_bypass_env_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator()
+    council_config = _build_council_config(voting_mode="judge_llm")
+    question = _build_question()
+
+    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": False})
+
+    with pytest.raises(RuntimeError):
+        orchestrator.deliberate(council_config, question)
+
+    outcome = orchestrator.deliberate(
+        council_config, question, allow_disabled_mode=True
+    )
+
+    assert outcome.winning_member_ids
+
+
 class DummyRetriever:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, int, int | None]] = []


### PR DESCRIPTION
## Summary
- add an allow_disabled_mode flag to council orchestration to optionally bypass the USE_COUNCIL_MODE guard
- update the council CLI to bypass the guard by default while allowing users to enforce it via flags
- cover the new bypass behavior in council orchestrator unit tests

## Testing
- python -m ruff check scripts/council_cli.py src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py
- python -m pytest tests/unit/agents/council/test_council_orchestrator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953edf8720c83268af294305e98d4f6)