### PR TITLE
Require explicit DEFAULT_LLM_MODEL for council defaults

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -513,7 +513,10 @@ def _resolve_default_model(
 ) -> str:
     default_model = get_config("DEFAULT_LLM_MODEL")
     if not default_model or str(default_model).strip() == "":
-        raise RuntimeError("DEFAULT_LLM_MODEL must be configured for council orchestration.")
+        raise RuntimeError(
+            "DEFAULT_LLM_MODEL must be configured for council orchestration. "
+            "Set DEFAULT_LLM_MODEL in the environment or config."
+        )
     return _guard_local_model(
         str(default_model),
         allow_remote=allow_remote,

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -163,7 +163,12 @@ _CONFIG: dict[str, object] = {}
 
 def _build_default_council_config() -> dict[str, Any]:
     """Return default council roster entries."""
-    model_name = str(getattr(settings, "DEFAULT_LLM_MODEL", "mistral:latest"))
+    model_name = str(getattr(settings, "DEFAULT_LLM_MODEL", "")).strip()
+    if not model_name:
+        raise RuntimeError(
+            "DEFAULT_LLM_MODEL must be configured to build council defaults. "
+            "Set DEFAULT_LLM_MODEL in the environment or config."
+        )
     return {
         "members": [
             {

--- a/tests/unit/infra/test_council_config.py
+++ b/tests/unit/infra/test_council_config.py
@@ -35,6 +35,18 @@ def test_load_council_config_returns_defaults_when_missing(
     assert result["members"][0]["temperature"] == pytest.approx(0.4)
 
 
+def test_load_council_config_requires_default_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reset_cache(monkeypatch)
+    missing = tmp_path / "council.yml"
+    monkeypatch.setattr(infra_config.settings, "COUNCIL_CONFIG_PATH", str(missing), raising=False)
+    monkeypatch.setattr(infra_config.settings, "DEFAULT_LLM_MODEL", "", raising=False)
+
+    with pytest.raises(RuntimeError, match="DEFAULT_LLM_MODEL must be configured"):
+        infra_config.load_council_config(reload=True)
+
+
 def test_load_council_config_reads_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _reset_cache(monkeypatch)
     path = tmp_path / "council.yml"


### PR DESCRIPTION
### Motivation

- Prevent silent fallback to an implicit model when building the default council roster by requiring an explicit `DEFAULT_LLM_MODEL` setting. 
- Make failures around council model configuration explicit and actionable so operators can fix environment/configuration quickly. 
- Align council orchestration validation messaging to clearly instruct how to correct missing defaults.

### Description

- Replace the previous `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696663e58370832681585dfe54d8cfba)