### PR TITLE
Add per-member DU/IP budget overrides and enforce them in orchestrator

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -108,9 +108,7 @@ class CouncilRunMetrics:
         self._runs_total = getattr(prom_metrics, "COUNCIL_RUNS_TOTAL", None)
         self._member_wins_total = getattr(prom_metrics, "COUNCIL_MEMBER_WINS_TOTAL", None)
         self._member_score = getattr(prom_metrics, "COUNCIL_MEMBER_SCORE", None)
-        self._pairwise_agreement = getattr(
-            prom_metrics, "COUNCIL_PAIRWISE_AGREEMENT", None
-        )
+        self._pairwise_agreement = getattr(prom_metrics, "COUNCIL_PAIRWISE_AGREEMENT", None)
         self._collusion_warnings_total = getattr(
             prom_metrics, "COUNCIL_COLLUSION_WARNINGS_TOTAL", None
         )
@@ -201,15 +199,18 @@ class CouncilRunMetrics:
             self.record_collusion_warnings(warnings)
 
     def record_du_usage(
-        self, member_states: Mapping[str, SimpleNamespace], budget: float | None
+        self, member_states: Mapping[str, SimpleNamespace], budgets: Mapping[str, float] | None
     ) -> None:
-        if budget is None:
-            return
-        try:
-            budget_value = float(budget)
-        except (TypeError, ValueError):
+        if not budgets:
             return
         for member_id, state in member_states.items():
+            budget = budgets.get(member_id)
+            if budget is None:
+                continue
+            try:
+                budget_value = float(budget)
+            except (TypeError, ValueError):
+                continue
             remaining = getattr(state, "du", None)
             if remaining is None:
                 continue
@@ -760,7 +761,9 @@ def _extract_category_scores(raw: Mapping[str, Any]) -> dict[str, float]:
     return scores
 
 
-def _extract_metrics_member_scores(metrics: Mapping[str, Any] | None) -> dict[str, dict[str, float]]:
+def _extract_metrics_member_scores(
+    metrics: Mapping[str, Any] | None,
+) -> dict[str, dict[str, float]]:
     if not isinstance(metrics, Mapping):
         return {}
     raw_member_scores = metrics.get("member_scores")
