### PR TITLE
feat: add EMA tracking for council pairwise agreements

### DIFF
--- a/src/agents/council/stats_store.py
+++ b/src/agents/council/stats_store.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import threading
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 
 from src.agents.council.types import CouncilOutcome, MemberAnswer
@@ -11,6 +12,10 @@ from src.agents.council.types import CouncilOutcome, MemberAnswer
 
 class CouncilStatsStore:
     """Persist council member statistics and agreement metrics."""
+
+    _DEFAULT_EMA_ALPHA = 0.3
+    _EMA_HIGH_THRESHOLD = 0.75
+    _EMA_LOW_THRESHOLD = 0.25
 
     def __init__(self, db_path: str | Path | None = None) -> None:
         self._lock = threading.RLock()
@@ -60,14 +65,81 @@ class CouncilStatsStore:
                     member_b TEXT,
                     agreements INTEGER DEFAULT 0,
                     disagreements INTEGER DEFAULT 0,
+                    ema_agreement REAL DEFAULT 0.0,
+                    last_updated TEXT,
                     PRIMARY KEY(member_a, member_b)
                 )
                 """
             )
+            self._ensure_pairwise_columns()
             self.conn.commit()
+
+    def _ensure_pairwise_columns(self) -> None:
+        columns = {
+            row[1]
+            for row in self.conn.execute("PRAGMA table_info(council_pairwise_agreements)")
+        }
+        if "ema_agreement" not in columns:
+            self.conn.execute(
+                "ALTER TABLE council_pairwise_agreements ADD COLUMN ema_agreement REAL DEFAULT 0.0"
+            )
+        if "last_updated" not in columns:
+            self.conn.execute(
+                "ALTER TABLE council_pairwise_agreements ADD COLUMN last_updated TEXT"
+            )
 
     def _normalize_answer(self, answer: str | None) -> str:
         return (answer or "").strip().lower()
+
+    @staticmethod
+    def _coerce_score(value: object) -> float | None:
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        return None
+
+    def _extract_score_value(self, value: object) -> float | None:
+        if isinstance(value, Mapping):
+            total = self._coerce_score(value.get("total"))
+            if total is not None:
+                return total
+            numeric_values = [
+                score
+                for score in (self._coerce_score(item) for item in value.values())
+                if score is not None
+            ]
+            if numeric_values:
+                return sum(numeric_values) / len(numeric_values)
+            return None
+        return self._coerce_score(value)
+
+    def _normalize_score_map(self, score_map: Mapping[str, object] | None) -> dict[str, float]:
+        if not isinstance(score_map, Mapping):
+            return {}
+        normalized: dict[str, float] = {}
+        for member_id, value in score_map.items():
+            score = self._extract_score_value(value)
+            if score is not None:
+                normalized[str(member_id)] = score
+        return normalized
+
+    def _extract_scores_from_outcome(self, outcome: CouncilOutcome) -> Mapping[str, object] | None:
+        if outcome.votes:
+            return outcome.votes
+        if outcome.metadata and isinstance(outcome.metadata.get("scores"), Mapping):
+            return outcome.metadata["scores"]
+        if outcome.metrics:
+            member_scores = outcome.metrics.get("member_scores")
+            if isinstance(member_scores, Mapping):
+                return member_scores
+            scores = outcome.metrics.get("scores")
+            if isinstance(scores, Mapping):
+                return scores
+        return None
 
     def _update_member_stats(
         self, cur: sqlite3.Cursor, answers: Sequence[MemberAnswer], winning_ids: set[str]
@@ -91,37 +163,102 @@ class CouncilStatsStore:
             )
 
     def _update_pairwise_agreements(
-        self, cur: sqlite3.Cursor, answers: Sequence[MemberAnswer]
+        self,
+        cur: sqlite3.Cursor,
+        answers: Sequence[MemberAnswer],
+        score_map: Mapping[str, float],
+        ema_alpha: float,
+        timestamp: str,
     ) -> None:
+        scores = dict(score_map)
+        score_min = min(scores.values()) if scores else 0.0
+        score_max = max(scores.values()) if scores else 0.0
+        score_range = score_max - score_min
         for idx, left in enumerate(answers):
             for right in answers[idx + 1 :]:
                 member_a, member_b = sorted((left.member_id, right.member_id))
                 agrees = self._normalize_answer(left.answer) == self._normalize_answer(
                     right.answer
                 )
+                agreement_score: float
+                if member_a in scores and member_b in scores:
+                    delta = abs(scores[member_a] - scores[member_b])
+                    if score_range:
+                        agreement_score = 1.0 - (delta / score_range)
+                    else:
+                        agreement_score = 1.0
+                    agreement_score = max(0.0, min(1.0, agreement_score))
+                else:
+                    agreement_score = 1.0 if agrees else 0.0
                 cur.execute(
                     """
