### PR TITLE
Enhance council metrics reporting

### DIFF
--- a/scripts/council_metrics.py
+++ b/scripts/council_metrics.py
@@ -1,7 +1,9 @@
 """Utility script for inspecting council metrics from the stats store."""
 from __future__ import annotations
 
-from collections.abc import Iterable
+import argparse
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 from src.agents.council.orchestrator import CouncilOrchestrator
 
@@ -10,7 +12,7 @@ def _format_percentage(value: float) -> str:
     return f"{value * 100:.2f}%"
 
 
-def _iter_member_lines(metrics: dict[str, list[dict[str, float]]]) -> Iterable[str]:
+def _iter_member_lines(metrics: Mapping[str, Any]) -> Iterable[str]:
     for member in metrics.get("members", []):
         member_id = member.get("member_id", "unknown")
         win_rate = _format_percentage(float(member.get("win_rate", 0.0)))
@@ -23,21 +25,47 @@ def _iter_member_lines(metrics: dict[str, list[dict[str, float]]]) -> Iterable[s
         )
 
 
-def _iter_pairwise_lines(metrics: dict[str, list[dict[str, float]]]) -> Iterable[str]:
+def _iter_pairwise_lines(metrics: Mapping[str, Any], *, show_flags: bool) -> Iterable[str]:
     for pair in metrics.get("pairwise", []):
         member_a = pair.get("member_a", "unknown")
         member_b = pair.get("member_b", "unknown")
         agreement_rate = _format_percentage(float(pair.get("agreement_rate", 0.0)))
         agreements = int(pair.get("agreements", 0))
         disagreements = int(pair.get("disagreements", 0))