@@ -820,7 +823,8 @@ def _normalize_vote_metrics(
 
     if not totals and breakdown:
         totals = {
-            member_id: sum(scores.values()) / len(scores) for member_id, scores in breakdown.items()
+            member_id: sum(scores.values()) / len(scores)
+            for member_id, scores in breakdown.items()
         }
 
     member_ids = {answer.member_id for answer in answers}
@@ -905,8 +909,7 @@ def _derive_agreement_summary(
             else:
                 agreement_score = (
                     1.0
-                    if _normalize_answer_text(left.answer)
-                    == _normalize_answer_text(right.answer)
+                    if _normalize_answer_text(left.answer) == _normalize_answer_text(right.answer)
                     else 0.0
                 )
             agreement_scores.append(agreement_score)
@@ -922,9 +925,7 @@ def _derive_agreement_summary(
         if isinstance(warnings, Sequence) and not isinstance(warnings, (str, bytes)):
             collusion_warnings = [warning for warning in warnings if isinstance(warning, str)]
 
-    agreement_score = (
-        sum(agreement_scores) / len(agreement_scores) if agreement_scores else 0.0
-    )
+    agreement_score = sum(agreement_scores) / len(agreement_scores) if agreement_scores else 0.0
     return {
         "agreement_score": agreement_score,
         "pairwise_ema": pairwise_ema,
@@ -1324,9 +1325,7 @@ class CouncilOrchestrator:
     ) -> CouncilOutcome:
         council_enabled = bool(get_config("USE_COUNCIL_MODE"))
         if not allow_disabled_mode and not council_enabled:
-            raise RuntimeError(
-                "Council mode is disabled; set USE_COUNCIL_MODE=true to enable it."
-            )
+            raise RuntimeError("Council mode is disabled; set USE_COUNCIL_MODE=true to enable it.")
 
         if not context.config.enabled:
             raise RuntimeError("Council mode is disabled in the council configuration.")
@@ -1348,7 +1347,7 @@ class CouncilOrchestrator:
         )
         metrics: dict[str, Any] = {
             "du_budget_exhausted": False,
-            "du_budget_per_member": self._resolve_du_budget(context.config),
+            "du_budget_per_member": self._resolve_du_budgets(context.config),
         }
         if not context.config.members:
             metrics.update({"member_count": 0, "error": "no_active_members"})
@@ -1442,9 +1441,7 @@ class CouncilOrchestrator:
 
         base_metrics = dict(metrics or {})
         base_metrics.setdefault("du_budget_exhausted", False)
-        base_metrics.setdefault(
-            "du_budget_per_member", self._resolve_du_budget(context.config)
-        )
+        base_metrics.setdefault("du_budget_per_member", self._resolve_du_budgets(context.config))
         outcome = self._build_outcome(
             question, answers, vote, base_metrics, run_metrics=run_metrics
         )
@@ -1457,10 +1454,19 @@ class CouncilOrchestrator:
             return float(config.du_budget_per_question)
         return float(self.du_budget_per_question)
 
+    def _resolve_du_budgets(self, config: CouncilConfig) -> dict[str, float]:
+        default_budget = self._resolve_du_budget(config)
+        return {
+            member.member_id: (
+                float(member.du_budget) if member.du_budget is not None else default_budget
+            )
+            for member in config.members
+        }
+
     def _allocate_du_budgets(
         self, config: CouncilConfig, metrics: dict[str, Any]
     ) -> dict[str, SimpleNamespace]:
-        budget = self._resolve_du_budget(config)
+        budgets = self._resolve_du_budgets(config)
         member_states: dict[str, SimpleNamespace] = {}
         try:
             resource_manager = get_resource_manager()
@@ -1469,7 +1475,9 @@ class CouncilOrchestrator:
             resource_manager = None
 
         for member in config.members:
-            state = SimpleNamespace(agent_id=member.member_id, du=budget, ip=0.0)
+            budget = budgets.get(member.member_id, 0.0)
+            ip_budget = float(member.ip_budget) if member.ip_budget is not None else 0.0
+            state = SimpleNamespace(agent_id=member.member_id, du=budget, ip=ip_budget)
             member_states[member.member_id] = state
             if resource_manager is None:
                 continue
@@ -1478,7 +1486,7 @@ class CouncilOrchestrator:
             except Exception as exc:  # pragma: no cover - defensive
                 logger.debug("Failed to allocate DU budget for %s: %s", member.member_id, exc)
 
-        metrics["du_budget_per_member"] = budget
+        metrics["du_budget_per_member"] = budgets
         return member_states
 
     async def _gather_member_answers(
@@ -1491,9 +1499,7 @@ class CouncilOrchestrator:
         rag_docs: Sequence[str],
         metrics: dict[str, Any],
     ) -> list[MemberAnswer]:
-        max_concurrent = max(
-            1, context.config.max_concurrent_calls or self.max_concurrent_calls
-        )
+        max_concurrent = max(1, context.config.max_concurrent_calls or self.max_concurrent_calls)
         semaphore = asyncio.Semaphore(max_concurrent)
         failures: list[str] = []
         answers: list[MemberAnswer] = []
@@ -1538,9 +1544,7 @@ class CouncilOrchestrator:
             except RuntimeError as exc:
                 if "budget" in str(exc).lower():
                     metrics["du_budget_exhausted"] = True
-                    logger.warning(
-                        "DU budget exhausted for member %s: %s", member.member_id, exc
-                    )
+                    logger.warning("DU budget exhausted for member %s: %s", member.member_id, exc)
                 else:
                     logger.exception("Council member call failed: %s", exc)
                 return member.member_id, None
@@ -1572,9 +1576,7 @@ class CouncilOrchestrator:
             state = member_states.get(member.member_id)
             if not _has_available_budget(member, state):
                 metrics["du_budget_exhausted"] = True
-                logger.warning(
-                    "DU budget exhausted before scheduling member %s", member.member_id
-                )
+                logger.warning("DU budget exhausted before scheduling member %s", member.member_id)
                 break
             tasks.append(asyncio.create_task(_call_member(member)))
             if len(tasks) >= max_concurrent:
@@ -1591,9 +1593,7 @@ class CouncilOrchestrator:
 
         if metrics.get("du_budget_exhausted"):
             if answers:
-                metrics.setdefault(
-                    "completed_members", [answer.member_id for answer in answers]
-                )
+                metrics.setdefault("completed_members", [answer.member_id for answer in answers])
             metrics.setdefault("partial", True)
         return answers
 
@@ -1613,9 +1613,9 @@ class CouncilOrchestrator:
         )
         failures: list[str] = []
 
-        async def _call_member(member: CouncilMemberConfig) -> tuple[
-            CouncilMemberConfig, CouncilPeerVoteModel
-        ] | None:
+        async def _call_member(
+            member: CouncilMemberConfig,
+        ) -> tuple[CouncilMemberConfig, CouncilPeerVoteModel] | None:
             state = member_states.get(member.member_id)
             try:
                 async with semaphore:
@@ -1692,14 +1692,10 @@ class CouncilOrchestrator:
             metadata.update({"scores": vote.scores or votes, "judge_reasoning": vote.reasoning})
             summary = vote.summary
             answer_lookup = {answer.member_id: answer.answer for answer in answers}
-            resolution = vote.resolution or answer_lookup.get(
-                vote.winning_member_id, resolution
-            )
+            resolution = vote.resolution or answer_lookup.get(vote.winning_member_id, resolution)
             winner_answer = answer_lookup.get(vote.winning_member_id)
             fitness_start = time.perf_counter()
-            fitness_snapshot = self.fitness_store.update_from_vote(
-                question, answers, vote
-            )
+            fitness_snapshot = self.fitness_store.update_from_vote(question, answers, vote)
             if run_metrics is not None:
                 run_metrics.record_latency(
                     "fitness_update", (time.perf_counter() - fitness_start) * 1000
@@ -1767,7 +1763,9 @@ class CouncilOrchestrator:
                 exc_info=True,
             )
 
-    def serialize_metrics(self, *, question_id: str | None = None) -> dict[str, list[dict[str, float]]]:
+    def serialize_metrics(
+        self, *, question_id: str | None = None
+    ) -> dict[str, list[dict[str, float]]]:
         """Return a snapshot of aggregated council metrics."""
 
         return council_stats_store.serialize_metrics(question_id=question_id)

--- a/src/agents/council/types.py
+++ b/src/agents/council/types.py
@@ -85,6 +85,12 @@ class CouncilMemberConfig(BaseModel):
     system_prompt: str = ""
     description: str = ""
     decision_weight: float = Field(default=1.0, ge=0.0)
+    du_budget: float | None = Field(
+        default=None, ge=0.0, validation_alias=AliasChoices("du_budget", "duBudget")
+    )
+    ip_budget: float | None = Field(
+        default=None, ge=0.0, validation_alias=AliasChoices("ip_budget", "ipBudget")
+    )
     metadata: Mapping[str, Any] | None = None
 
     @model_validator(mode="before")
@@ -183,7 +189,9 @@ class CouncilConfig(BaseModel):
 
         if duplicate_display_names:
             duplicates = ", ".join(sorted(duplicate_display_names))
-            raise ValueError(f"Council member display names should be unique; duplicates: {duplicates}")
+            raise ValueError(
+                f"Council member display names should be unique; duplicates: {duplicates}"
+            )
 
         return value
 
@@ -202,9 +210,7 @@ class CouncilQuestion(BaseModel):
         validation_alias=AliasChoices("question_id", "questionId", "id", "name")
     )
     prompt: str = Field(validation_alias=AliasChoices("prompt", "question"))
