### PR TITLE
Support structured council extra_context, add winner_answer, and stabilize tests

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -11,7 +11,7 @@ from typing import Any
 import typer
 
 from src.agents.council.orchestrator import run_council
-from src.agents.council.types import CouncilQuestion
+from src.agents.council.types import CouncilOutcome, CouncilQuestion
 from src.infra import config as infra_config
 from src.infra.config import get_config, load_council_config
 
@@ -58,7 +58,9 @@ def _format_metrics(outcome_metrics: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _format_answers(outcome, members: Mapping[str, str], show_all: bool) -> str:
+def _format_answers(
+    outcome: CouncilOutcome, members: Mapping[str, str], show_all: bool
+) -> str:
     answers = outcome.answers
     if not show_all and outcome.winning_member_ids:
         winner_ids = set(outcome.winning_member_ids)
@@ -101,7 +103,7 @@ def _ensure_council_enabled(
         raise typer.Exit(code=1)
 
 
-def _collect_metrics(outcome) -> Mapping[str, Any]:
+def _collect_metrics(outcome: CouncilOutcome) -> Mapping[str, Any]:
     if outcome.metrics:
         return outcome.metrics
     if isinstance(outcome.metadata, Mapping):
@@ -112,7 +114,7 @@ def _collect_metrics(outcome) -> Mapping[str, Any]:
 
 
 def _print_outcome(
-    outcome,
+    outcome: CouncilOutcome,
     members: Mapping[str, str],
     *,
     show_all: bool,
@@ -236,14 +238,14 @@ def main(
     rag_docs = list(rag_doc or [])
     question = CouncilQuestion(
         question_id=question_id or str(uuid.uuid4()),
-        prompt=resolved_prompt,
+        question=resolved_prompt,
         context=context,
         rag_documents=rag_docs,
     )
 
     outcome = run_council(
         question,
-        extra_context=context,
+        extra_context=question.extra_context,
         rag_docs=rag_docs,
         allow_disabled_mode=bypass_env_guard,
     )

--- a/src/agents/council/graph_state.py
+++ b/src/agents/council/graph_state.py
@@ -41,14 +41,14 @@ async def council_outcome_node(state: CouncilState) -> dict[str, CouncilOutcome 
     rag_docs = [str(message) for message in state.get("messages", [])]
     question = CouncilQuestion(
         question_id="council-question",
-        prompt=state.get("question", ""),
+        question=state.get("question", ""),
         context="\n".join(rag_docs) if rag_docs else None,
         rag_documents=rag_docs,
     )
 
     try:
         outcome: CouncilOutcome = await asyncio.to_thread(
-            run_council, question, extra_context=question.context, rag_docs=rag_docs
+            run_council, question, extra_context=question.extra_context, rag_docs=rag_docs
         )
     except Exception as exc:  # pragma: no cover - defensive logging only
         logger.error("Council deliberation failed: %s", exc, exc_info=True)
@@ -56,4 +56,3 @@ async def council_outcome_node(state: CouncilState) -> dict[str, CouncilOutcome 
 
     final_answer = outcome.resolution or outcome.summary or ""
     return {"council_outcome": outcome, "final_answer": final_answer}
-

--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -526,15 +526,30 @@ def _format_rag_docs(rag_docs: Sequence[str]) -> str:
     return "\n".join(f"- {doc}" for doc in rag_docs)
 
 
+def _stringify_extra_context(extra_context: Mapping[str, Any] | None) -> str:
+    if not extra_context:
+        return "(no extra context provided)"
+    text = extra_context.get("text")
+    if isinstance(text, str) and text:
+        return text
+    summary = extra_context.get("summary")
+    if isinstance(summary, str) and summary:
+        return summary
+    try:
+        return json.dumps(extra_context, ensure_ascii=False)
+    except TypeError:
+        return str(extra_context)
+
+
 def _build_member_prompt(
     member: CouncilMemberConfig,
     question: CouncilQuestion,
     *,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
 ) -> str:
     rag_section = _format_rag_docs(rag_docs or [])
-    additional_context = extra_context or "(no extra context provided)"
+    additional_context = _stringify_extra_context(extra_context)
     return (
         "[council-member-answer] "
         f"member_id={member.member_id} question={question.prompt} context={question.context or ''} "
@@ -549,7 +564,7 @@ def _ask_council_member(
     member: CouncilMemberConfig,
     question: CouncilQuestion,
     *,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
     agent_state: Any | None = None,
 ) -> MemberAnswer:
@@ -642,11 +657,11 @@ def _build_judge_prompt(
     question: CouncilQuestion,
     answers: Sequence[MemberAnswer],
     *,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
 ) -> str:
     rag_section = _format_rag_docs(rag_docs or [])
-    additional_context = extra_context or "(no extra context provided)"
+    additional_context = _stringify_extra_context(extra_context)
     member_blocks = []
     for answer in answers:
         member_blocks.append(
@@ -831,11 +846,11 @@ def _build_peer_vote_prompt(
     answers: Sequence[MemberAnswer],
     *,
     voter: CouncilMemberConfig,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
 ) -> str:
     rag_section = _format_rag_docs(rag_docs or [])
-    additional_context = extra_context or "(no extra context provided)"
+    additional_context = _stringify_extra_context(extra_context)
     member_blocks = []
     for answer in answers:
         member_blocks.append(
@@ -877,7 +892,7 @@ def _ask_peer_vote(
     question: CouncilQuestion,
     answers: Sequence[MemberAnswer],
     *,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
     agent_state: Any | None = None,
 ) -> CouncilPeerVoteModel | None:
@@ -1114,7 +1129,7 @@ class CouncilOrchestrator:
         config: CouncilConfig | None,
         question: CouncilQuestion,
         *,
-        extra_context: str | None = None,
+        extra_context: Mapping[str, Any] | None = None,
         rag_docs: Sequence[str] | None = None,
         allow_disabled_mode: bool = False,
     ) -> CouncilOutcome:
@@ -1136,7 +1151,7 @@ class CouncilOrchestrator:
         context: CouncilContext,
         question: CouncilQuestion,
         *,
-        extra_context: str | None = None,
+        extra_context: Mapping[str, Any] | None = None,
         rag_docs: Sequence[str] | None = None,
         allow_disabled_mode: bool = False,
     ) -> CouncilOutcome:
@@ -1305,7 +1320,7 @@ class CouncilOrchestrator:
         question: CouncilQuestion,
         member_states: Mapping[str, SimpleNamespace],
         *,
-        extra_context: str | None,
+        extra_context: Mapping[str, Any] | None,
         rag_docs: Sequence[str],
         metrics: dict[str, Any],
     ) -> list[MemberAnswer]:
@@ -1422,7 +1437,7 @@ class CouncilOrchestrator:
         answers: Sequence[MemberAnswer],
         member_states: Mapping[str, SimpleNamespace],
         *,
-        extra_context: str | None,
+        extra_context: Mapping[str, Any] | None,
         rag_docs: Sequence[str],
         metrics: dict[str, Any],
     ) -> list[tuple[CouncilMemberConfig, CouncilPeerVoteModel]]:
@@ -1501,6 +1516,7 @@ class CouncilOrchestrator:
         votes: dict[str, float] = {}
         metadata: dict[str, Any] = {}
         fitness_snapshot: Mapping[str, Any] | None = None
+        winner_answer: str | None = None
 
         if vote is not None:
             winning_member_ids = [vote.winning_member_id]
@@ -1512,6 +1528,7 @@ class CouncilOrchestrator:
             resolution = vote.resolution or answer_lookup.get(
                 vote.winning_member_id, resolution
             )
+            winner_answer = answer_lookup.get(vote.winning_member_id)
             fitness_start = time.perf_counter()
             fitness_snapshot = self.fitness_store.update_from_vote(
                 question, answers, vote
@@ -1533,6 +1550,7 @@ class CouncilOrchestrator:
             resolution=resolution,
             winner_id=winning_member_ids[0] if winning_member_ids else None,
             winning_member_ids=winning_member_ids,
+            winner_answer=winner_answer,
             votes=votes,
             metrics=outcome_metrics,
             summary=summary,
@@ -1566,7 +1584,7 @@ class CouncilOrchestrator:
 def run_council(
     question: CouncilQuestion,
     *,
-    extra_context: str | None = None,
+    extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
     allow_disabled_mode: bool = False,
 ) -> CouncilOutcome:

--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
@@ -54,6 +55,18 @@ def _normalize_voting_mode(value: Any) -> str:
         return "judge_llm"
     key = re.sub(r"[\s-]+", "_", text).strip().lower()
     return _VOTING_MODE_ALIASES.get(key, text)
+
+
+def _normalize_extra_context(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        if not value:
+            return None
+        return {"text": value}
+    return {"value": value}
 
 
 class CouncilMemberConfig(BaseModel):
@@ -161,24 +174,48 @@ class CouncilQuestion(BaseModel):
     question_id: str = Field(
         validation_alias=AliasChoices("question_id", "questionId", "id", "name")
     )
-    prompt: str
+    prompt: str = Field(validation_alias=AliasChoices("prompt", "question"))
     user_id: str | None = Field(
         default=None, validation_alias=AliasChoices("user_id", "userId")
     )
-    extra_context: str | None = Field(
+    extra_context: dict[str, Any] | None = Field(
         default=None, validation_alias=AliasChoices("extra_context", "extraContext", "context")
     )
     rag_documents: list[str] = Field(default_factory=list)
     metadata: Mapping[str, Any] | None = None
     metrics: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("extra_context", mode="before")
+    @classmethod
+    def _normalize_extra_context(cls, value: Any) -> dict[str, Any] | None:
+        return _normalize_extra_context(value)
+
+    @property
+    def question(self) -> str:
+        return self.prompt
+
+    @question.setter
+    def question(self, value: str) -> None:
+        self.prompt = value
+
     @property
     def context(self) -> str | None:
-        return self.extra_context
+        if not self.extra_context:
+            return None
+        text = self.extra_context.get("text")
+        if isinstance(text, str):
+            return text
+        summary = self.extra_context.get("summary")
+        if isinstance(summary, str):
+            return summary
+        try:
+            return json.dumps(self.extra_context, ensure_ascii=False)
+        except TypeError:
+            return str(self.extra_context)
 
     @context.setter
     def context(self, value: str | None) -> None:
-        self.extra_context = value
+        self.extra_context = _normalize_extra_context(value)
 
 
 class MemberAnswer(BaseModel):
@@ -202,6 +239,7 @@ class CouncilOutcome(BaseModel):
     resolution: str
     winner_id: str | None = None
     winning_member_ids: list[str] = Field(default_factory=list)
+    winner_answer: str | None = None
     votes: dict[str, float] = Field(default_factory=dict)
     metrics: dict[str, Any] = Field(default_factory=dict)
     summary: str | None = None
@@ -213,6 +251,9 @@ class CouncilOutcome(BaseModel):
             self.winning_member_ids = [self.winner_id]
         elif self.winning_member_ids and not self.winner_id:
             self.winner_id = self.winning_member_ids[0]
+        if self.winner_id and not self.winner_answer:
+            answer_map = {answer.member_id: answer.answer for answer in self.answers}
+            self.winner_answer = answer_map.get(self.winner_id)
         return self
 
     def has_consensus(self) -> bool:

--- a/src/agents/graphs/council_graph.py
+++ b/src/agents/graphs/council_graph.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Any, TypedDict, cast
 
 from langgraph.graph import END, StateGraph
-
 from src.agents.council.orchestrator import run_council
 from src.agents.council.types import CouncilOutcome, CouncilQuestion
 
@@ -16,7 +15,7 @@ class CouncilGraphState(TypedDict, total=False):
 
     question: str
     question_id: str
-    context: str | None
+    context: dict[str, Any] | str | None
     rag_documents: list[str]
     council_outcome: CouncilOutcome
     final_answer: str
@@ -27,7 +26,7 @@ async def council_node(state: CouncilGraphState) -> dict[str, Any]:
 
     question = CouncilQuestion(
         question_id=cast(str, state.get("question_id", "council-question")),
-        prompt=cast(str, state.get("question", "")),
+        question=cast(str, state.get("question", "")),
         context=state.get("context"),
         rag_documents=state.get("rag_documents", []),
     )
@@ -35,7 +34,7 @@ async def council_node(state: CouncilGraphState) -> dict[str, Any]:
     outcome = await asyncio.to_thread(
         run_council,
         question,
-        extra_context=state.get("context"),
+        extra_context=question.extra_context,
         rag_docs=state.get("rag_documents"),
     )
 

--- a/src/agents/graphs/graph_nodes.py
+++ b/src/agents/graphs/graph_nodes.py
@@ -244,7 +244,7 @@ async def council_decision_node(state: AgentTurnState) -> dict[str, AgentActionO
 
     question = CouncilQuestion(
         question_id=f"{state.get('agent_id', 'agent')}-{state.get('simulation_step', 0)}",
-        prompt=(
+        question=(
             "Given the agent context and proposed action below, propose the best response. "
             "Return a concise resolution summarizing the recommended action."
             f"\n\nGoal: {state.get('agent_goal', '')}"
@@ -255,6 +255,7 @@ async def council_decision_node(state: AgentTurnState) -> dict[str, AgentActionO
             f"\nThought: {getattr(output, 'thought', '')}"
             f"\nMessage: {getattr(output, 'message_content', '') or '(no message)'}"
         ),
+        extra_context=state.get("prompt_modifier"),
         metadata={
             "agent_id": state.get("agent_id"),
             "simulation_step": state.get("simulation_step"),
@@ -273,7 +274,7 @@ async def council_decision_node(state: AgentTurnState) -> dict[str, AgentActionO
         outcome: CouncilOutcome = await asyncio.to_thread(
             run_council,
             question,
-            extra_context=state.get("prompt_modifier"),
+            extra_context=question.extra_context,
             rag_docs=rag_docs,
         )
     except Exception as exc:  # pragma: no cover - defensive

--- a/tests/performance/test_council_mock_performance.py
+++ b/tests/performance/test_council_mock_performance.py
@@ -6,11 +6,16 @@ import pytest
 from src.agents.council import orchestrator as council_orchestrator
 from src.agents.council.orchestrator import CouncilVoteModel, MemberAnswer
 from src.agents.council.types import CouncilConfig, CouncilMemberConfig, CouncilQuestion
+from src.infra import config as infra_config
 
 
 @pytest.mark.performance
 @pytest.mark.parametrize("member_count", [3])
 def test_council_run_meets_latency_and_budget(member_count: int) -> None:
+    infra_config._CONFIG = {
+        "USE_COUNCIL_MODE": True,
+        "DEFAULT_LLM_MODEL": "http://localhost/mock",
+    }
     members = [
         CouncilMemberConfig(
             member_id=f"member-{idx}",
@@ -69,7 +74,7 @@ def test_council_run_meets_latency_and_budget(member_count: int) -> None:
         outcome = orchestrator.deliberate(
             config,
             question,
-            extra_context="throughput check",
+            extra_context={"text": "throughput check"},
             allow_disabled_mode=True,
         )
         duration = time.perf_counter() - start

--- a/tests/unit/agents/council/conftest.py
+++ b/tests/unit/agents/council/conftest.py
@@ -8,14 +8,19 @@ def _configure_council_env(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: py
     config_path = tmp_path_factory.mktemp("council-config") / "config.yml"
     config_path.write_text("enabled: true\nmembers: []\n")
 
-    monkeypatch.setenv("DEFAULT_LLM_MODEL", "local/default")
+    monkeypatch.setenv("DEFAULT_LLM_MODEL", "http://localhost/mock")
     monkeypatch.setenv("COUNCIL_CONFIG_PATH", str(config_path))
-    monkeypatch.setattr(config.settings, "DEFAULT_LLM_MODEL", "local/default", raising=False)
+    monkeypatch.setattr(
+        config.settings, "DEFAULT_LLM_MODEL", "http://localhost/mock", raising=False
+    )
     monkeypatch.setattr(config.settings, "COUNCIL_CONFIG_PATH", str(config_path), raising=False)
     monkeypatch.setattr(
         config,
         "_CONFIG",
-        {"DEFAULT_LLM_MODEL": "local/default", "COUNCIL_CONFIG_PATH": str(config_path)},
+        {
+            "DEFAULT_LLM_MODEL": "http://localhost/mock",
+            "COUNCIL_CONFIG_PATH": str(config_path),
+        },
         raising=False,
     )
     monkeypatch.setattr(config, "_COUNCIL_CONFIG", None, raising=False)

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -85,7 +85,11 @@ def reset_fitness_store() -> None:
 
 @pytest.fixture(autouse=True)
 def enable_council_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"USE_COUNCIL_MODE": True, "DEFAULT_LLM_MODEL": "http://localhost/mock"},
+    )
 
 
 def _build_council_config(num_members: int = 3, voting_mode: str = "judge_llm") -> CouncilConfig:
@@ -170,7 +174,11 @@ def test_council_orchestrator_can_bypass_env_guard(
     council_config = _build_council_config(voting_mode="judge_llm")
     question = _build_question()
 
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": False})
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"USE_COUNCIL_MODE": False, "DEFAULT_LLM_MODEL": "http://localhost/mock"},
+    )
 
     with pytest.raises(RuntimeError):
         orchestrator.deliberate(council_config, question)
@@ -212,6 +220,7 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
 
     assert outcome.winning_member_ids == ["facilitator"]
     assert outcome.winner_id == "facilitator"
+    assert outcome.winner_answer == "facilitator proposal selected"
     assert outcome.resolution == "facilitator proposal selected"
     assert outcome.votes["facilitator"] == pytest.approx(0.8375)
     assert outcome.metadata is not None
@@ -390,7 +399,7 @@ def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPat
     question = _build_question()
 
     rag_marker = "<mocked-rag-docs>"
-    extra_context = "<extra-context>"
+    extra_context = {"text": "<extra-context>"}
     member_prompts: list[str] = []
     judge_prompts: list[str] = []
 
@@ -420,8 +429,8 @@ def test_council_orchestrator_includes_rag_markers(monkeypatch: pytest.MonkeyPat
 
     assert all(rag_marker in prompt for prompt in member_prompts)
     assert all(rag_marker in prompt for prompt in judge_prompts)
-    assert all(extra_context in prompt for prompt in member_prompts)
-    assert all(extra_context in prompt for prompt in judge_prompts)
+    assert all("<extra-context>" in prompt for prompt in member_prompts)
+    assert all("<extra-context>" in prompt for prompt in judge_prompts)
     assert all("facilitator proposal selected" in prompt for prompt in judge_prompts)
 
 
@@ -472,7 +481,11 @@ def test_council_orchestrator_flags_partial_metrics_on_errors(
 
 
 def test_council_orchestrator_requires_enabled_council(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": False})
+    monkeypatch.setattr(
+        config,
+        "_CONFIG",
+        {"USE_COUNCIL_MODE": False, "DEFAULT_LLM_MODEL": "http://localhost/mock"},
+    )
     orchestrator = CouncilOrchestrator()
 
     with pytest.raises(RuntimeError, match="Council mode is disabled"):

--- a/tests/unit/agents/council/test_council_types.py
+++ b/tests/unit/agents/council/test_council_types.py
@@ -137,7 +137,7 @@ def test_council_question_aliases() -> None:
     question = CouncilQuestion.model_validate(
         {
             "name": "question-1",
-            "prompt": "What should we do next?",
+            "question": "What should we do next?",
             "userId": "user-123",
             "extraContext": "Focus on the roadmap.",
         }
@@ -145,5 +145,15 @@ def test_council_question_aliases() -> None:
 
     assert question.question_id == "question-1"
     assert question.user_id == "user-123"
-    assert question.extra_context == "Focus on the roadmap."
+    assert question.prompt == "What should we do next?"
+    assert question.question == "What should we do next?"
+    assert question.extra_context == {"text": "Focus on the roadmap."}
     assert question.context == "Focus on the roadmap."
+
+    question.question = "Updated prompt"
+    assert question.prompt == "Updated prompt"
+
+    prompt_only = CouncilQuestion.model_validate(
+        {"question_id": "question-2", "prompt": "What is next?"}
+    )
+    assert prompt_only.question == "What is next?"

--- a/tests/unit/agents/graphs/test_council_node.py
+++ b/tests/unit/agents/graphs/test_council_node.py
@@ -3,9 +3,13 @@ import pytest
 pytest.importorskip("langgraph")
 pytestmark = pytest.mark.unit
 
-from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
-from src.agents.graphs import council_graph
-from src.agents.graphs.council_graph import CouncilGraphState, build_graph
+from src.agents.council.types import (  # noqa: E402
+    CouncilOutcome,
+    CouncilQuestion,
+    MemberAnswer,
+)
+from src.agents.graphs import council_graph  # noqa: E402
+from src.agents.graphs.council_graph import CouncilGraphState, build_graph  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -18,12 +22,16 @@ async def test_council_node_sets_outcome_and_final_answer(
         answers=[MemberAnswer(member_id="alpha", answer="Proceed")],
         resolution="Resolution text",
         winning_member_ids=["alpha"],
+        winner_answer="Proceed",
         summary="Summary text",
         metadata={},
     )
 
     def fake_run_council(
-        question: CouncilQuestion, *, extra_context: str | None, rag_docs: list[str] | None
+        question: CouncilQuestion,
+        *,
+        extra_context: dict[str, object] | None,
+        rag_docs: list[str] | None,
     ) -> CouncilOutcome:
         recorded["question"] = question
         recorded["extra_context"] = extra_context
@@ -46,5 +54,5 @@ async def test_council_node_sets_outcome_and_final_answer(
     assert result["final_answer"] == dummy_outcome.summary
     assert isinstance(recorded["question"], CouncilQuestion)
     assert recorded["question"].prompt == starting_state["question"]
-    assert recorded["extra_context"] == starting_state["context"]
+    assert recorded["extra_context"] == {"text": starting_state["context"]}
     assert recorded["rag_docs"] == starting_state["rag_documents"]


### PR DESCRIPTION
### Motivation
- Make `CouncilQuestion.extra_context` more flexible so callers can provide structured context (maps) in addition to legacy plain strings.
- Preserve backward compatibility by normalizing string context into a structured payload and exposing a readable `context` property for prompts.
- Surface the selected answer text on outcomes by adding `winner_answer` to `CouncilOutcome` so consumers can access the winning text directly.
- Ensure orchestration, graph nodes, and the CLI propagate and format structured context consistently and stabilize tests that hit the local/remote model guard.

### Description
- Add normalization for `extra_context` and `prompt`/`question` aliasing in `src/agents/council/types.py`, plus a `context` property and `winner_answer` with post-validation sync logic.
- Update `src/agents/council/orchestrator.py` to accept `Mapping[str, Any] | None` for `extra_context`, stringify structured context via `_stringify_extra_context` when building prompts, and populate `winner_answer` when assembling `CouncilOutcome`.
- Propagate the structured context through `src/agents/graphs/*` and `scripts/council_cli.py` by constructing `CouncilQuestion` with the new alias and passing `question.extra_context` into `run_council` calls.
- Update unit and performance test fixtures to set `DEFAULT_LLM_MODEL` to a localhost mock (`http://localhost/mock`) so the orchestrator remote-model guard does not block tests and adjust tests to assert the new fields and behaviors.

### Testing
- Ran `python -m ruff check src tests scripts` which failed due to existing repository-wide lint issues unrelated to these changes.
- Ran `python -m ruff format --check src tests scripts` which reported formatting diffs across the repository (not specific to the council changes).
- Ran targeted unit/performance tests: `pytest tests/unit/agents/council tests/unit/agents/graphs/test_council_node.py tests/performance/test_council_mock_performance.py` and the suite passed (35 passed, 3 deselected) after fixing the test fixtures to use the localhost default model.
- Updated tests to validate `extra_context` normalization, `question`/`prompt` aliases, and that `winner_answer` is populated; these assertions are present and exercised by the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e944a26a0832694f29e746f2a2a1f)