### PR TITLE
Add council metrics utility script and unit test

### DIFF
--- a/scripts/council_metrics.py
+++ b/scripts/council_metrics.py
@@ -1,0 +1,81 @@
+"""Utility script for inspecting council metrics from the stats store."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.agents.council.orchestrator import CouncilOrchestrator
+
+
+def _format_percentage(value: float) -> str:
+    return f"{value * 100:.2f}%"
+
+
+def _iter_member_lines(metrics: dict[str, list[dict[str, float]]]) -> Iterable[str]:
+    for member in metrics.get("members", []):
+        member_id = member.get("member_id", "unknown")
+        win_rate = _format_percentage(float(member.get("win_rate", 0.0)))
+        wins = int(member.get("wins", 0))
+        participations = int(member.get("participations", 0))
+        avg_confidence = float(member.get("avg_confidence", 0.0))
+        yield (
+            f"- {member_id}: {win_rate} win rate "
+            f"({wins}/{participations} wins, avg confidence {avg_confidence:.2f})"
+        )
+
+
+def _iter_pairwise_lines(metrics: dict[str, list[dict[str, float]]]) -> Iterable[str]:
+    for pair in metrics.get("pairwise", []):
+        member_a = pair.get("member_a", "unknown")
+        member_b = pair.get("member_b", "unknown")
+        agreement_rate = _format_percentage(float(pair.get("agreement_rate", 0.0)))
+        agreements = int(pair.get("agreements", 0))
+        disagreements = int(pair.get("disagreements", 0))
+        yield (
+            f"- {member_a} vs {member_b}: {agreement_rate} agreement "
+            f"({agreements} agreements / {disagreements} disagreements)"
+        )
+
+
+def _collect_warnings(metrics: dict[str, list[dict[str, float]]]) -> list[str]:
+    warnings: list[str] = []
+
+    members = metrics.get("members", [])
+    pairwise = metrics.get("pairwise", [])
+
+    if not members:
+        warnings.append("No member statistics available.")
+    else:
+        for member in members:
+            if int(member.get("participations", 0)) <= 0:
+                member_id = member.get("member_id", "unknown")
+                warnings.append(f"Member {member_id} has no recorded participations.")
+
+    if not pairwise:
+        warnings.append("No pairwise agreement metrics available.")
+
+    return warnings
+
+
+def main() -> None:
+    orchestrator = CouncilOrchestrator()
+    metrics = orchestrator.serialize_metrics()
+
+    print("Member Win Rates:")
+    for line in _iter_member_lines(metrics):
+        print(line)
+
+    print("\nPairwise Agreement Rates:")
+    for line in _iter_pairwise_lines(metrics):
+        print(line)
+
+    warnings = _collect_warnings(metrics)
+    print("\nWarnings:")
+    if warnings:
+        for warning in warnings:
+            print(f"- {warning}")
+    else:
+        print("- None")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_council_metrics.py
+++ b/tests/unit/scripts/test_council_metrics.py
@@ -1,0 +1,54 @@
+import pytest
+
+from scripts import council_metrics
+
+pytestmark = pytest.mark.unit
+
+
+def test_council_metrics_reports_stats(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_metrics = {
+        "members": [
+            {
+                "member_id": "alpha",
+                "participations": 5,
+                "wins": 3,
+                "win_rate": 0.6,
+                "avg_confidence": 0.8,
+            },
+            {
+                "member_id": "bravo",
+                "participations": 0,
+                "wins": 0,
+                "win_rate": 0.0,
+                "avg_confidence": 0.0,
+            },
+        ],
+        "pairwise": [
+            {
+                "member_a": "alpha",
+                "member_b": "bravo",
+                "agreements": 2,
+                "disagreements": 1,
+                "agreement_rate": 2 / 3,
+            }
+        ],
+    }
+
+    class FakeOrchestrator:
+        def serialize_metrics(self) -> dict[str, list[dict[str, float]]]:
+            return mock_metrics
+
+    monkeypatch.setattr(council_metrics, "CouncilOrchestrator", FakeOrchestrator)
+
+    council_metrics.main()
+
+    output = capsys.readouterr().out
+    assert "Member Win Rates:" in output
+    assert "- alpha: 60.00% win rate (3/5 wins, avg confidence 0.80)" in output
+    assert "- bravo: 0.00% win rate (0/0 wins, avg confidence 0.00)" in output
+
+    assert "Pairwise Agreement Rates:" in output
+    assert "- alpha vs bravo: 66.67% agreement (2 agreements / 1 disagreements)" in output
+
+    assert "Warnings:" in output
+    assert "Member bravo has no recorded participations." in output


### PR DESCRIPTION
## Summary
- add a council_metrics script that surfaces council member win rates, pairwise agreement rates, and warnings
- include helpers for formatting percentages and collecting missing-data warnings
- add a unit test that mocks the orchestrator to validate the script output

## Testing
- ruff check scripts/council_metrics.py tests/unit/scripts/test_council_metrics.py
- pytest tests/unit/scripts/test_council_metrics.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953edf7e1d0832688a0e2e0c7af2f98)