-    user_id: str | None = Field(
-        default=None, validation_alias=AliasChoices("user_id", "userId")
-    )
+    user_id: str | None = Field(default=None, validation_alias=AliasChoices("user_id", "userId"))
     extra_context: dict[str, Any] | None = Field(
         default=None, validation_alias=AliasChoices("extra_context", "extraContext", "context")
     )

--- a/tests/integration/agents/council/test_council_du_budget.py
+++ b/tests/integration/agents/council/test_council_du_budget.py
@@ -76,7 +76,9 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
     fake_resource_manager = FakeResourceManager(fake_ledger)
 
     monkeypatch.setattr(resource_manager_module, "_resource_manager", fake_resource_manager)
-    monkeypatch.setattr(resource_manager_module, "get_resource_manager", lambda: fake_resource_manager)
+    monkeypatch.setattr(
+        resource_manager_module, "get_resource_manager", lambda: fake_resource_manager
+    )
     monkeypatch.setattr(
         "src.agents.council.orchestrator.get_resource_manager", lambda: fake_resource_manager
     )
@@ -130,7 +132,9 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
         enabled=True,
         du_budget_per_question=2.0,
     )
-    question = CouncilQuestion(question_id="q1", prompt="What is DU?", context="", task_context=None)
+    question = CouncilQuestion(
+        question_id="q1", prompt="What is DU?", context="", task_context=None
+    )
 
     context = orchestrator._resolve_context(config)
     outcome = await orchestrator.adeliberate(context, question)
@@ -140,7 +144,9 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
 
     for member_id in ("member-a", "member-b"):
         initial_budget = fake_resource_manager.initial_budgets[member_id]
