### PR TITLE
Add EMA agreement stats to council outcomes

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1724,7 +1724,18 @@ class CouncilOrchestrator:
             )
             pairwise_stats = stats_snapshot.get("pairwise")
             if isinstance(pairwise_stats, list):
+                pairwise_map: dict[str, dict[str, Any]] = {}
+                for entry in pairwise_stats:
+                    if not isinstance(entry, Mapping):
+                        continue
+                    member_a = entry.get("member_a")
+                    member_b = entry.get("member_b")
+                    if not member_a or not member_b:
+                        continue
+                    pair_key = "|".join(sorted((str(member_a), str(member_b))))
+                    pairwise_map[pair_key] = dict(entry)
                 outcome.metrics["pairwise_ema_stats"] = pairwise_stats
+                outcome.metrics["pairwise_ema_by_pair"] = pairwise_map
                 metadata: dict[str, Any] = dict(outcome.metadata or {})
                 metrics = metadata.get("metrics")
                 if isinstance(metrics, Mapping):
@@ -1732,6 +1743,7 @@ class CouncilOrchestrator:
                 else:
                     metrics = {}
                 metrics["pairwise_ema_stats"] = pairwise_stats
+                metrics["pairwise_ema_by_pair"] = pairwise_map
                 metadata["metrics"] = metrics
                 outcome.metadata = metadata
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -330,10 +330,18 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
         ("facilitator", "innovator"),
     }
     assert all(entry["ema_last_updated"] for entry in pairwise_stats)
+    pairwise_by_pair = outcome.metrics["pairwise_ema_by_pair"]
+    assert set(pairwise_by_pair.keys()) == {
+        "analyst|facilitator",
+        "analyst|innovator",
+        "facilitator|innovator",
+    }
+    assert pairwise_by_pair["analyst|facilitator"]["ema_agreement"] >= 0.0
 
     serialized = json.loads(json.dumps(outcome.metadata))
     assert serialized["metrics"]["cohesion"] == pytest.approx(0.91)
     assert serialized["metrics"]["pairwise_ema_stats"] == pairwise_stats
+    assert serialized["metrics"]["pairwise_ema_by_pair"] == pairwise_by_pair
     fitness = serialized.get("fitness", {})
     member_fitness = fitness.get("members", {})
     assert member_fitness["facilitator"]["wins"] == 1


### PR DESCRIPTION
### Motivation

- Persist the latest pairwise EMA agreement data into the recorded council outcome so downstream consumers can access per-pair agreement metrics keyed by member pairs.

### Description

- After persisting an outcome, fetch `serialize_metrics_async` from `council_stats_store` and extract `pairwise` entries into a map keyed by a canonical pair string `"member_a|member_b"`.
- Attach the raw `pairwise` list to `outcome.metrics["pairwise_ema_stats"]` and the derived map to `outcome.metrics["pairwise_ema_by_pair"]`.
- Mirror the same `pairwise_ema_stats` and `pairwise_ema_by_pair` into `outcome.metadata["metrics"]` so serialized metadata includes the EMA payload.
- Add assertions in `tests/unit/agents/council/test_council_orchestrator.py` that verify `outcome.metrics` contains `pairwise_ema_by_pair` with the expected keys and that the serialized `outcome.metadata["metrics"]` includes the same mapping.

### Testing

- Ran `pytest tests/unit/agents/council/test_council_orchestrator.py` and all tests in that file passed (`20 passed`).
- Ran `ruff check .` which reported pre-existing lint violations in other parts of the repo (not introduced by this change), so linting did not fully pass in the repository context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f30424508326b490ee9fdcc976a4)