### PR TITLE
Centralize council orchestrator LLM retry logic and expose retry metrics

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -7,12 +7,12 @@ import json
 import logging
 import re
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, TypeVar
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 
 from src.agents.council.fitness_store import CouncilFitnessStore, council_fitness_store
 from src.agents.council.stats_store import council_stats_store
@@ -35,8 +35,11 @@ from src.sim.resource_manager import get_resource_manager
 
 logger = logging.getLogger(__name__)
 LLM_MAX_ATTEMPTS = 2
+LLM_RETRY_BASE_DELAY_SECONDS = 0.05
+LLM_RETRY_MAX_DELAY_SECONDS = 0.2
 JUDGE_SCORE_CATEGORIES = ("correctness", "clarity", "usefulness", "safety")
 PAIRWISE_EMA_ALPHA = 0.3
+TModel = TypeVar("TModel")
 
 DEFAULT_MEMBER_PROMPT = (
     "You are participating in a council of AI personas. Stay fully in character and keep your unique voice. "
@@ -92,6 +95,106 @@ class CouncilContext:
     judge_model: str
     member_model: str
     allow_remote_models: bool
+
+
+@dataclass(slots=True)
+class LLMRetryResult:
+    """Result envelope for LLM retries."""
+
+    value: Any | None
+    retry_count: int
+    failed_after_retries: bool
+    errors: list[str]
+
+
+@dataclass(slots=True)
+class PeerVoteResult:
+    """Peer vote payload including retry metadata."""
+
+    vote: CouncilPeerVoteModel
+    retry_count: int
+    failed_after_retries: bool
+
+
+def _is_retryable_llm_exception(exc: Exception) -> bool:
+    """Return True for transient/time-bound failures that should be retried."""
+
+    if isinstance(exc, ValidationError):
+        return False
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, ConnectionError)):
+        return True
+
+    retryable_markers = (
+        "timeout",
+        "timed out",
+        "temporarily unavailable",
+        "connection reset",
+        "connection aborted",
+        "connection refused",
+        "service unavailable",
+        "bad gateway",
+        "gateway timeout",
+        "rate limit",
+        "transport",
+    )
+    text = str(exc).lower()
+    return any(marker in text for marker in retryable_markers)
+
+
+def _call_with_retries(
+    call: Callable[[], TModel | None],
+    *,
+    max_attempts: int = LLM_MAX_ATTEMPTS,
+    base_delay_seconds: float = LLM_RETRY_BASE_DELAY_SECONDS,
+    max_delay_seconds: float = LLM_RETRY_MAX_DELAY_SECONDS,
+    log_message: str,
+    log_extra: Mapping[str, Any],
+) -> LLMRetryResult:
+    """Execute an LLM call with bounded exponential backoff for retryable errors."""
+
+    errors: list[str] = []
+    retry_count = 0
+    for attempt in range(1, max(1, max_attempts) + 1):
+        try:
+            value = call()
+            if value is not None:
+                return LLMRetryResult(
+                    value=value,
+                    retry_count=retry_count,
+                    failed_after_retries=False,
+                    errors=errors,
+                )
+            if attempt < max_attempts:
+                retry_count += 1
+        except Exception as exc:  # pragma: no cover - defensive logging behavior
+            if isinstance(exc, RuntimeError) and "budget" in str(exc).lower():
+                raise
+            errors.append(str(exc))
+            retryable = _is_retryable_llm_exception(exc)
+            logger.warning(
+                log_message,
+                extra={**dict(log_extra), "attempt": attempt, "retryable": retryable},
+                exc_info=True,
+            )
+            if not retryable:
+                return LLMRetryResult(
+                    value=None,
+                    retry_count=retry_count,
+                    failed_after_retries=True,
+                    errors=errors,
+                )
+            if attempt >= max_attempts:
+                break
+            retry_count += 1
+            delay = min(base_delay_seconds * (2 ** (attempt - 1)), max_delay_seconds)
+            time.sleep(max(0.0, delay))
+
+    return LLMRetryResult(
+        value=None,
+        retry_count=retry_count,
+        failed_after_retries=bool(errors),
+        errors=errors,
+    )
 
 
 class CouncilRunMetrics:
