### PR TITLE
Add question-scoped council stats persistence and filtering

### DIFF
--- a/src/agents/council/stats_store.py
+++ b/src/agents/council/stats_store.py
@@ -48,31 +48,129 @@ class CouncilStatsStore:
 
     def _ensure_schema(self) -> None:
         with self._lock:
+            self._ensure_member_stats_schema()
+            self._ensure_pairwise_schema()
+            self._ensure_pairwise_columns()
+            self.conn.commit()
+
+    def _ensure_member_stats_schema(self) -> None:
+        columns = {
+            row[1] for row in self.conn.execute("PRAGMA table_info(council_member_stats)")
+        }
+        if not columns:
             self.conn.execute(
                 """
-                CREATE TABLE IF NOT EXISTS council_member_stats (
-                    member_id TEXT PRIMARY KEY,
+                CREATE TABLE council_member_stats (
+                    question_id TEXT NOT NULL DEFAULT '',
+                    member_id TEXT NOT NULL,
                     participations INTEGER DEFAULT 0,
                     wins INTEGER DEFAULT 0,
-                    total_confidence REAL DEFAULT 0.0
+                    total_confidence REAL DEFAULT 0.0,
+                    PRIMARY KEY(question_id, member_id)
                 )
                 """
             )
+            return
+        if "question_id" in columns:
+            return
+        self.conn.execute(
+            """
+            CREATE TABLE council_member_stats_new (
+                question_id TEXT NOT NULL DEFAULT '',
+                member_id TEXT NOT NULL,
+                participations INTEGER DEFAULT 0,
+                wins INTEGER DEFAULT 0,
+                total_confidence REAL DEFAULT 0.0,
+                PRIMARY KEY(question_id, member_id)
+            )
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO council_member_stats_new(
+                question_id,
+                member_id,
+                participations,
+                wins,
+                total_confidence
+            )
+            SELECT
+                '',
+                member_id,
+                participations,
+                wins,
+                total_confidence
+            FROM council_member_stats
+            """
+        )
+        self.conn.execute("DROP TABLE council_member_stats")
+        self.conn.execute("ALTER TABLE council_member_stats_new RENAME TO council_member_stats")
+
+    def _ensure_pairwise_schema(self) -> None:
+        columns = {
+            row[1]
+            for row in self.conn.execute("PRAGMA table_info(council_pairwise_agreements)")
+        }
+        if not columns:
             self.conn.execute(
                 """
-                CREATE TABLE IF NOT EXISTS council_pairwise_agreements (
+                CREATE TABLE council_pairwise_agreements (
+                    question_id TEXT NOT NULL DEFAULT '',
                     member_a TEXT,
                     member_b TEXT,
                     agreements INTEGER DEFAULT 0,
                     disagreements INTEGER DEFAULT 0,
                     ema_agreement REAL DEFAULT 0.0,
                     last_updated TEXT,
-                    PRIMARY KEY(member_a, member_b)
+                    PRIMARY KEY(question_id, member_a, member_b)
                 )
                 """
             )
