### PR TITLE
Improve Discord human routing and simulation budget attribution

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -9,6 +9,7 @@ IP/DU cost for the currently active agent.
 import asyncio
 import json
 import logging
+import re
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
@@ -148,8 +149,47 @@ def embed_from_payload(payload: dict[str, Any]) -> Any:
 
 
 MAX_EMBED_DESCRIPTION_LENGTH = 4096
+_MENTION_TARGET_RE = re.compile(r"^@(?P<agent>[\w.-]+)\s*:\s*(?P<content>.+)$", re.DOTALL)
+_DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.DOTALL)
 
 
+
+
+def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str]:
+    """Parse optional routing directives from plain Discord messages."""
+    cleaned = content.strip()
+    if not cleaned:
+        return None, False, ""
+
+    if cleaned.startswith("/broadcast"):
+        payload = cleaned[len("/broadcast") :].strip()
+        return None, True, payload
+
+    mention_match = _MENTION_TARGET_RE.match(cleaned)
+    if mention_match:
+        return mention_match.group("agent"), False, mention_match.group("content").strip()
+
+    dm_match = _DM_TARGET_RE.match(cleaned)
+    if dm_match:
+        return dm_match.group("agent"), False, dm_match.group("content").strip()
+
+    return None, False, cleaned
+
+
+def _default_agent_for_channel(self: "SimulationDiscordBot", channel_id: int | None) -> str | None:
+    """Resolve a deterministic fallback agent for an unmapped incoming message."""
+    if channel_id is not None:
+        mapped = self.channel_to_agent.get(channel_id)
+        if mapped:
+            return mapped
+
+    if self.last_agent_id:
+        return self.last_agent_id
+
+    if self.channel_map:
+        return sorted(self.channel_map)[0]
+
+    return None
 def _truncate_for_code_block(content: str, max_length: int = MAX_EMBED_DESCRIPTION_LENGTH) -> str:
     """Wrap ``content`` in a code block, truncating safely to ``max_length`` characters."""
 
@@ -621,17 +661,26 @@ class SimulationDiscordBot:
                     if user_id and channel_id:
                         self.user_channels[str(user_id)] = channel_id
                         self.last_user_id = str(user_id)
-                    recipient = self.channel_to_agent.get(channel_id)
-                    agent_id = None
-                    if user_id:
-                        agent_id = self.user_agents.get(str(user_id))
-                        if agent_id is None and recipient:
-                            agent_id = recipient
-                            self.user_agents[str(user_id)] = agent_id
-                    span.set_attribute("discord.agent.id", agent_id or "")
-                    if not agent_id:
-                        await send_channel_message(channel, content="Unknown agent mapping")
+                    explicit_recipient, explicit_broadcast, parsed_content = (
+                        _parse_human_message_routing(content)
+                    )
+                    if not parsed_content:
                         return