@@ -603,46 +706,38 @@ def _ask_council_member(
     if not member_model:
         member_model = _resolve_default_model()
     track_mock_usage = is_mock_mode_enabled()
-    errors: list[str] = []
     generation_params = _resolve_member_generation_params(member)
-
-    structured: MemberResponseModel | None = None
-    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
-        try:
-            if track_mock_usage:
-                llm_client.client.generate(prompt=prompt)
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=MemberResponseModel,
-                    model=member_model,
-                    temperature=generation_params["temperature"],
-                    max_tokens=generation_params["max_tokens"],
-                    agent_state=agent_state,
-                )
-            else:
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=MemberResponseModel,
-                    model=member_model,
-                    temperature=generation_params["temperature"],
-                    max_tokens=generation_params["max_tokens"],
-                    agent_state=agent_state,
-                )
-            if structured is not None:
-                break
-        except Exception as exc:  # pragma: no cover - defensive
-            if isinstance(exc, RuntimeError) and "budget" in str(exc).lower():
-                raise
-            errors.append(str(exc))
-            logger.warning(
-                "Council member structured response failed",
-                extra={
-                    "event": "council.member.llm_error",
-                    "member_id": member.member_id,
-                    "attempt": attempt,
-                },
-                exc_info=True,
+    retry_result = _call_with_retries(
+        lambda: (
+            llm_client.client.generate(prompt=prompt)
+            and generate_structured_output(
+                prompt,
+                response_model=MemberResponseModel,
+                model=member_model,
+                temperature=generation_params["temperature"],
+                max_tokens=generation_params["max_tokens"],
+                agent_state=agent_state,
             )
+        )
+        if track_mock_usage
+        else generate_structured_output(
+            prompt,
+            response_model=MemberResponseModel,
+            model=member_model,
+            temperature=generation_params["temperature"],
+            max_tokens=generation_params["max_tokens"],
+            agent_state=agent_state,
+        ),
+        log_message="Council member structured response failed",
+        log_extra={"event": "council.member.llm_error", "member_id": member.member_id},
+    )
+
+    structured = retry_result.value
+    errors = list(retry_result.errors)
+    retry_metrics = {
+        "retry_count": retry_result.retry_count,
+        "failed_after_retries": retry_result.failed_after_retries,
+    }
 
     fallback_text = ""
     if structured is None:
@@ -673,7 +768,7 @@ def _ask_council_member(
             reasoning=None,
             confidence=None,
             citations=[],
-            metadata={"errors": errors, "fallback_used": True},
+            metadata={"errors": errors, "fallback_used": True, **retry_metrics},
         )
 
     return MemberAnswer(
@@ -682,7 +777,7 @@ def _ask_council_member(
         reasoning=structured.reasoning,
         confidence=structured.confidence,
         citations=structured.citations,
-        metadata={"errors": errors, "fallback_used": False},
+        metadata={"errors": errors, "fallback_used": False, **retry_metrics},
     )
 
 
@@ -946,38 +1041,28 @@ def _judge_council_answers(
 
     track_mock_usage = is_mock_mode_enabled()
     prompt = _build_judge_prompt(question, answers, extra_context=extra_context, rag_docs=rag_docs)
-    errors: list[str] = []
-    structured: CouncilVoteModel | None = None
-    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
-        try:
-            if track_mock_usage:
-                llm_client.client.generate(prompt=prompt)
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=CouncilVoteModel,
-                    model=context.judge_model,
-                    temperature=0.1,
-                )
-            else:
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=CouncilVoteModel,
-                    model=context.judge_model,
-                    temperature=0.1,
-                )
-            if structured is not None:
-                break
-        except Exception as exc:  # pragma: no cover - defensive
-            errors.append(str(exc))
-            logger.warning(
-                "Council judge evaluation failed",
-                extra={
-                    "event": "council.judge.llm_error",
-                    "question_id": question.question_id,
-                    "attempt": attempt,
-                },
-                exc_info=True,
+    retry_result = _call_with_retries(
+        lambda: (
+            llm_client.client.generate(prompt=prompt)
+            and generate_structured_output(
+                prompt,
+                response_model=CouncilVoteModel,
+                model=context.judge_model,
+                temperature=0.1,
             )
+        )
+        if track_mock_usage
+        else generate_structured_output(
+            prompt,
+            response_model=CouncilVoteModel,
+            model=context.judge_model,
+            temperature=0.1,
+        ),
+        log_message="Council judge evaluation failed",
+        log_extra={"event": "council.judge.llm_error", "question_id": question.question_id},
+    )
+    errors = retry_result.errors
+    structured = retry_result.value
 
     if structured is None and errors:
         logger.error(
@@ -986,11 +1071,18 @@ def _judge_council_answers(
                 "event": "council.judge.failure",
                 "question_id": question.question_id,
                 "errors": errors,
+                "retry_count": retry_result.retry_count,
+                "failed_after_retries": retry_result.failed_after_retries,
             },
         )
 
     if structured is not None:
         structured = _normalize_vote_metrics(structured, answers)
+        structured.metrics = {
+            **structured.metrics,
+            "retry_count": retry_result.retry_count,
+            "failed_after_retries": retry_result.failed_after_retries,
+        }
 
     return structured
 
@@ -1049,7 +1141,7 @@ def _ask_peer_vote(
     extra_context: Mapping[str, Any] | None = None,
     rag_docs: Sequence[str] | None = None,
     agent_state: Any | None = None,
-) -> CouncilPeerVoteModel | None:
+) -> PeerVoteResult | None:
     prompt = _build_peer_vote_prompt(
         question, answers, voter=member, extra_context=extra_context, rag_docs=rag_docs
     )
@@ -1058,44 +1150,33 @@ def _ask_peer_vote(
     if not member_model:
         member_model = _resolve_default_model()
     track_mock_usage = is_mock_mode_enabled()
-    errors: list[str] = []
     generation_params = _resolve_member_generation_params(member)
-
-    structured: CouncilPeerVoteModel | None = None
-    for attempt in range(1, LLM_MAX_ATTEMPTS + 1):
-        try:
-            if track_mock_usage:
-                llm_client.client.generate(prompt=prompt)
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=CouncilPeerVoteModel,
-                    model=member_model,
-                    temperature=generation_params["temperature"],
-                    max_tokens=generation_params["max_tokens"],
-                    agent_state=agent_state,
-                )
-            else:
-                structured = generate_structured_output(
-                    prompt,
-                    response_model=CouncilPeerVoteModel,
-                    model=member_model,
-                    temperature=generation_params["temperature"],
-                    max_tokens=generation_params["max_tokens"],
-                    agent_state=agent_state,
-                )
-            if structured is not None:
-                break
-        except Exception as exc:  # pragma: no cover - defensive
-            errors.append(str(exc))
-            logger.warning(
-                "Council peer vote failed",
-                extra={
-                    "event": "council.peer_vote.llm_error",
-                    "member_id": member.member_id,
-                    "attempt": attempt,
-                },
-                exc_info=True,
+    retry_result = _call_with_retries(
+        lambda: (
+            llm_client.client.generate(prompt=prompt)
+            and generate_structured_output(
+                prompt,
+                response_model=CouncilPeerVoteModel,
+                model=member_model,
+                temperature=generation_params["temperature"],
+                max_tokens=generation_params["max_tokens"],
+                agent_state=agent_state,
             )
+        )
+        if track_mock_usage
+        else generate_structured_output(
+            prompt,
+            response_model=CouncilPeerVoteModel,
+            model=member_model,
+            temperature=generation_params["temperature"],
+            max_tokens=generation_params["max_tokens"],
+            agent_state=agent_state,
+        ),
+        log_message="Council peer vote failed",
+        log_extra={"event": "council.peer_vote.llm_error", "member_id": member.member_id},
+    )
+    errors = retry_result.errors
+    structured = retry_result.value
 
     if structured is None and errors:
         logger.error(
@@ -1104,9 +1185,17 @@ def _ask_peer_vote(
                 "event": "council.peer_vote.failure",
                 "member_id": member.member_id,
                 "errors": errors,
+                "retry_count": retry_result.retry_count,
+                "failed_after_retries": retry_result.failed_after_retries,
             },
         )
-    return structured
+    if structured is None:
+        return None
+    return PeerVoteResult(
+        vote=structured,
+        retry_count=retry_result.retry_count,
+        failed_after_retries=retry_result.failed_after_retries,
+    )
 
 
 def _select_winner_id(
@@ -1154,7 +1243,7 @@ def _build_vote_from_scores(
 
 def _aggregate_peer_votes(
     answers: Sequence[MemberAnswer],
-    peer_votes: Sequence[tuple[CouncilMemberConfig, CouncilPeerVoteModel]],
+    peer_votes: Sequence[tuple[CouncilMemberConfig, PeerVoteResult]],
 ) -> CouncilVoteModel | None:
     if not peer_votes:
         return None
@@ -1162,10 +1251,15 @@ def _aggregate_peer_votes(
     totals: dict[str, float] = {}
     per_voter: dict[str, dict[str, float]] = {}
     weights: dict[str, float] = {}
+    retry_counts: dict[str, int] = {}
+    failed_after_retries: dict[str, bool] = {}
 
-    for voter, vote in peer_votes:
+    for voter, peer_vote_result in peer_votes:
+        vote = peer_vote_result.vote
         weight = float(voter.decision_weight or 1.0)
         weights[voter.member_id] = weight
+        retry_counts[voter.member_id] = peer_vote_result.retry_count
+        failed_after_retries[voter.member_id] = peer_vote_result.failed_after_retries
         vote_scores: dict[str, float] = {}
         for member_id, raw_score in vote.votes.items():
             score = _coerce_score(raw_score)
@@ -1193,6 +1287,8 @@ def _aggregate_peer_votes(
             "voter_count": len(per_voter),
             "votes": per_voter,
             "weights": weights,
+            "retry_count": retry_counts,
+            "failed_after_retries": failed_after_retries,
         }
     }
     summary = "Peer vote aggregation complete."
@@ -1607,7 +1703,7 @@ class CouncilOrchestrator:
         extra_context: Mapping[str, Any] | None,
         rag_docs: Sequence[str],
         metrics: dict[str, Any],
-    ) -> list[tuple[CouncilMemberConfig, CouncilPeerVoteModel]]:
+    ) -> list[tuple[CouncilMemberConfig, PeerVoteResult]]:
         semaphore = asyncio.Semaphore(
             max(1, context.config.max_concurrent_calls or self.max_concurrent_calls)
         )
@@ -1615,7 +1711,7 @@ class CouncilOrchestrator:
 
         async def _call_member(
             member: CouncilMemberConfig,
-        ) -> tuple[CouncilMemberConfig, CouncilPeerVoteModel] | None:
+        ) -> tuple[CouncilMemberConfig, PeerVoteResult] | None:
             state = member_states.get(member.member_id)
             try:
                 async with semaphore:
@@ -1649,7 +1745,7 @@ class CouncilOrchestrator:
             return_exceptions=True,
         )
 
