### PR TITLE
Enforce council CLI env guard by default

### DIFF
--- a/docs/council_mode_design.md
+++ b/docs/council_mode_design.md
@@ -89,7 +89,7 @@ Qualitative checks should include manual review of L1/L2 summaries and Knowledge
   ```
   The CLI accepts repeated `--rag-doc/--rag-docs` flags to supply additional evidence, and `--question-id` is persisted in metrics to link answers to observability traces.
 
-> If `USE_COUNCIL_MODE` is omitted or set to `false`, the CLI will raise `RuntimeError: Council mode is disabled; set USE_COUNCIL_MODE=true to enable it.` instead of running the council deliberation.
+> If `USE_COUNCIL_MODE` is omitted or set to `false`, the CLI exits with a guardrail message and status 1 unless you pass `--bypass-env-guard` to override the default enforcement.
 
 ### Council-specific toggles
 - `USE_COUNCIL_MODE`: Enable/disable council orchestration globally; set in `.env` or via `export USE_COUNCIL_MODE=true` before running simulations.

--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -209,11 +209,11 @@ def main(
         help="Display fitness or collusion metrics from the council outcome",
     ),
     bypass_env_guard: bool = typer.Option(
-        True,
+        False,
         "--bypass-env-guard/--enforce-env-guard",
         help=(
-            "Allow the council to run even when USE_COUNCIL_MODE is false. Disable to "
-            "respect the environment guard."
+            "Enforce the USE_COUNCIL_MODE guard by default; pass --bypass-env-guard to "
+            "run even when USE_COUNCIL_MODE is false."
         ),
     ),
     question_id: str | None = typer.Option(

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -303,14 +303,46 @@ def test_council_cli_show_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Key metrics:" not in result_default.output
 
 
-def test_council_cli_honors_env_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_council_cli_defaults_to_env_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     monkeypatch.setattr(council_cli, "get_config", lambda *_args, **_kwargs: False)
 
-    result = runner.invoke(council_cli.app, ["Prompt", "--enforce-env-guard"])
+    result = runner.invoke(council_cli.app, ["Prompt"])
 
     assert result.exit_code == 1
     assert "Council Mode is disabled" in result.output
+
+
+def test_council_cli_bypass_env_guard_allows_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+    monkeypatch.setattr(council_cli, "get_config", lambda *_args, **_kwargs: False)
+    recorded_allow_disabled: list[bool] = []
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+        allow_disabled_mode: bool,
+    ) -> CouncilOutcome:
+        recorded_allow_disabled.append(allow_disabled_mode)
+        return CouncilOutcome(
+            question=question,
+            answers=[],
+            resolution="Mock resolution",
+            winning_member_ids=[],
+            summary=None,
+            metadata={"fitness": {"scores": []}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
+
+    result = runner.invoke(council_cli.app, ["Prompt", "--bypass-env-guard"])
+
+    assert result.exit_code == 0
+    assert recorded_allow_disabled == [True]
 
 
 def test_council_cli_supports_legacy_short_flags(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Make the council CLI safer by enforcing the `USE_COUNCIL_MODE` guard by default so councils do not run unless explicitly enabled.  
- Ensure help text and docs reflect the enforced default and provide an explicit override.  
- Add unit coverage to assert both the default guarded behavior and the explicit bypass path.

### Description
- Changed the `bypass_env_guard` CLI option default in `scripts/council_cli.py` from `True` to `False` and updated the option help text to explain that `--bypass-env-guard` must be passed to override enforcement.  
- Updated `tests/unit/scripts/test_council_cli.py` to assert the CLI exits when `USE_COUNCIL_MODE` is false by default (`test_council_cli_defaults_to_env_guard`) and added `test_council_cli_bypass_env_guard_allows_run` which passes `--bypass-env-guard` to confirm the override still works.  
- Updated `docs/council_mode_design.md` to document the enforced default behavior and the `--bypass-env-guard` escape hatch.

### Testing
- Ran `pytest tests/unit/scripts/test_council_cli.py`, which passed (`9 passed`).  
- Ran `ruff check .`, which returned non-zero due to pre-existing lint issues in the repository (reported by the tool).  
- Ran `black --check .`, which reported files that would be reformatted (formatting needed across the repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4083aa8c83268c1b9bb4bc7c5481)