### PR TITLE
Add owner DU budget gating and partial-budget council integration tests

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -1480,7 +1480,9 @@ class CouncilOrchestrator:
                 allow_remote_models=context.allow_remote_models,
             )
 
-        member_states = self._allocate_du_budgets(context.config, metrics)
+        member_states = self._allocate_du_budgets(context.config, active_members, metrics)
+
+        self._initialize_owner_du_budget(question, active_members, metrics)
 
         member_fanout_start = time.perf_counter()
         answers = await self._gather_member_answers(
@@ -1609,6 +1611,53 @@ class CouncilOrchestrator:
         metrics["du_budget_per_member"] = budgets
         return member_states
 
+    def _initialize_owner_du_budget(
+        self,
+        question: CouncilQuestion,
+        members: Sequence[CouncilMemberConfig],
+        metrics: dict[str, Any],
+    ) -> None:
+        metadata = question.metadata if isinstance(question.metadata, Mapping) else {}
+        owner_budget = metadata.get("owner_du_budget")
+        if owner_budget is None:
+            return
+
+        owner_agent_id = _resolve_question_agent_id(question, None) or "owner"
+        try:
+            owner_budget_value = float(owner_budget)
+        except (TypeError, ValueError):
+            return
+
+        metrics["owner_agent_id"] = owner_agent_id
+        metrics["owner_du_before"] = owner_budget_value
+
+        try:
+            base_price, _ = llm_client.ledger.calculate_gas_price(owner_agent_id)
+        except Exception:
+            base_price = 1.0
+
+        required_raw = metadata.get("owner_du_required")
+        try:
+            required_value = (
+                float(required_raw) if required_raw is not None else float(len(members)) * float(base_price)
+            )
+        except (TypeError, ValueError):
+            required_value = float(len(members)) * float(base_price)
+
+        metrics["owner_du_required"] = required_value
+        metrics["owner_du_after"] = owner_budget_value
+        metrics["owner_du_debited"] = 0.0
+
+        try:
+            resource_manager = get_resource_manager()
+            resource_manager.set_du_budget(owner_agent_id, owner_budget_value)
+        except Exception:
+            pass
+
+        if owner_budget_value < float(base_price):
+            metrics["du_budget_exhausted"] = True
+            metrics["partial"] = True
+
     async def _gather_member_answers(
         self,
         context: CouncilContext,
@@ -1624,6 +1673,30 @@ class CouncilOrchestrator:
         semaphore = asyncio.Semaphore(max_concurrent)
         failures: list[str] = []
         answers: list[MemberAnswer] = []
+        owner_agent_id = metrics.get("owner_agent_id")
+
+        def _charge_owner_budget_for_member_call() -> bool:
+            if not owner_agent_id:
+                return True
+            owner_id = str(owner_agent_id)
+            try:
+                base_price, _ = llm_client.ledger.calculate_gas_price(owner_id)
+            except Exception:
+                base_price = 1.0
+            try:
+                resource_manager = get_resource_manager()
+                resource_manager.ensure_du_budget(owner_id, float(base_price))
+                resource_manager.charge_du(owner_id, float(base_price))
+                llm_client.ledger.log_change(owner_id, 0.0, -float(base_price), "llm_gas")
+                metrics["owner_du_debited"] = float(metrics.get("owner_du_debited", 0.0)) + float(
+                    base_price
+                )
+                metrics["owner_du_after"] = resource_manager.get_du_budget(owner_id)
+                return True
+            except Exception:
+                metrics["du_budget_exhausted"] = True
+                metrics["partial"] = True
+                return False
 
         def _has_available_budget(
             member: CouncilMemberConfig, state: SimpleNamespace | None
@@ -1698,6 +1771,9 @@ class CouncilOrchestrator:
             if not _has_available_budget(member, state):
                 metrics["du_budget_exhausted"] = True
                 logger.warning("DU budget exhausted before scheduling member %s", member.member_id)
+                break
+            if not _charge_owner_budget_for_member_call():
+                logger.warning("Owner DU budget exhausted before scheduling member %s", member.member_id)
                 break
             tasks.append(asyncio.create_task(_call_member(member)))
             if len(tasks) >= max_concurrent:

--- a/tests/integration/agents/council/test_council_du_budget.py
+++ b/tests/integration/agents/council/test_council_du_budget.py
@@ -67,6 +67,48 @@ class FakeResourceManager:
         return float(self.du_budgets.get(agent_id, 0.0))
 
 
+def _sum_du_debits(ledger: FakeLedger, *, agent_id: str) -> float:
+    return abs(
+        sum(delta_du for logged_agent_id, delta_du, _ in ledger.log_entries if logged_agent_id == agent_id)
+    )
+
+
+def _build_council_config_with_two_members(*, member_budget: float = 2.0) -> CouncilConfig:
+    return CouncilConfig(
+        members=[
+            CouncilMemberConfig(
+                member_id="member-a",
+                display_name="Member A",
+                role="Analyzer",
+                description="",
+                system_prompt="",
+                decision_weight=1.0,
+                persona="Curious analyst persona",
+                model="mistral:latest",
+                temperature=0.1,
+                max_tokens=32,
+                is_active=True,
+            ),
+            CouncilMemberConfig(
+                member_id="member-b",
+                display_name="Member B",
+                role="Generalist",
+                description="",
+                system_prompt="",
+                decision_weight=1.0,
+                persona="Helpful generalist persona",
+                model="mistral:latest",
+                temperature=0.1,
+                max_tokens=32,
+                is_active=True,
+            ),
+        ],
+        voting_mode="judge_llm",
+        enabled=True,
+        du_budget_per_question=member_budget,
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -252,3 +294,122 @@ async def test_council_orchestrator_honors_per_member_du_budget_overrides(
         ("member-a", pytest.approx(3.0)),
         ("member-b", pytest.approx(2.0)),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_council_orchestrator_blocks_member_launch_when_owner_du_budget_is_below_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(infra_config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+
+    fake_ledger = FakeLedger()
+    fake_resource_manager = FakeResourceManager(fake_ledger)
+
+    monkeypatch.setattr(resource_manager_module, "_resource_manager", fake_resource_manager)
+    monkeypatch.setattr(resource_manager_module, "get_resource_manager", lambda: fake_resource_manager)
+    monkeypatch.setattr("src.agents.council.orchestrator.get_resource_manager", lambda: fake_resource_manager)
+
+    monkeypatch.setattr(llm_client, "ledger", fake_ledger)
+    monkeypatch.setattr(infra_metrics, "ledger", fake_ledger)
+
+    llm_client.enable_mock_mode(
+        True,
+        {
+            "MemberResponseModel": {
+                "answer": "stubbed",
+                "reasoning": "",
+                "confidence": 1.0,
+                "citations": [],
+            }
+        },
+    )
+
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config_with_two_members(member_budget=2.0)
+    question = CouncilQuestion(
+        question_id="q-owner-insufficient",
+        prompt="What is DU?",
+        context="",
+        metadata={"agent_id": "owner-1", "owner_du_budget": 0.5, "owner_du_required": 1.0},
+        task_context=None,
+    )
+
+    context = orchestrator._resolve_context(config)
+    outcome = await orchestrator.adeliberate(context, question)
+
+    assert not outcome.answers
+    assert outcome.metadata
+    assert outcome.metadata.get("du_exhausted", False)
+    assert fake_resource_manager.charge_calls == []
+    assert fake_resource_manager.ensure_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_council_orchestrator_reports_partial_outcome_and_owner_du_accounting_when_budget_partially_sufficient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(infra_config, "_CONFIG", {"USE_COUNCIL_MODE": True})
+
+    fake_ledger = FakeLedger()
+    fake_resource_manager = FakeResourceManager(fake_ledger)
+
+    monkeypatch.setattr(resource_manager_module, "_resource_manager", fake_resource_manager)
+    monkeypatch.setattr(resource_manager_module, "get_resource_manager", lambda: fake_resource_manager)
+    monkeypatch.setattr("src.agents.council.orchestrator.get_resource_manager", lambda: fake_resource_manager)
+
+    monkeypatch.setattr(llm_client, "ledger", fake_ledger)
+    monkeypatch.setattr(infra_metrics, "ledger", fake_ledger)
+
+    llm_client.enable_mock_mode(
+        True,
+        {
+            "MemberResponseModel": {
+                "answer": "stubbed",
+                "reasoning": "",
+                "confidence": 1.0,
+                "citations": [],
+            }
+        },
+    )
+
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config_with_two_members(member_budget=1.0)
+    question = CouncilQuestion(
+        question_id="q-owner-partial",
+        prompt="What is DU?",
+        context="",
+        metadata={"agent_id": "owner-1", "owner_du_budget": 1.1, "owner_du_required": 2.0},
+        task_context=None,
+    )
+
+    context = orchestrator._resolve_context(config)
+
+    outcome = await orchestrator.adeliberate(context, question)
+
+    owner_before = 1.1
+    owner_after = fake_resource_manager.get_du_budget("owner-1")
+
+    assert outcome.metadata
+    assert outcome.metadata.get("partial", False)
+    assert outcome.metadata.get("du_exhausted", False)
+    assert 0 < len(outcome.answers) < 2
+
+    for member_id in ("member-a", "member-b"):
+        initial_budget = fake_resource_manager.initial_budgets[member_id]
+        debited = _sum_du_debits(fake_ledger, agent_id=member_id)
+        remaining = fake_resource_manager.get_du_budget(member_id)
+        assert remaining == pytest.approx(initial_budget - debited)
+        assert fake_ledger.du_budgets.get(member_id, 0.0) == pytest.approx(remaining)
+
+    owner_debited = _sum_du_debits(fake_ledger, agent_id="owner-1")
+    assert owner_after == pytest.approx(owner_before - owner_debited)
+    assert fake_ledger.du_budgets.get("owner-1", 0.0) == pytest.approx(owner_after)
+
+    metrics = outcome.metadata.get("metrics", {})
+    assert metrics.get("du_budget_exhausted", False)
+    assert metrics.get("owner_agent_id") == "owner-1"
+    assert metrics.get("owner_du_before") == pytest.approx(owner_before)
+    assert metrics.get("owner_du_after") == pytest.approx(owner_after)
+    assert metrics.get("owner_du_debited") == pytest.approx(owner_debited)


### PR DESCRIPTION
### Motivation
- Ensure council orchestration can honor an owner-level DU budget supplied via question metadata and gate member scheduling when owner funds are insufficient.
- Provide integration coverage for owner-budget edge cases and verify ledger/resource-manager accounting and metrics are correctly recorded.

### Description
- Pass `active_members` into `_allocate_du_budgets` and add `_initialize_owner_du_budget` to seed owner DU from `question.metadata` (`owner_du_budget`, optional `owner_du_required`).
- Gate member scheduling with an owner pre-charge implemented in `_gather_member_answers`, which attempts to debit owner DU before launching each member call and marks `du_budget_exhausted`/`partial` when owner funds are inadequate.
- Record owner-level accounting fields in run metrics (`owner_agent_id`, `owner_du_before`, `owner_du_after`, `owner_du_debited`, `owner_du_required`).
- Extend `tests/integration/agents/council/test_council_du_budget.py` with helpers and two new tests: one asserting no member calls when owner DU is below threshold, and one asserting partial outcomes, DU exhaustion flags, ledger/resource balance checks, and owner-level metric assertions.

### Testing
- Ran `pytest -q tests/integration/agents/council/test_council_du_budget.py -m integration` and all tests in that file passed (`4 passed, 1 warning`).
- Ran linter checks with `ruff check src/agents/council/orchestrator.py tests/integration/agents/council/test_council_du_budget.py` and they passed with no findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986409028288326a57bbb3c4e6236db)