### PR TITLE
Omit per-member model overrides in council roster and document defaulting

### DIFF
--- a/config/council.yml
+++ b/config/council.yml
@@ -11,7 +11,6 @@ members:
     system_prompt: >-
       Channel a high-energy PewDiePie vibe—riff with playful "bro" humor, quick reactions, and hype-heavy positivity while still delivering grounded suggestions.
       Keep answers concise but animated.
-    model: mistral:latest
     temperature: 0.45
     max_tokens: 256
     is_active: true
@@ -22,7 +21,6 @@ members:
     system_prompt: >-
       Speak like a sarcastic PewDiePie-style commentator: roast flaws with sharp wit, toss in playful jabs, and push for stronger answers.
       Stay concise and constructive even when you tease.
-    model: mistral:latest
     temperature: 0.35
     max_tokens: 256
     is_active: true
@@ -33,7 +31,6 @@ members:
     system_prompt: >-
       Respond like a gentle, upbeat PewDiePie-style friend: encourage the team, smooth over tension, and ground advice in care and clarity.
       Keep it concise, kind, and reassuring.
-    model: mistral:latest
     temperature: 0.25
     max_tokens: 256
     is_active: true

--- a/docs/council_mode_design.md
+++ b/docs/council_mode_design.md
@@ -97,7 +97,7 @@ Qualitative checks should include manual review of L1/L2 summaries and Knowledge
 - `COUNCIL_MAX_CONCURRENT_CALLS`: Maximum concurrent LLM invocations per council run, used to bound latency and spend.
 - `DU_BUDGET_PER_QUESTION`: DU envelope shared by all council members for a single prompt.
 - `ROLE_DU_GENERATION`: Per-persona DU generation settings that control how the Facilitator/Innovator/Analyzer accumulate budget across ticks.
-- `config/council.yml`: Example roster showing `max_concurrent_calls`, `du_budget_per_question`, and `members` with per-role models; override values here or through environment variables consumed in [`src/infra/config.py`](../src/infra/config.py) and [`src/infra/settings.py`](../src/infra/settings.py).
+- `config/council.yml`: Example roster showing `max_concurrent_calls`, `du_budget_per_question`, and `members`. Member `model` values are optional and default to `DEFAULT_LLM_MODEL` when omitted; override values here or through environment variables consumed in [`src/infra/config.py`](../src/infra/config.py) and [`src/infra/settings.py`](../src/infra/settings.py).
 
 When the YAML file is missing or malformed, Culture falls back to defaults emitted by `_build_default_council_config`, so corrupted configs do not block simulations.
 
@@ -113,7 +113,6 @@ members:
     display_name: Bro Facilitator
     role: Facilitator
     persona: Keeps the pacing high, summarizes takes with signature "Bro Army" hype, and calls on others quickly.
-    model: mistral:latest
     temperature: 0.35
     max_tokens: 256
     is_active: true
@@ -121,7 +120,6 @@ members:
     display_name: Meme Engineer
     role: Innovator
     persona: Drops punchy meme riffs and wildcard pivots to keep ideation lively, while citing receipts.
-    model: mistral:latest
     temperature: 0.55
     max_tokens: 256
     is_active: true
@@ -129,7 +127,6 @@ members:
     display_name: Zero Deaths Critic
     role: Analyzer
     persona: Applies "zero deaths" rigor to poke holes, spot contradictions, and demand clear receipts.
-    model: mistral:latest
     temperature: 0.25
     max_tokens: 256
     is_active: true


### PR DESCRIPTION
### Motivation

- Make the sample council roster rely on the global default LLM model rather than hard-coding per-member `model` values so `DEFAULT_LLM_MODEL` applies by default. 
- Reduce maintenance friction and accidental divergence between example YAML and runtime defaults. 

### Description

- Removed `model` entries from the sample members in `config/council.yml` and from the PewDiePie example. 
- Updated `docs/council_mode_design.md` to document that member `model` values are optional and default to `DEFAULT_LLM_MODEL` when omitted. 
- Did not change `load_council_config` because it already supplies missing `model`/`temperature`/`max_tokens` from the built-in defaults in `_build_default_council_config`.

### Testing

- Ran `bash scripts/lint.sh`, which reported Ruff warnings about unused unpacked variables and regex match patterns unrelated to these changes. 
- Ran `pytest`, which executed the test suite and produced a summary of `368 passed, 21 failed, 18 skipped, 243 deselected, 1 error` (failures appear unrelated to the council YAML/doc edits). 
- Verified council-related config unit tests such as `tests/unit/infra/test_council_config.py` passed locally after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665c7de1188326b42fab124e2575ca)