### PR TITLE
Attach EMA pairwise agreement stats to CouncilOutcome and test inclusion

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1719,6 +1719,21 @@ class CouncilOrchestrator:
     async def _record_outcome_metrics(self, outcome: CouncilOutcome) -> None:
         try:
             await council_stats_store.record_outcome_async(outcome)
+            stats_snapshot = await council_stats_store.serialize_metrics_async(
+                question_id=outcome.question.question_id
+            )
+            pairwise_stats = stats_snapshot.get("pairwise")
+            if isinstance(pairwise_stats, list):
+                outcome.metrics["pairwise_ema_stats"] = pairwise_stats
+                metadata: dict[str, Any] = dict(outcome.metadata or {})
+                metrics = metadata.get("metrics")
+                if isinstance(metrics, Mapping):
+                    metrics = dict(metrics)
+                else:
+                    metrics = {}
+                metrics["pairwise_ema_stats"] = pairwise_stats
+                metadata["metrics"] = metrics
+                outcome.metadata = metadata
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(
                 "Failed to persist council metrics",

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -322,9 +322,18 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
         "analyst|innovator",
         "facilitator|innovator",
     }
+    pairwise_stats = outcome.metrics["pairwise_ema_stats"]
+    pairwise_pairs = {(entry["member_a"], entry["member_b"]) for entry in pairwise_stats}
+    assert pairwise_pairs == {
+        ("analyst", "facilitator"),
+        ("analyst", "innovator"),
+        ("facilitator", "innovator"),
+    }
+    assert all(entry["ema_last_updated"] for entry in pairwise_stats)
 
     serialized = json.loads(json.dumps(outcome.metadata))
     assert serialized["metrics"]["cohesion"] == pytest.approx(0.91)
+    assert serialized["metrics"]["pairwise_ema_stats"] == pairwise_stats
     fitness = serialized.get("fitness", {})
     member_fitness = fitness.get("members", {})
     assert member_fitness["facilitator"]["wins"] == 1


### PR DESCRIPTION
### Motivation
- Expose the latest pairwise EMA agreement statistics alongside a recorded council outcome so downstream consumers can inspect agreement history per question.
- Ensure the EMA payload is available both in `CouncilOutcome.metrics` and mirrored into `metadata.metrics` after persisting stats.

### Description
- After recording an outcome with `council_stats_store.record_outcome_async`, fetch a serialized metrics snapshot via `council_stats_store.serialize_metrics_async(question_id=...)` and extract the `pairwise` list.
- If present, attach the pairwise EMA rows to `outcome.metrics["pairwise_ema_stats"]` and also inject them into `outcome.metadata["metrics"]["pairwise_ema_stats"]` so the metadata payload mirrors the enriched metrics.
- Added targeted unit assertions in `tests/unit/agents/council/test_council_orchestrator.py` that verify `pairwise_ema_stats` is present in `outcome.metrics`, contains the expected member pairs, includes `ema_last_updated`, and is mirrored in serialized `outcome.metadata`.

### Testing
- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py` and the suite passed (`20 passed`).
- Ran `ruff check .` which reported existing repository lint issues unrelated to these changes (no new lint failures introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4084abb8832698f0691dfb353394)