### PR TITLE
Persist outcome question_id and enable question-scoped metrics

### DIFF
--- a/src/agents/council/stats_store.py
+++ b/src/agents/council/stats_store.py
@@ -51,6 +51,7 @@ class CouncilStatsStore:
             self._ensure_member_stats_schema()
             self._ensure_pairwise_schema()
             self._ensure_pairwise_columns()
+            self._ensure_outcomes_schema()
             self.conn.commit()
 
     def _ensure_member_stats_schema(self) -> None:
@@ -185,6 +186,45 @@ class CouncilStatsStore:
             self.conn.execute(
                 "ALTER TABLE council_pairwise_agreements ADD COLUMN last_updated TEXT"
             )
+
+    def _ensure_outcomes_schema(self) -> None:
+        columns = {row[1] for row in self.conn.execute("PRAGMA table_info(council_outcomes)")}
+        if not columns:
+            self.conn.execute(
+                """
+                CREATE TABLE council_outcomes (
+                    outcome_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    question_id TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT ''
+                )
+                """
+            )
+            return
+        if "question_id" in columns:
+            return
+        outcome_id_expr = "outcome_id" if "outcome_id" in columns else "NULL"
+        created_expr = "created_at" if "created_at" in columns else "''"
+        self.conn.execute(
+            """
+            CREATE TABLE council_outcomes_new (
+                outcome_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                question_id TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        self.conn.execute(
+            f"""
+            INSERT INTO council_outcomes_new(outcome_id, question_id, created_at)
+            SELECT
+                {outcome_id_expr},
+                '',
+                {created_expr}
+            FROM council_outcomes
+            """
+        )
+        self.conn.execute("DROP TABLE council_outcomes")
+        self.conn.execute("ALTER TABLE council_outcomes_new RENAME TO council_outcomes")
 
     def _normalize_answer(self, answer: str | None) -> str:
         return (answer or "").strip().lower()
@@ -363,6 +403,13 @@ class CouncilStatsStore:
         winning_ids = {member_id for member_id in outcome.winning_member_ids}
         with self._lock:
             cur = self.conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO council_outcomes(question_id, created_at)
+                VALUES(?, ?)
+                """,
+                (question_id, timestamp),
+            )
             self._update_member_stats(cur, question_id, answers, winning_ids)
             self._update_pairwise_agreements(
                 cur,
@@ -461,7 +508,9 @@ class CouncilStatsStore:
     def serialize_metrics(
         self, *, question_id: str | None = None
     ) -> dict[str, list[dict[str, float | str | bool]]]:
-        filter_question_id = (question_id or "").strip() if question_id else None
+        filter_question_id = None
+        if question_id is not None:
+            filter_question_id = question_id.strip()
         with self._lock:
             if filter_question_id is None:
                 member_rows = self.conn.execute(

--- a/tests/unit/agents/council/test_stats_store.py
+++ b/tests/unit/agents/council/test_stats_store.py
@@ -106,6 +106,17 @@ def test_stats_store_serializes_filtered_metrics(store: CouncilStatsStore) -> No
     assert pairwise_filtered["agreements"] == 1
 
 
+def test_stats_store_records_outcome_question_id(store: CouncilStatsStore) -> None:
+    store.record_outcome(_build_outcome("q-9"))
+
+    row = store.conn.execute(
+        "SELECT question_id FROM council_outcomes ORDER BY outcome_id DESC LIMIT 1"
+    ).fetchone()
+
+    assert row
+    assert row[0] == "q-9"
+
+
 def test_stats_store_updates_pairwise_ema(store: CouncilStatsStore) -> None:
     outcome = _build_outcome()
 
@@ -197,6 +208,14 @@ def test_stats_store_migrates_schema(tmp_path: Path) -> None:
     )
     conn.execute(
         """
+        CREATE TABLE council_outcomes (
+            outcome_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
         INSERT INTO council_member_stats(member_id, participations, wins, total_confidence)
         VALUES('alpha', 2, 1, 1.2)
         """
@@ -205,6 +224,12 @@ def test_stats_store_migrates_schema(tmp_path: Path) -> None:
         """
         INSERT INTO council_pairwise_agreements(member_a, member_b, agreements, disagreements)
         VALUES('alpha', 'beta', 3, 1)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO council_outcomes(created_at)
+        VALUES('2024-01-01T00:00:00+00:00')
         """
     )
     conn.commit()
@@ -218,8 +243,12 @@ def test_stats_store_migrates_schema(tmp_path: Path) -> None:
     pairwise_columns = {
         row[1] for row in store.conn.execute("PRAGMA table_info(council_pairwise_agreements)")
     }
+    outcomes_columns = {
+        row[1] for row in store.conn.execute("PRAGMA table_info(council_outcomes)")
+    }
     assert "question_id" in member_columns
     assert "question_id" in pairwise_columns
+    assert "question_id" in outcomes_columns
 
     stats = store.get_member_stats("alpha")
     assert stats["participations"] == 2
@@ -232,3 +261,9 @@ def test_stats_store_migrates_schema(tmp_path: Path) -> None:
     ).fetchone()
     assert question_id
     assert question_id[0] == ""
+
+    outcome_question = store.conn.execute(
+        "SELECT question_id FROM council_outcomes WHERE outcome_id=1"
+    ).fetchone()
+    assert outcome_question
+    assert outcome_question[0] == ""


### PR DESCRIPTION
### Motivation
- Persist the `question_id` associated with recorded outcomes so metrics can be scoped and filtered per question.
- Migrate legacy schemas that lacked a place to store outcome question ids to avoid data loss and ensure consistent behavior.

### Description
- Add `_ensure_outcomes_schema` which creates a `council_outcomes` table and implements migration logic for legacy schemas. 
- Record an entry in `council_outcomes` (including `question_id` and timestamp) inside `record_outcome`. 
- Adjust `serialize_metrics` filtering to treat a provided `question_id` (after `strip()`) as a filter and preserve global behavior when `None`. 
- Add unit tests in `tests/unit/agents/council/test_stats_store.py` to assert outcome question persistence and verify migration of legacy schemas.

### Testing
- Ran `ruff check src/agents/council/stats_store.py tests/unit/agents/council/test_stats_store.py` and the linter passed. 
- Ran `pytest tests/unit/agents/council/test_stats_store.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977e1eaea04832692a40616c375724b)