### PR TITLE
Score-based pair agreement detection with tolerance in CouncilFitnessStore

### DIFF
--- a/src/agents/council/fitness_store.py
+++ b/src/agents/council/fitness_store.py
@@ -1,4 +1,5 @@
 """Fitness tracking for council outcomes."""
+
 from __future__ import annotations
 
 from collections import Counter
@@ -31,6 +32,7 @@ class CouncilFitnessStore:
         *,
         agreement_threshold: float = 0.75,
         min_samples: int = 3,
+        score_tolerance: float = 0.05,
     ) -> None:
         self._wins: Counter[str] = Counter()
         self._appearances: Counter[str] = Counter()
@@ -39,6 +41,7 @@ class CouncilFitnessStore:
         self._agreement_scores: list[float] = []
         self.agreement_threshold = float(agreement_threshold)
         self.min_samples = int(min_samples)
+        self.score_tolerance = float(score_tolerance)
 
     def reset(self) -> None:
         """Clear accumulated fitness statistics."""
@@ -50,8 +53,56 @@ class CouncilFitnessStore:
         self._agreement_scores.clear()
 
     @staticmethod
-    def _normalize_answer(answer: str | None) -> str:
-        return (answer or "").strip().lower()
+    def _coerce_score(value: Any) -> float | None:
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        return None
+
+    def _extract_total_scores(self, vote: Any) -> dict[str, float]:
+        totals: dict[str, float] = {}
+        metrics = getattr(vote, "metrics", None)
+        if isinstance(metrics, Mapping):
+            member_scores = metrics.get("member_scores")
+            if isinstance(member_scores, Mapping):
+                for member_id, score_map in member_scores.items():
+                    if not isinstance(score_map, Mapping):
+                        continue
+                    total_value = self._coerce_score(score_map.get("total"))
+                    if total_value is not None:
+                        totals[str(member_id)] = total_value
+
+        def _update_from_mapping(raw: Mapping[str, Any]) -> None:
+            for member_id, value in raw.items():
+                total_value: float | None = None
+                if isinstance(value, Mapping):
+                    total_value = self._coerce_score(value.get("total"))
+                    if total_value is None:
+                        numeric_values = [
+                            score
+                            for score in (self._coerce_score(item) for item in value.values())
+                            if score is not None
+                        ]
+                        if numeric_values:
+                            total_value = sum(numeric_values) / len(numeric_values)
+                else:
+                    total_value = self._coerce_score(value)
+                if total_value is not None:
+                    totals.setdefault(str(member_id), total_value)
+
+        scores = getattr(vote, "scores", None)
+        if isinstance(scores, Mapping):
+            _update_from_mapping(scores)
+
+        votes = getattr(vote, "votes", None)
+        if isinstance(votes, Mapping):
+            _update_from_mapping(votes)
+
+        return totals
 
     def update_from_vote(
         self, question: CouncilQuestion, answers: Sequence[MemberAnswer], vote: Any
@@ -60,6 +111,7 @@ class CouncilFitnessStore:
 
         winners = {getattr(vote, "winning_member_id", "")}
         winners.discard("")
+        total_scores = self._extract_total_scores(vote)
 
         for answer in answers:
             member_id = str(answer.member_id)
@@ -70,7 +122,13 @@ class CouncilFitnessStore:
         for left, right in combinations(answers, 2):
             key = "|".join(sorted((left.member_id, right.member_id)))
             self._pair_counts[key] += 1
-            if self._normalize_answer(left.answer) == self._normalize_answer(right.answer):
+            left_score = total_scores.get(left.member_id)
+            right_score = total_scores.get(right.member_id)
+            if (
+                left_score is not None
+                and right_score is not None
+                and abs(left_score - right_score) <= self.score_tolerance
+            ):
                 self._pair_agreements[key] += 1
 
         members_snapshot: dict[str, Any] = {}
@@ -96,7 +154,7 @@ class CouncilFitnessStore:
             }
             if together >= self.min_samples and rate >= self.agreement_threshold:
                 warnings.append(
-                    f"Potential collusion detected between {pair} (agreement rate {rate:.2f})"
+                    f"Repeated high agreement detected between {pair} (agreement rate {rate:.2f})"
                 )
 
         return {"members": members_snapshot, "pairs": pairs_snapshot, "warnings": warnings}
