### PR TITLE
Reserve run-level DU from resolved owner and allocate per-member allowances

### DIFF
--- a/src/agents/council/orchestrator.py
+++ b/src/agents/council/orchestrator.py
@@ -31,7 +31,7 @@ from src.infra.llm_client import (
     generate_text,
     is_mock_mode_enabled,
 )
-from src.sim.resource_manager import get_resource_manager
+from src.sim.resource_manager import ResourceManager, get_resource_manager
 
 logger = logging.getLogger(__name__)
 LLM_MAX_ATTEMPTS = 2
@@ -1446,6 +1446,7 @@ class CouncilOrchestrator:
         metrics: dict[str, Any] = {
             "du_budget_exhausted": False,
             "du_budget_per_member": {},
+            "member_count": len(active_members),
         }
         if not active_members:
             metrics.update(
@@ -1480,7 +1481,7 @@ class CouncilOrchestrator:
                 allow_remote_models=context.allow_remote_models,
             )
 
-        member_states = self._allocate_du_budgets(context.config, metrics)
+        member_states = self._allocate_du_budgets(context.config, question, active_members, metrics)
 
         member_fanout_start = time.perf_counter()
         answers = await self._gather_member_answers(
@@ -1556,7 +1557,7 @@ class CouncilOrchestrator:
 
         base_metrics = dict(metrics or {})
         base_metrics.setdefault("du_budget_exhausted", False)
-        base_metrics.setdefault("du_budget_per_member", self._resolve_du_budgets(context.config, active_members))
+        base_metrics.setdefault("du_budget_per_member", metrics.get("du_budget_per_member", {}))
         outcome = self._build_outcome(
             question, answers, vote, base_metrics, run_metrics=run_metrics
         )
@@ -1564,35 +1565,101 @@ class CouncilOrchestrator:
         await self._record_outcome_metrics(outcome)
         return outcome
 
+    def _resolve_owner_id(self, config: CouncilConfig, question: CouncilQuestion) -> str:
+        metadata = question.metadata if isinstance(question.metadata, Mapping) else None
+        candidate_keys = ("owner_id", "owner", "council_owner", "council_owner_id")
+
+        for key in candidate_keys:
+            value = metadata.get(key) if metadata else None
+            if value is not None and str(value).strip():
+                return str(value).strip()
+
+        if question.user_id and str(question.user_id).strip():
+            return str(question.user_id).strip()
+
+        config_metadata = config.metadata if isinstance(config.metadata, Mapping) else None
+        for key in candidate_keys:
+            value = config_metadata.get(key) if config_metadata else None
+            if value is not None and str(value).strip():
+                return str(value).strip()
+
+        configured_owner = get_config("COUNCIL_OWNER_ID")
+        if configured_owner is not None and str(configured_owner).strip():
+            return str(configured_owner).strip()
+
+        return "council"
+
+    def _reserve_owner_budget(
+        self,
+        *,
+        resource_manager: ResourceManager | None,
+        owner_id: str,
+        budget: float,
+        metrics: dict[str, Any],
+    ) -> float:
+        reserve_budget = max(float(budget), 0.0)
+        metrics["du_owner_id"] = owner_id
+        metrics["du_owner_reserved"] = reserve_budget
+
+        if reserve_budget <= 0:
+            metrics["du_owner_remaining"] = 0.0
+            return 0.0
+
+        if resource_manager is None:
+            metrics["du_owner_remaining"] = 0.0
+            return reserve_budget
+
+        remaining_after_reserve = resource_manager.reserve_du_budget(
+            owner_id, reserve_budget, reason="council_du_reserve"
+        )
+        metrics["du_owner_remaining"] = float(remaining_after_reserve)
+        return reserve_budget
+
     def _resolve_du_budget(self, config: CouncilConfig) -> float:
         if config.du_budget_per_question is not None:
             return float(config.du_budget_per_question)
         return float(self.du_budget_per_question)
 
     def _resolve_du_budgets(
-        self, config: CouncilConfig, members: Sequence[CouncilMemberConfig]
+        self, config: CouncilConfig, members: Sequence[CouncilMemberConfig], owner_reserved: float
     ) -> dict[str, float]:
-        default_budget = self._resolve_du_budget(config)
-        return {
-            member.member_id: (
-                float(member.du_budget) if member.du_budget is not None else default_budget
-            )
-            for member in members
-        }
+        if not members:
+            return {}
+
+        reserved_total = max(float(owner_reserved), 0.0)
+        even_share = reserved_total / len(members) if members else 0.0
+        budgets: dict[str, float] = {}
+        for member in members:
+            budget = even_share
+            if member.du_budget is not None:
+                budget = min(budget, float(member.du_budget))
+            budgets[member.member_id] = max(float(budget), 0.0)
+        return budgets
 
     def _allocate_du_budgets(
         self,
         config: CouncilConfig,
+        question: CouncilQuestion,
         members: Sequence[CouncilMemberConfig],
         metrics: dict[str, Any],
     ) -> dict[str, SimpleNamespace]:
-        budgets = self._resolve_du_budgets(config, members)
+        owner_id = self._resolve_owner_id(config, question)
+        owner_budget = self._resolve_du_budget(config)
         member_states: dict[str, SimpleNamespace] = {}
         try:
             resource_manager = get_resource_manager()
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("Resource manager unavailable for council DU budgeting: %s", exc)
             resource_manager = None
+
+        reserved_total = self._reserve_owner_budget(
+            resource_manager=resource_manager,
+            owner_id=owner_id,
+            budget=owner_budget,
+            metrics=metrics,
+        )
+
+        budgets = self._resolve_du_budgets(config, members, reserved_total)
 
         for member in members:
             budget = budgets.get(member.member_id, 0.0)

--- a/src/sim/resource_manager.py
+++ b/src/sim/resource_manager.py
@@ -33,6 +33,11 @@ class ResourceManager:
         self._du_budgets[agent_id] = remaining
         record_du_budget(agent_id, remaining)
 
+    def has_du_budget(self, agent_id: str) -> bool:
+        """Return whether an explicit DU budget exists for ``agent_id``."""
+
+        return agent_id in self._du_budgets
+
     def ensure_du_budget(self, agent_id: str, amount: float) -> None:
         """Verify that the agent has at least ``amount`` DU available."""
         remaining = self._du_budgets.get(agent_id, 0.0)
@@ -66,6 +71,27 @@ class ResourceManager:
 
     def get_du_budget(self, agent_id: str) -> float:
         return float(self._du_budgets.get(agent_id, 0.0))
+
+    def reserve_du_budget(self, agent_id: str, amount: float, *, reason: str = "du_reserve") -> float:
+        """Reserve DU for ``agent_id`` and record the debit in the ledger."""
+
+        reserve_amount = float(max(amount, 0.0))
+        if reserve_amount <= 0:
+            return self.get_du_budget(agent_id)
+
+        if (not self.has_du_budget(agent_id)) or self.get_du_budget(agent_id) < reserve_amount:
+            self.set_du_budget(agent_id, reserve_amount)
+
+        self.charge_du(agent_id, reserve_amount)
+        remaining = self.get_du_budget(agent_id)
+
+        try:
+            from src.infra.ledger import ledger
+
+            ledger.log_change(agent_id, 0.0, -reserve_amount, reason)
+        except Exception:  # pragma: no cover - optional logging
+            pass
+        return remaining
 
 
 _resource_manager: ResourceManager | None = None

--- a/tests/integration/agents/council/test_council_du_budget.py
+++ b/tests/integration/agents/council/test_council_du_budget.py
@@ -50,6 +50,15 @@ class FakeResourceManager:
         self.set_calls.append((agent_id, float(budget)))
         self.ledger.record_du_budget(agent_id, budget)
 
+    def has_du_budget(self, agent_id: str) -> bool:
+        return agent_id in self.du_budgets
+
+    def reserve_du_budget(self, agent_id: str, amount: float, *, reason: str = "du_reserve") -> float:
+        reserve = float(amount)
+        self.charge_du(agent_id, reserve)
+        self.ledger.log_change(agent_id, 0.0, -reserve, reason)
+        return self.get_du_budget(agent_id)
+
     def ensure_du_budget(self, agent_id: str, amount: float) -> None:
         self.ensure_calls.append((agent_id, float(amount)))
         remaining = self.du_budgets.get(agent_id, 0.0)
@@ -133,7 +142,7 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
         du_budget_per_question=2.0,
     )
     question = CouncilQuestion(
-        question_id="q1", prompt="What is DU?", context="", task_context=None
+        question_id="q1", prompt="What is DU?", user_id="question-owner", context="", task_context=None
     )
 
     context = orchestrator._resolve_context(config)
