### PR TITLE
Prioritize council member_id mapping in CLI lookup

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -40,10 +40,13 @@ def _build_member_lookup(raw_config: Mapping[str, Any] | None) -> dict[str, str]
         display_name = str(
             entry.get("display_name")
             or entry.get("name")
+            or entry.get("member_id")
             or entry.get("id")
             or f"Member {index + 1}"
         )
-        member_id = str(entry.get("id") or _slugify(display_name))
+        member_id = str(
+            entry.get("member_id") or entry.get("id") or _slugify(display_name)
+        )
         lookup[member_id] = display_name
     return lookup
 

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -15,12 +15,12 @@ def stub_council_config(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_load_settings() -> tuple[dict, dict[str, str]]:
         config = {
             "members": [
-                {"id": "alpha", "display_name": "Alpha Prime"},
-                {"id": "bravo", "display_name": "Bravo Squad"},
+                {"member_id": "alpha-id", "id": "alpha", "display_name": "Alpha Prime"},
+                {"member_id": "bravo-id", "id": "bravo", "display_name": "Bravo Squad"},
             ],
             "enabled": True,
         }
-        members = {"alpha": "Alpha Prime", "bravo": "Bravo Squad"}
+        members = {"alpha-id": "Alpha Prime", "bravo-id": "Bravo Squad"}
         return config, members
 
     monkeypatch.setattr(council_cli, "_load_council_settings", fake_load_settings)
@@ -48,14 +48,14 @@ def test_council_cli_reports_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
             ),
             answers=[
                 MemberAnswer(
-                    member_id="alpha",
+                    member_id="alpha-id",
                     answer="Alpha answer",
                     confidence=0.7,
                     reasoning="Alpha reasoning",
                 )
             ],
             resolution="Mock resolution",
-            winning_member_ids=["alpha"],
+            winning_member_ids=["alpha-id"],
             summary="Mock summary",
             metrics={"fitness": {"score": 1}},
         )
@@ -83,9 +83,9 @@ def test_council_cli_reports_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "- doc-b" in result.output
     assert "Resolution: Mock resolution" in result.output
     assert "Summary: Mock summary" in result.output
-    assert "Winners: Alpha Prime (alpha)" in result.output
+    assert "Winners: Alpha Prime (alpha-id)" in result.output
     assert "Answers:" in result.output
-    assert "- Alpha Prime (alpha)" in result.output
+    assert "- Alpha Prime (alpha-id)" in result.output
     assert "Confidence: 0.7" in result.output
     assert "Reasoning: Alpha reasoning" in result.output
     assert "Answer: Alpha answer" in result.output
@@ -199,11 +199,11 @@ def test_council_cli_show_all_answers(monkeypatch: pytest.MonkeyPatch) -> None:
         return CouncilOutcome(
             question=question,
             answers=[
-                MemberAnswer(member_id="alpha", answer="Alpha answer"),
-                MemberAnswer(member_id="bravo", answer="Bravo answer"),
+                MemberAnswer(member_id="alpha-id", answer="Alpha answer"),
+                MemberAnswer(member_id="bravo-id", answer="Bravo answer"),
             ],
             resolution="Mock resolution",
-            winning_member_ids=["alpha"],
+            winning_member_ids=["alpha-id"],
             summary=None,
             metadata={"fitness": {"scores": []}},
         )