-                    INSERT INTO council_pairwise_agreements(member_a, member_b, agreements, disagreements)
-                    VALUES(?, ?, ?, ?)
+                    INSERT INTO council_pairwise_agreements(
+                        member_a,
+                        member_b,
+                        agreements,
+                        disagreements,
+                        ema_agreement,
+                        last_updated
+                    )
+                    VALUES(?, ?, ?, ?, 0.0, NULL)
                     ON CONFLICT(member_a, member_b) DO UPDATE SET
                         agreements = agreements + excluded.agreements,
                         disagreements = disagreements + excluded.disagreements
                     """,
                     (member_a, member_b, 1 if agrees else 0, 0 if agrees else 1),
                 )
+                row = cur.execute(
+                    """
+                    SELECT ema_agreement, last_updated
+                    FROM council_pairwise_agreements
+                    WHERE member_a=? AND member_b=?
+                    """,
+                    (member_a, member_b),
+                ).fetchone()
+                previous_ema = float(row[0]) if row and row[0] is not None else 0.0
+                has_prior = bool(row and row[1])
+                new_ema = (
+                    agreement_score
+                    if not has_prior
+                    else (ema_alpha * agreement_score + (1.0 - ema_alpha) * previous_ema)
+                )
+                cur.execute(
+                    """
+                    UPDATE council_pairwise_agreements
+                    SET ema_agreement=?, last_updated=?
+                    WHERE member_a=? AND member_b=?
+                    """,
+                    (new_ema, timestamp, member_a, member_b),
+                )
 
-    def record_outcome(self, outcome: CouncilOutcome) -> None:
+    def record_outcome(
+        self,
+        outcome: CouncilOutcome,
+        *,
+        score_map: Mapping[str, float] | None = None,
+        ema_alpha: float | None = None,
+    ) -> None:
         """Persist statistics for a council ``outcome``."""
 
         answers = list(outcome.answers)
         if not answers:
             return
 
+        raw_scores = score_map or self._extract_scores_from_outcome(outcome)
+        normalized_scores = self._normalize_score_map(raw_scores)
+        alpha = self._DEFAULT_EMA_ALPHA if ema_alpha is None else float(ema_alpha)
+        timestamp = datetime.now(timezone.utc).isoformat()
         winning_ids = {member_id for member_id in outcome.winning_member_ids}
         with self._lock:
             cur = self.conn.cursor()
             self._update_member_stats(cur, answers, winning_ids)
-            self._update_pairwise_agreements(cur, answers)
+            self._update_pairwise_agreements(
+                cur,
+                answers,
+                normalized_scores,
+                alpha,
+                timestamp,
+            )
             self.conn.commit()
 
     async def record_outcome_async(self, outcome: CouncilOutcome) -> None:
@@ -147,11 +284,17 @@ class CouncilStatsStore:
             "avg_confidence": avg_confidence,
         }
 
-    def get_pairwise_agreement(self, member_a: str, member_b: str) -> dict[str, float]:
+    def get_pairwise_agreement(
+        self, member_a: str, member_b: str
+    ) -> dict[str, float | str | bool]:
         left, right = sorted((member_a, member_b))
         with self._lock:
             row = self.conn.execute(
-                "SELECT agreements, disagreements FROM council_pairwise_agreements WHERE member_a=? AND member_b=?",
+                """
+                SELECT agreements, disagreements, ema_agreement, last_updated
+                FROM council_pairwise_agreements
+                WHERE member_a=? AND member_b=?
+                """,
                 (left, right),
             ).fetchone()
         if not row:
@@ -161,9 +304,15 @@ class CouncilStatsStore:
                 "agreements": 0,
                 "disagreements": 0,
                 "agreement_rate": 0.0,
+                "ema_agreement": 0.0,
+                "ema_last_updated": None,
+                "ema_high_agreement": False,
+                "ema_low_agreement": False,
             }
 
         agreements, disagreements = int(row[0]), int(row[1])
+        ema_agreement = float(row[2]) if row[2] is not None else 0.0
+        last_updated = row[3]
         total = agreements + disagreements
         agreement_rate = agreements / total if total else 0.0
         return {
@@ -172,18 +321,27 @@ class CouncilStatsStore:
             "agreements": agreements,
             "disagreements": disagreements,
             "agreement_rate": agreement_rate,
+            "ema_agreement": ema_agreement,
+            "ema_last_updated": last_updated,
+            "ema_high_agreement": ema_agreement >= self._EMA_HIGH_THRESHOLD,
+            "ema_low_agreement": ema_agreement <= self._EMA_LOW_THRESHOLD,
         }
 
-    def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+    def serialize_metrics(
+        self, *, question_id: str | None = None
+    ) -> dict[str, list[dict[str, float | str | bool]]]:
         with self._lock:
             member_rows = self.conn.execute(
                 "SELECT member_id, participations, wins, total_confidence FROM council_member_stats"
             ).fetchall()
             pair_rows = self.conn.execute(
-                "SELECT member_a, member_b, agreements, disagreements FROM council_pairwise_agreements"
+                """
+                SELECT member_a, member_b, agreements, disagreements, ema_agreement, last_updated
+                FROM council_pairwise_agreements
+                """
             ).fetchall()
 
-        members: list[dict[str, float]] = []
+        members: list[dict[str, float | str | bool]] = []
         for member_id, participations, wins, total_confidence in member_rows:
             participations_i = int(participations)
             wins_i = int(wins)
@@ -198,10 +356,11 @@ class CouncilStatsStore:
                 }
             )
 
-        pairwise: list[dict[str, float]] = []
-        for member_a, member_b, agreements, disagreements in pair_rows:
+        pairwise: list[dict[str, float | str | bool]] = []
+        for member_a, member_b, agreements, disagreements, ema_agreement, last_updated in pair_rows:
             agreements_i = int(agreements)
             disagreements_i = int(disagreements)
+            ema_value = float(ema_agreement) if ema_agreement is not None else 0.0
             total = agreements_i + disagreements_i
             pairwise.append(
                 {
@@ -210,6 +369,10 @@ class CouncilStatsStore:
                     "agreements": agreements_i,
                     "disagreements": disagreements_i,
                     "agreement_rate": agreements_i / total if total else 0.0,
+                    "ema_agreement": ema_value,
+                    "ema_last_updated": last_updated,
+                    "ema_high_agreement": ema_value >= self._EMA_HIGH_THRESHOLD,
+                    "ema_low_agreement": ema_value <= self._EMA_LOW_THRESHOLD,
                 }
             )
 
@@ -217,7 +380,9 @@ class CouncilStatsStore:
         # metrics but currently returns global aggregates only.
         return {"members": members, "pairwise": pairwise}
 
-    async def serialize_metrics_async(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+    async def serialize_metrics_async(
+        self, *, question_id: str | None = None
+    ) -> dict[str, list[dict[str, float | str | bool]]]:
         return await asyncio.to_thread(self.serialize_metrics, question_id=question_id)
 
     def record_batch(self, outcomes: Iterable[CouncilOutcome]) -> None:

--- a/tests/unit/agents/council/test_stats_store.py
+++ b/tests/unit/agents/council/test_stats_store.py
@@ -1,12 +1,18 @@
+from pathlib import Path
+
 import pytest
 
 from src.agents.council.stats_store import CouncilStatsStore
 from src.agents.council.types import CouncilOutcome, CouncilQuestion, MemberAnswer
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
-def store(tmp_path: pytest.TempPathFactory) -> CouncilStatsStore:
-    return CouncilStatsStore(db_path=tmp_path.mktemp("council") / "stats.sqlite3")
+def store(tmp_path: Path) -> CouncilStatsStore:
+    db_dir = tmp_path / "council"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    return CouncilStatsStore(db_path=db_dir / "stats.sqlite3")
 
 
 def _build_outcome() -> CouncilOutcome:
@@ -29,7 +35,11 @@ def test_stats_store_records_member_and_pairwise_metrics(
 ) -> None:
     outcome = _build_outcome()
 
-    store.record_outcome(outcome)
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 0.5, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
 
     alpha_stats = store.get_member_stats("alpha")
     assert alpha_stats["participations"] == 1
@@ -44,6 +54,9 @@ def test_stats_store_records_member_and_pairwise_metrics(
     pairwise = store.get_pairwise_agreement("alpha", "beta")
     assert pairwise["agreements"] == 1
     assert pairwise["disagreements"] == 0
+    assert pairwise["ema_agreement"] == pytest.approx(0.5)
+    assert pairwise["ema_last_updated"]
+    assert pairwise["ema_high_agreement"] is False
     divergent = store.get_pairwise_agreement("alpha", "gamma")
     assert divergent["agreements"] == 0
     assert divergent["disagreements"] == 1
@@ -62,4 +75,25 @@ def test_stats_store_serializes_aggregates(store: CouncilStatsStore) -> None:
 
     pairwise_entries = {(p["member_a"], p["member_b"]): p for p in snapshot["pairwise"]}
     assert pairwise_entries[("alpha", "beta")]["agreement_rate"] == 1.0
+    assert pairwise_entries[("alpha", "beta")]["ema_agreement"] == 1.0
+    assert pairwise_entries[("alpha", "beta")]["ema_high_agreement"] is True
+    assert pairwise_entries[("alpha", "beta")]["ema_last_updated"]
     assert pairwise_entries[("alpha", "gamma")]["agreements"] == 0
+
+
+def test_stats_store_updates_pairwise_ema(store: CouncilStatsStore) -> None:
+    outcome = _build_outcome()
+
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 0.5, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 1.0, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
+
+    pairwise = store.get_pairwise_agreement("alpha", "beta")
+    assert pairwise["ema_agreement"] == pytest.approx(0.75)


### PR DESCRIPTION
### Motivation

- Provide smoother per-pair agreement signals by storing and updating an exponential moving average (EMA) for pairwise agreements so downstream components can detect high/low agreement patterns. 
- Allow EMA updates to incorporate judge scores (or a provided score map) rather than only raw same/different answers.

### Description

- Extend the `council_pairwise_agreements` schema with `ema_agreement` and `last_updated`, and add a migration helper `_ensure_pairwise_columns` to add these columns if missing.
- Add score extraction/normalization helpers (`_coerce_score`, `_extract_score_value`, `_normalize_score_map`, `_extract_scores_from_outcome`) and allow `record_outcome` to accept an optional `score_map` and `ema_alpha` parameter.
- Update `_update_pairwise_agreements` to compute a per-pair agreement score using normalized judge/member scores when available and to update the EMA using `ema = alpha * new + (1 - alpha) * old` (first observed value initializes EMA); store a UTC `last_updated` timestamp.
- Expand `get_pairwise_agreement` and `serialize_metrics` to include `ema_agreement`, `ema_last_updated`, and derived boolean flags `ema_high_agreement`/`ema_low_agreement` (thresholds set on the store), and update async serialize typing accordingly.
- Update unit tests in `tests/unit/agents/council/test_stats_store.py` to exercise score-based EMA updates, serialization of EMA fields, and fixture/db directory setup.

### Testing

- Ran `pytest tests/unit/agents/council/test_stats_store.py`, which executed the updated tests and all tests in that file passed (`3 passed`).
- Ran the repository linter script `bash scripts/lint.sh`; the run failed due to pre-existing `RUF059`/`RUF043` Ruff warnings in unrelated files (these are unrelated to the changes in the council stats store).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679e495b748326b9675c489dabb317)