### PR TITLE
Validate uniqueness of CouncilConfig member IDs and display names

### DIFF
--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -158,6 +158,33 @@ class CouncilConfig(BaseModel):
             raise ValueError("Council configuration must include at least one member")
         if not any(member.is_active for member in value):
             raise ValueError("At least one council member must be active")
+
+        seen_member_ids: set[str] = set()
+        duplicate_member_ids: set[str] = set()
+        seen_display_names: set[str] = set()
+        duplicate_display_names: set[str] = set()
+        for member in value:
+            if member.member_id in seen_member_ids:
+                duplicate_member_ids.add(member.member_id)
+            else:
+                seen_member_ids.add(member.member_id)
+
+            display_name = member.display_name.strip()
+            if not display_name:
+                continue
+            if display_name in seen_display_names:
+                duplicate_display_names.add(display_name)
+            else:
+                seen_display_names.add(display_name)
+
+        if duplicate_member_ids:
+            duplicates = ", ".join(sorted(duplicate_member_ids))
+            raise ValueError(f"Council member IDs must be unique; duplicates: {duplicates}")
+
+        if duplicate_display_names:
+            duplicates = ", ".join(sorted(duplicate_display_names))
+            raise ValueError(f"Council member display names should be unique; duplicates: {duplicates}")
+
         return value
 
     @field_validator("voting_mode", mode="before")

--- a/tests/unit/agents/council/test_council_types.py
+++ b/tests/unit/agents/council/test_council_types.py
@@ -108,6 +108,73 @@ def test_load_fails_without_active_members(
         )
 
 
+def test_load_fails_with_duplicate_member_ids(
+    council_config_adapter: TypeAdapter[CouncilConfig],
+) -> None:
+    with pytest.raises(ValidationError):
+        council_config_adapter.validate_python(
+            {
+                "enabled": True,
+                "members": [
+                    {
+                        "member_id": "facilitator",
+                        "display_name": "Facilitator",
+                        "role": "Moderator",
+                        "persona": "Guides the discussion",
+                        "model": "mistral:latest",
+                        "temperature": 0.2,
+                        "max_tokens": 256,
+                        "is_active": True,
+                    },
+                    {
+                        "member_id": "facilitator",
+                        "display_name": "Innovator",
+                        "role": "Innovator",
+                        "persona": "Contributes new ideas",
+                        "model": "mistral:latest",
+                        "temperature": 0.4,
+                        "max_tokens": 256,
+                        "is_active": True,
+                    },
+                ],
+            }
+        )
+
+
+def test_load_passes_with_distinct_member_ids(
+    council_config_adapter: TypeAdapter[CouncilConfig],
+) -> None:
+    config = council_config_adapter.validate_python(
+        {
+            "enabled": True,
+            "members": [
+                {
+                    "member_id": "facilitator",
+                    "display_name": "Facilitator",
+                    "role": "Moderator",
+                    "persona": "Guides the discussion",
+                    "model": "mistral:latest",
+                    "temperature": 0.2,
+                    "max_tokens": 256,
+                    "is_active": True,
+                },
+                {
+                    "member_id": "innovator",
+                    "display_name": "Innovator",
+                    "role": "Innovator",
+                    "persona": "Contributes new ideas",
+                    "model": "mistral:latest",
+                    "temperature": 0.4,
+                    "max_tokens": 256,
+                    "is_active": True,
+                },
+            ],
+        }
+    )
+
+    assert [member.member_id for member in config.members] == ["facilitator", "innovator"]
+
+
 def test_load_accepts_legacy_voting_mode(
     council_config_adapter: TypeAdapter[CouncilConfig],
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent ambiguous council configuration by ensuring each `CouncilMemberConfig.member_id` is unique within a `CouncilConfig` and discouraging duplicate non-empty `display_name` values. 

### Description
- Add members validation in `CouncilConfig._validate_members` that collects `member_id` and non-empty `display_name` occurrences and raises `ValueError` when duplicates are detected. 
- Duplicate error messages include the offending values for easier debugging (e.g. `Council member IDs must be unique; duplicates: ...`).
- Add two unit tests in `tests/unit/agents/council/test_council_types.py`: `test_load_fails_with_duplicate_member_ids` which asserts validation fails for duplicate IDs, and `test_load_passes_with_distinct_member_ids` which asserts success when IDs are distinct.

### Testing
- Ran `ruff check src/agents/council/types.py tests/unit/agents/council/test_council_types.py` and it passed for the modified files.
- Ran `pytest tests/unit/agents/council/test_council_types.py -q` and the suite passed (`8 passed`).
- Ran the repository lint script `bash ./scripts/lint.sh`, which failed due to pre-existing repo-wide lint violations unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986281dd2f08326b695b6b7021964e7)