### PR TITLE
Forward council member LLM settings (temperature, max_tokens) to LLM client

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -545,6 +545,28 @@ def _build_member_prompt(
     )
 
 
+def _resolve_member_generation_params(member: CouncilMemberConfig) -> dict[str, float | int]:
+    temperature = getattr(member, "temperature", None)
+    if temperature is None:
+        temperature_value = 0.3
+    else:
+        try:
+            temperature_value = float(temperature)
+        except (TypeError, ValueError):
+            temperature_value = 0.3
+
+    max_tokens = getattr(member, "max_tokens", None)
+    if max_tokens is None:
+        max_tokens_value = 256
+    else:
+        try:
+            max_tokens_value = int(max_tokens)
+        except (TypeError, ValueError):
+            max_tokens_value = 256
+
+    return {"temperature": temperature_value, "max_tokens": max_tokens_value}
+
+
 def _ask_council_member(
     member: CouncilMemberConfig,
     question: CouncilQuestion,
@@ -560,6 +582,7 @@ def _ask_council_member(
         member_model = _resolve_default_model()
     track_mock_usage = is_mock_mode_enabled()
     errors: list[str] = []
+    generation_params = _resolve_member_generation_params(member)
 
     structured: MemberResponseModel | None = None
     for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
@@ -570,7 +593,8 @@ def _ask_council_member(
                     prompt,
                     response_model=MemberResponseModel,
                     model=member_model,
-                    temperature=0.3,
+                    temperature=generation_params["temperature"],
+                    max_tokens=generation_params["max_tokens"],
                     agent_state=agent_state,
                 )
             else:
@@ -578,7 +602,8 @@ def _ask_council_member(
                     prompt,
                     response_model=MemberResponseModel,
                     model=member_model,
-                    temperature=0.3,
+                    temperature=generation_params["temperature"],
+                    max_tokens=generation_params["max_tokens"],
                     agent_state=agent_state,
                 )
             if structured is not None:
@@ -604,7 +629,8 @@ def _ask_council_member(
                 generate_text(
                     prompt,
                     model=member_model,
-                    temperature=0.3,
+                    temperature=generation_params["temperature"],
+                    max_tokens=generation_params["max_tokens"],
                     agent_state=agent_state,
                 )
                 or ""
@@ -890,6 +916,7 @@ def _ask_peer_vote(
         member_model = _resolve_default_model()
     track_mock_usage = is_mock_mode_enabled()
     errors: list[str] = []
+    generation_params = _resolve_member_generation_params(member)
 
     structured: CouncilPeerVoteModel | None = None
     for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
@@ -900,7 +927,8 @@ def _ask_peer_vote(
                     prompt,
                     response_model=CouncilPeerVoteModel,
                     model=member_model,
-                    temperature=0.2,
+                    temperature=generation_params["temperature"],
+                    max_tokens=generation_params["max_tokens"],
                     agent_state=agent_state,
                 )
             else:
@@ -908,7 +936,8 @@ def _ask_peer_vote(
                     prompt,
                     response_model=CouncilPeerVoteModel,
                     model=member_model,
-                    temperature=0.2,
+                    temperature=generation_params["temperature"],
+                    max_tokens=generation_params["max_tokens"],
                     agent_state=agent_state,
                 )
             if structured is not None:

--- a/src/infra/llm_client.py
+++ b/src/infra/llm_client.py
@@ -833,6 +833,7 @@ def generate_text(
     prompt: str,
     model: str = "mistral:latest",
     temperature: float = 0.7,
+    max_tokens: int | None = None,
     *,
     agent_state: Any | None = None,
 ) -> str | None:
@@ -846,6 +847,7 @@ def generate_text(
         prompt (str): The prompt to send to the model.
         model (str): The model to use for generation.
         temperature (float): The temperature for text generation.
+        max_tokens (int | None): Optional cap on generated tokens.
         agent_state (Any, optional): The state of the agent making the call.
 
     Returns:
@@ -884,10 +886,13 @@ def generate_text(
 
                 wrapper = LLMClient(LLMClientConfig())
                 messages: list[LLMMessage] = [{"role": "user", "content": prompt}]
+                options = {"temperature": temperature}
+                if max_tokens is not None:
+                    options["num_predict"] = max_tokens
                 return wrapper.chat_sync(
                     model=model,
                     messages=messages,
-                    options={"temperature": temperature},
+                    options=options,
                 )
 
             try:
@@ -1131,6 +1136,7 @@ async def async_generate_structured_output(
     model: str = "mistral:latest",
     temperature: float = 0.2,
     timeout: int | None = None,
+    max_tokens: int | None = None,
     *,
     agent_state: Any | None = None,
 ) -> BaseModel | None:
@@ -1145,6 +1151,7 @@ async def async_generate_structured_output(
         temperature (float): The temperature for generation
         timeout (int | None): Request timeout in seconds. Defaults to the
             `OLLAMA_REQUEST_TIMEOUT` config value.
+        max_tokens (int | None): Optional cap on generated tokens.
 
     Returns:
         T | None: An instance of the response_model, or None if parsing failed
@@ -1295,14 +1302,17 @@ async def async_generate_structured_output(
                 "messages": [{"role": "user", "content": structured_prompt}],
                 "temperature": temperature,
             }
+            if max_tokens is not None:
+                payload["max_tokens"] = max_tokens
         else:
             url = f"{LLM_API_BASE.rstrip('/')}/api/generate"
+            num_predict = max_tokens if max_tokens is not None else 400
             payload = {
                 "model": model,
                 "prompt": structured_prompt,
                 "format": "json",
                 "stream": False,
-                "options": {"temperature": temperature, "top_p": 0.95, "num_predict": 400},
+                "options": {"temperature": temperature, "top_p": 0.95, "num_predict": num_predict},
             }
         async with httpx.AsyncClient() as http_client:
             response = await http_client.post(url, json=payload, timeout=timeout_value)
@@ -1357,6 +1367,7 @@ def generate_structured_output(
     model: str = "mistral:latest",
     temperature: float = 0.2,
     timeout: int | None = None,
+    max_tokens: int | None = None,
     *,
     agent_state: Any | None = None,
 ) -> BaseModel | None:
@@ -1369,6 +1380,7 @@ def generate_structured_output(
                 model=model,
                 temperature=temperature,
                 timeout=timeout,
+                max_tokens=max_tokens,
                 agent_state=agent_state,
             )
         )

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -85,7 +85,13 @@ def reset_fitness_store() -> None:
 
 @pytest.fixture(autouse=True)
 def enable_council_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"USE_COUNCIL_MODE": True, "DEFAULT_LLM_MODEL": "mistral:latest"},
+    )
+    monkeypatch.setattr(config, "_COUNCIL_CONFIG", None)
+    monkeypatch.setattr(config.settings, "DEFAULT_LLM_MODEL", "mistral:latest")
 
 
 def _build_council_config(num_members: int = 3, voting_mode: str = "judge_llm") -> CouncilConfig:
@@ -161,6 +167,87 @@ def _build_question(metadata: Mapping[str, Any] | None = None) -> CouncilQuestio
         context="We have budget for only one initiative this quarter.",
         metadata=metadata,
     )
+
+
+def test_council_member_forwards_generation_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _build_council_config()
+    member = config.members[0]
+    question = _build_question()
+    captured: dict[str, float | int] = {}
+
+    def fake_generate_structured_output(*args: object, **kwargs: object):
+        captured["temperature"] = float(kwargs.get("temperature"))
+        captured["max_tokens"] = int(kwargs.get("max_tokens"))
+        return council_orchestrator.MemberResponseModel(
+            answer="captured answer",
+            reasoning="captured reasoning",
+            confidence=0.5,
+            citations=[],
+        )
+
+    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+
+    answer = council_orchestrator._ask_council_member(member, question)
+
+    assert answer.answer == "captured answer"
+    assert captured["temperature"] == pytest.approx(member.temperature)
+    assert captured["max_tokens"] == member.max_tokens
+
+
+def test_council_member_fallback_forwards_generation_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _build_council_config()
+    member = config.members[1]
+    question = _build_question()
+    captured: dict[str, float | int] = {}
+
+    def fake_generate_structured_output(*args: object, **kwargs: object):
+        return None
+
+    def fake_generate_text(*args: object, **kwargs: object) -> str:
+        captured["temperature"] = float(kwargs.get("temperature"))
+        captured["max_tokens"] = int(kwargs.get("max_tokens"))
+        return "fallback answer"
+
+    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+    monkeypatch.setattr(council_orchestrator, "generate_text", fake_generate_text)
+
+    answer = council_orchestrator._ask_council_member(member, question)
+
+    assert answer.answer == "fallback answer"
+    assert captured["temperature"] == pytest.approx(member.temperature)
+    assert captured["max_tokens"] == member.max_tokens
+
+
+def test_peer_vote_forwards_generation_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _build_council_config()
+    member = config.members[2]
+    question = _build_question()
+    answers = [
+        MemberAnswer(member_id="facilitator", answer="Answer A"),
+        MemberAnswer(member_id="innovator", answer="Answer B"),
+    ]
+    captured: dict[str, float | int] = {}
+
+    def fake_generate_structured_output(*args: object, **kwargs: object):
+        captured["temperature"] = float(kwargs.get("temperature"))
+        captured["max_tokens"] = int(kwargs.get("max_tokens"))
+        return council_orchestrator.CouncilPeerVoteModel(
+            winner_id="facilitator",
+            votes={"facilitator": 0.9},
+            summary="Peer vote summary",
+            reasoning="Peer vote reasoning",
+        )
+
+    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+
+    result = council_orchestrator._ask_peer_vote(member, question, answers)
+
+    assert result is not None
+    assert result.winner_id == "facilitator"
+    assert captured["temperature"] == pytest.approx(member.temperature)
+    assert captured["max_tokens"] == member.max_tokens
 
 
 def test_council_orchestrator_can_bypass_env_guard(


### PR DESCRIPTION
### Motivation

- Ensure each council member's configured sampling `temperature` and `max_tokens` are actually used when generating their answers and peer votes.
- Provide a small resolver to safely derive defaults when member fields are missing or malformed.
- Allow the LLM client helpers to accept an explicit `max_tokens` so member limits can be enforced at the request layer.

### Description

- Add `_resolve_member_generation_params(member)` to normalize and provide defaults for `temperature` and `max_tokens`.
- Pass the resolved `temperature` and `max_tokens` into `generate_structured_output` and `generate_text` calls used by `_ask_council_member` and `_ask_peer_vote` (including fallback text generation).
- Extend `generate_text`, `async_generate_structured_output`, and `generate_structured_output` to accept a `max_tokens` parameter and propagate it into the underlying request options/payload (`num_predict` / `max_tokens`).
- Update unit tests in `tests/unit/agents/council/test_council_orchestrator.py` to assert that the `temperature` and `max_tokens` parameters are forwarded to the LLM call and stabilize the test config by setting `DEFAULT_LLM_MODEL` in the fixture.

### Testing

- Ran `ruff check .` which failed due to existing, unrelated repository lint issues (preexisting errors were reported). 
- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py` and the file's tests passed (`20 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e930890e8832687d92ace95494be7)