### PR TITLE
Add council stats EMA tests

### DIFF
--- a/tests/unit/agents/council/test_stats_store.py
+++ b/tests/unit/agents/council/test_stats_store.py
@@ -97,3 +97,47 @@ def test_stats_store_updates_pairwise_ema(store: CouncilStatsStore) -> None:
 
     pairwise = store.get_pairwise_agreement("alpha", "beta")
     assert pairwise["ema_agreement"] == pytest.approx(0.75)
+
+
+def test_stats_store_updates_pairwise_ema_across_outcomes(
+    store: CouncilStatsStore,
+) -> None:
+    outcome = _build_outcome()
+
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 1.0, "gamma": 1.0},
+        ema_alpha=0.5,
+    )
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 0.0, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 0.8, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
+
+    pairwise = store.get_pairwise_agreement("alpha", "beta")
+    assert pairwise["ema_agreement"] == pytest.approx(0.65)
+
+
+def test_stats_store_serializes_ema_flags(store: CouncilStatsStore) -> None:
+    outcome = _build_outcome()
+
+    store.record_outcome(
+        outcome,
+        score_map={"alpha": 1.0, "beta": 0.0, "gamma": 0.0},
+        ema_alpha=0.5,
+    )
+
+    snapshot = store.serialize_metrics()
+
+    pairwise_entries = {(p["member_a"], p["member_b"]): p for p in snapshot["pairwise"]}
+    alpha_beta = pairwise_entries[("alpha", "beta")]
+    assert alpha_beta["ema_agreement"] == pytest.approx(0.0)
+    assert alpha_beta["ema_high_agreement"] is False
+    assert alpha_beta["ema_low_agreement"] is True
+    assert alpha_beta["ema_last_updated"]


### PR DESCRIPTION
### Motivation

- Ensure the council statistics store correctly updates exponential moving average (EMA) values across multiple recorded outcomes.
- Ensure serialized metrics include EMA fields and the computed high/low agreement flags for downstream consumers.

### Description

- Added `test_stats_store_updates_pairwise_ema_across_outcomes` in `tests/unit/agents/council/test_stats_store.py` to record multiple outcomes and assert EMA updates across successive records using `ema_alpha`.
- Added `test_stats_store_serializes_ema_flags` in `tests/unit/agents/council/test_stats_store.py` to assert serialized `pairwise` metrics include `ema_agreement`, `ema_last_updated`, `ema_high_agreement`, and `ema_low_agreement`.
- Tests reuse the existing `store` fixture and the `_build_outcome()` helper to exercise `record_outcome` and `serialize_metrics` paths.

### Testing

- Ran `pytest tests/unit/agents/council/test_stats_store.py`, which succeeded with all tests passing (5 passed).
- Ran `ruff check .`, which reported pre-existing linter violations in the repository and is unrelated to these test additions (linting failed due to existing issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3836c9348326bd9e308611bc5bc6)