-            self._ensure_pairwise_columns()
-            self.conn.commit()
+            return
+        if "question_id" in columns:
+            return
+        ema_expr = "ema_agreement" if "ema_agreement" in columns else "0.0"
+        updated_expr = "last_updated" if "last_updated" in columns else "NULL"
+        self.conn.execute(
+            """
+            CREATE TABLE council_pairwise_agreements_new (
+                question_id TEXT NOT NULL DEFAULT '',
+                member_a TEXT,
+                member_b TEXT,
+                agreements INTEGER DEFAULT 0,
+                disagreements INTEGER DEFAULT 0,
+                ema_agreement REAL DEFAULT 0.0,
+                last_updated TEXT,
+                PRIMARY KEY(question_id, member_a, member_b)
+            )
+            """
+        )
+        self.conn.execute(
+            f"""
+            INSERT INTO council_pairwise_agreements_new(
+                question_id,
+                member_a,
+                member_b,
+                agreements,
+                disagreements,
+                ema_agreement,
+                last_updated
+            )
+            SELECT
+                '',
+                member_a,
+                member_b,
+                agreements,
+                disagreements,
+                {ema_expr},
+                {updated_expr}
+            FROM council_pairwise_agreements
+            """
+        )
+        self.conn.execute("DROP TABLE council_pairwise_agreements")
+        self.conn.execute(
+            "ALTER TABLE council_pairwise_agreements_new RENAME TO council_pairwise_agreements"
+        )
 
     def _ensure_pairwise_columns(self) -> None:
         columns = {
@@ -142,20 +240,31 @@ class CouncilStatsStore:
         return None
 
     def _update_member_stats(
-        self, cur: sqlite3.Cursor, answers: Sequence[MemberAnswer], winning_ids: set[str]
+        self,
+        cur: sqlite3.Cursor,
+        question_id: str,
+        answers: Sequence[MemberAnswer],
+        winning_ids: set[str],
     ) -> None:
         for answer in answers:
             confidence = float(answer.confidence or 0.0)
             cur.execute(
                 """
-                INSERT INTO council_member_stats(member_id, participations, wins, total_confidence)
-                VALUES(?, 1, ?, ?)
-                ON CONFLICT(member_id) DO UPDATE SET
+                INSERT INTO council_member_stats(
+                    question_id,
+                    member_id,
+                    participations,
+                    wins,
+                    total_confidence
+                )
+                VALUES(?, ?, 1, ?, ?)
+                ON CONFLICT(question_id, member_id) DO UPDATE SET
                     participations = participations + 1,
                     wins = wins + excluded.wins,
                     total_confidence = total_confidence + excluded.total_confidence
                 """,
                 (
+                    question_id,
                     answer.member_id,
                     1 if answer.member_id in winning_ids else 0,
                     confidence,
@@ -165,6 +274,7 @@ class CouncilStatsStore:
     def _update_pairwise_agreements(
         self,
         cur: sqlite3.Cursor,
+        question_id: str,
         answers: Sequence[MemberAnswer],
         score_map: Mapping[str, float],
         ema_alpha: float,
@@ -193,6 +303,7 @@ class CouncilStatsStore:
                 cur.execute(
                     """
                     INSERT INTO council_pairwise_agreements(
+                        question_id,
                         member_a,
                         member_b,
                         agreements,
@@ -200,20 +311,20 @@ class CouncilStatsStore:
                         ema_agreement,
                         last_updated
                     )
-                    VALUES(?, ?, ?, ?, 0.0, NULL)
-                    ON CONFLICT(member_a, member_b) DO UPDATE SET
+                    VALUES(?, ?, ?, ?, ?, 0.0, NULL)
+                    ON CONFLICT(question_id, member_a, member_b) DO UPDATE SET
                         agreements = agreements + excluded.agreements,
                         disagreements = disagreements + excluded.disagreements
                     """,
-                    (member_a, member_b, 1 if agrees else 0, 0 if agrees else 1),
+                    (question_id, member_a, member_b, 1 if agrees else 0, 0 if agrees else 1),
                 )
                 row = cur.execute(
                     """
                     SELECT ema_agreement, last_updated
                     FROM council_pairwise_agreements
-                    WHERE member_a=? AND member_b=?
+                    WHERE question_id=? AND member_a=? AND member_b=?
                     """,
-                    (member_a, member_b),
+                    (question_id, member_a, member_b),
                 ).fetchone()
                 previous_ema = float(row[0]) if row and row[0] is not None else 0.0
                 has_prior = bool(row and row[1])
@@ -226,9 +337,9 @@ class CouncilStatsStore:
                     """
                     UPDATE council_pairwise_agreements
                     SET ema_agreement=?, last_updated=?
-                    WHERE member_a=? AND member_b=?
+                    WHERE question_id=? AND member_a=? AND member_b=?
                     """,
-                    (new_ema, timestamp, member_a, member_b),
+                    (new_ema, timestamp, question_id, member_a, member_b),
                 )
 
     def record_outcome(
@@ -248,12 +359,14 @@ class CouncilStatsStore:
         normalized_scores = self._normalize_score_map(raw_scores)
         alpha = self._DEFAULT_EMA_ALPHA if ema_alpha is None else float(ema_alpha)
         timestamp = datetime.now(timezone.utc).isoformat()
+        question_id = (outcome.question.question_id or "").strip()
         winning_ids = {member_id for member_id in outcome.winning_member_ids}
         with self._lock:
             cur = self.conn.cursor()
-            self._update_member_stats(cur, answers, winning_ids)
+            self._update_member_stats(cur, question_id, answers, winning_ids)
             self._update_pairwise_agreements(
                 cur,
+                question_id,
                 answers,
                 normalized_scores,
                 alpha,
@@ -266,14 +379,20 @@ class CouncilStatsStore:
 
     def get_member_stats(self, member_id: str) -> dict[str, float]:
         with self._lock:
-            row = self.conn.execute(
-                "SELECT participations, wins, total_confidence FROM council_member_stats WHERE member_id=?",
+            rows = self.conn.execute(
+                """
+                SELECT participations, wins, total_confidence
+                FROM council_member_stats
+                WHERE member_id=?
+                """,
                 (member_id,),
-            ).fetchone()
-        if not row:
+            ).fetchall()
+        if not rows:
             return {"member_id": member_id, "participations": 0, "wins": 0, "win_rate": 0.0, "avg_confidence": 0.0}
 
-        participations, wins, total_confidence = int(row[0]), int(row[1]), float(row[2])
+        participations = sum(int(row[0]) for row in rows)
+        wins = sum(int(row[1]) for row in rows)
+        total_confidence = sum(float(row[2]) for row in rows)
         win_rate = wins / participations if participations else 0.0
         avg_confidence = total_confidence / participations if participations else 0.0
         return {
@@ -289,15 +408,15 @@ class CouncilStatsStore:
     ) -> dict[str, float | str | bool]:
         left, right = sorted((member_a, member_b))
         with self._lock:
-            row = self.conn.execute(
+            rows = self.conn.execute(
                 """
                 SELECT agreements, disagreements, ema_agreement, last_updated
                 FROM council_pairwise_agreements
                 WHERE member_a=? AND member_b=?
                 """,
                 (left, right),
-            ).fetchone()
-        if not row:
+            ).fetchall()
+        if not rows:
             return {
                 "member_a": left,
                 "member_b": right,
@@ -310,9 +429,21 @@ class CouncilStatsStore:
                 "ema_low_agreement": False,
             }
 
-        agreements, disagreements = int(row[0]), int(row[1])
-        ema_agreement = float(row[2]) if row[2] is not None else 0.0
-        last_updated = row[3]
+        agreements = sum(int(row[0]) for row in rows)
+        disagreements = sum(int(row[1]) for row in rows)
+        total_weight = 0.0
+        weighted_ema = 0.0
+        last_updated = None
+        for row in rows:
+            ema_value = float(row[2]) if row[2] is not None else 0.0
+            weight = int(row[0]) + int(row[1])
+            if weight:
+                total_weight += weight
+                weighted_ema += ema_value * weight
+            timestamp = row[3]
+            if timestamp and (not last_updated or timestamp > last_updated):
+                last_updated = timestamp
+        ema_agreement = weighted_ema / total_weight if total_weight else 0.0
         total = agreements + disagreements
         agreement_rate = agreements / total if total else 0.0
         return {
@@ -330,25 +461,54 @@ class CouncilStatsStore:
     def serialize_metrics(
         self, *, question_id: str | None = None
     ) -> dict[str, list[dict[str, float | str | bool]]]:
+        filter_question_id = (question_id or "").strip() if question_id else None
         with self._lock:
-            member_rows = self.conn.execute(
-                "SELECT member_id, participations, wins, total_confidence FROM council_member_stats"
-            ).fetchall()
-            pair_rows = self.conn.execute(
-                """
-                SELECT member_a, member_b, agreements, disagreements, ema_agreement, last_updated
-                FROM council_pairwise_agreements
-                """
-            ).fetchall()
+            if filter_question_id is None:
+                member_rows = self.conn.execute(
+                    "SELECT question_id, member_id, participations, wins, total_confidence FROM council_member_stats"
+                ).fetchall()
+                pair_rows = self.conn.execute(
+                    """
+                    SELECT question_id, member_a, member_b, agreements, disagreements, ema_agreement, last_updated
+                    FROM council_pairwise_agreements
+                    """
+                ).fetchall()
+            else:
+                member_rows = self.conn.execute(
+                    """
+                    SELECT question_id, member_id, participations, wins, total_confidence
+                    FROM council_member_stats
+                    WHERE question_id=?
+                    """,
+                    (filter_question_id,),
+                ).fetchall()
+                pair_rows = self.conn.execute(
+                    """
+                    SELECT question_id, member_a, member_b, agreements, disagreements, ema_agreement, last_updated
+                    FROM council_pairwise_agreements
+                    WHERE question_id=?
+                    """,
+                    (filter_question_id,),
+                ).fetchall()
+
+        member_totals: dict[str, dict[str, float]] = {}
+        for _, member_id, participations, wins, total_confidence in member_rows:
+            entry = member_totals.setdefault(
+                str(member_id),
+                {"participations": 0.0, "wins": 0.0, "total_confidence": 0.0},
+            )
+            entry["participations"] += float(participations)
+            entry["wins"] += float(wins)
+            entry["total_confidence"] += float(total_confidence)
 
         members: list[dict[str, float | str | bool]] = []
-        for member_id, participations, wins, total_confidence in member_rows:
-            participations_i = int(participations)
-            wins_i = int(wins)
-            total_conf = float(total_confidence)
+        for member_id, totals in member_totals.items():
+            participations_i = int(totals["participations"])
+            wins_i = int(totals["wins"])
+            total_conf = float(totals["total_confidence"])
             members.append(
                 {
-                    "member_id": str(member_id),
+                    "member_id": member_id,
                     "participations": participations_i,
                     "wins": wins_i,
                     "win_rate": wins_i / participations_i if participations_i else 0.0,
@@ -356,16 +516,47 @@ class CouncilStatsStore:
                 }
             )
 
-        pairwise: list[dict[str, float | str | bool]] = []
-        for member_a, member_b, agreements, disagreements, ema_agreement, last_updated in pair_rows:
+        pairwise_totals: dict[tuple[str, str], dict[str, float | str | None]] = {}
+        for _, member_a, member_b, agreements, disagreements, ema_agreement, last_updated in pair_rows:
+            key = (str(member_a), str(member_b))
+            entry = pairwise_totals.setdefault(
+                key,
+                {
+                    "agreements": 0.0,
+                    "disagreements": 0.0,
+                    "weighted_ema": 0.0,
+                    "ema_weight": 0.0,
+                    "last_updated": None,
+                },
+            )
             agreements_i = int(agreements)
             disagreements_i = int(disagreements)
+            weight = agreements_i + disagreements_i
+            entry["agreements"] = float(entry["agreements"]) + agreements_i
+            entry["disagreements"] = float(entry["disagreements"]) + disagreements_i
             ema_value = float(ema_agreement) if ema_agreement is not None else 0.0
+            if weight:
+                entry["weighted_ema"] = float(entry["weighted_ema"]) + ema_value * weight
+                entry["ema_weight"] = float(entry["ema_weight"]) + weight
+            if last_updated and (
+                entry["last_updated"] is None or str(last_updated) > str(entry["last_updated"])
+            ):
+                entry["last_updated"] = str(last_updated)
+
+        pairwise: list[dict[str, float | str | bool]] = []
+        for (member_a, member_b), totals in pairwise_totals.items():
+            agreements_i = int(totals["agreements"])
+            disagreements_i = int(totals["disagreements"])
             total = agreements_i + disagreements_i
+            ema_weight = float(totals["ema_weight"])
+            ema_value = (
+                float(totals["weighted_ema"]) / ema_weight if ema_weight else 0.0
+            )
+            last_updated = totals["last_updated"]
             pairwise.append(
                 {
-                    "member_a": str(member_a),
-                    "member_b": str(member_b),
+                    "member_a": member_a,
+                    "member_b": member_b,
                     "agreements": agreements_i,
                     "disagreements": disagreements_i,
                     "agreement_rate": agreements_i / total if total else 0.0,
@@ -376,8 +567,6 @@ class CouncilStatsStore:
                 }
             )
 
-        # ``question_id`` is accepted for forward compatibility with question-scoped
-        # metrics but currently returns global aggregates only.
         return {"members": members, "pairwise": pairwise}
 
     async def serialize_metrics_async(

--- a/tests/unit/agents/council/test_stats_store.py
+++ b/tests/unit/agents/council/test_stats_store.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -15,8 +16,8 @@ def store(tmp_path: Path) -> CouncilStatsStore:
     return CouncilStatsStore(db_path=db_dir / "stats.sqlite3")
 
 
-def _build_outcome() -> CouncilOutcome:
-    question = CouncilQuestion(question_id="q-1", prompt="What now?")
+def _build_outcome(question_id: str = "q-1") -> CouncilOutcome:
+    question = CouncilQuestion(question_id=question_id, prompt="What now?")
     answers = [
         MemberAnswer(member_id="alpha", answer="Option A", confidence=0.8),
         MemberAnswer(member_id="beta", answer="Option A", confidence=0.6),
@@ -81,6 +82,30 @@ def test_stats_store_serializes_aggregates(store: CouncilStatsStore) -> None:
     assert pairwise_entries[("alpha", "gamma")]["agreements"] == 0
 
 
+def test_stats_store_serializes_filtered_metrics(store: CouncilStatsStore) -> None:
+    store.record_outcome(_build_outcome("q-1"))
+    store.record_outcome(_build_outcome("q-2"))
+
+    snapshot = store.serialize_metrics()
+    filtered = store.serialize_metrics(question_id="q-1")
+
+    alpha_snapshot = next(m for m in snapshot["members"] if m["member_id"] == "alpha")
+    alpha_filtered = next(m for m in filtered["members"] if m["member_id"] == "alpha")
+
+    assert alpha_snapshot["participations"] == 2
+    assert alpha_filtered["participations"] == 1
+    assert alpha_filtered["wins"] == 1
+
+    pairwise_global = next(
+        p for p in snapshot["pairwise"] if p["member_a"] == "alpha" and p["member_b"] == "beta"
+    )
+    pairwise_filtered = next(
+        p for p in filtered["pairwise"] if p["member_a"] == "alpha" and p["member_b"] == "beta"
+    )
+    assert pairwise_global["agreements"] == 2
+    assert pairwise_filtered["agreements"] == 1
+
+
 def test_stats_store_updates_pairwise_ema(store: CouncilStatsStore) -> None:
     outcome = _build_outcome()
 
@@ -141,3 +166,69 @@ def test_stats_store_serializes_ema_flags(store: CouncilStatsStore) -> None:
     assert alpha_beta["ema_high_agreement"] is False
     assert alpha_beta["ema_low_agreement"] is True
     assert alpha_beta["ema_last_updated"]
+
+
+def test_stats_store_migrates_schema(tmp_path: Path) -> None:
+    db_dir = tmp_path / "council"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / "legacy.sqlite3"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE council_member_stats (
+            member_id TEXT PRIMARY KEY,
+            participations INTEGER DEFAULT 0,
+            wins INTEGER DEFAULT 0,
+            total_confidence REAL DEFAULT 0.0
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE council_pairwise_agreements (
+            member_a TEXT,
+            member_b TEXT,
+            agreements INTEGER DEFAULT 0,
+            disagreements INTEGER DEFAULT 0,
+            PRIMARY KEY(member_a, member_b)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO council_member_stats(member_id, participations, wins, total_confidence)
+        VALUES('alpha', 2, 1, 1.2)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO council_pairwise_agreements(member_a, member_b, agreements, disagreements)
+        VALUES('alpha', 'beta', 3, 1)
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = CouncilStatsStore(db_path=db_path)
+
+    member_columns = {
+        row[1] for row in store.conn.execute("PRAGMA table_info(council_member_stats)")
+    }
+    pairwise_columns = {
+        row[1] for row in store.conn.execute("PRAGMA table_info(council_pairwise_agreements)")
+    }
+    assert "question_id" in member_columns
+    assert "question_id" in pairwise_columns
+
+    stats = store.get_member_stats("alpha")
+    assert stats["participations"] == 2
+
+    pairwise = store.get_pairwise_agreement("alpha", "beta")
+    assert pairwise["agreements"] == 3
+
+    question_id = store.conn.execute(
+        "SELECT question_id FROM council_member_stats WHERE member_id='alpha'"
+    ).fetchone()
+    assert question_id
+    assert question_id[0] == ""


### PR DESCRIPTION
### Motivation
- Enable question-scoped storage for council metrics so metrics can be persisted and queried per-question while preserving backward compatibility with existing databases.
- Allow consumers to request either global aggregates or question-specific metrics via `serialize_metrics` to support question-scoped views and analytics.

### Description
- Added `question_id` to both `council_member_stats` and `council_pairwise_agreements` schemas and implemented migration paths that upgrade legacy tables into new tables with a default empty `question_id` key.
- Updated persistence to include question context: `record_outcome` extracts `question.question_id` and persists member and pairwise rows scoped to that `question_id`.
- Adjusted aggregation and read paths: `get_member_stats` and `get_pairwise_agreement` now aggregate across question-scoped rows for global queries, and `serialize_metrics` supports an optional `question_id` filter while still producing the same output shape.
- Added unit tests in `tests/unit/agents/council/test_stats_store.py` covering filtered vs global serialization and legacy schema migration behavior.

### Testing
- Ran `ruff check .` which failed due to pre-existing lint issues elsewhere in the repository and not related to these changes (reported but not resolved here).
- Ran `pytest tests/unit/agents/council/test_stats_store.py` which passed (all tests in that file succeeded with a single PytestConfigWarning about `asyncio_mode`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3ea219c08326b63b22d1e5b9b152)