### PR TITLE
Require USE_COUNCIL_MODE by default for council CLI

### DIFF
--- a/docs/council_mode_design.md
+++ b/docs/council_mode_design.md
@@ -89,7 +89,7 @@ Qualitative checks should include manual review of L1/L2 summaries and Knowledge
   ```
   The CLI accepts repeated `--rag-doc/--rag-docs` flags to supply additional evidence, and `--question-id` is persisted in metrics to link answers to observability traces.
 
-> If `USE_COUNCIL_MODE` is omitted or set to `false`, the CLI exits with a guardrail message and status 1 unless you pass `--bypass-env-guard` to override the default enforcement.
+> If `USE_COUNCIL_MODE` is omitted or set to `false`, the CLI exits with a guardrail message and status 1 by default; use `--bypass-env-guard` to override.
 
 ### Council-specific toggles
 - `USE_COUNCIL_MODE`: Enable/disable council orchestration globally; set in `.env` or via `export USE_COUNCIL_MODE=true` before running simulations.

--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -210,7 +210,7 @@ def main(
         False,
         "--bypass-env-guard/--enforce-env-guard",
         help=(
-            "Enforce the USE_COUNCIL_MODE guard by default; pass --bypass-env-guard to "
+            "Require USE_COUNCIL_MODE=true by default; pass --bypass-env-guard to "
             "run even when USE_COUNCIL_MODE is false."
         ),
     ),

--- a/tests/unit/scripts/test_council_cli.py
+++ b/tests/unit/scripts/test_council_cli.py
@@ -306,11 +306,32 @@ def test_council_cli_show_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_council_cli_defaults_to_env_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     monkeypatch.setattr(council_cli, "get_config", lambda *_args, **_kwargs: False)
+    recorded_calls: list[bool] = []
+
+    def fake_run_council(
+        question: CouncilQuestion,
+        *,
+        extra_context: str | None,
+        rag_docs: list[str] | None,
+        allow_disabled_mode: bool,
+    ) -> CouncilOutcome:
+        recorded_calls.append(allow_disabled_mode)
+        return CouncilOutcome(
+            question=question,
+            answers=[],
+            resolution="Mock resolution",
+            winning_member_ids=[],
+            summary=None,
+            metadata={"fitness": {"scores": []}},
+        )
+
+    monkeypatch.setattr(council_cli, "run_council", fake_run_council)
 
     result = runner.invoke(council_cli.app, ["Prompt"])
 
     assert result.exit_code == 1
     assert "Council Mode is disabled" in result.output
+    assert recorded_calls == []
 
 
 def test_council_cli_bypass_env_guard_allows_run(


### PR DESCRIPTION
### Motivation
- Ensure the council CLI enforces the `USE_COUNCIL_MODE` guard by default and make the UX and docs explicit about that behavior.
- Prevent accidental runs when the global council mode flag is not enabled while preserving an explicit bypass for advanced uses.

### Description
- Clarify the `--bypass-env-guard/--enforce-env-guard` help text in `scripts/council_cli.py` to state that `USE_COUNCIL_MODE=true` is required by default.
- Strengthen `tests/unit/scripts/test_council_cli.py` to assert that the CLI exits without invoking `run_council` when `USE_COUNCIL_MODE` is false and to retain the existing test that passing `--bypass-env-guard` allows the run and passes `allow_disabled_mode=True`.
- Update the CLI guard wording in `docs/council_mode_design.md` to match the enforced default behavior.

### Testing
- Ran the linter checks with `ruff check scripts/council_cli.py tests/unit/scripts/test_council_cli.py` which completed successfully.
- Ran the unit tests with `pytest tests/unit/scripts/test_council_cli.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f3030d788326912b4e0957de50b3)