-        yield (
-            f"- {member_a} vs {member_b}: {agreement_rate} agreement "
+
+        flagged = bool(
+            pair.get("flagged")
+            or pair.get("flagged_for_collusion")
+            or pair.get("pairwise_flag")
+            or pair.get("collusion_warning")
+            or pair.get("warning")
+        )
+        label = " [FLAGGED]" if show_flags and flagged else ""
+        base_line = (
+            f"- {member_a} vs {member_b}: {agreement_rate} agreement{label} "
             f"({agreements} agreements / {disagreements} disagreements)"
         )
 
+        if show_flags:
+            note = pair.get("collusion_warning") or pair.get("warning")
+            if note:
+                yield f"{base_line} - {note}"
+                continue
+        yield base_line
 
-def _collect_warnings(metrics: dict[str, list[dict[str, float]]]) -> list[str]:
+
+def _collect_warnings(
+    metrics: Mapping[str, Any], *, include_pairwise_flags: bool
+) -> list[str]:
     warnings: list[str] = []
+
+    raw_warnings = metrics.get("warnings", [])
+    if isinstance(raw_warnings, Iterable):
+        warnings.extend(str(warning) for warning in raw_warnings)
+
+    collusion_warnings = metrics.get("collusion_warnings", [])
+    if isinstance(collusion_warnings, Iterable):
+        warnings.extend(str(warning) for warning in collusion_warnings)
 
     members = metrics.get("members", [])
     pairwise = metrics.get("pairwise", [])
@@ -53,28 +81,104 @@ def _collect_warnings(metrics: dict[str, list[dict[str, float]]]) -> list[str]:
     if not pairwise:
         warnings.append("No pairwise agreement metrics available.")
 
+    if include_pairwise_flags:
+        for pair in pairwise:
+            flagged = bool(
+                pair.get("flagged")
+                or pair.get("flagged_for_collusion")
+                or pair.get("pairwise_flag")
+            )
+            if not flagged:
+                continue
+            member_a = pair.get("member_a", "unknown")
+            member_b = pair.get("member_b", "unknown")
+            reason = pair.get("collusion_warning") or pair.get("warning")
+            if reason:
+                warnings.append(str(reason))
+            else:
+                warnings.append(
+                    f"Pair {member_a} vs {member_b} flagged for follow-up."
+                )
+
     return warnings
 
 
-def main() -> None:
-    orchestrator = CouncilOrchestrator()
-    metrics = orchestrator.serialize_metrics()
-
-    print("Member Win Rates:")
-    for line in _iter_member_lines(metrics):
+def _print_section(title: str, lines: Iterable[str]) -> None:
+    print(title)
+    printed = False
+    for line in lines:
         print(line)
+        printed = True
+    if not printed:
+        print("- None")
 
+
+def _render_metrics_block(metrics: Mapping[str, Any], *, show_flags: bool) -> None:
+    _print_section("Member Win Rates:", _iter_member_lines(metrics))
     print("\nPairwise Agreement Rates:")
-    for line in _iter_pairwise_lines(metrics):
+    for line in _iter_pairwise_lines(metrics, show_flags=show_flags):
         print(line)
 
-    warnings = _collect_warnings(metrics)
+    warnings = _collect_warnings(metrics, include_pairwise_flags=show_flags)
     print("\nWarnings:")
     if warnings:
         for warning in warnings:
             print(f"- {warning}")
     else:
         print("- None")
+
+
+def _iter_questions(
+    metrics: Mapping[str, Any], question_filter: str | None
+) -> Iterable[Mapping[str, Any]]:
+    questions = metrics.get("questions", [])
+    if not isinstance(questions, Iterable):
+        return []
+
+    if question_filter:
+        return [
+            question
+            for question in questions
+            if isinstance(question, Mapping)
+            and question.get("question_id") == question_filter
+        ]
+
+    return [question for question in questions if isinstance(question, Mapping)]
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect council metrics and agreements")
+    parser.add_argument(
+        "--question-id",
+        help="Filter metrics to a specific question identifier when available.",
+    )
+    parser.add_argument(
+        "--show-collusion-flags",
+        action="store_true",
+        help="Surface collusion warnings and flagged pairwise agreements.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    orchestrator = CouncilOrchestrator()
+    metrics = orchestrator.serialize_metrics(question_id=args.question_id)
+
+    print("Council Metrics")
+    print("================")
+    _render_metrics_block(metrics, show_flags=args.show_collusion_flags)
+
+    for question_metrics in _iter_questions(metrics, args.question_id):
+        question_id = question_metrics.get("question_id", "unknown-question")
+        prompt = question_metrics.get("prompt")
+
+        print("\n---")
+        print(f"Question: {question_id}")
+        if prompt:
+            print(f"Prompt: {prompt}")
+        _render_metrics_block(question_metrics, show_flags=args.show_collusion_flags)
 
 
 if __name__ == "__main__":

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1481,13 +1481,15 @@ class CouncilOrchestrator:
                 exc_info=True,
             )
 
-    def serialize_metrics(self) -> dict[str, list[dict[str, float]]]:
+    def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
         """Return a snapshot of aggregated council metrics."""
 
-        return council_stats_store.serialize_metrics()
+        return council_stats_store.serialize_metrics(question_id=question_id)
 
-    async def serialize_metrics_async(self) -> dict[str, list[dict[str, float]]]:
-        return await council_stats_store.serialize_metrics_async()
+    async def serialize_metrics_async(
+        self, *, question_id: str | None = None
+    ) -> dict[str, list[dict[str, float]]]:
+        return await council_stats_store.serialize_metrics_async(question_id=question_id)
 
 
 def run_council(

--- a/src/agents/council/stats_store.py
+++ b/src/agents/council/stats_store.py
@@ -174,7 +174,7 @@ class CouncilStatsStore:
             "agreement_rate": agreement_rate,
         }
 
-    def serialize_metrics(self) -> dict[str, list[dict[str, float]]]:
+    def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
         with self._lock:
             member_rows = self.conn.execute(
                 "SELECT member_id, participations, wins, total_confidence FROM council_member_stats"
@@ -213,10 +213,12 @@ class CouncilStatsStore:
                 }
             )
 
+        # ``question_id`` is accepted for forward compatibility with question-scoped
+        # metrics but currently returns global aggregates only.
         return {"members": members, "pairwise": pairwise}
 