@@ -213,14 +213,14 @@ def test_council_cli_show_all_answers(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(council_cli.app, ["Prompt"])
 
     assert result.exit_code == 0
-    assert "- Alpha Prime (alpha)" in result.output
-    assert "- Bravo Squad (bravo)" not in result.output
+    assert "- Alpha Prime (alpha-id)" in result.output
+    assert "- Bravo Squad (bravo-id)" not in result.output
 
     result = runner.invoke(council_cli.app, ["Prompt", "--show-all"])
 
     assert result.exit_code == 0
-    assert "- Alpha Prime (alpha)" in result.output
-    assert "- Bravo Squad (bravo)" in result.output
+    assert "- Alpha Prime (alpha-id)" in result.output
+    assert "- Bravo Squad (bravo-id)" in result.output
 
 
 def test_council_cli_show_votes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -236,12 +236,16 @@ def test_council_cli_show_votes(monkeypatch: pytest.MonkeyPatch) -> None:
         return CouncilOutcome(
             question=question,
             answers=[
-                MemberAnswer(member_id="alpha", answer="Alpha answer", votes={"bravo": 0.6}),
-                MemberAnswer(member_id="bravo", answer="Bravo answer", votes={"alpha": 0.4}),
+                MemberAnswer(
+                    member_id="alpha-id", answer="Alpha answer", votes={"bravo-id": 0.6}
+                ),
+                MemberAnswer(
+                    member_id="bravo-id", answer="Bravo answer", votes={"alpha-id": 0.4}
+                ),
             ],
             resolution="Mock resolution",
-            winning_member_ids=["alpha"],
-            votes={"alpha": 0.55, "bravo": 0.45},
+            winning_member_ids=["alpha-id"],
+            votes={"alpha-id": 0.55, "bravo-id": 0.45},
             summary=None,
             metrics={"fitness": {"score": 0.95}},
         )
@@ -252,13 +256,13 @@ def test_council_cli_show_votes(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result.exit_code == 0
     assert "Judge Scores:" in result.output
-    assert "- Alpha Prime (alpha): 0.55" in result.output
-    assert "- Bravo Squad (bravo): 0.45" in result.output
+    assert "- Alpha Prime (alpha-id): 0.55" in result.output
+    assert "- Bravo Squad (bravo-id): 0.45" in result.output
     assert "Votes:" in result.output
-    assert "- Alpha Prime (alpha):" in result.output
-    assert "  - Bravo Squad (bravo): 0.6" in result.output
-    assert "- Bravo Squad (bravo):" in result.output
-    assert "  - Alpha Prime (alpha): 0.4" in result.output
+    assert "- Alpha Prime (alpha-id):" in result.output
+    assert "  - Bravo Squad (bravo-id): 0.6" in result.output
+    assert "- Bravo Squad (bravo-id):" in result.output
+    assert "  - Alpha Prime (alpha-id): 0.4" in result.output
 
     result_default = runner.invoke(council_cli.app, ["Prompt"])
 
@@ -278,9 +282,9 @@ def test_council_cli_show_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> CouncilOutcome:
         return CouncilOutcome(
             question=question,
-            answers=[MemberAnswer(member_id="alpha", answer="Alpha answer")],
+            answers=[MemberAnswer(member_id="alpha-id", answer="Alpha answer")],
             resolution="Mock resolution",
-            winning_member_ids=["alpha"],
+            winning_member_ids=["alpha-id"],
             summary=None,
             metrics={"fitness": {"score": 0.87}, "collusion": {"flagged": False}},
         )
@@ -322,11 +326,11 @@ def test_council_cli_supports_legacy_short_flags(monkeypatch: pytest.MonkeyPatch
         return CouncilOutcome(
             question=question,
             answers=[
-                MemberAnswer(member_id="alpha", answer="Alpha answer"),
-                MemberAnswer(member_id="bravo", answer="Bravo answer"),
+                MemberAnswer(member_id="alpha-id", answer="Alpha answer"),
+                MemberAnswer(member_id="bravo-id", answer="Bravo answer"),
             ],
             resolution="Mock resolution",
-            winning_member_ids=["alpha"],
+            winning_member_ids=["alpha-id"],
             summary=None,
             metadata={"fitness": {"scores": []}},
         )
@@ -336,5 +340,5 @@ def test_council_cli_supports_legacy_short_flags(monkeypatch: pytest.MonkeyPatch
     result = runner.invoke(council_cli.app, ["-q", "Prompt", "-a"])
 
     assert result.exit_code == 0
-    assert "- Alpha Prime (alpha)" in result.output
-    assert "- Bravo Squad (bravo)" in result.output
+    assert "- Alpha Prime (alpha-id)" in result.output
+    assert "- Bravo Squad (bravo-id)" in result.output


### PR DESCRIPTION
### Motivation
- Ensure the council CLI maps members using the authoritative `member_id` field so printed names and IDs match entries in `config/council.yml` instead of falling back to `id` or a slugified display name.

### Description
- Update `_build_member_lookup` in `scripts/council_cli.py` to prefer `member_id`, then `id`, then a slugified display name when constructing the `member_id -> display_name` mapping.
- Adjust `tests/unit/scripts/test_council_cli.py` fixture data to include `member_id` entries and update all `MemberAnswer`, `votes`, and `winning_member_ids` expectations to use the `member_id` values.
- Update test assertions to expect winner and answer lines to include the `member_id` (e.g. `alpha-id` / `bravo-id`).

### Testing
- Ran `pytest tests/unit/scripts/test_council_cli.py` which completed successfully (`8 passed`).
- Ran `ruff check .` which reported existing repository lint issues unrelated to this change and therefore failed linting for the full repo.
- Ran `black --check .` which indicated files would be reformatted (repo-wide formatting changes) and therefore failed the formatter check for the full repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3e94a94483268953d040ca23dbef)