### PR TITLE
Clean world map state when agents retire or are killed

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -544,12 +544,7 @@ class Simulation:
             if agent_id:
                 agent = next((a for a in self.agents if a.agent_id == str(agent_id)), None)
                 if agent is not None:
-                    await self.retire_agent(agent)
-                    try:
-                        self.agents.remove(agent)
-                    except ValueError:  # pragma: no cover - defensive
-                        pass
-                    self._update_collective_metrics()
+                    await self.retire_agent(agent, remove_from_simulation=True)
         elif action == "set_speed":
             try:
                 self.speed = float(cmd.get("value", 1))
@@ -689,8 +684,10 @@ class Simulation:
         self._update_collective_metrics()
         ACTIVE_AGENT_COUNT.set(len(self.agents))
 
-    async def retire_agent(self: Self, agent: "Agent") -> None:
-        """Retire an agent and compute inheritance."""
+    async def retire_agent(
+        self: Self, agent: "Agent", *, remove_from_simulation: bool = False
+    ) -> None:
+        """Retire an agent, compute inheritance, and optionally remove from simulation."""
         state = agent.state
         state.is_alive = False
         state.inheritance = state.ip + state.du
@@ -709,6 +706,13 @@ class Simulation:
                     self.vector.to_dict(),
                 )
         agent.update_state(state)
+        await self.world_map.remove_agent(agent.agent_id)
+        if remove_from_simulation:
+            try:
+                self.agents.remove(agent)
+            except ValueError:  # pragma: no cover - defensive
+                pass
+        self._update_collective_metrics()
 
     def get_other_agents_public_state(self: Self, current_agent_id: str) -> list[dict[str, Any]]:
         """

--- a/src/sim/world_map.py
+++ b/src/sim/world_map.py
@@ -52,6 +52,13 @@ class WorldMap:
             self.agent_positions[agent_id] = (x, y)
             self.agent_resources.setdefault(agent_id, {})
 
+    async def remove_agent(self, agent_id: str) -> None:
+        """Remove ``agent_id`` from map position and inventory state."""
+
+        async with self.lock:
+            self.agent_positions.pop(agent_id, None)
+            self.agent_resources.pop(agent_id, None)
+
     async def add_resource(self, x: int, y: int, resource: ResourceToken, amount: int = 1) -> None:
         """Add ``amount`` of ``resource`` to the specified cell."""
 

--- a/tests/unit/sim/test_simulation_agent_count.py
+++ b/tests/unit/sim/test_simulation_agent_count.py
@@ -64,3 +64,25 @@ async def test_active_agent_count_gauge_updates() -> None:
     assert ACTIVE_AGENT_COUNT._value.get() == 0
 
     sim.close()
+
+
+@pytest.mark.asyncio
+async def test_retire_and_kill_remove_agent_from_world_map_state() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    agent_a = DummyAgent("A")
+    agent_b = DummyAgent("B")
+    sim = Simulation([agent_a, agent_b])
+
+    await sim.retire_agent(agent_a)
+    assert agent_a in sim.agents
+    assert "A" not in sim.world_map.agent_positions
+    assert "A" not in sim.world_map.agent_resources
+
+    await sim.handle_control_command({"command": "kill_agent", "agent_id": "B"})
+    assert all(agent.agent_id != "B" for agent in sim.agents)
+    assert "B" not in sim.world_map.agent_positions
+    assert "B" not in sim.world_map.agent_resources
+
+    sim.close()

--- a/tests/unit/sim/test_world_map.py
+++ b/tests/unit/sim/test_world_map.py
@@ -34,6 +34,17 @@ def test_build_structure() -> None:
     assert m.agent_resources["A"].get("wood", 0) == 0
 
 
+def test_remove_agent_cleans_world_map_state() -> None:
+    m = WorldMap()
+    asyncio.run(m.add_agent("A", x=2, y=3))
+    m.agent_resources["A"] = {"wood": 2}
+
+    asyncio.run(m.remove_agent("A"))
+
+    assert "A" not in m.agent_positions
+    assert "A" not in m.agent_resources
+
+
 class DummyNeo4j:
     Driver = object
     GraphDatabase = object


### PR DESCRIPTION
### Motivation
- Ensure agent removals clean up all world-map state (position and inventory) under the map lock to avoid stale data in dashboards/emitters.
- Make control-command kill flow and programmatic retirement share the same safe cleanup path so emitters/readers observe a consistent, cleaned state.

### Description
- Added `WorldMap.remove_agent(agent_id: str)` which acquires the world map lock and removes the agent from `agent_positions` and `agent_resources`.
- Extended `Simulation.retire_agent` with an optional `remove_from_simulation: bool` parameter and made it always call `await self.world_map.remove_agent(agent.agent_id)` so map state is cleared on retirement.
- Updated control-command `kill_agent` to call `retire_agent(..., remove_from_simulation=True)` so killed agents are removed from both the world map and `self.agents` via the same cleanup logic.
- Added regression tests: `test_remove_agent_cleans_world_map_state` (unit) and `test_retire_and_kill_remove_agent_from_world_map_state` (integration/unit) to assert retired/killed agents are absent from `self.agents` (for kills) and from all world-map structures.

### Testing
- Ran `ruff check src/sim/world_map.py src/sim/simulation.py tests/unit/sim/test_world_map.py tests/unit/sim/test_simulation_agent_count.py` and it passed.
- Ran full `pytest tests/unit/sim/test_world_map.py tests/unit/sim/test_simulation_agent_count.py` and observed two failing tests unrelated to these changes due to JSON serialization of tuple keys in an event log snapshot during existing event logging (error: "keys must be str, int, float, bool or None, not tuple").
- Ran the targeted new/affected tests `pytest tests/unit/sim/test_world_map.py::test_remove_agent_cleans_world_map_state tests/unit/sim/test_simulation_agent_count.py::test_retire_and_kill_remove_agent_from_world_map_state` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc67360c8326b980917293125a95)