### PR TITLE
Add council member health warnings

### DIFF
--- a/scripts/council_metrics.py
+++ b/scripts/council_metrics.py
@@ -5,6 +5,7 @@ import argparse
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from src.agents.council.health import iter_health_warnings
 from src.agents.council.orchestrator import CouncilOrchestrator
 
 
@@ -77,6 +78,7 @@ def _collect_warnings(
             if int(member.get("participations", 0)) <= 0:
                 member_id = member.get("member_id", "unknown")
                 warnings.append(f"Member {member_id} has no recorded participations.")
+        warnings.extend(iter_health_warnings(members))
 
     if not pairwise:
         warnings.append("No pairwise agreement metrics available.")

--- a/src/agents/council/health.py
+++ b/src/agents/council/health.py
@@ -1,0 +1,34 @@
+"""Health signal helpers for council members."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+DEFAULT_MIN_PARTICIPATIONS = 10
+DEFAULT_WIN_RATE_THRESHOLD = 0.2
+
+
+def iter_health_warnings(
+    members: Iterable[Mapping[str, Any]],
+    *,
+    min_participations: int = DEFAULT_MIN_PARTICIPATIONS,
+    win_rate_threshold: float = DEFAULT_WIN_RATE_THRESHOLD,
+) -> Iterable[str]:
+    """Yield health warnings for members below win-rate thresholds."""
+    for member in members:
+        participations = int(member.get("participations", 0) or 0)
+        win_rate = float(member.get("win_rate", 0.0) or 0.0)
+        if participations >= min_participations and win_rate < win_rate_threshold:
+            member_id = member.get("member_id", "unknown")
+            yield (
+                f"Member {member_id} is a candidate for deactivation "
+                f"(win rate {win_rate:.2%} below {win_rate_threshold:.2%} after "
+                f"{participations} participations)."
+            )
+
+
+__all__ = [
+    "DEFAULT_MIN_PARTICIPATIONS",
+    "DEFAULT_WIN_RATE_THRESHOLD",
+    "iter_health_warnings",
+]

--- a/tests/unit/scripts/test_council_metrics.py
+++ b/tests/unit/scripts/test_council_metrics.py
@@ -10,9 +10,9 @@ def test_council_metrics_reports_stats(monkeypatch: pytest.MonkeyPatch, capsys: 
         "members": [
             {
                 "member_id": "alpha",
-                "participations": 5,
+                "participations": 12,
                 "wins": 3,
-                "win_rate": 0.6,
+                "win_rate": 0.1,
                 "avg_confidence": 0.8,
             },
             {
@@ -52,7 +52,7 @@ def test_council_metrics_reports_stats(monkeypatch: pytest.MonkeyPatch, capsys: 
     output = capsys.readouterr().out
     assert orchestrator.received_question is None
     assert "Council Metrics" in output
-    assert "- alpha: 60.00% win rate (3/5 wins, avg confidence 0.80)" in output
+    assert "- alpha: 10.00% win rate (3/12 wins, avg confidence 0.80)" in output
     assert "- bravo: 0.00% win rate (0/0 wins, avg confidence 0.00)" in output
 
     assert "Pairwise Agreement Rates:" in output
@@ -61,6 +61,7 @@ def test_council_metrics_reports_stats(monkeypatch: pytest.MonkeyPatch, capsys: 
     assert "Warnings:" in output
     assert "Member bravo has no recorded participations." in output
     assert "Global collusion alert" in output
+    assert "Member alpha is a candidate for deactivation" in output
 
 
 def test_council_metrics_filters_questions(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
@@ -74,9 +75,9 @@ def test_council_metrics_filters_questions(monkeypatch: pytest.MonkeyPatch, caps
                 "members": [
                     {
                         "member_id": "alpha",
-                        "participations": 2,
-                        "wins": 2,
-                        "win_rate": 1.0,
+                        "participations": 12,
+                        "wins": 1,
+                        "win_rate": 1 / 12,
                         "avg_confidence": 0.9,
                     }
                 ],
@@ -119,5 +120,6 @@ def test_council_metrics_filters_questions(monkeypatch: pytest.MonkeyPatch, caps
     assert "Question: target-question" in output
     assert "Prompt: What now?" in output
     assert "Custom question warning" in output
+    assert "Member alpha is a candidate for deactivation" in output
     assert "Potential collusion detected" in output
     assert "other-question" not in output


### PR DESCRIPTION
### Motivation
- Flag council members who have participated sufficiently but maintain a low win rate so operators can consider deactivation.
- Surface health signals alongside existing collusion and warning messages in the council metrics output for easier triage.
- Provide a reusable helper for health checks that can be reused elsewhere in council tooling.

### Description
- Add `src/agents/council/health.py` with `iter_health_warnings` and defaults `DEFAULT_MIN_PARTICIPATIONS=10` and `DEFAULT_WIN_RATE_THRESHOLD=0.2`.
- Import and call `iter_health_warnings` from `scripts/council_metrics.py` to include health messages in the aggregated warnings block.
- Update `tests/unit/scripts/test_council_metrics.py` to simulate low win-rate members and assert that the health warning text is printed.

### Testing
- Ran `python -m ruff check .` which reported existing repository lint issues and did not complete successfully.
- Ran `python -m pytest tests/unit/scripts/test_council_metrics.py` which passed (2 tests).
- The added unit tests confirm that health warnings are emitted when thresholds are met.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696663e496a083268d69e960e11f89c1)