-        member_charges = [amt for aid, amt in fake_resource_manager.charge_calls if aid == member_id]
+        member_charges = [
+            amt for aid, amt in fake_resource_manager.charge_calls if aid == member_id
+        ]
         remaining_budget = initial_budget - sum(member_charges)
 
         assert initial_budget == pytest.approx(2.0)
@@ -155,3 +161,94 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
     recorded_du_spend = [entry for entry in fake_ledger.log_entries if entry[2] == "llm_gas"]
     assert len(recorded_du_spend) == len(fake_resource_manager.charge_calls)
     assert all(delta_du == -1.0 for _, delta_du, _ in recorded_du_spend)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_council_orchestrator_honors_per_member_du_budget_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(infra_config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+
+    fake_ledger = FakeLedger()
+    fake_resource_manager = FakeResourceManager(fake_ledger)
+
+    monkeypatch.setattr(resource_manager_module, "_resource_manager", fake_resource_manager)
+    monkeypatch.setattr(
+        resource_manager_module, "get_resource_manager", lambda: fake_resource_manager
+    )
+    monkeypatch.setattr(
+        "src.agents.council.orchestrator.get_resource_manager", lambda: fake_resource_manager
+    )
+
+    monkeypatch.setattr(llm_client, "ledger", fake_ledger)
+    monkeypatch.setattr(infra_metrics, "ledger", fake_ledger)
+
+    llm_client.enable_mock_mode(
+        True,
+        {
+            "MemberResponseModel": {
+                "answer": "stubbed",
+                "reasoning": "",
+                "confidence": 1.0,
+                "citations": [],
+            }
+        },
+    )
+
+    orchestrator = CouncilOrchestrator()
+    config = CouncilConfig(
+        members=[
+            CouncilMemberConfig(
+                member_id="member-a",
+                display_name="Member A",
+                role="Analyzer",
+                description="",
+                system_prompt="",
+                decision_weight=1.0,
+                persona="Curious analyst persona",
+                model="mistral:latest",
+                temperature=0.1,
+                max_tokens=32,
+                du_budget=3.0,
+                is_active=True,
+            ),
+            CouncilMemberConfig(
+                member_id="member-b",
+                display_name="Member B",
+                role="Generalist",
+                description="",
+                system_prompt="",
+                decision_weight=1.0,
+                persona="Helpful generalist persona",
+                model="mistral:latest",
+                temperature=0.1,
+                max_tokens=32,
+                is_active=True,
+            ),
+        ],
+        voting_mode="judge_llm",
+        enabled=True,
+        du_budget_per_question=2.0,
+    )
+    question = CouncilQuestion(
+        question_id="q1", prompt="What is DU?", context="", task_context=None
+    )
+
+    context = orchestrator._resolve_context(config)
+    outcome = await orchestrator.adeliberate(context, question)
+
+    assert outcome.answers
+    metrics = outcome.metadata.get("metrics", {}) if outcome.metadata else {}
+    assert metrics.get("du_budget_per_member") == {
+        "member-a": pytest.approx(3.0),
+        "member-b": pytest.approx(2.0),
+    }
+    assert fake_resource_manager.initial_budgets == {
+        "member-a": pytest.approx(3.0),
+        "member-b": pytest.approx(2.0),
+    }
+    assert fake_resource_manager.set_calls == [
+        ("member-a", pytest.approx(3.0)),
+        ("member-b", pytest.approx(2.0)),
+    ]

--- a/tests/performance/test_council_mock_performance.py
+++ b/tests/performance/test_council_mock_performance.py
@@ -66,9 +66,7 @@ def test_council_run_meets_latency_and_budget(member_count: int) -> None:
 
     with (
         patch.object(council_orchestrator, "_ask_council_member", side_effect=_fake_member_call),
-        patch.object(
-            council_orchestrator, "_judge_council_answers", side_effect=_fake_judge
-        ),
+        patch.object(council_orchestrator, "_judge_council_answers", side_effect=_fake_judge),
     ):
         start = time.perf_counter()
         outcome = orchestrator.deliberate(
@@ -84,6 +82,8 @@ def test_council_run_meets_latency_and_budget(member_count: int) -> None:
     assert throughput_per_minute >= 25
 
     metrics = outcome.metadata.get("metrics", {}) if outcome.metadata else {}
-    assert metrics.get("du_budget_per_member") <= 2.0
+    per_member_budget = metrics.get("du_budget_per_member", {})
+    assert per_member_budget
+    assert all(value <= 2.0 for value in per_member_budget.values())
     assert not metrics.get("du_budget_exhausted")
     assert outcome.winner_id in {member.member_id for member in members}

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -186,7 +186,9 @@ def test_council_member_forwards_generation_params(monkeypatch: pytest.MonkeyPat
             citations=[],
         )
 
-    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+    monkeypatch.setattr(
+        council_orchestrator, "generate_structured_output", fake_generate_structured_output
+    )
 
     answer = council_orchestrator._ask_council_member(member, question)
 
@@ -211,7 +213,9 @@ def test_council_member_fallback_forwards_generation_params(
         captured["max_tokens"] = int(kwargs.get("max_tokens"))
         return "fallback answer"
 
-    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+    monkeypatch.setattr(
+        council_orchestrator, "generate_structured_output", fake_generate_structured_output
+    )
     monkeypatch.setattr(council_orchestrator, "generate_text", fake_generate_text)
 
     answer = council_orchestrator._ask_council_member(member, question)
@@ -241,7 +245,9 @@ def test_peer_vote_forwards_generation_params(monkeypatch: pytest.MonkeyPatch) -
             reasoning="Peer vote reasoning",
         )
 
-    monkeypatch.setattr(council_orchestrator, "generate_structured_output", fake_generate_structured_output)
+    monkeypatch.setattr(
+        council_orchestrator, "generate_structured_output", fake_generate_structured_output
+    )
 
     result = council_orchestrator._ask_peer_vote(member, question, answers)
 
@@ -267,9 +273,7 @@ def test_council_orchestrator_can_bypass_env_guard(
     with pytest.raises(RuntimeError):
         orchestrator.deliberate(council_config, question)
 
-    outcome = orchestrator.deliberate(
-        council_config, question, allow_disabled_mode=True
-    )
+    outcome = orchestrator.deliberate(council_config, question, allow_disabled_mode=True)
 
     assert outcome.winning_member_ids
 
@@ -281,9 +285,7 @@ def test_run_council_raises_clear_error_inside_event_loop() -> None:
         with pytest.raises(RuntimeError) as excinfo:
             council_orchestrator.run_council(question)
 
-        assert (
-            "cannot run inside an active event loop" in str(excinfo.value)
-        )
+        assert "cannot run inside an active event loop" in str(excinfo.value)
         assert "await CouncilOrchestrator.adeliberate(...)" in str(excinfo.value)
 
     asyncio.run(invoke_inside_loop())
@@ -325,7 +327,11 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
     assert outcome.metadata is not None
     metrics = outcome.metadata.get("metrics", {})
     assert metrics.get("du_budget_exhausted") is False
-    assert metrics.get("du_budget_per_member") == pytest.approx(5.0)
+    assert metrics.get("du_budget_per_member") == {
+        "facilitator": pytest.approx(5.0),
+        "innovator": pytest.approx(5.0),
+        "analyst": pytest.approx(5.0),
+    }
     assert "member_scores" in metrics
     assert outcome.metrics["member_scores"]["facilitator"]["total"] == pytest.approx(0.8375)
     assert outcome.summary == "Deterministic council summary"


### PR DESCRIPTION
### Motivation
- Allow individual council members to override the global per-question DU/IP budget so orchestration can allocate and record resource usage per-member.

### Description
- Add optional `du_budget` and `ip_budget` fields (with camelCase aliases) to `CouncilMemberConfig` in `src/agents/council/types.py`.
- Resolve per-member DU budgets with `_resolve_du_budgets` and allocate member state using each member's `du_budget`/`ip_budget`, falling back to the global `du_budget_per_question` when not set in `src/agents/council/orchestrator.py`.
- Update DU metrics recording to accept a per-member budget mapping and report budget/spend per member instead of a single scalar budget.
- Add an integration test `test_council_orchestrator_honors_per_member_du_budget_overrides` and adjust unit/performance assertions to expect `du_budget_per_member` as a per-member mapping.

### Testing
- Ran lint/format checks with `ruff check` and `ruff format`; formatting was applied and checks passed.
- Ran targeted unit + integration tests with `pytest -q tests/unit/agents/council/test_council_orchestrator.py tests/integration/agents/council/test_council_du_budget.py` and they passed (`21 passed, 2 deselected`).
- Also ran the updated performance smoke that asserts per-member budgets in `tests/performance/test_council_mock_performance.py` (assertions adjusted to validate per-member mapping).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862df589548326947cb7ca9b579a4b)