### PR TITLE
Prevent synchronous council runner from running inside an active asyncio event loop

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1291,6 +1291,17 @@ class CouncilOrchestrator:
     ) -> CouncilOutcome:
         """Synchronously deliberate by awaiting the async implementation."""
 
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "CouncilOrchestrator.deliberate() and run_council() cannot run inside an active "
+                "event loop. In async code, call `await CouncilOrchestrator.adeliberate(...)` "
+                "with a resolved council context instead."
+            )
+
         context = self._resolve_context(config)
         return asyncio.run(
             self.adeliberate(

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import time
@@ -271,6 +272,21 @@ def test_council_orchestrator_can_bypass_env_guard(
     )
 
     assert outcome.winning_member_ids
+
+
+def test_run_council_raises_clear_error_inside_event_loop() -> None:
+    question = _build_question()
+
+    async def invoke_inside_loop() -> None:
+        with pytest.raises(RuntimeError) as excinfo:
+            council_orchestrator.run_council(question)
+
+        assert (
+            "cannot run inside an active event loop" in str(excinfo.value)
+        )
+        assert "await CouncilOrchestrator.adeliberate(...)" in str(excinfo.value)
+
+    asyncio.run(invoke_inside_loop())
 
 
 class DummyRetriever:


### PR DESCRIPTION
### Motivation
- Calling `asyncio.run` from code that is already inside an event loop raises a confusing error and can break async callers; the sync entrypoints should detect this and provide actionable guidance. 
- Tests should assert the guidance so callers are routed to the async `adeliberate` API when appropriate.

### Description
- Added an active-event-loop guard in `CouncilOrchestrator.deliberate()` that checks `asyncio.get_running_loop()` and raises a clear `RuntimeError` directing async callers to `await CouncilOrchestrator.adeliberate(...)` instead of using the sync runner. 
- The error message explicitly mentions that `deliberate()` and `run_council()` cannot run inside an active event loop and recommends `adeliberate`. 
- Added a focused unit test `test_run_council_raises_clear_error_inside_event_loop` in `tests/unit/agents/council/test_council_orchestrator.py` that invokes `run_council` inside an event loop and asserts the guidance text is present. 
- Imported `asyncio` in the test module to drive the event-loop-based assertion.

### Testing
- Ran linting with `ruff check src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py` and it passed. 
- Ran unit tests with `pytest tests/unit/agents/council/test_council_orchestrator.py -q` and the suite passed (`21 passed`, `1 warning` related to pytest config).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986281e5f308326965f8158782ba774)