-    async def serialize_metrics_async(self) -> dict[str, list[dict[str, float]]]:
-        return await asyncio.to_thread(self.serialize_metrics)
+    async def serialize_metrics_async(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+        return await asyncio.to_thread(self.serialize_metrics, question_id=question_id)
 
     def record_batch(self, outcomes: Iterable[CouncilOutcome]) -> None:
         """Convenience helper to persist multiple outcomes."""

--- a/tests/unit/scripts/test_council_metrics.py
+++ b/tests/unit/scripts/test_council_metrics.py
@@ -30,25 +30,94 @@ def test_council_metrics_reports_stats(monkeypatch: pytest.MonkeyPatch, capsys: 
                 "agreements": 2,
                 "disagreements": 1,
                 "agreement_rate": 2 / 3,
+                "collusion_warning": "alpha vs bravo agreeing too often",
             }
         ],
+        "collusion_warnings": ["Global collusion alert"],
     }
 
     class FakeOrchestrator:
-        def serialize_metrics(self) -> dict[str, list[dict[str, float]]]:
+        def __init__(self) -> None:
+            self.received_question = None
+
+        def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+            self.received_question = question_id
             return mock_metrics
 
-    monkeypatch.setattr(council_metrics, "CouncilOrchestrator", FakeOrchestrator)
+    orchestrator = FakeOrchestrator()
+    monkeypatch.setattr(council_metrics, "CouncilOrchestrator", lambda: orchestrator)
 
-    council_metrics.main()
+    council_metrics.main(["--show-collusion-flags"])
 
     output = capsys.readouterr().out
-    assert "Member Win Rates:" in output
+    assert orchestrator.received_question is None
+    assert "Council Metrics" in output
     assert "- alpha: 60.00% win rate (3/5 wins, avg confidence 0.80)" in output
     assert "- bravo: 0.00% win rate (0/0 wins, avg confidence 0.00)" in output
 
     assert "Pairwise Agreement Rates:" in output
-    assert "- alpha vs bravo: 66.67% agreement (2 agreements / 1 disagreements)" in output
+    assert "- alpha vs bravo: 66.67% agreement [FLAGGED] (2 agreements / 1 disagreements) - alpha vs bravo agreeing too often" in output
 
     assert "Warnings:" in output
     assert "Member bravo has no recorded participations." in output
+    assert "Global collusion alert" in output
+
+
+def test_council_metrics_filters_questions(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    mock_metrics = {
+        "members": [],
+        "pairwise": [],
+        "questions": [
+            {
+                "question_id": "target-question",
+                "prompt": "What now?",
+                "members": [
+                    {
+                        "member_id": "alpha",
+                        "participations": 2,
+                        "wins": 2,
+                        "win_rate": 1.0,
+                        "avg_confidence": 0.9,
+                    }
+                ],
+                "pairwise": [
+                    {
+                        "member_a": "alpha",
+                        "member_b": "bravo",
+                        "agreements": 3,
+                        "disagreements": 0,
+                        "agreement_rate": 1.0,
+                        "flagged": True,
+                        "collusion_warning": "Potential collusion detected",
+                    }
+                ],
+                "warnings": ["Custom question warning"],
+            },
+            {
+                "question_id": "other-question",
+                "members": [],
+                "pairwise": [],
+            },
+        ],
+    }
+
+    class FakeOrchestrator:
+        def __init__(self) -> None:
+            self.received_question: str | None = None
+
+        def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+            self.received_question = question_id
+            return mock_metrics
+
+    orchestrator = FakeOrchestrator()
+    monkeypatch.setattr(council_metrics, "CouncilOrchestrator", lambda: orchestrator)
+
+    council_metrics.main(["--question-id", "target-question", "--show-collusion-flags"])
+
+    output = capsys.readouterr().out
+    assert orchestrator.received_question == "target-question"
+    assert "Question: target-question" in output
+    assert "Prompt: What now?" in output
+    assert "Custom question warning" in output
+    assert "Potential collusion detected" in output
+    assert "other-question" not in output


### PR DESCRIPTION
## Summary
- add argparse-based council metrics CLI options for question filtering and collusion flag visibility
- forward question_id filters through council metric serialization methods
- expand council metrics tests to cover flagged pairwise agreements and question-scoped sections

## Testing
- python -m pytest tests/unit/scripts/test_council_metrics.py tests/unit/agents/council/test_stats_store.py
- ruff check scripts/council_metrics.py src/agents/council/stats_store.py src/agents/council/orchestrator.py tests/unit/scripts/test_council_metrics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2b6bc1f883269f1ccbcfecff868c)