@@ -150,7 +208,6 @@ class CouncilFitnessStore:
         if not self._agreement_scores:
             return 0.0
         return sum(self._agreement_scores) / len(self._agreement_scores)
-
 
 
 council_fitness_store = CouncilFitnessStore()

--- a/tests/unit/agents/council/test_fitness_store.py
+++ b/tests/unit/agents/council/test_fitness_store.py
@@ -22,10 +22,10 @@ def _build_vote(winner: str, scores: dict[str, float]) -> CouncilVoteModel:
 
 
 def test_fitness_store_tracks_win_rates_and_pairs() -> None:
-    store = CouncilFitnessStore()
+    store = CouncilFitnessStore(score_tolerance=0.05)
     question = CouncilQuestion(question_id="q1", prompt="p")
     answers = _build_answers(["a", "b", "c"])
-    vote = _build_vote("a", {"a": 0.9, "b": 0.4, "c": 0.4})
+    vote = _build_vote("a", {"a": 0.9, "b": 0.92, "c": 0.4})
 
     snapshot = store.update_from_vote(question, answers, vote)
 
@@ -38,13 +38,32 @@ def test_fitness_store_tracks_win_rates_and_pairs() -> None:
     assert pair_stats["a|b"]["questions_together"] == 1
     assert pair_stats["a|b"]["top_agreements"] == 1
     assert pair_stats["a|b"]["agreement_rate"] == pytest.approx(1.0)
+    assert pair_stats["a|c"]["top_agreements"] == 0
+    assert pair_stats["a|c"]["agreement_rate"] == pytest.approx(0.0)
+
+
+def test_fitness_store_treats_large_score_deltas_as_disagreement() -> None:
+    store = CouncilFitnessStore(score_tolerance=0.05)
+    question = CouncilQuestion(question_id="q-gap", prompt="p")
+    answers = _build_answers(["a", "b"])
+    vote = _build_vote("a", {"a": 0.9, "b": 0.7})
+
+    snapshot = store.update_from_vote(question, answers, vote)
+
+    pair_stats = snapshot["pairs"]
+    assert pair_stats["a|b"]["top_agreements"] == 0
+    assert pair_stats["a|b"]["agreement_rate"] == pytest.approx(0.0)
 
 
 def test_fitness_store_flags_collusion_when_pairs_align_repeatedly() -> None:
-    store = CouncilFitnessStore(agreement_threshold=0.6, min_samples=2)
+    store = CouncilFitnessStore(
+        agreement_threshold=0.6,
+        min_samples=2,
+        score_tolerance=0.05,
+    )
     question = CouncilQuestion(question_id="q2", prompt="p")
     answers = _build_answers(["x", "y"])
-    vote = _build_vote("x", {"x": 0.8, "y": 0.8})
+    vote = _build_vote("x", {"x": 0.8, "y": 0.82})
 
     store.update_from_vote(question, answers, vote)
     snapshot = store.update_from_vote(question, answers, vote)


### PR DESCRIPTION
### Motivation
- Replace brittle exact-answer equality with a score-based similarity so pairwise agreement reflects judge scoring deltas rather than literal answers.
- Surface repeated high agreement as warnings based on configurable thresholds while tolerating small score differences.
- Ensure unit tests validate new score-based agreement logic and edge cases for large deltas.

### Description
- Replace answer-normalization agreement checks with score similarity in `src/agents/council/fitness_store.py` using a new `score_tolerance` parameter.
- Add `_coerce_score` and `_extract_total_scores` helpers to pull per-member total scores from `vote.metrics`, `vote.scores`, or `vote.votes` payloads and normalize them.
- Count a pairwise agreement when both members have total scores and their absolute delta is within `score_tolerance`, and update the collusion warning text to indicate repeated high agreement.
- Update `tests/unit/agents/council/test_fitness_store.py` to exercise score-based agreement, to assert disagreement for large score deltas, and to verify threshold-based warnings for repeated high agreement.

### Testing
- Ran `pytest tests/unit/agents/council/test_fitness_store.py` and the modified test module passed (`3 passed`).
- Ran `ruff check .` and `ruff format --check .` which reported existing repo-wide formatting/lint issues unrelated to these changes and therefore failed the global lint check.
- Ran `ruff format` on the modified files to apply formatting for those changes (one file reformatted, one left unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679e494c208326ada4d6a7af27c746)