### PR TITLE
Add council performance targets and mock benchmark test

### DIFF
--- a/docs/council_mode_design.md
+++ b/docs/council_mode_design.md
@@ -12,6 +12,11 @@ Implement local council mode (multiple AI agents + judge) on a single GPU.
 - **Improve memory grounding:** Increase the proportion of council outputs backed by retrieved memories through nodes like [`src/agents/graphs/retriever_node.py`](../src/agents/graphs/retriever_node.py) and [`src/agents/memory/multi_layer_retriever.py`](../src/agents/memory/multi_layer_retriever.py).
 - **Enable measurable progress:** Track council deliberation quality via Prometheus gauges in [`src/interfaces/metrics.py`](../src/interfaces/metrics.py) to support automated regression alerts.
 
+### Single-GPU performance & DU targets
+- **Latency (A100-class, 3 members, 1 round):** p95 end-to-end council latency ≤ **1.5s** with member fan-out ≤ **0.75s**.
+- **Throughput:** Sustain **≥25 questions/minute** on a single GPU with the default 3-member roster (judge + members).
+- **DU ceilings:** Cap per-member DU at **2.0** (≤**6 DU** aggregate for the default roster) and reserve **≤1 DU** for the judge step; runs that would exceed these ceilings should short-circuit with partial outcomes.
+
 ## Component Overview (Spec Alignment)
 Council Mode is composed of the following spec-aligned components and responsibilities:
 

--- a/tests/performance/test_council_mock_performance.py
+++ b/tests/performance/test_council_mock_performance.py
@@ -1,0 +1,84 @@
+import time
+from unittest.mock import patch
+
+import pytest
+
+from src.agents.council import orchestrator as council_orchestrator
+from src.agents.council.orchestrator import CouncilVoteModel, MemberAnswer
+from src.agents.council.types import CouncilConfig, CouncilMemberConfig, CouncilQuestion
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize("member_count", [3])
+def test_council_run_meets_latency_and_budget(member_count: int) -> None:
+    members = [
+        CouncilMemberConfig(
+            member_id=f"member-{idx}",
+            display_name=f"Member {idx}",
+            persona="Moves quickly and keeps answers minimal.",
+            model="mock-model",
+            temperature=0.1,
+            max_tokens=64,
+            role="Generalist",
+            is_active=True,
+        )
+        for idx in range(member_count)
+    ]
+    config = CouncilConfig(
+        members=members,
+        max_concurrent_calls=member_count,
+        du_budget_per_question=2.0,
+    )
+    question = CouncilQuestion(question_id="perf-smoke", prompt="How fast is the mock council?")
+
+    def _fake_member_call(*_: object, **__: object) -> MemberAnswer:
+        return MemberAnswer(
+            member_id=members[0].member_id,
+            answer="mock-answer",
+            reasoning="short",
+            confidence=0.9,
+            citations=[],
+            metadata={"du_consumed": 0.05},
+        )
+
+    def _fake_judge(
+        *_: object, answers: list[MemberAnswer] | None = None, **__: object
+    ) -> CouncilVoteModel:
+        winner_id = (answers or members)[0].member_id
+        return CouncilVoteModel(
+            winning_member_id=winner_id,
+            votes={winner_id: 1.0},
+            scores={winner_id: {"overall": 1.0}},
+            metrics={"member_scores": {winner_id: {"correctness": 1.0}}},
+            summary="mock-win",
+            reasoning="",
+            resolution="mock resolution",
+        )
+
+    orchestrator = council_orchestrator.CouncilOrchestrator(
+        max_concurrent_calls=member_count, du_budget_per_question=2.0
+    )
+
+    with (
+        patch.object(council_orchestrator, "_ask_council_member", side_effect=_fake_member_call),
+        patch.object(
+            council_orchestrator, "_judge_council_answers", side_effect=_fake_judge
+        ),
+    ):
+        start = time.perf_counter()
+        outcome = orchestrator.deliberate(
+            config,
+            question,
+            extra_context="throughput check",
+            allow_disabled_mode=True,
+        )
+        duration = time.perf_counter() - start
+
+    assert duration < 1.5
+    throughput_per_minute = 60.0 / duration
+    assert throughput_per_minute >= 25
+
+    metrics = outcome.metadata.get("metrics", {}) if outcome.metadata else {}
+    assert metrics.get("du_budget_per_member") <= 2.0
+    assert not metrics.get("du_budget_exhausted")
+    assert outcome.winner_id in {member.member_id for member in members}


### PR DESCRIPTION
## Summary
- document single-GPU council latency/throughput targets and DU ceilings
- add a mocked performance smoke test that exercises run_council against those limits

## Testing
- PYTEST_ADDOPTS="" pytest -m "performance" tests/performance/test_council_mock_performance.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2ee602748326b56c946dae8c9a0e)