### PR TITLE
Add world-time progression, perception context, and tests

### DIFF
--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -153,6 +153,8 @@ DEFAULT_CONFIG: dict[str, object] = {
         "Analyzer": {"base": 1.0},
     },
     "GENE_MUTATION_RATE": 0.1,
+    "WORLD_TICKS_PER_DAY": 24,
+    "WORLD_SEASON_LENGTH_DAYS": 0,
 }
 
 # Cache for council roster configuration
@@ -203,12 +205,11 @@ def _build_default_council_config() -> dict[str, Any]:
                 "is_active": True,
             },
         ],
-        "max_concurrent_calls": int(
-            getattr(settings, "COUNCIL_MAX_CONCURRENT_CALLS", 3)
-        ),
+        "max_concurrent_calls": int(getattr(settings, "COUNCIL_MAX_CONCURRENT_CALLS", 3)),
         "du_budget_per_question": float(getattr(settings, "DU_BUDGET_PER_QUESTION", 0.0)),
         "voting_mode": "judge_llm",
     }
+
 
 # Define keys that should be floats and ints for type conversion
 FLOAT_CONFIG_KEYS = [
@@ -301,6 +302,8 @@ INT_CONFIG_KEYS = [
     "MEMORY_RETRIEVER_TOKEN_LIMIT",
     "LLM_BATCH_SIZE",
     "COUNCIL_MAX_CONCURRENT_CALLS",
+    "WORLD_TICKS_PER_DAY",
+    "WORLD_SEASON_LENGTH_DAYS",
 ]
 BOOL_CONFIG_KEYS = [
     "MEMORY_PRUNING_ENABLED",

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -149,6 +149,8 @@ class ConfigSettings(BaseSettings):
     COUNCIL_MAX_CONCURRENT_CALLS: int = 3
     DU_BUDGET_PER_QUESTION: float = 5.0
     GENE_MUTATION_RATE: float = 0.1
+    WORLD_TICKS_PER_DAY: int = 24
+    WORLD_SEASON_LENGTH_DAYS: int = 0
     ROLE_DU_GENERATION: ClassVar[dict[str, dict[str, float]]] = {
         "Facilitator": {"base": 1.2, "bonus_factor": 0.3},
         "Innovator": {"base": 1.0, "bonus_factor": 0.5},

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -124,6 +124,13 @@ class Simulation:
         ACTIVE_AGENT_COUNT.set(len(self.agents))
         self.current_step: int = 0
         self.current_agent_index: int = 0
+        self.world_hour: int = 0
+        self.world_day: int = 0
+        self.world_season: int | None = 0
+        self.world_ticks_per_day: int = max(1, int(config.get_config("WORLD_TICKS_PER_DAY") or 24))
+        season_len = int(config.get_config("WORLD_SEASON_LENGTH_DAYS") or 0)
+        self.world_season_length_days: int | None = season_len if season_len > 0 else None
+        self._last_time_update_step = 0
         self.last_completed_agent_index: int | None = None
         self.steps_to_run: int = 0  # Number of steps to run, set externally
         self.total_turns_executed = 0
@@ -641,8 +648,7 @@ class Simulation:
                 async with self.knowledge_board.lock:
                     self.knowledge_board.add_entry(
                         BoardEntry(
-                            content_full=
-                            f"Agent {parent.agent_id} spawned child {agent.agent_id}",
+                            content_full=f"Agent {parent.agent_id} spawned child {agent.agent_id}",
                             entry_type="spawn_event",
                             tags=["population", "spawn"],
                             reference_metadata={"child_id": agent.agent_id},
@@ -712,6 +718,44 @@ class Simulation:
                     )
         return other_agents_info
 
+    def _format_world_time(self: Self) -> str:
+        """Return human-readable world time for prompts/events."""
+        time_str = f"Day {self.world_day}, {self.world_hour:02d}:00"
+        if self.world_season is not None:
+            time_str += f" (Season {self.world_season})"
+        return time_str
+
+    async def _advance_world_time(self: Self) -> None:
+        """Advance world clock by one tick and broadcast periodic updates."""
+        self.world_hour += 1
+        if self.world_hour >= self.world_ticks_per_day:
+            self.world_hour = 0
+            self.world_day += 1
+            if self.world_season_length_days and self.world_day > 0:
+                self.world_season = self.world_day // self.world_season_length_days
+
+        cadence = self.world_ticks_per_day
+        if (
+            self.current_step > 0
+            and self.current_step % cadence == 0
+            and self.current_step != self._last_time_update_step
+        ):
+            self._last_time_update_step = self.current_step
+            payload = {
+                "type": "world_time",
+                "step": self.current_step,
+                "world_hour": self.world_hour,
+                "world_day": self.world_day,
+                "world_season": self.world_season,
+                "world_time": self._format_world_time(),
+            }
+            event = log_event(payload)
+            if event is None:
+                event = {**payload}
+                event["trace_hash"] = compute_trace_hash(payload)
+            await emit_event(SimulationEvent(type="world_time", data=event))
+            await self.send_discord_update(message=f"🕒 {payload['world_time']}")
+
     async def send_discord_update(
         self: Self,
         message: str | None = None,
@@ -742,6 +786,7 @@ class Simulation:
 
         # Increment step and select agent
         self.current_step += 1
+        await self._advance_world_time()
         agent = self.agents[agent_index]
         agent_id = agent.agent_id
         if agent_id in self.muted_agents:
@@ -799,6 +844,12 @@ class Simulation:
             perception_data["knowledge_board_content"] = (
                 self.knowledge_board.get_recent_entries_for_prompt()
             )
+        perception_data["world_time"] = {
+            "world_hour": self.world_hour,
+            "world_day": self.world_day,
+            "world_season": self.world_season,
+            "formatted": self._format_world_time(),
+        }
         with trace_agent_action("agent_activation", agent_id=agent_id, step=self.current_step):
             agent_output = await agent.run_turn(
                 simulation_step=self.current_step,
@@ -980,6 +1031,9 @@ class Simulation:
                 ],
                 "seed": self.seed,
                 "rng_state": capture_rng_state(),
+                "world_hour": self.world_hour,
+                "world_day": self.world_day,
+                "world_season": self.world_season,
                 "trace_hash": self._last_trace_hash,
             }
             snapshot_no_vector = {
@@ -1732,6 +1786,9 @@ class Simulation:
 
             restore_rng_state(snapshot["rng_state"])
         sim.current_step = int(snapshot.get("step", 0))
+        sim.world_hour = int(snapshot.get("world_hour", 0))
+        sim.world_day = int(snapshot.get("world_day", 0))
+        sim.world_season = snapshot.get("world_season", 0)
         sim.collective_ip = float(snapshot.get("collective_ip", 0.0))
         sim.collective_du = float(snapshot.get("collective_du", 0.0))
         sim._last_trace_hash = snapshot.get("trace_hash", "")
@@ -1780,7 +1837,6 @@ class Simulation:
         end_step: int | None = None,
         seed: int | None = None,
         events_path: str | Path | None = None,
-
     ) -> Self:
         """Load a snapshot and replay events from the event log."""
         snap = load_snapshot(snapshot_path)
@@ -1794,7 +1850,6 @@ class Simulation:
         for event in event_log.stream_events(
             after_step=after_step, end_step=end_step, path=events_path
         ):
-
             step = int(event.get("step", 0))
             if start_step is not None and step < start_step:
                 continue

--- a/tests/unit/sim/test_simulation_world_time.py
+++ b/tests/unit/sim/test_simulation_world_time.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.sim.simulation import Simulation
+
+
+class DummyAgent:
+    def __init__(self) -> None:
+        self.agent_id = "agent"
+        self.last_perception = None
+        self.state = SimpleNamespace(
+            agent_id="agent",
+            ip=1.0,
+            du=1.0,
+            messages_sent_count=0,
+            last_message_step=0,
+            short_term_memory=[],
+            mood_level=0.0,
+            is_alive=True,
+            age=0,
+        )
+
+    async def run_turn(self, **kwargs):
+        self.last_perception = kwargs.get("environment_perception")
+        return {"action_intent": "idle"}
+
+    def update_state(self, state):
+        self.state = state
+
+    def get_id(self):
+        return self.agent_id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_world_time_rollover_hour_to_day(monkeypatch):
+    monkeypatch.setenv("WORLD_TICKS_PER_DAY", "2")
+    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "0")
+
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event", lambda data: {**data, "trace_hash": "hash"}
+    )
+    monkeypatch.setattr("src.sim.simulation.emit_event", AsyncMock())
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    sim = Simulation(
+        [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+    sim.current_step = 1
+    await sim._advance_world_time()
+    assert sim.world_hour == 1
+    assert sim.world_day == 0
+
+    sim.current_step = 2
+    await sim._advance_world_time()
+    assert sim.world_hour == 0
+    assert sim.world_day == 1
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_world_time_rollover_day_to_season(monkeypatch):
+    monkeypatch.setenv("WORLD_TICKS_PER_DAY", "2")
+    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "2")
+
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event", lambda data: {**data, "trace_hash": "hash"}
+    )
+    emit_event = AsyncMock()
+    monkeypatch.setattr("src.sim.simulation.emit_event", emit_event)
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    sim = Simulation(
+        [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+
+    for step in range(1, 5):
+        sim.current_step = step
+        await sim._advance_world_time()
+
+    assert sim.world_day == 2
+    assert sim.world_season == 1
+    assert any(call.args[0].type == "world_time" for call in emit_event.await_args_list)
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_turn_includes_world_time_perception(monkeypatch):
+    monkeypatch.setenv("WORLD_TICKS_PER_DAY", "24")
+    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "0")
+
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event", lambda data: {**data, "trace_hash": "hash"}
+    )
+    monkeypatch.setattr("src.sim.simulation.emit_event", AsyncMock())
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    agent = DummyAgent()
+    sim = Simulation(
+        [agent], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+    await sim._run_agent_turn(0)
+
+    assert agent.last_perception is not None
+    world_time = agent.last_perception.get("world_time")
+    assert world_time is not None
+    assert world_time["world_hour"] == sim.world_hour
+    assert world_time["world_day"] == sim.world_day
+    assert "formatted" in world_time
+    sim.close()


### PR DESCRIPTION
### Motivation

- Provide an explicit, simulation-level world clock so prompts and observers can reason about in-sim time progression.
- Make tick cadence configurable so tests and deployments can control how many simulation turns equal a world day or season.
- Surface time to external observers (dashboard/Discord) and persist it across snapshots for replay continuity.

### Description

- Add configuration keys `WORLD_TICKS_PER_DAY` and `WORLD_SEASON_LENGTH_DAYS` to `src/infra/settings.py` and `src/infra/config.py` so cadence is environment-driven.
- Extend `Simulation` with `world_hour`, `world_day`, `world_season`, `world_ticks_per_day`, `world_season_length_days`, and `_last_time_update_step`, initialized from config at startup in `src/sim/simulation.py`.
- Implement `_advance_world_time` and `_format_world_time` helpers and invoke `await self._advance_world_time()` once per `_run_agent_turn` so the world clock advances each turn.
- Insert `world_time` into `environment_perception` before calling `agent.run_turn(...)` so agents receive formatted time context, and emit periodic `world_time` `SimulationEvent` plus a short Discord update for observers on cadence boundaries.
- Persist `world_hour`, `world_day`, and `world_season` into snapshots and restore them in `Simulation.from_snapshot` to keep continuity when replaying.
- Add unit tests `tests/unit/sim/test_simulation_world_time.py` validating hour→day rollover, day→season rollover (and event emission), and that `environment_perception` contains the current `world_time`.

### Testing

- Ran linter/formatter checks with `ruff` against the modified files and it passed.
- Ran `pytest -q tests/unit/sim/test_simulation_world_time.py tests/unit/sim/test_simulation_spans.py` and the test suite passed (all tests passed; only unrelated warnings observed in the environment). 
- The new unit tests exercise rollover behavior and confirm `emit_event` is invoked for `world_time` events and that agents receive the `world_time` payload in their perception.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868eabfaf48326a924e3cdc7c88c53)