### PR TITLE
Add fitness snapshot to council outcome metrics

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1572,6 +1572,7 @@ class CouncilOrchestrator:
 
         if fitness_snapshot is not None:
             metadata["fitness"] = fitness_snapshot
+            outcome_metrics["fitness_snapshot"] = fitness_snapshot
 
         metadata["metrics"] = outcome_metrics
 

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -313,6 +313,7 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
     assert "member_scores" in metrics
     assert outcome.metrics["member_scores"]["facilitator"]["total"] == pytest.approx(0.8375)
     assert outcome.summary == "Deterministic council summary"
+    assert "fitness_snapshot" in outcome.metrics
 
     serialized = json.loads(json.dumps(outcome.metadata))
     assert serialized["metrics"]["cohesion"] == pytest.approx(0.91)
@@ -321,6 +322,7 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
     assert member_fitness["facilitator"]["wins"] == 1
     assert member_fitness["facilitator"]["win_rate"] == pytest.approx(1.0)
     assert not fitness.get("warnings")
+    assert outcome.metrics["fitness_snapshot"]["members"]["facilitator"]["wins"] == 1
 
 
 def test_council_orchestrator_limits_concurrent_generate_calls(


### PR DESCRIPTION
### Motivation
- Ensure the council fitness snapshot produced after adjudication is available in a stable place on the outcome for downstream consumers and telemetry. 
- Previously the snapshot was only stored in `outcome.metadata`, making programmatic access inconvenient and unstable.
- Expose the snapshot under a predictable metrics key so metrics consumers and tests can rely on it.

### Description
- Merge the fitness snapshot into `outcome.metrics` under the stable key `fitness_snapshot` by setting `outcome_metrics["fitness_snapshot"] = fitness_snapshot` in `_build_outcome`.
- Preserve the existing `metadata["fitness"]` entry so backwards compatibility is maintained.
- Update `tests/unit/agents/council/test_council_orchestrator.py` to assert that `outcome.metrics` contains `fitness_snapshot` and that the snapshot includes expected member data.

### Testing
- Ran `ruff check src tests`, which reported pre-existing lint issues (RUF059/RUF043) unrelated to these changes and did not block this targeted update.
- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py tests/unit/agents/council/test_council_metrics.py`, and all tests passed (`22 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665fbb1eec8326a371bdbc8f11baed)