### PR TITLE
Filter council orchestration fanout to active members

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1347,9 +1347,11 @@ class CouncilOrchestrator:
         )
         metrics: dict[str, Any] = {
             "du_budget_exhausted": False,
-            "du_budget_per_member": self._resolve_du_budgets(context.config),
+            "du_budget_per_member": {},
         }
-        if not context.config.members:
+        active_members = [member for member in context.config.members if member.is_active]
+        metrics["member_count"] = len(active_members)
+        if not active_members:
             metrics.update({"member_count": 0, "error": "no_active_members"})
             logger.warning(
                 "No active council members available",
@@ -1367,11 +1369,12 @@ class CouncilOrchestrator:
                 summary=None,
                 metadata={"metrics": metrics},
             )
-        member_states = self._allocate_du_budgets(context.config, metrics)
+        member_states = self._allocate_du_budgets(context.config, active_members, metrics)
 
         member_fanout_start = time.perf_counter()
         answers = await self._gather_member_answers(
             context,
+            active_members,
             question,
             member_states,
             extra_context=extra_context,
@@ -1418,6 +1421,7 @@ class CouncilOrchestrator:
             elif context.config.voting_mode == "peer_vote":
                 peer_votes = await self._gather_peer_votes(
                     context,
+                    active_members,
                     question,
                     answers,
                     member_states,
@@ -1427,7 +1431,7 @@ class CouncilOrchestrator:
                 )
                 vote = _aggregate_peer_votes(answers, peer_votes)
             elif context.config.voting_mode == "heuristic":
-                member_lookup = {member.member_id: member for member in context.config.members}
+                member_lookup = {member.member_id: member for member in active_members}
                 vote = _score_heuristic_votes(answers, member_lookup)
             else:
                 logger.warning(
@@ -1441,7 +1445,7 @@ class CouncilOrchestrator:
 
         base_metrics = dict(metrics or {})
         base_metrics.setdefault("du_budget_exhausted", False)
-        base_metrics.setdefault("du_budget_per_member", self._resolve_du_budgets(context.config))
+        base_metrics.setdefault("du_budget_per_member", self._resolve_du_budgets(context.config, active_members))
         outcome = self._build_outcome(
             question, answers, vote, base_metrics, run_metrics=run_metrics
         )
@@ -1454,19 +1458,24 @@ class CouncilOrchestrator:
             return float(config.du_budget_per_question)
         return float(self.du_budget_per_question)
 
-    def _resolve_du_budgets(self, config: CouncilConfig) -> dict[str, float]:
+    def _resolve_du_budgets(
+        self, config: CouncilConfig, members: Sequence[CouncilMemberConfig]
+    ) -> dict[str, float]:
         default_budget = self._resolve_du_budget(config)
         return {
             member.member_id: (
                 float(member.du_budget) if member.du_budget is not None else default_budget
             )
-            for member in config.members
+            for member in members
         }
 
     def _allocate_du_budgets(
-        self, config: CouncilConfig, metrics: dict[str, Any]
+        self,
+        config: CouncilConfig,
+        members: Sequence[CouncilMemberConfig],
+        metrics: dict[str, Any],
     ) -> dict[str, SimpleNamespace]:
-        budgets = self._resolve_du_budgets(config)
+        budgets = self._resolve_du_budgets(config, members)
         member_states: dict[str, SimpleNamespace] = {}
         try:
             resource_manager = get_resource_manager()
@@ -1474,7 +1483,7 @@ class CouncilOrchestrator:
             logger.debug("Resource manager unavailable for council DU budgeting: %s", exc)
             resource_manager = None
 
-        for member in config.members:
+        for member in members:
             budget = budgets.get(member.member_id, 0.0)
             ip_budget = float(member.ip_budget) if member.ip_budget is not None else 0.0
             state = SimpleNamespace(agent_id=member.member_id, du=budget, ip=ip_budget)
@@ -1492,6 +1501,7 @@ class CouncilOrchestrator:
     async def _gather_member_answers(
         self,
         context: CouncilContext,
+        members: Sequence[CouncilMemberConfig],
         question: CouncilQuestion,
         member_states: Mapping[str, SimpleNamespace],
         *,
@@ -1570,7 +1580,7 @@ class CouncilOrchestrator:
 
         tasks: list[asyncio.Task[tuple[str, MemberAnswer | None]]] = []
 
-        for member in context.config.members:
+        for member in members:
             if metrics.get("du_budget_exhausted"):
                 break
             state = member_states.get(member.member_id)
@@ -1600,6 +1610,7 @@ class CouncilOrchestrator:
     async def _gather_peer_votes(
         self,
         context: CouncilContext,
+        members: Sequence[CouncilMemberConfig],
         question: CouncilQuestion,
         answers: Sequence[MemberAnswer],
         member_states: Mapping[str, SimpleNamespace],
@@ -1645,12 +1656,12 @@ class CouncilOrchestrator:
                 return None
 
         results = await asyncio.gather(
-            *[_call_member(member) for member in context.config.members],
+            *[_call_member(member) for member in members],
             return_exceptions=True,
         )
 
         votes: list[tuple[CouncilMemberConfig, CouncilPeerVoteModel]] = []
-        for member, result in zip(context.config.members, results):
+        for member, result in zip(members, results):
             if isinstance(result, Exception):
                 if "budget" in str(result).lower():
                     metrics["du_budget_exhausted"] = True

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -612,6 +612,55 @@ def test_council_orchestrator_flags_partial_metrics_on_errors(
     assert len(outcome.answers) == len(config.members) - 1
 
 
+def test_council_orchestrator_filters_inactive_members_for_fanout(monkeypatch: pytest.MonkeyPatch) -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="peer_vote")
+    config.members[1].is_active = False
+    question = _build_question()
+
+    member_calls: list[str] = []
+    peer_vote_calls: list[str] = []
+    original_member = council_orchestrator._ask_council_member
+    original_peer_vote = council_orchestrator._ask_peer_vote
+
+    def _count_member(member: CouncilMemberConfig, *args: object, **kwargs: object):
+        member_calls.append(member.member_id)
+        return original_member(member, *args, **kwargs)
+
+    def _count_peer_vote(member: CouncilMemberConfig, *args: object, **kwargs: object):
+        peer_vote_calls.append(member.member_id)
+        return original_peer_vote(member, *args, **kwargs)
+
+    monkeypatch.setattr(council_orchestrator, "_ask_council_member", _count_member)
+    monkeypatch.setattr(council_orchestrator, "_ask_peer_vote", _count_peer_vote)
+
+    outcome = orchestrator.deliberate(config, question)
+
+    metrics = outcome.metadata.get("metrics", {})
+    assert set(member_calls) == {"facilitator", "analyst"}
+    assert set(peer_vote_calls) == {"facilitator", "analyst"}
+    assert {answer.member_id for answer in outcome.answers} == {"facilitator", "analyst"}
+    assert metrics.get("member_count") == 2
+    assert set(metrics.get("du_budget_per_member", {}).keys()) == {"facilitator", "analyst"}
+    assert metrics["peer_vote"]["voter_count"] == 2
+
+
+def test_council_orchestrator_returns_empty_outcome_when_no_active_members() -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    for member in config.members:
+        member.is_active = False
+
+    outcome = orchestrator.deliberate(config, _build_question())
+
+    assert outcome.answers == []
+    assert outcome.winning_member_ids == []
+    assert outcome.resolution == "No active council members available"
+    metrics = outcome.metadata.get("metrics", {})
+    assert metrics.get("error") == "no_active_members"
+    assert metrics.get("member_count") == 0
+    assert metrics.get("du_budget_per_member") == {}
+
 def test_council_orchestrator_requires_enabled_council(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         config,


### PR DESCRIPTION
### Motivation
- Ensure all council orchestration paths (DU allocation, member answer fan-out, peer voting, and heuristic lookup) operate only over active members and that metrics reflect the active roster.
- Provide a clear, early-return outcome when no members are active to avoid confusing downstream behavior and metrics.

### Description
- Compute `active_members = [m for m in context.config.members if m.is_active]` once in `CouncilOrchestrator.adeliberate` and set `metrics["member_count"]` from that roster.
- Return an empty/partial `CouncilOutcome` with `resolution = "No active council members available"` and `metrics` including `error: no_active_members` when `active_members` is empty.
- Thread `active_members` through DU allocation and fan-out helpers by changing helper signatures and calls: `_resolve_du_budgets(config, members)`, `_allocate_du_budgets(config, members, metrics)`, `_gather_member_answers(context, members, ...)`, and `_gather_peer_votes(context, members, ...)`.
- Ensure `du_budget_per_member`, `completed_members`, and other metrics are scoped to the active roster and keep behavior backward-compatible when all members remain active.

### Testing
- Ran `ruff check src/agents/council/orchestrator.py tests/unit/agents/council/test_council_orchestrator.py` and linting passed.
- Added unit tests covering inactive-member filtering and the all-inactive early-return, and executed targeted tests with `pytest -q tests/unit/agents/council/test_council_orchestrator.py -k "filters_inactive_members_for_fanout or returns_empty_outcome_when_no_active_members or peer_vote_mode"`, which passed.
- Addressed an earlier failing assertion found during development and re-ran the relevant unit tests until they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863471b1348326b2b9f9ecfe6b5d96)