### PR TITLE
test: cover council metrics propagation

### DIFF
--- a/tests/unit/agents/graphs/test_council_node.py
+++ b/tests/unit/agents/graphs/test_council_node.py
@@ -24,7 +24,16 @@ async def test_council_node_sets_outcome_and_final_answer(
         winning_member_ids=["alpha"],
         winner_answer="Proceed",
         summary="Summary text",
-        metadata={},
+        metrics={
+            "fitness_snapshot": {"members": {}, "pairs": {}, "warnings": ["collusion"]},
+            "collusion_warnings": ["collusion"],
+        },
+        metadata={
+            "metrics": {
+                "fitness_snapshot": {"members": {}, "pairs": {}, "warnings": ["collusion"]},
+                "collusion_warnings": ["collusion"],
+            }
+        },
     )
 
     def fake_run_council(
@@ -52,6 +61,14 @@ async def test_council_node_sets_outcome_and_final_answer(
 
     assert result["council_outcome"] == dummy_outcome
     assert result["final_answer"] == dummy_outcome.summary
+    assert {
+        "fitness_snapshot",
+        "collusion_warnings",
+    }.issubset(result["council_outcome"].metrics)
+    assert {
+        "fitness_snapshot",
+        "collusion_warnings",
+    }.issubset(result["council_outcome"].metadata["metrics"])
     assert isinstance(recorded["question"], CouncilQuestion)
     assert recorded["question"].prompt == starting_state["question"]
     assert recorded["extra_context"] == {"text": starting_state["context"]}


### PR DESCRIPTION
### Motivation
- Ensure council graph preserves and exposes new `fitness`/`collusion` metrics added to `CouncilOutcome` so downstream graph state consumers can access them.

### Description
- Updated `tests/unit/agents/graphs/test_council_node.py` to construct a `CouncilOutcome` containing `metrics` and `metadata["metrics"]` with `fitness_snapshot` and `collusion_warnings`, mocked `run_council` to return that outcome, and added assertions that those keys are present on the propagated graph state.

### Testing
- Ran `python -m pytest tests/unit/agents/graphs/test_council_node.py` which passed (1 passed, 1 warning about `asyncio_mode`).
- Ran `python -m ruff check tests/unit/agents/graphs/test_council_node.py` which passed.
- Ran `python -m ruff format --check tests/unit/agents/graphs/test_council_node.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3802dc788326818d9b3119ebc70c)