### PR TITLE
Filter inactive council members during orchestrator fanout

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1333,6 +1333,8 @@ class CouncilOrchestrator:
         if not context.config.members:
             raise ValueError("Council configuration must include at least one member")
 
+        active_members = [member for member in context.config.members if member.is_active]
+
         run_metrics = CouncilRunMetrics()
         run_metrics.record_run()
         total_start = time.perf_counter()
@@ -1349,8 +1351,14 @@ class CouncilOrchestrator:
             "du_budget_exhausted": False,
             "du_budget_per_member": self._resolve_du_budgets(context.config),
         }
-        if not context.config.members:
-            metrics.update({"member_count": 0, "error": "no_active_members"})
+        if not active_members:
+            metrics.update(
+                {
+                    "member_count": 0,
+                    "error": "no_active_members",
+                    "no_active_members": True,
+                }
+            )
             logger.warning(
                 "No active council members available",
                 extra={
@@ -1365,8 +1373,17 @@ class CouncilOrchestrator:
                 resolution="No active council members available",
                 winning_member_ids=[],
                 summary=None,
-                metadata={"metrics": metrics},
+                metadata={"no_active_members": True, "metrics": metrics},
             )
+
+        if len(active_members) != len(context.config.members):
+            context = CouncilContext(
+                config=context.config.model_copy(update={"members": active_members}),
+                judge_model=context.judge_model,
+                member_model=context.member_model,
+                allow_remote_models=context.allow_remote_models,
+            )
+
         member_states = self._allocate_du_budgets(context.config, metrics)
 
         member_fanout_start = time.perf_counter()

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -667,6 +667,83 @@ def test_build_council_context_requires_default_model(
         council_orchestrator._build_council_context()
 
 
+def test_council_orchestrator_skips_inactive_members_for_answer_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    config.members[1].is_active = False
+    question = _build_question()
+
+    invoked_member_ids: list[str] = []
+    original_member = council_orchestrator._ask_council_member
+
+    def _capture_member(member: CouncilMemberConfig, *args: object, **kwargs: object):
+        invoked_member_ids.append(member.member_id)
+        return original_member(member, *args, **kwargs)
+
+    monkeypatch.setattr(council_orchestrator, "_ask_council_member", _capture_member)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    active_member_ids = [member.member_id for member in config.members if member.is_active]
+
+    assert invoked_member_ids == active_member_ids
+    assert [answer.member_id for answer in outcome.answers] == active_member_ids
+
+
+def test_council_orchestrator_skips_inactive_members_for_peer_vote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="peer_vote")
+    config.members[2].is_active = False
+    question = _build_question()
+
+    member_call_ids: list[str] = []
+    peer_vote_call_ids: list[str] = []
+    original_member = council_orchestrator._ask_council_member
+    original_peer_vote = council_orchestrator._ask_peer_vote
+
+    def _capture_member(member: CouncilMemberConfig, *args: object, **kwargs: object):
+        member_call_ids.append(member.member_id)
+        return original_member(member, *args, **kwargs)
+
+    def _capture_peer_vote(member: CouncilMemberConfig, *args: object, **kwargs: object):
+        peer_vote_call_ids.append(member.member_id)
+        return original_peer_vote(member, *args, **kwargs)
+
+    monkeypatch.setattr(council_orchestrator, "_ask_council_member", _capture_member)
+    monkeypatch.setattr(council_orchestrator, "_ask_peer_vote", _capture_peer_vote)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    active_member_ids = [member.member_id for member in config.members if member.is_active]
+
+    assert member_call_ids == active_member_ids
+    assert peer_vote_call_ids == active_member_ids
+    assert [answer.member_id for answer in outcome.answers] == active_member_ids
+
+
+def test_council_orchestrator_returns_deterministic_outcome_without_active_members() -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    for member in config.members:
+        member.is_active = False
+    question = _build_question()
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert outcome.answers == []
+    assert outcome.winning_member_ids == []
+    assert outcome.resolution == "No active council members available"
+    assert outcome.metadata is not None
+    assert outcome.metadata.get("no_active_members") is True
+    metrics = outcome.metadata.get("metrics", {})
+    assert metrics.get("error") == "no_active_members"
+    assert metrics.get("no_active_members") is True
+
+
 def test_council_orchestrator_peer_vote_mode() -> None:
     orchestrator = CouncilOrchestrator()
     config = _build_council_config(voting_mode="peer_vote")


### PR DESCRIPTION
### Motivation
- Prevent inactive council members from being invoked during answer generation and peer-vote fanout and provide a clear deterministic outcome when no members are active.

### Description
- In `CouncilOrchestrator.adeliberate`, compute `active_members` and return a deterministic outcome when the list is empty, setting `metrics["error"] = "no_active_members"` and a top-level `metadata["no_active_members"] = True`.
- When some members are inactive, replace `context.config.members` with only the active members via `context.config.model_copy(update={"members": active_members})` so subsequent fanout and peer-vote logic operate only on active members.
- Add unit tests in `tests/unit/agents/council/test_council_orchestrator.py` to assert that only active members are invoked for answer generation and peer-vote, and to verify the deterministic all-inactive outcome path (`test_council_orchestrator_skips_inactive_members_for_answer_generation`, `test_council_orchestrator_skips_inactive_members_for_peer_vote`, `test_council_orchestrator_returns_deterministic_outcome_without_active_members`).

### Testing
- Ran linting with `ruff check tests/unit/agents/council/test_council_orchestrator.py src/agents/council/orchestrator.py` and the checks passed.
- Ran unit tests with `pytest -q tests/unit/agents/council/test_council_orchestrator.py` and all tests passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863472be888326b88c95210b06a6c0)