### PR TITLE
Add role-aware PersonalityTraits, bounded trait drift, and trait-aware DSPy prompts

### DIFF
--- a/src/agents/core/agent_actions.py
+++ b/src/agents/core/agent_actions.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from src.infra.config import get_config
 
-from .roles import create_role_profile
+from .roles import create_role_profile, get_role_trait_template
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints
     from .agent_state import AgentState
@@ -26,6 +26,7 @@ def update_relationship(
     effective = (
         sentiment_score * state._targeted_message_multiplier if is_targeted else sentiment_score
     )
+    effective *= 0.75 + (0.5 * state.traits.trust_baseline)
     if effective > 0:
         lr = state._positive_relationship_learning_rate
     elif effective < 0:
@@ -40,6 +41,16 @@ def update_relationship(
         state.relationship_history.setdefault(other_agent_id, []).append(
             (state.step_counter, new_score)
         )
+
+    # Small trait drift from social outcomes.
+    state.apply_trait_drift(
+        {
+            "trust_baseline": 0.01 * effective,
+            "empathy": 0.006 * effective,
+            "assertiveness": -0.004 * effective if effective < 0 else 0.002 * effective,
+        },
+        max_step=0.01,
+    )
 
 
 def can_change_role(state: AgentState, new_role: str, current_step: int) -> bool:
@@ -104,6 +115,27 @@ def change_role(state: AgentState, new_role: str, current_step: int) -> bool:
         logger.debug("Ledger logging failed", exc_info=True)
     state.current_role = create_role_profile(new_role)
     state.role_embedding = list(state.current_role.embedding)
+    template = state.traits.__class__(**get_role_trait_template(new_role))
+    state.apply_trait_drift(
+        {
+            "openness": (template.openness - state.traits.openness) * 0.25,
+            "analytical_focus": (
+                template.analytical_focus - state.traits.analytical_focus
+            )
+            * 0.25,
+            "empathy": (template.empathy - state.traits.empathy) * 0.25,
+            "assertiveness": (template.assertiveness - state.traits.assertiveness) * 0.25,
+            "emotional_sensitivity": (
+                template.emotional_sensitivity - state.traits.emotional_sensitivity
+            )
+            * 0.25,
+            "resilience": (template.resilience - state.traits.resilience) * 0.25,
+            "trust_baseline": (template.trust_baseline - state.traits.trust_baseline)
+            * 0.25,
+            "adaptability": (template.adaptability - state.traits.adaptability) * 0.25,
+        },
+        max_step=0.03,
+    )
     state.reputation_score = state.current_role.reputation
     state.steps_in_current_role = 0
     state.role_history.append((current_step, new_role))

--- a/src/agents/core/agent_controller.py
+++ b/src/agents/core/agent_controller.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from typing_extensions import Self
 
 from src.agents.core.agent_state import AgentState
-from src.agents.core.mood_utils import get_descriptive_mood
+from src.agents.core.mood_utils import get_descriptive_mood, modulate_emotional_impact
 from src.agents.dspy_programs.intent_selector import IntentSelectorProgram
 
 from .agent_actions import (
@@ -49,7 +49,12 @@ class AgentController:
         current_numeric = state.mood_level
         decayed = current_numeric * (1.0 - state._mood_decay_rate)
         sentiment_float = float(sentiment_score) if sentiment_score is not None else 0.0
-        change = sentiment_float * state._mood_update_rate
+        trait_adjusted_sentiment = modulate_emotional_impact(
+            sentiment_float,
+            state.traits.emotional_sensitivity,
+            state.traits.resilience,
+        )
+        change = trait_adjusted_sentiment * state._mood_update_rate
         new_level = max(-1.0, min(1.0, decayed + change))
         state.mood_level = new_level
         state.mood_history.append((state.step_counter, new_level))
@@ -59,7 +64,7 @@ class AgentController:
             state.agent_id,
             current_numeric,
             decayed,
-            sentiment_float,
+            trait_adjusted_sentiment,
             change,
             new_level,
             mood_desc,

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -29,11 +29,11 @@ from src.agents.core.roles import (
     RoleProfile,
     create_role_profile,
     ensure_profile,
+    get_role_trait_template,
 )
 from .embedding_utils import compute_embedding
 from src.infra.config import get_config  # Import get_config function
 from src.langgraph import RetrieverNode
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.infra.llm_client import LLMClient, LLMClientConfig
@@ -92,6 +92,37 @@ def _coerce_policy_bool(value: Any, default: bool = True) -> bool:
     if isinstance(value, (int, float)):
         return bool(value)
     return default
+
+
+
+
+class PersonalityTraits(BaseModel):
+    """Stable-but-adaptable personality dimensions used in social/emotional decisions."""
+
+    openness: float = Field(default=0.6, ge=0.0, le=1.0)
+    analytical_focus: float = Field(default=0.6, ge=0.0, le=1.0)
+    empathy: float = Field(default=0.6, ge=0.0, le=1.0)
+    assertiveness: float = Field(default=0.5, ge=0.0, le=1.0)
+    emotional_sensitivity: float = Field(default=0.5, ge=0.0, le=1.0)
+    resilience: float = Field(default=0.6, ge=0.0, le=1.0)
+    trust_baseline: float = Field(default=0.55, ge=0.0, le=1.0)
+    adaptability: float = Field(default=0.6, ge=0.0, le=1.0)
+
+    def summarize(self) -> str:
+        return (
+            "openness={:.2f}, analytical_focus={:.2f}, empathy={:.2f}, "
+            "assertiveness={:.2f}, sensitivity={:.2f}, resilience={:.2f}, "
+            "trust_baseline={:.2f}, adaptability={:.2f}"
+        ).format(
+            self.openness,
+            self.analytical_focus,
+            self.empathy,
+            self.assertiveness,
+            self.emotional_sensitivity,
+            self.resilience,
+            self.trust_baseline,
+            self.adaptability,
+        )
 
 
 class AgentActionIntent(str, Enum):
@@ -192,6 +223,18 @@ class AgentStateData(BaseModel):
 
     def __init__(self, **data: Any) -> None:
         """Initialize and conditionally call ``model_post_init`` for Pydantic v1."""
+        if "traits" not in data:
+            role_value = data.get("current_role")
+            if role_value is None:
+                role_name = _get_default_role()
+            elif isinstance(role_value, RoleProfile):
+                role_name = role_value.name
+            elif isinstance(role_value, dict):
+                role_name = str(role_value.get("name", _get_default_role()))
+            else:
+                role_name = str(role_value)
+            data["traits"] = PersonalityTraits(**get_role_trait_template(role_name))
+
         super().__init__(**data)
         if hasattr(self, "model_post_init"):
             self.model_post_init(None)
@@ -219,6 +262,7 @@ class AgentStateData(BaseModel):
     collective_ip: float = 0.0
     collective_du: float = 0.0
     current_role: RoleProfile = Field(default_factory=_get_default_role_profile)
+    traits: PersonalityTraits = Field(default_factory=PersonalityTraits)
     steps_in_current_role: int = 0
     reputation: dict[str, float] = Field(default_factory=dict)
     role_reputation: dict[str, float] = Field(default_factory=dict)
@@ -414,7 +458,31 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         avg_rep = sum(self.reputation.values()) / len(self.reputation) if self.reputation else 0.0
         role_rep = self.reputation_score
         emb_str = " ".join(f"{v:.2f}" for v in self.role_embedding)
-        return f"Embedding: {emb_str}; reputation: {avg_rep:.2f}; role_rep: {role_rep:.2f}"
+        return (
+            f"Embedding: {emb_str}; reputation: {avg_rep:.2f}; role_rep: {role_rep:.2f}; "
+            f"traits: {self.traits.summarize()}"
+        )
+
+
+    @property
+    def trait_summary(self) -> str:
+        return self.traits.summarize()
+
+    def apply_trait_drift(self, signals: dict[str, float] | None = None, max_step: float = 0.03) -> None:
+        """Apply bounded, small trait updates from interaction/reflection signals."""
+        updates = signals or {}
+        if not updates:
+            return
+
+        def _clamp01(value: float) -> float:
+            return max(0.0, min(1.0, value))
+
+        for key, influence in updates.items():
+            if not hasattr(self.traits, key):
+                continue
+            current = float(getattr(self.traits, key))
+            delta = max(-max_step, min(max_step, float(influence)))
+            setattr(self.traits, key, _clamp01(current + delta))
 
     # ------------------------------------------------------------------
     # Compatibility properties
@@ -531,6 +599,18 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
             llm_client_config = model.llm_client_config
             llm_client = model.llm_client
             mock_llm_client = model.mock_llm_client
+
+
+        if isinstance(model, dict):
+            if not model.get("traits"):
+                role_name = getattr(model.get("current_role"), "name", None) or str(
+                    model.get("current_role") or _get_default_role()
+                )
+                model["traits"] = PersonalityTraits(**get_role_trait_template(role_name))
+        else:
+            if getattr(model, "traits", None) is None:
+                role_name = getattr(model.current_role, "name", _get_default_role())
+                model.traits = PersonalityTraits(**get_role_trait_template(role_name))
 
         if not llm_client:
             if mock_llm_client:

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -7,13 +7,13 @@ import asyncio
 import copy
 import logging
 import uuid
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from math import sqrt
 
 # LangGraph imports
 # from langgraph.graph import StateGraph, END # No longer needed here
 # Import node functions and router from basic_agent_graph
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from pydantic import BaseModel
 from typing_extensions import Self
@@ -130,8 +130,8 @@ class Agent:
         initial_state: dict[str, Any] | None = None,
         name: str | None = None,
         memory_service: MemoryService | None = None,
-        vector_store_manager: Optional[MemoryStore] = None,
-        async_dspy_manager: Optional[AsyncDSPyManager] = None,
+        vector_store_manager: MemoryStore | None = None,
+        async_dspy_manager: AsyncDSPyManager | None = None,
     ):
         """
         Initializes a new agent with a unique ID and default state.
@@ -376,6 +376,15 @@ class Agent:
             updated_state (AgentState): The new state for the agent.
         """
         self._state = updated_state
+        # Controlled periodic reflection drift: tiny adaptation over time.
+        if self._state.step_counter and self._state.step_counter % 5 == 0:
+            self._state.apply_trait_drift(
+                {
+                    "adaptability": 0.004 * (1.0 - self._state.traits.adaptability),
+                    "resilience": 0.003 * (0.5 - abs(self._state.mood_level)),
+                },
+                max_step=0.01,
+            )
         logger.debug(f"Agent {self.agent_id} state updated")
 
     def add_memory(self: Self, step: int, memory_type: str, content: str) -> None:
@@ -824,6 +833,7 @@ class Agent:
             cast(Callable[..., object], generate_role_prefixed_thought),
             agent_role=role_prompt,
             current_situation=current_situation,
+            traits_summary=self._state.trait_summary,
         )
         result = await self.async_dspy_manager.get_result(
             future,
@@ -838,6 +848,7 @@ class Agent:
         current_situation: str,
         agent_goal: str,
         available_actions: str,
+        traits_summary: str | None = None,
     ) -> object:  # DSPy async output is dynamic
         """
         Asynchronously select an action intent using a DSPy program.
@@ -856,9 +867,10 @@ class Agent:
             current_situation=current_situation,
             agent_goal=agent_goal,
             available_actions=available_actions,
+            traits_summary=traits_summary or self._state.trait_summary,
         )
         default_value = action_intent_selector.get_failsafe_output(
-            role_prompt, current_situation, agent_goal, available_actions
+            role_prompt, current_situation, agent_goal, available_actions, traits_summary
         )
         result = await self.async_dspy_manager.get_result(
             future,

--- a/src/agents/core/mood_utils.py
+++ b/src/agents/core/mood_utils.py
@@ -58,3 +58,12 @@ def get_descriptive_mood(mood_value: float) -> str:
         return MoodType.FRUSTRATED.value
 
     return MoodType.NEUTRAL.value  # Catches values between -0.2 and 0.2 inclusive
+
+
+def modulate_emotional_impact(
+    sentiment_score: float, emotional_sensitivity: float, resilience: float
+) -> float:
+    """Scale sentiment impact by sensitivity and resilience in a bounded way."""
+    sensitivity_scale = 0.7 + (0.8 * max(0.0, min(1.0, emotional_sensitivity)))
+    resilience_scale = 1.15 - (0.6 * max(0.0, min(1.0, resilience)))
+    return sentiment_score * sensitivity_scale * resilience_scale

--- a/src/agents/core/roles.py
+++ b/src/agents/core/roles.py
@@ -26,6 +26,57 @@ ROLE_DESCRIPTIONS = {
     ROLE_ANALYZER: "Critique proposals, identify potential flaws, assess feasibility, and ensure solutions are robust and well-considered.",  # Long role description; breaking would harm context
 }
 
+# Role-aware defaults for typed personality traits.
+ROLE_TRAIT_TEMPLATES: dict[str, dict[str, float]] = {
+    ROLE_FACILITATOR: {
+        "openness": 0.7,
+        "analytical_focus": 0.5,
+        "empathy": 0.9,
+        "assertiveness": 0.5,
+        "emotional_sensitivity": 0.7,
+        "resilience": 0.6,
+        "trust_baseline": 0.75,
+        "adaptability": 0.8,
+    },
+    ROLE_INNOVATOR: {
+        "openness": 0.95,
+        "analytical_focus": 0.55,
+        "empathy": 0.6,
+        "assertiveness": 0.7,
+        "emotional_sensitivity": 0.5,
+        "resilience": 0.65,
+        "trust_baseline": 0.55,
+        "adaptability": 0.85,
+    },
+    ROLE_ANALYZER: {
+        "openness": 0.6,
+        "analytical_focus": 0.95,
+        "empathy": 0.45,
+        "assertiveness": 0.55,
+        "emotional_sensitivity": 0.4,
+        "resilience": 0.75,
+        "trust_baseline": 0.5,
+        "adaptability": 0.55,
+    },
+}
+
+DEFAULT_TRAIT_TEMPLATE: dict[str, float] = {
+    "openness": 0.6,
+    "analytical_focus": 0.6,
+    "empathy": 0.6,
+    "assertiveness": 0.5,
+    "emotional_sensitivity": 0.5,
+    "resilience": 0.6,
+    "trust_baseline": 0.55,
+    "adaptability": 0.6,
+}
+
+
+def get_role_trait_template(role_name: str) -> dict[str, float]:
+    """Return a copy of the default personality trait template for ``role_name``."""
+    template = ROLE_TRAIT_TEMPLATES.get(role_name, DEFAULT_TRAIT_TEMPLATE)
+    return dict(template)
+
 
 def _compute_embedding(text: str, dim: int = 8) -> list[float]:
     """Return a deterministic embedding vector for ``text``."""

--- a/src/agents/dspy_programs/action_intent_selector.py
+++ b/src/agents/dspy_programs/action_intent_selector.py
@@ -50,6 +50,9 @@ class ActionIntentSelection(dspy.Signature):
     available_actions = dspy.InputField(
         desc="A list of valid action intents the agent can choose from."
     )
+    traits_summary = dspy.InputField(
+        desc="Concise summary of personality traits that should influence action preference."
+    )
 
     chosen_action_intent = dspy.OutputField(
         desc="The single, most appropriate action intent selected from the available_actions list."
@@ -180,6 +183,7 @@ def test_module() -> bool:
             "agent_role": "Facilitator",
             "current_situation": "The discussion has stalled with multiple competing ideas.",
             "agent_goal": "Help the group reach consensus and make progress.",
+            "traits_summary": "openness=0.70, analytical_focus=0.40, empathy=0.80",
             "available_actions": [
                 "propose_idea",
                 "ask_clarification",

--- a/src/agents/dspy_programs/role_thought_generator.py
+++ b/src/agents/dspy_programs/role_thought_generator.py
@@ -18,6 +18,7 @@ class RoleThoughtGenerator(dspy.Signature):
 
     role_name = dspy.InputField(desc="The assigned role of the agent.")
     context = dspy.InputField(desc="The current situational context or recent interactions.")
+    traits_summary = dspy.InputField(desc="Concise summary of personality traits shaping tone and reasoning.")
     thought = dspy.OutputField(desc="The agent's generated thought, prefixed by their role.")
 
 
@@ -39,7 +40,12 @@ class FailsafeRoleThoughtGenerator:
     Failsafe version of the RoleThoughtGenerator. Always returns a safe default thought.
     """
 
-    def __call__(self: "FailsafeRoleThoughtGenerator", role_name: str, context: str) -> object:
+    def __call__(
+        self: "FailsafeRoleThoughtGenerator",
+        role_name: str,
+        context: str,
+        traits_summary: str | None = None,
+    ) -> object:
         return type(
             "FailsafeResult",
             (),
@@ -89,7 +95,9 @@ def get_role_thought_generator() -> object:
         return FailsafeRoleThoughtGenerator()
 
 
-def generate_role_prefixed_thought(agent_role: str, current_situation: str) -> str:
+def generate_role_prefixed_thought(
+    agent_role: str, current_situation: str, traits_summary: str = "balanced traits"
+) -> str:
     """
     Generate a role-prefixed thought using the robust loader.
     Returns a string thought process (for compatibility with agent graph).
@@ -99,7 +107,11 @@ def generate_role_prefixed_thought(agent_role: str, current_situation: str) -> s
         f"RoleThoughtGenerator inputs: agent_role='{agent_role}' (type: {type(agent_role)}), current_situation='{current_situation[:200]}...' (type: {type(current_situation)})"
     )
     if callable(generator):
-        dspy_result = generator(role_name=agent_role, context=current_situation)
+        dspy_result = generator(
+            role_name=agent_role,
+            context=current_situation,
+            traits_summary=traits_summary,
+        )
         return str(
             getattr(
                 _RolePrefixedThoughtResult(dspy_result),

--- a/tests/unit/agents/dspy/test_trait_influence.py
+++ b/tests/unit/agents/dspy/test_trait_influence.py
@@ -1,0 +1,40 @@
+import pytest
+
+from src.agents.dspy_programs.role_thought_generator import generate_role_prefixed_thought
+
+
+@pytest.mark.unit
+def test_role_thought_passes_traits_to_generator(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def dummy(*, role_name: str, context: str, traits_summary: str) -> object:
+        captured["traits"] = traits_summary
+        return type("Dummy", (), {"thought": f"As a {role_name}, {traits_summary}"})()
+
+    monkeypatch.setattr(
+        "src.agents.dspy_programs.role_thought_generator.get_role_thought_generator",
+        lambda: dummy,
+    )
+
+    out = generate_role_prefixed_thought("Innovator", "ctx", "openness=0.9")
+    assert "openness=0.9" in out
+    assert captured["traits"] == "openness=0.9"
+
+
+@pytest.mark.unit
+def test_trait_differences_change_output_style(monkeypatch: pytest.MonkeyPatch) -> None:
+    def style_gen(*, role_name: str, context: str, traits_summary: str) -> object:
+        style = "collaborative" if "empathy=0.90" in traits_summary else "direct"
+        return type("Dummy", (), {"thought": f"As a {role_name}, I respond in a {style} style."})()
+
+    monkeypatch.setattr(
+        "src.agents.dspy_programs.role_thought_generator.get_role_thought_generator",
+        lambda: style_gen,
+    )
+
+    high_empathy = generate_role_prefixed_thought("Facilitator", "ctx", "empathy=0.90")
+    low_empathy = generate_role_prefixed_thought("Facilitator", "ctx", "empathy=0.20")
+
+    assert high_empathy != low_empathy
+    assert "collaborative" in high_empathy
+    assert "direct" in low_empathy

--- a/tests/unit/core/test_base_agent.py
+++ b/tests/unit/core/test_base_agent.py
@@ -40,3 +40,26 @@ async def test_async_generate_l1_summary_failsafe(monkeypatch: MonkeyPatch) -> N
         assert "Failsafe" in result
     else:
         assert False, "Result is not a string as expected for failsafe output"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_select_action_intent_includes_trait_summary(monkeypatch: MonkeyPatch) -> None:
+    agent = Agent(agent_id="a3")
+    captured: dict[str, object] = {}
+
+    async def fake_submit(_callable: object, **kwargs: object) -> str:
+        captured.update(kwargs)
+        return "future"
+
+    monkeypatch.setattr(agent.async_dspy_manager, "submit", fake_submit)
+    monkeypatch.setattr(
+        agent.async_dspy_manager,
+        "get_result",
+        AsyncMock(return_value=type("R", (), {"chosen_action_intent": "idle"})()),
+    )
+
+    await agent.async_select_action_intent("role", "context", "goal", ["idle"])
+
+    assert "traits_summary" in captured
+    assert isinstance(captured["traits_summary"], str)

--- a/tests/unit/core/test_personality_traits.py
+++ b/tests/unit/core/test_personality_traits.py
@@ -1,0 +1,49 @@
+import pytest
+
+from src.agents.core.agent_controller import AgentController
+from src.agents.core.agent_state import AgentState, PersonalityTraits
+from src.agents.core.roles import ROLE_ANALYZER, ROLE_FACILITATOR, get_role_trait_template
+
+
+@pytest.mark.unit
+def test_role_trait_templates_seed_state() -> None:
+    facilitator = AgentState(
+        agent_id="a1",
+        name="fac",
+        current_role=ROLE_FACILITATOR,
+    )
+    analyzer = AgentState(agent_id="a2", name="ana", current_role=ROLE_ANALYZER)
+
+    assert facilitator.traits.empathy == pytest.approx(
+        get_role_trait_template(ROLE_FACILITATOR)["empathy"]
+    )
+    assert analyzer.traits.analytical_focus == pytest.approx(
+        get_role_trait_template(ROLE_ANALYZER)["analytical_focus"]
+    )
+
+
+@pytest.mark.unit
+def test_traits_modulate_mood_response() -> None:
+    sensitive = AgentState(
+        agent_id="s1",
+        name="sensitive",
+        traits=PersonalityTraits(emotional_sensitivity=0.95, resilience=0.2),
+    )
+    resilient = AgentState(
+        agent_id="r1",
+        name="resilient",
+        traits=PersonalityTraits(emotional_sensitivity=0.2, resilience=0.95),
+    )
+
+    AgentController(sensitive).update_mood(-1.0)
+    AgentController(resilient).update_mood(-1.0)
+
+    assert sensitive.mood_level < resilient.mood_level
+
+
+@pytest.mark.unit
+def test_trait_drift_is_bounded() -> None:
+    state = AgentState(agent_id="a3", name="drift")
+    before = state.traits.trust_baseline
+    state.apply_trait_drift({"trust_baseline": 1.0}, max_step=0.01)
+    assert state.traits.trust_baseline == pytest.approx(before + 0.01)

--- a/tests/unit/dspy_programs/test_role_thought_generator.py
+++ b/tests/unit/dspy_programs/test_role_thought_generator.py
@@ -21,7 +21,7 @@ def test_failsafe_role_thought_generator_returns_expected() -> None:
 @pytest.mark.unit
 @pytest.mark.dspy
 def test_generate_role_prefixed_thought_uses_generator(monkeypatch: MonkeyPatch) -> None:
-    def dummy(role_name: str, context: str) -> object:
+    def dummy(role_name: str, context: str, traits_summary: str) -> object:
         return type(
             "Dummy",
             (),
@@ -33,7 +33,7 @@ def test_generate_role_prefixed_thought_uses_generator(monkeypatch: MonkeyPatch)
         lambda: dummy,
     )
 
-    result = generate_role_prefixed_thought("Builder", "blueprint")
+    result = generate_role_prefixed_thought("Builder", "blueprint", "openness=0.5")
     assert result == "As a Builder, thinking about blueprint"
 
 
@@ -45,5 +45,5 @@ def test_generate_role_prefixed_thought_noncallable(monkeypatch: MonkeyPatch) ->
         lambda: object(),
     )
 
-    result = generate_role_prefixed_thought("Artist", "painting")
+    result = generate_role_prefixed_thought("Artist", "painting", "empathy=0.8")
     assert result == "Failsafe: Unable to generate thought (generator not callable)."


### PR DESCRIPTION
### Motivation
- Provide a typed personality/trait model to let agents have stable-but-adaptable dispositions that influence reasoning and social/emotional updates.  
- Seed trait defaults from role-aware templates so different roles start with distinct dispositions.  
- Ensure traits influence mood and relationship calculations and are surfaced to DSPy programs so intent and thought generation can reflect personality.  
- Keep trait evolution controlled via bounded drift after interactions, role changes, and periodic reflection.

### Description
- Added a `PersonalityTraits` Pydantic model and attached it to `AgentState` as `traits`, with a `trait_summary` helper and an `apply_trait_drift` method for bounded updates (`src/agents/core/agent_state.py`).
- Introduced role-aware trait templates and a helper `get_role_trait_template` to seed defaults for roles (`src/agents/core/roles.py`).
- Wired trait-aware modulation into emotional/relationship logic by adding `modulate_emotional_impact` and using emotional sensitivity/resilience in mood updates, and using `trust_baseline` in relationship updates (`src/agents/core/mood_utils.py`, `src/agents/core/agent_controller.py`, `src/agents/core/agent_actions.py`).
- Triggered small, bounded trait drift from social outcomes and blended toward role templates on role change; added periodic reflection-based drift in `Agent.update_state` (`src/agents/core/agent_actions.py`, `src/agents/core/base_agent.py`).
- Passed `traits_summary` into DSPy entry points for role-thought generation and action-intent selection and extended DSPy signatures to accept `traits_summary` (`src/agents/dspy_programs/role_thought_generator.py`, `src/agents/dspy_programs/action_intent_selector.py`, `src/agents/core/base_agent.py`).
- Added unit tests exercising trait seeding, trait-modulated mood response, bounded drift, trait propagation into DSPy calls, and trait-driven output style differences (`tests/unit/core/test_personality_traits.py`, `tests/unit/agents/dspy/test_trait_influence.py`), and adjusted a few existing DSPy/base-agent tests to include the new parameter plumbing.

### Testing
- Ran `ruff check` over the modified modules which completed with no remaining issues.  
- Ran targeted unit tests via `pytest -q` for the new and affected tests: `tests/unit/core/test_personality_traits.py`, `tests/unit/agents/dspy/test_trait_influence.py`, `tests/unit/dspy_programs/test_role_thought_generator.py`, `tests/unit/dspy_programs/test_action_intent_selector_fallback.py`, `tests/unit/core/test_agent_state_serialization.py`, and `tests/unit/core/test_base_agent.py`, with all selected tests passing (final run: 9 passed, 4 deselected; a small number of deprecation warnings were emitted from Pydantic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d8ed62d483268e7154ddde99936b)