-        votes: list[tuple[CouncilMemberConfig, CouncilPeerVoteModel]] = []
+        votes: list[tuple[CouncilMemberConfig, PeerVoteResult]] = []
         for member, result in zip(context.config.members, results):
             if isinstance(result, Exception):
                 if "budget" in str(result).lower():
@@ -1707,6 +1803,38 @@ class CouncilOrchestrator:
             outcome_metrics["fitness_snapshot"] = fitness_snapshot
             agreement_summary = _derive_agreement_summary(answers, vote, fitness_snapshot)
             outcome_metrics.update(agreement_summary)
+
+        answer_retry_count = 0
+        answer_failed_after_retries = False
+        for answer in answers:
+            answer_metadata = answer.metadata if isinstance(answer.metadata, Mapping) else {}
+            if not isinstance(answer_metadata, Mapping):
+                continue
+            retry_count_value = answer_metadata.get("retry_count")
+            if isinstance(retry_count_value, int):
+                answer_retry_count += retry_count_value
+            elif isinstance(retry_count_value, float):
+                answer_retry_count += int(retry_count_value)
+            answer_failed_after_retries = answer_failed_after_retries or bool(
+                answer_metadata.get("failed_after_retries")
+            )
+
+        vote_retry_count = 0
+        vote_failed_after_retries = False
+        if vote is not None:
+            retry_count_value = vote.metrics.get("retry_count") if vote.metrics else None
+            if isinstance(retry_count_value, int):
+                vote_retry_count = retry_count_value
+            elif isinstance(retry_count_value, float):
+                vote_retry_count = int(retry_count_value)
+            vote_failed_after_retries = bool(
+                vote.metrics.get("failed_after_retries") if vote.metrics else False
+            )
+
+        outcome_metrics["retry_count"] = answer_retry_count + vote_retry_count
+        outcome_metrics["failed_after_retries"] = (
+            answer_failed_after_retries or vote_failed_after_retries
+        )
 
         metadata["metrics"] = outcome_metrics
 

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -19,7 +19,7 @@ from src.agents.council import (
     MemberAnswer,
 )
 from src.agents.council.fitness_store import council_fitness_store
