### PR TITLE
Refactor _gather_member_answers to use asyncio tasks with semaphore and preserve ordering

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1309,9 +1309,10 @@ class CouncilOrchestrator:
         rag_docs: Sequence[str],
         metrics: dict[str, Any],
     ) -> list[MemberAnswer]:
-        semaphore = asyncio.Semaphore(
-            max(1, context.config.max_concurrent_calls or self.max_concurrent_calls)
+        max_concurrent = max(
+            1, context.config.max_concurrent_calls or self.max_concurrent_calls
         )
+        semaphore = asyncio.Semaphore(max_concurrent)
         failures: list[str] = []
         answers: list[MemberAnswer] = []
 
@@ -1337,11 +1338,13 @@ class CouncilOrchestrator:
 
             return True
 
-        async def _call_member(member: CouncilMemberConfig) -> MemberAnswer | None:
+        async def _call_member(
+            member: CouncilMemberConfig,
+        ) -> tuple[str, MemberAnswer | None]:
             state = member_states.get(member.member_id)
             try:
                 async with semaphore:
-                    return await asyncio.to_thread(
+                    result = await asyncio.to_thread(
                         _ask_council_member,
                         member,
                         question,
@@ -1349,6 +1352,7 @@ class CouncilOrchestrator:
                         rag_docs=rag_docs,
                         agent_state=state,
                     )
+                    return member.member_id, result
             except RuntimeError as exc:
                 if "budget" in str(exc).lower():
                     metrics["du_budget_exhausted"] = True
@@ -1357,8 +1361,28 @@ class CouncilOrchestrator:
                     )
                 else:
                     logger.exception("Council member call failed: %s", exc)
-                    failures.append(member.member_id)
-                return None
+                return member.member_id, None
+            except Exception as exc:
+                if "budget" in str(exc).lower():
+                    metrics["du_budget_exhausted"] = True
+                else:
+                    logger.exception("Unexpected error during council call", exc_info=exc)
+                return member.member_id, None
+
+        async def _drain_tasks(
+            tasks: list[asyncio.Task[tuple[str, MemberAnswer | None]]],
+        ) -> None:
+            if not tasks:
+                return
+            results = await asyncio.gather(*tasks)
+            tasks.clear()
+            for member_id, result in results:
+                if result is None:
+                    failures.append(member_id)
+                else:
+                    answers.append(result)
+
+        tasks: list[asyncio.Task[tuple[str, MemberAnswer | None]]] = []
 
         for member in context.config.members:
             if metrics.get("du_budget_exhausted"):
@@ -1370,25 +1394,14 @@ class CouncilOrchestrator:
                     "DU budget exhausted before scheduling member %s", member.member_id
                 )
                 break
-            try:
-                result = await _call_member(member)
-            except Exception as exc:
-                if "budget" in str(exc).lower():
-                    metrics["du_budget_exhausted"] = True
-                else:
-                    logger.exception("Unexpected error during council call", exc_info=exc)
-                    failures.append(member.member_id)
-                result = None
-
-            if result is None:
-                failures.append(member.member_id)
+            tasks.append(asyncio.create_task(_call_member(member)))
+            if len(tasks) >= max_concurrent:
+                await _drain_tasks(tasks)
                 if metrics.get("du_budget_exhausted"):
                     break
-                continue
 
-            answers.append(result)
-            if metrics.get("du_budget_exhausted"):
-                break
+        if tasks:
+            await _drain_tasks(tasks)
 
         if failures:
             metrics["partial"] = True

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -13,6 +15,7 @@ from src.agents.council import (
     CouncilMemberConfig,
     CouncilOrchestrator,
     CouncilQuestion,
+    MemberAnswer,
 )
 from src.agents.council.fitness_store import council_fitness_store
 from src.agents.council.stats_store import CouncilStatsStore
@@ -242,6 +245,30 @@ def test_council_orchestrator_limits_concurrent_generate_calls(
     assert outcome.winning_member_ids
     assert llm_mocks.mock_generate_stats.peak_concurrent_calls <= orchestrator.max_concurrency
     assert llm_mocks.mock_generate_stats.call_count == len(config.members) + 1
+
+
+def test_council_orchestrator_runs_member_calls_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator(max_concurrency=3)
+    config = _build_council_config(num_members=3, voting_mode="judge_llm")
+    question = _build_question()
+
+    barrier = threading.Barrier(len(config.members))
+    delays = {"facilitator": 0.15, "innovator": 0.05, "analyst": 0.1}
+
+    def _slow_member(member: CouncilMemberConfig, *args: object, **kwargs: object) -> MemberAnswer:
+        barrier.wait(timeout=1.0)
+        time.sleep(delays[member.member_id])
+        return MemberAnswer(member_id=member.member_id, answer=f"Answer {member.member_id}")
+
+    monkeypatch.setattr(council_orchestrator, "_ask_council_member", _slow_member)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert [answer.member_id for answer in outcome.answers] == [
+        member.member_id for member in config.members
+    ]
 
 
 def test_council_orchestrator_marks_du_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Improve concurrency of council member calls by scheduling them as asyncio tasks while enforcing the configured concurrency limit via a semaphore.
- Preserve deterministic ordering of returned `answers` even when member calls run concurrently.
- Ensure DU exhaustion short-circuits scheduling but still returns partial results with `metrics["du_budget_exhausted"] = True` and recorded `completed_members` when applicable.
- Add unit coverage to validate the new concurrency scheduling behavior.

### Description
- Compute `max_concurrent` and create an `asyncio.Semaphore` and refactor `_call_member` to return a `(member_id, MemberAnswer|None)` tuple for tracked results.
- Schedule member calls with `asyncio.create_task` and batch `await` them via `asyncio.gather` in a `_drain_tasks` helper so results are processed in the original scheduling order, preserving deterministic ordering.
- Retain DU-budget checks before scheduling and set `metrics["du_budget_exhausted"]` on runtime budget errors to short-circuit further scheduling while still returning any completed answers.
- Add `test_council_orchestrator_runs_member_calls_concurrently` in `tests/unit/agents/council/test_council_orchestrator.py` to assert concurrent member calls return answers in the configured deterministic order.

### Testing
- Ran linter checks with `python -m ruff check src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py` and it passed.
- Ran unit tests with `python -m pytest tests/unit/agents/council/test_council_orchestrator.py` and the suite completed with `3 passed, 14 failed` due to a `ValueError` raised by the local-model guard (`Remote model 'local/default' detected for council default; configure a local model or enable allow_remote_models.`), so further test failures are environment/config related and not specific to the concurrency changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e912d4f788326bdb945ef40b63e75)