+                    recipient = explicit_recipient or self.channel_to_agent.get(channel_id)
+                    sender = None
+                    if user_id:
+                        sender = self.user_agents.get(str(user_id))
+                    agent_id = recipient or sender or _default_agent_for_channel(self, channel_id)
+                    span.set_attribute("discord.agent.id", agent_id or "")
+                    if agent_id is None:
+                        await send_channel_message(
+                            channel,
+                            content="No agents available to route this message",
+                        )
+                        return
+                    if user_id and sender is None:
+                        self.user_agents[str(user_id)] = agent_id
+                    is_broadcast = explicit_broadcast or recipient is None
                     ip_cost = float(
                         config.get_config("IP_COST_BROADCAST_MESSAGE")
                         or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
@@ -648,11 +697,16 @@ class SimulationDiscordBot:
                         return
                     self.last_agent_id = agent_id
                     self.last_channel_id = channel_id
-                    evt_type = "broadcast"
-                    data = {"author": agent_id, "content": content}
-                    if recipient:
+                    data = {
+                        "author": str(user_id) if user_id is not None else "human",
+                        "content": parsed_content,
+                        "sender_id": str(user_id) if user_id is not None else "human",
+                        "target_agent_id": agent_id,
+                        "broadcast": is_broadcast,
+                    }
+                    if recipient is not None:
                         data["recipient_id"] = recipient
-                    await self.event_queue.put(SimulationEvent(type=evt_type, data=data))
+                    await self.event_queue.put(SimulationEvent(type="broadcast", data=data))
 
     async def _select_client(self: Self, agent_id: str | None) -> Any:
         """Return the Discord client for the given agent."""

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import heapq
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 from opentelemetry import trace
 from typing_extensions import Self
@@ -257,7 +257,7 @@ class EventKernel:
             await emit_event(SimulationEvent(type=event["type"], data=event_with_hash))
 
     async def forward_external_events(
-        self: Self, handler: Callable[[str], Awaitable[None]]
+        self: Self, handler: Callable[[str, dict[str, Any] | None], Awaitable[None]]
     ) -> None:
         """Forward broadcast events from the shared queue to ``handler``.
 
@@ -280,7 +280,7 @@ class EventKernel:
                 if evt.type == "broadcast" and evt.data:
                     content = evt.data.get("content")
                     if isinstance(content, str):
-                        await handler(content)
+                        await handler(content, dict(evt.data))
         except asyncio.CancelledError:
             pass
         finally:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -339,7 +339,9 @@ class Simulation:
 
         # current_round = (self.current_step -1) // len(self.agents) # Not clearly used, commenting out
 
-    async def _handle_human_command(self: Self, text: str) -> None:
+    async def _handle_human_command(
+        self: Self, text: str, metadata: dict[str, Any] | None = None
+    ) -> None:
         """Handle a human-issued command or prompt."""
         now = time.monotonic()
         if text.startswith("/kb ") and self.knowledge_board:
@@ -368,18 +370,35 @@ class Simulation:
         if not self.agents:
             return
 
-        broadcast = False
+        routing = metadata or {}
+        sender_id = str(routing.get("sender_id", "human"))
+        raw_recipient = routing.get("recipient_id")
+        recipient_id = str(raw_recipient) if isinstance(raw_recipient, str) else None
+        broadcast = bool(routing.get("broadcast", False))
         if text.startswith("/broadcast "):
             broadcast = True
             text = text[len("/broadcast ") :].strip()
 
-        agent_id = None
-        if self.discord_bot and self.discord_bot.last_agent_id:
-            agent_id = self.discord_bot.last_agent_id
-        target = next((a for a in self.agents if a.agent_id == agent_id), None)
+        raw_target = routing.get("target_agent_id")
+        target_agent_id = str(raw_target) if isinstance(raw_target, str) else None
+        raw_budget = routing.get("budget_agent_id")
+        target = next((a for a in self.agents if a.agent_id == target_agent_id), None)
+        if target is None and recipient_id:
+            target = next((a for a in self.agents if a.agent_id == recipient_id), None)
+        if target is None and self.discord_bot and self.discord_bot.last_agent_id:
+            last_id = self.discord_bot.last_agent_id
+            target = next((a for a in self.agents if a.agent_id == last_id), None)
         if target is None:
             target = self.agents[self.current_agent_index]
-        state = target.state
+        configured_budget_id = config.get_config("HUMAN_COMMAND_BUDGET_AGENT_ID")
+        if isinstance(raw_budget, str) and raw_budget:
+            budget_agent_id = raw_budget
+        elif isinstance(configured_budget_id, str) and configured_budget_id:
+            budget_agent_id = configured_budget_id
+        else:
+            budget_agent_id = target.agent_id
+        budget_agent = next((a for a in self.agents if a.agent_id == budget_agent_id), None)
+        state = budget_agent.state if budget_agent is not None else None
         if broadcast:
             ip_cost = float(
                 config.get_config("IP_COST_BROADCAST_MESSAGE")
@@ -396,41 +415,42 @@ class Simulation:
             du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
 
         try:
-            get_resource_manager().ensure_du_budget(target.agent_id, du_cost)
+            get_resource_manager().ensure_du_budget(budget_agent_id, du_cost)
         except Exception as exc:  # pragma: no cover - defensive
             logger.info(
                 "Rejecting human %s for %s: %s",
                 "broadcast" if broadcast else "command",
-                target.agent_id,
+                budget_agent_id,
                 exc,
             )
             if self.discord_bot:
                 await self.discord_bot.send_simulation_update(
                     str(exc),
-                    agent_id=target.agent_id,
+                    agent_id=budget_agent_id,
                     target_channel_id=self.discord_bot.last_channel_id,
                 )
             return
 
-        if state.ip < ip_cost or state.du < du_cost:
+        if state is not None and (state.ip < ip_cost or state.du < du_cost):
             logger.info(
                 "Rejecting human %s for %s: insufficient resources",
                 "broadcast" if broadcast else "command",
-                target.agent_id,
+                budget_agent_id,
             )
             if self.discord_bot:
                 await self.discord_bot.send_simulation_update(
                     "Insufficient IP/DU",
-                    agent_id=target.agent_id,
+                    agent_id=budget_agent_id,
                     target_channel_id=self.discord_bot.last_channel_id,
                 )
             return
 
-        state.ip -= ip_cost
-        state.du -= du_cost
+        if state is not None:
+            state.ip -= ip_cost
+            state.du -= du_cost
         try:
             await ledger.spend(
-                target.agent_id,
+                budget_agent_id,
                 ip=ip_cost,
                 du=du_cost,
                 reason="human_broadcast" if broadcast else "human_dm",
@@ -444,7 +464,7 @@ class Simulation:
                 msgs.append(
                     {
                         "step": self.current_step,
-                        "sender_id": "human",
+                        "sender_id": sender_id,
                         "recipient_id": ag.agent_id,
                         "content": text,
                         "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
@@ -455,7 +475,7 @@ class Simulation:
             msgs.append(
                 {
                     "step": self.current_step,
-                    "sender_id": "human",
+                    "sender_id": sender_id,
                     "recipient_id": target.agent_id,
                     "content": text,
                     "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
@@ -471,9 +491,11 @@ class Simulation:
                 "type": "human_command",
                 "step": self.current_step,
                 "tick": self.current_step + 1,
-                "sender_id": "human",
+                "sender_id": sender_id,
                 "target_agent_id": target.agent_id,
+                "budget_agent_id": budget_agent_id,
                 "broadcast": broadcast,
+                "recipient_id": recipient_id,
                 "text": text,
                 "ip_cost": ip_cost,
                 "du_cost": du_cost,
@@ -1745,7 +1767,7 @@ class Simulation:
                     )
                     for recipient in recipients
                 ]
-            target_id = event.get("target_agent_id")
+            budget_id = event.get("budget_agent_id") or event.get("target_agent_id")
             try:
                 ip_cost = float(event.get("ip_cost", 0.0))
             except (TypeError, ValueError):
@@ -1754,9 +1776,9 @@ class Simulation:
                 du_cost = float(event.get("du_cost", 0.0))
             except (TypeError, ValueError):
                 du_cost = 0.0
-            if isinstance(target_id, str):
+            if isinstance(budget_id, str):
                 for agent in self.agents:
-                    if agent.agent_id == target_id:
+                    if agent.agent_id == budget_id:
                         agent.state.ip -= ip_cost
                         agent.state.du -= du_cost
                         break

--- a/tests/unit/interfaces/test_discord_human_messages.py
+++ b/tests/unit/interfaces/test_discord_human_messages.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import sys
 from types import SimpleNamespace
@@ -27,6 +28,20 @@ class DummyBot:
 
 def reload_module(monkeypatch: pytest.MonkeyPatch):
     dummy_commands = SimpleNamespace(Bot=DummyBot)
+    class DummyTree:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def command(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    dummy_app_commands = SimpleNamespace(
+        CommandTree=DummyTree,
+        describe=lambda **_kwargs: (lambda func: func),
+    )
     dummy_discord = SimpleNamespace(
         Intents=SimpleNamespace(default=lambda: SimpleNamespace(message_content=True)),
         Client=DummyClient,
@@ -35,8 +50,10 @@ def reload_module(monkeypatch: pytest.MonkeyPatch):
         Thread=object,
         DiscordException=Exception,
         Color=SimpleNamespace(blue=lambda: None),
+        app_commands=dummy_app_commands,
     )
     monkeypatch.setitem(sys.modules, "discord", dummy_discord)
+    monkeypatch.setitem(sys.modules, "discord.app_commands", dummy_discord.app_commands)
     monkeypatch.setitem(sys.modules, "discord.ext", SimpleNamespace(commands=dummy_commands))
     monkeypatch.setitem(sys.modules, "discord.ext.commands", dummy_commands)
     module = importlib.reload(importlib.import_module("src.interfaces.discord_bot"))
@@ -76,3 +93,63 @@ async def test_human_messages_counter_increments(discord_module, monkeypatch):
     after = metrics.HUMAN_MESSAGES_TOTAL._value.get()
 
     assert after == before + 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_message_routes_to_default_agent_when_user_unmapped(discord_module, monkeypatch):
+    monkeypatch.setattr(discord_module, "allow_message", lambda _: True)
+    monkeypatch.setattr(discord_module, "evaluate_with_opa", lambda content: asyncio.sleep(0, result=(True, content)))
+    monkeypatch.setattr(discord_module.ledger, "get_balance_async", lambda _: asyncio.sleep(0, result=(10.0, 10.0)))
+
+    from src.sim.context import SimulationContext
+
+    bot = discord_module.SimulationDiscordBot(
+        "token", 123, context=SimulationContext(), channel_map={"agent-b": 456, "agent-a": 123}
+    )
+    bot.event_queue = asyncio.Queue()
+
+    message = SimpleNamespace(
+        content="hello everyone",
+        author=SimpleNamespace(id="new-user"),
+        channel=SimpleNamespace(id=888, send=lambda *_: asyncio.sleep(0)),
+    )
+    await bot.client.on_message(message)
+    evt = await bot.event_queue.get()
+
+    assert evt.type == "broadcast"
+    assert evt.data["target_agent_id"] == "agent-a"
+    assert evt.data["broadcast"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_message_parses_explicit_dm_target(discord_module, monkeypatch):
+    monkeypatch.setattr(discord_module, "allow_message", lambda _: True)
+
+    async def _eval(content: str):
+        return True, content
+
+    async def _bal(agent_id: str):
+        return (10.0, 10.0)
+
+    monkeypatch.setattr(discord_module, "evaluate_with_opa", _eval)
+    monkeypatch.setattr(discord_module.ledger, "get_balance_async", _bal)
+
+    from src.sim.context import SimulationContext
+
+    bot = discord_module.SimulationDiscordBot("token", 123, context=SimulationContext())
+    bot.event_queue = asyncio.Queue()
+
+    message = SimpleNamespace(
+        content="/dm agent-z hi there",
+        author=SimpleNamespace(id="human-1"),
+        channel=SimpleNamespace(id=123, send=lambda *_: asyncio.sleep(0)),
+    )
+    await bot.client.on_message(message)
+    evt = await bot.event_queue.get()
+
+    assert evt.data["recipient_id"] == "agent-z"
+    assert evt.data["target_agent_id"] == "agent-z"
+    assert evt.data["broadcast"] is False
+    assert evt.data["content"] == "hi there"

--- a/tests/unit/sim/test_event_kernel.py
+++ b/tests/unit/sim/test_event_kernel.py
@@ -162,14 +162,14 @@ async def test_forward_external_events(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     kernel = EventKernel()
-    received: list[str] = []
+    received: list[tuple[str, dict[str, object] | None]] = []
 
-    async def handler(text: str) -> None:
-        received.append(text)
+    async def handler(text: str, metadata: dict[str, object] | None) -> None:
+        received.append((text, metadata))
 
     task = asyncio.create_task(kernel.forward_external_events(handler))
     await queue.put(SimulationEvent(type="broadcast", data={"content": "hi"}))
     await queue.put(None)
     await task
 
-    assert received == ["hi"]
+    assert received == [("hi", {"content": "hi"})]

--- a/tests/unit/sim/test_human_command.py
+++ b/tests/unit/sim/test_human_command.py
@@ -102,3 +102,65 @@ async def test_human_command_rejected_without_resources(
     async with sim._msg_lock:
         assert sim.pending_messages_for_next_round == []
     sim.close()
+
+
+@pytest.mark.asyncio
+async def test_human_command_uses_structured_routing_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    alpha = DummyAgent("alpha")
+    beta = DummyAgent("beta")
+    sim = Simulation([alpha, beta])
+
+    await sim._handle_human_command(
+        "hello beta",
+        {
+            "sender_id": "human-42",
+            "recipient_id": "beta",
+            "target_agent_id": "beta",
+            "broadcast": False,
+            "budget_agent_id": "alpha",
+        },
+    )
+
+    assert alpha.state.ip == pytest.approx(1.0)
+    assert beta.state.ip == pytest.approx(2.0)
+    async with sim._msg_lock:
+        msg = sim.pending_messages_for_next_round[-1]
+    assert msg["sender_id"] == "human-42"
+    assert msg["recipient_id"] == "beta"
+    sim.close()
+
+
+@pytest.mark.asyncio
+async def test_human_command_broadcast_falls_back_to_current_agent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    alpha = DummyAgent("alpha")
+    beta = DummyAgent("beta")
+    sim = Simulation([alpha, beta])
+    sim.current_agent_index = 1
+
+    await sim._handle_human_command("hello all", {"sender_id": "human-x", "broadcast": True})
+
+    assert beta.state.ip == pytest.approx(1.0)
+    async with sim._msg_lock:
+        recipients = [msg["recipient_id"] for msg in sim.pending_messages_for_next_round]
+    assert recipients == ["alpha", "beta"]
+    sim.close()

--- a/tests/unit/sim/test_human_command_costs.py
+++ b/tests/unit/sim/test_human_command_costs.py
@@ -97,10 +97,42 @@ async def test_handle_human_command_missing_config(
         monkeypatch.setitem(config._CONFIG, key, None)
 
     await sim._handle_human_command("hello")
+    sim._last_relay_time = 0.0
     await sim._handle_human_command("/broadcast hi")
 
     assert agent.state.ip == pytest.approx(2.0)
     assert agent.state.du == pytest.approx(2.0)
     async with sim._msg_lock:
         assert len(sim.pending_messages_for_next_round) == 2
+    sim.close()
+
+
+@pytest.mark.asyncio
+async def test_human_command_uses_human_budget_without_agent_state_deduction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+    monkeypatch.setitem(config._CONFIG, "HUMAN_COMMAND_BUDGET_AGENT_ID", "human")
+
+    agent = DummyAgent("A")
+    ledger.log_change("human", 10.0, 10.0, "init")
+    sim = Simulation([agent])
+
+    monkeypatch.setattr(
+        "src.sim.simulation.get_resource_manager",
+        lambda: types.SimpleNamespace(ensure_du_budget=lambda *_args, **_kwargs: None),
+    )
+
+    await sim._handle_human_command("hello")
+
+    assert agent.state.ip == pytest.approx(2.0)
+    hip, hdu = ledger.get_balance("human")
+    assert hip == pytest.approx(9.0)
+    assert hdu == pytest.approx(9.0)
     sim.close()


### PR DESCRIPTION
### Motivation
- Make plain Discord human messages routable with explicit targets (e.g. `@agent:...` or `/dm agent ...`) and eliminate hard-failure when no mapping exists.  
- Provide deterministic fallback routing for unmapped users (channel mapping, last active agent, or deterministic channel_map choice).  
- Surface structured routing metadata to the simulation so human commands carry sender/recipient/broadcast/budget info instead of relying on an implicit "current" agent.  
- Preserve resource accounting but attribute costs to a clearer budget agent (metadata override > config > target) rather than silently deducting from whichever agent happened to be current.

### Description
- Added parsing helpers and regexes in `src/interfaces/discord_bot.py` to accept `@agent: message`, `/dm agent message`, and `/broadcast message`, and built a deterministic `_default_agent_for_channel` fallback.  
- Replaced the prior hard-fail path for unmapped users with deterministic routing and enqueued structured `SimulationEvent` payloads (`sender_id`, `recipient_id`, `target_agent_id`, `broadcast`, etc.).  
- Updated `src/sim/event_kernel.py::forward_external_events` to forward both the broadcast text and event metadata into handlers.  
- Extended `src/sim/simulation.py::_handle_human_command` to accept `metadata: dict` and to resolve a `budget_agent_id` (metadata > config > resolved target), apply resource checks against that budget, and include `budget_agent_id` in logged/replayed events and replay handling.  
- Updated replay handling so replayed events deduct from the correct budget agent when present.  
- Added and adjusted unit tests under `tests/unit/interfaces/test_discord_human_messages.py`, `tests/unit/sim/test_human_command.py`, `tests/unit/sim/test_human_command_costs.py`, and `tests/unit/sim/test_event_kernel.py` to cover unmapped users, explicit targeting, broadcast fallback, structured routing metadata, and human-budget charging.

### Testing
- Ran linter/formatter checks with `ruff` on the modified files and observed no remaining issues.  
- Executed unit tests: `pytest -q tests/unit/interfaces/test_discord_human_messages.py tests/unit/sim/test_human_command.py tests/unit/sim/test_human_command_costs.py tests/unit/sim/test_event_kernel.py` and all tests passed.  
- Verified new and existing unit tests that exercise: unmapped-user routing, explicit `/dm` parsing, broadcast fallback, structured routing metadata handling, budget-agent charging, and event-kernel metadata forwarding (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989da2b876c832688d8d61b3ce0c8ea)