@@ -154,9 +163,15 @@ async def test_council_orchestrator_charges_du_and_logs(monkeypatch: pytest.Monk
         assert fake_ledger.du_budgets[member_id] == pytest.approx(remaining_budget)
         assert member_charges, "Expected DU charges for each council member"
 
-    assert len(fake_resource_manager.set_calls) == 2
-    assert all(amount == 2.0 for _, amount in fake_resource_manager.set_calls)
+    assert len(fake_resource_manager.set_calls) == 3
+    assert fake_resource_manager.set_calls[0] == ("question-owner", pytest.approx(2.0))
+    assert fake_resource_manager.set_calls[1:] == [
+        ("member-a", pytest.approx(1.0)),
+        ("member-b", pytest.approx(1.0)),
+    ]
     assert len(fake_resource_manager.ensure_calls) == 2 * len(fake_resource_manager.charge_calls)
+    assert outcome.metadata["metrics"]["du_owner_id"] == "question-owner"
+    assert outcome.metadata["metrics"]["du_owner_reserved"] == pytest.approx(2.0)
 
     recorded_du_spend = [entry for entry in fake_ledger.log_entries if entry[2] == "llm_gas"]
     assert len(recorded_du_spend) == len(fake_resource_manager.charge_calls)
@@ -232,7 +247,7 @@ async def test_council_orchestrator_honors_per_member_du_budget_overrides(
         du_budget_per_question=2.0,
     )
     question = CouncilQuestion(
-        question_id="q1", prompt="What is DU?", context="", task_context=None
+        question_id="q1", prompt="What is DU?", user_id="question-owner", context="", task_context=None
     )
 
     context = orchestrator._resolve_context(config)
@@ -241,14 +256,16 @@ async def test_council_orchestrator_honors_per_member_du_budget_overrides(
     assert outcome.answers
     metrics = outcome.metadata.get("metrics", {}) if outcome.metadata else {}
     assert metrics.get("du_budget_per_member") == {
-        "member-a": pytest.approx(3.0),
-        "member-b": pytest.approx(2.0),
+        "member-a": pytest.approx(1.0),
+        "member-b": pytest.approx(1.0),
     }
     assert fake_resource_manager.initial_budgets == {
-        "member-a": pytest.approx(3.0),
-        "member-b": pytest.approx(2.0),
+        "question-owner": pytest.approx(2.0),
+        "member-a": pytest.approx(1.0),
+        "member-b": pytest.approx(1.0),
     }
     assert fake_resource_manager.set_calls == [
-        ("member-a", pytest.approx(3.0)),
-        ("member-b", pytest.approx(2.0)),
+        ("question-owner", pytest.approx(2.0)),
+        ("member-a", pytest.approx(1.0)),
+        ("member-b", pytest.approx(1.0)),
     ]

--- a/tests/unit/agents/council/test_council_orchestrator.py
+++ b/tests/unit/agents/council/test_council_orchestrator.py
@@ -178,6 +178,25 @@ def _build_question(metadata: Mapping[str, Any] | None = None) -> CouncilQuestio
     )
 
 
+
+
+def test_council_orchestrator_resolves_du_owner_from_question_user_id() -> None:
+    orchestrator = CouncilOrchestrator()
+    config = _build_council_config(voting_mode="judge_llm")
+    question = CouncilQuestion(
+        question_id="q-owner",
+        prompt="Who pays for this run?",
+        user_id="requesting-user",
+        context="Owner resolution test",
+    )
+
+    outcome = orchestrator.deliberate(config, question)
+
+    metrics = outcome.metadata.get("metrics", {})
+    assert metrics.get("du_owner_id") == "requesting-user"
+    assert metrics.get("du_owner_reserved") == pytest.approx(5.0)
+
+
 def test_council_member_forwards_generation_params(monkeypatch: pytest.MonkeyPatch) -> None:
     config = _build_council_config()
     member = config.members[0]
@@ -410,10 +429,13 @@ def test_council_orchestrator_invokes_all_members_and_aggregates(
     metrics = outcome.metadata.get("metrics", {})
     assert metrics.get("du_budget_exhausted") is False
     assert metrics.get("du_budget_per_member") == {
-        "facilitator": pytest.approx(5.0),
-        "innovator": pytest.approx(5.0),
-        "analyst": pytest.approx(5.0),
+        "facilitator": pytest.approx(5.0 / 3.0),
+        "innovator": pytest.approx(5.0 / 3.0),
+        "analyst": pytest.approx(5.0 / 3.0),
     }
+    assert metrics.get("du_owner_id") == "council"
+    assert metrics.get("du_owner_reserved") == pytest.approx(5.0)
+    assert metrics.get("du_owner_remaining") == pytest.approx(0.0)
     assert "member_scores" in metrics
     assert outcome.metrics["member_scores"]["facilitator"]["total"] == pytest.approx(0.8375)
     assert outcome.summary == "Deterministic council summary"


### PR DESCRIPTION
### Motivation
- Introduce a run-level DU owner so council runs debit a single owner budget before scheduling members and avoid unconstrained per-member DU allocations.
- Ensure per-member DU comes from the reserved run pool while preserving any explicit `member.du_budget` caps.
- Surface owner allocation metrics for observability (`du_owner_id`, `du_owner_reserved`, `du_owner_remaining`).

### Description
- Resolve an owner ID for a council run via `CouncilQuestion.metadata` keys (`owner_id`, `owner`, `council_owner`, `council_owner_id`), then `CouncilQuestion.user_id`, config metadata, then `COUNCIL_OWNER_ID`, falling back to the literal `"council"` in `_resolve_owner_id`.
- Add `_reserve_owner_budget` to debit/reserve `du_budget_per_question` from the resolved owner via the resource manager before member scheduling and record owner metrics into the run `metrics` dict.
- Change per-member budget allocation: `_resolve_du_budgets` now derives member budgets as an equal share of the reserved run pool, capped by any explicit `member.du_budget`, and `_allocate_du_budgets` wires this flow (owner reserve -> derive per-member budgets -> set per-member budgets).
- Preserve member-level caps by using `member.du_budget` as a secondary cap when computing the derived per-member allowance.
- Add new metrics keys emitted in the outcome: `du_owner_id`, `du_owner_reserved`, and `du_owner_remaining`, and ensure `member_count` is present in `metrics`.
- Add `ResourceManager.has_du_budget` and `ResourceManager.reserve_du_budget` to support owner reservation semantics and ledger logging; existing `set_du_budget`, `charge_du`, and `ensure_du_budget` behaviors are preserved.
- Update unit and integration tests to cover owner resolution, reservation, and derived per-member allocations and to adapt expectations to the new allocation model.

### Testing
- Ran linter: `ruff check src/agents/council/orchestrator.py src/sim/resource_manager.py tests/unit/agents/council/test_council_orchestrator.py tests/integration/agents/council/test_council_du_budget.py` and it passed.
- Ran targeted tests: `pytest -q tests/unit/agents/council/test_council_orchestrator.py tests/integration/agents/council/test_council_du_budget.py` and all tests passed (unit + integration expectations for the updated owner/reservation flow succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986408ea32c8326bdeefa3a087d4cfd)