### PR TITLE
Gate council decision graph wiring behind scoped flag

### DIFF
--- a/src/agents/graphs/agent_graph_builder.py
+++ b/src/agents/graphs/agent_graph_builder.py
@@ -64,6 +64,8 @@ def route_action_intent(state: AgentTurnState) -> str:
 
 def build_graph() -> Any:
     use_council_mode = bool(config.get_config("USE_COUNCIL_MODE"))
+    use_council_for_decisions = bool(config.get_config("USE_COUNCIL_FOR_DECISIONS"))
+    enable_council_decision_node = use_council_mode and use_council_for_decisions
 
     graph_builder = StateGraph(AgentTurnState)
     graph_builder.add_node("analyze_perception_sentiment", analyze_perception_sentiment_node)
@@ -72,7 +74,7 @@ def build_graph() -> Any:
     graph_builder.add_node("retrieve_and_summarize_memories", retrieve_and_summarize_memories_node)
     graph_builder.add_node("generate_thought_and_message", generate_thought_and_message_node)
 
-    if use_council_mode:
+    if enable_council_decision_node:
         graph_builder.add_node("council_decision", council_decision_node)
 
     graph_builder.add_node("handle_propose_idea", handle_propose_idea_node)
@@ -98,7 +100,7 @@ def build_graph() -> Any:
     graph_builder.add_edge("retrieve_and_summarize_memories", "generate_thought_and_message")
 
     branch_source = "generate_thought_and_message"
-    if use_council_mode:
+    if enable_council_decision_node:
         graph_builder.add_edge("generate_thought_and_message", "council_decision")
         branch_source = "council_decision"
 

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -143,6 +143,7 @@ DEFAULT_CONFIG: dict[str, object] = {
     "MEMORY_RETRIEVER_TOP_K": 5,
     "MEMORY_RETRIEVER_TOKEN_LIMIT": 1000,
     "USE_COUNCIL_MODE": False,
+    "USE_COUNCIL_FOR_DECISIONS": False,
     "COUNCIL_CONFIG_PATH": "config/council.yml",
     "COUNCIL_MAX_CONCURRENT_CALLS": 3,
     "DU_BUDGET_PER_QUESTION": 5.0,
@@ -308,6 +309,7 @@ BOOL_CONFIG_KEYS = [
     "MEMORY_PRUNING_L2_MUS_ENABLED",
     "SNAPSHOT_COMPRESS",
     "USE_COUNCIL_MODE",
+    "USE_COUNCIL_FOR_DECISIONS",
 ]
 
 # Keys that must be defined for a complete runtime configuration.

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -144,6 +144,7 @@ class ConfigSettings(BaseSettings):
     MEMORY_RETRIEVER_TOP_K: int = 5
     MEMORY_RETRIEVER_TOKEN_LIMIT: int = 1000
     USE_COUNCIL_MODE: bool = False
+    USE_COUNCIL_FOR_DECISIONS: bool = False
     COUNCIL_CONFIG_PATH: str = "config/council.yml"
     COUNCIL_MAX_CONCURRENT_CALLS: int = 3
     DU_BUDGET_PER_QUESTION: float = 5.0

--- a/tests/unit/agents/graphs/test_agent_graph_builder.py
+++ b/tests/unit/agents/graphs/test_agent_graph_builder.py
@@ -53,27 +53,27 @@ def _patch_graph_nodes(monkeypatch: pytest.MonkeyPatch, *, include_council: bool
 
 
 @pytest.mark.asyncio
-async def test_graph_skips_council_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("config_values", "expect_council"),
+    [
+        ({"USE_COUNCIL_MODE": False, "USE_COUNCIL_FOR_DECISIONS": True}, False),
+        ({"USE_COUNCIL_MODE": True, "USE_COUNCIL_FOR_DECISIONS": False}, False),
+        ({"USE_COUNCIL_MODE": True, "USE_COUNCIL_FOR_DECISIONS": True}, True),
+    ],
+)
+async def test_graph_council_routing_requires_master_and_scoped_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    config_values: dict[str, bool],
+    expect_council: bool,
+) -> None:
     calls: list[str] = []
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": False})
-    _patch_graph_nodes(monkeypatch, include_council=False, calls=calls)
+    monkeypatch.setattr(config, "_CONFIG", config_values)
+    _patch_graph_nodes(monkeypatch, include_council=expect_council, calls=calls)
 
     executor = agent_graph_builder.build_graph()
     await executor.ainvoke({})
 
-    assert "council_decision_node" not in calls
+    assert ("council_decision_node" in calls) is expect_council
     assert "generate_thought_and_message_node" in calls
-
-
-@pytest.mark.asyncio
-async def test_graph_routes_to_council_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[str] = []
-    monkeypatch.setattr(config, "_CONFIG", {"USE_COUNCIL_MODE": True})
-    _patch_graph_nodes(monkeypatch, include_council=True, calls=calls)
-
-    executor = agent_graph_builder.build_graph()
-    await executor.ainvoke({})
-
-    assert "council_decision_node" in calls
-    # Ensure decision handlers still run after council
+    # Ensure decision handlers still run after council/no-council routing
     assert any(call.startswith("handle_") for call in calls)


### PR DESCRIPTION
### Motivation
- Allow fine-grained control over whether the council decision node is used for routing, not just a global on/off toggle.

### Description
- Added a new boolean config `USE_COUNCIL_FOR_DECISIONS` to `src/infra/settings.py` and `DEFAULT_CONFIG` in `src/infra/config.py`, and included it in `BOOL_CONFIG_KEYS` so it can be controlled via environment/config.
- Updated `src/agents/graphs/agent_graph_builder.py` to read `USE_COUNCIL_FOR_DECISIONS` and compute `enable_council_decision_node = USE_COUNCIL_MODE and USE_COUNCIL_FOR_DECISIONS`, and only add the `council_decision` node and wiring when both flags are true.
- Reworked unit test coverage in `tests/unit/agents/graphs/test_agent_graph_builder.py` to a parametrized test `test_graph_council_routing_requires_master_and_scoped_flags` that verifies the three combinations of master/scoped flags and asserts council routing only when both are enabled.

### Testing
- Ran linter checks with `ruff` on the modified files and they passed.
- Ran unit tests `pytest -q tests/unit/agents/graphs/test_agent_graph_builder.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864528b07483268e0d26bcb05510bb)