-from src.agents.council.stats_store import CouncilStatsStore
+from src.agents.council.stats_store import CouncilStatsStore, council_stats_store
 from src.infra import config, llm_client
 from src.shared import llm_mocks
 
@@ -82,6 +82,14 @@ def patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def reset_fitness_store() -> None:
     council_fitness_store.reset()
+
+
+@pytest.fixture(autouse=True)
+def reset_stats_store() -> None:
+    council_stats_store.conn.execute("DELETE FROM council_member_stats")
+    council_stats_store.conn.execute("DELETE FROM council_pairwise_agreements")
+    council_stats_store.conn.execute("DELETE FROM council_outcomes")
+    council_stats_store.conn.commit()
 
 
 @pytest.fixture(autouse=True)
@@ -252,9 +260,83 @@ def test_peer_vote_forwards_generation_params(monkeypatch: pytest.MonkeyPatch) -
     result = council_orchestrator._ask_peer_vote(member, question, answers)
 
     assert result is not None
-    assert result.winner_id == "facilitator"
+    assert result.vote.winner_id == "facilitator"
     assert captured["temperature"] == pytest.approx(member.temperature)
     assert captured["max_tokens"] == member.max_tokens
+
+
+def test_council_retry_success_updates_outcome_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    question = _build_question()
+    call_state = {"member_attempts": 0}
+
+    def fake_generate_structured_output(*args: object, **kwargs: object):
+        response_model = kwargs.get("response_model")
+        if response_model is council_orchestrator.MemberResponseModel:
+            call_state["member_attempts"] += 1
+            if call_state["member_attempts"] == 1:
+                raise TimeoutError("temporary timeout")
+            return council_orchestrator.MemberResponseModel(
+                answer="Recovered member answer",
+                reasoning="Recovered after retry",
+                confidence=0.7,
+                citations=[],
+            )
+        if response_model is council_orchestrator.CouncilVoteModel:
+            return council_orchestrator.CouncilVoteModel(
+                winning_member_id="facilitator",
+                votes={"facilitator": 1.0},
+                scores={},
+                metrics={},
+                summary="Judge summary",
+                reasoning="Judge reasoning",
+                resolution="Recovered member answer",
+            )
+        raise AssertionError("Unexpected response model")
+
+    monkeypatch.setattr(
+        council_orchestrator, "generate_structured_output", fake_generate_structured_output
+    )
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert outcome.metrics["retry_count"] == 1
+    assert outcome.metrics["failed_after_retries"] is False
+
+
+def test_council_retry_exhaustion_updates_outcome_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    question = _build_question()
+
+    def fake_generate_structured_output(*args: object, **kwargs: object):
+        response_model = kwargs.get("response_model")
+        if response_model is council_orchestrator.MemberResponseModel:
+            raise TimeoutError("persistent timeout")
+        if response_model is council_orchestrator.CouncilVoteModel:
+            return council_orchestrator.CouncilVoteModel(
+                winning_member_id="facilitator",
+                votes={"facilitator": 1.0},
+                scores={},
+                metrics={},
+                summary="Judge summary",
+                reasoning="Judge reasoning",
+                resolution="Fallback resolution",
+            )
+        raise AssertionError("Unexpected response model")
+
+    monkeypatch.setattr(
+        council_orchestrator, "generate_structured_output", fake_generate_structured_output
+    )
+    monkeypatch.setattr(council_orchestrator, "generate_text", lambda *args, **kwargs: "fallback")
+
+    outcome = orchestrator.deliberate(config, question)
+
+    assert outcome.metrics["retry_count"] == len(config.members)
+    assert outcome.metrics["failed_after_retries"] is True
 
 
 def test_council_orchestrator_can_bypass_env_guard(


### PR DESCRIPTION
### Motivation

- Reduce duplicated LLM retry loops and make retry behavior consistent across member generation, judge voting, and peer votes.
- Distinguish transient transport/timeouts from non-retryable validation/schema errors so we avoid pointless retries.
- Surface retry outcomes so downstream consumers and metrics stores can observe retry counts and exhaustion.

### Description

- Introduced a reusable helper `_call_with_retries` with bounded exponential backoff and configurable attempts/delays, plus `LLMRetryResult` envelope and `PeerVoteResult` wrapper. (`src/agents/council/orchestrator.py`)
- Added `_is_retryable_llm_exception` to classify retryable errors (timeouts/connection/transport markers) and treat schema/validation errors (e.g., `ValidationError`) as non-retryable. (`src/agents/council/orchestrator.py`)
- Replaced ad-hoc retry loops with `_call_with_retries` in member answer generation (`_ask_council_member`), judge voting (`_judge_council_answers`), and peer vote calls (`_ask_peer_vote`), propagating retry metadata into returned payloads. (`src/agents/council/orchestrator.py`)
- Propagated retry metadata into aggregated peer-vote metrics and consolidated per-question metrics: `metrics.retry_count` and `metrics.failed_after_retries` on the final `CouncilOutcome`. (`src/agents/council/orchestrator.py`)
- Updated peer-vote pipeline types to carry retry information and adjusted aggregation accordingly. (`src/agents/council/orchestrator.py`)
- Added focused unit tests covering a retry-then-success path and retry exhaustion, and added a test fixture to clear stats tables for test isolation. (`tests/unit/agents/council/test_council_orchestrator.py`)

### Testing

- Ran linter: `python -m ruff check src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py` and it passed.
- Ran unit tests: `pytest -q tests/unit/agents/council/test_council_orchestrator.py` and all tests passed (23 passed, 1 warning about pytest config option).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863473140083269d9332463def1812)