### PR TITLE
Add /event Discord command and inject_event handling in Simulation

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -601,6 +601,30 @@ class SimulationDiscordBot:
                         )
                         await interaction.response.send_message("killed", ephemeral=True)
 
+                @tree.command(name="event")
+                @app_commands.describe(text="World event text to inject for all agents")
+                async def _tree_event(interaction: "discord.Interaction", text: str) -> None:
+                    with command_span("event", interaction) as span:
+                        span.set_attribute("discord.message.length", len(text))
+                        if not await _has_control_command_permission(
+                            getattr(interaction, "user", None),
+                            "inject_event",
+                        ):
+                            await interaction.response.send_message("unauthorized", ephemeral=True)
+                            return
+                        await self.event_queue.put(
+                            SimulationEvent(
+                                type="control",
+                                data={
+                                    "command": "inject_event",
+                                    "text": text,
+                                    "scope": "global",
+                                    "author": str(getattr(interaction, "user", "human")),
+                                },
+                            )
+                        )
+                        await interaction.response.send_message("event injected", ephemeral=True)
+
                 @tree.command(name="nudge")
                 @app_commands.describe(prompt="Prompt to nudge the simulation")
                 @moderation_rate_limit("nudge")
@@ -1649,6 +1673,33 @@ async def slash_kb(interaction: Any, text: str) -> None:
             )
         )
         await send_interaction_response(interaction, "KB entry created", ephemeral=True)
+
+
+@bot.tree.command(name="event")
+async def slash_event(interaction: Any, text: str) -> None:
+    """Inject a world event that all agents will perceive next cycle."""
+    with command_span("event", interaction) as span:
+        span.set_attribute("discord.message.length", len(text))
+        if not await _has_control_command_permission(
+            getattr(interaction, "user", None),
+            "inject_event",
+        ):
+            await send_interaction_response(interaction, "unauthorized", ephemeral=True)
+            return
+        bot_instance = get_active_bot()
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        await ctx.get_event_queue().put(
+            SimulationEvent(
+                type="control",
+                data={
+                    "command": "inject_event",
+                    "text": text,
+                    "scope": "global",
+                    "author": str(getattr(interaction, "user", "human")),
+                },
+            )
+        )
+        await send_interaction_response(interaction, "event injected", ephemeral=True)
 
 
 @bot.tree.command(name="propose")

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -578,6 +578,44 @@ class Simulation:
                         )
                     )
                     _ = task
+        elif action == "inject_event":
+            text = str(cmd.get("text", "")).strip()
+            if not text:
+                return
+            author = str(cmd.get("author", "human"))
+            scope = str(cmd.get("scope", "global"))
+            event_payload = {
+                "type": "world_event",
+                "author": author,
+                "step": self.current_step,
+                "timestamp": time.time(),
+                "scope": scope,
+                "text": text,
+            }
+            msg: SimulationMessage = {
+                "step": self.current_step,
+                "sender_id": author,
+                "recipient_id": None,
+                "content": f"[World Event] {text}",
+                "action_intent": None,
+                "sentiment_score": None,
+            }
+            async with self._msg_lock:
+                self.pending_messages_for_next_round.append(msg)
+                self.messages_to_perceive_this_round.append(msg)
+            await self.event_kernel.emit_environment_event(event_payload)
+            if self.knowledge_board:
+                async with self.knowledge_board.lock:
+                    self.knowledge_board.add_entry(
+                        BoardEntry(
+                            content_full=text,
+                            entry_type="world_event",
+                            tags=["event", scope],
+                        ),
+                        author,
+                        self.current_step,
+                        self.vector.to_dict(),
+                    )
 
     async def mute_agent(self: Self, agent_id: str, *, emit_event: bool = True) -> None:
         from .resources import mute_agent as _mute_agent

--- a/tests/unit/interfaces/test_discord_bot_moderation_commands.py
+++ b/tests/unit/interfaces/test_discord_bot_moderation_commands.py
@@ -162,6 +162,7 @@ async def test_command_tree_registers_moderation_commands(discord_module: object
     for name in {"reset_memory", "penalty", "mute", "unmute"}:
         assert name in tree.commands
         assert hasattr(tree.commands[name], "__wrapped__")
+    assert "event" in tree.commands
 
 
 @pytest.mark.unit
@@ -254,3 +255,28 @@ async def test_mute_command_respects_rate_limiting(
     assert moderation_module._ACTION_COUNTS["user-mute-rate:mute"] == 1
     assert queue_put.await_count == 0
     penalty_logger.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_event_command_requires_control_permission(discord_module: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    context = discord_module.DEFAULT_CONTEXT
+    bot = discord_module.SimulationDiscordBot("token", 123, context=context)
+    tree = next(iter(bot.command_trees.values()))
+    event_cmd = tree.commands["event"]
+
+    unauthorized = DummyInteraction(admin=False, user_id="user-event-unauth")
+    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=False))
+    await event_cmd(unauthorized, "volcano")
+    unauthorized.response.send_message.assert_awaited_once_with("unauthorized", ephemeral=True)
+    assert bot.event_queue.empty()
+
+    authorized = DummyInteraction(admin=False, user_id="user-event-auth")
+    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=True))
+    await event_cmd(authorized, "solar flare")
+    event = await bot.event_queue.get()
+    assert event.type == "control"
+    assert event.data["command"] == "inject_event"
+    assert event.data["text"] == "solar flare"
+    assert event.data["scope"] == "global"
+    authorized.response.send_message.assert_awaited_once_with("event injected", ephemeral=True)

--- a/tests/unit/interfaces/test_discord_commands.py
+++ b/tests/unit/interfaces/test_discord_commands.py
@@ -228,6 +228,45 @@ async def test_message_relay_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     ledger_module.ledger.spend.assert_awaited_once()
 
 
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_event_enqueues_control_event(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    ctx = SimpleNamespace(get_event_queue=lambda: queue)
+    bot = SimpleNamespace(context=ctx)
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=True))
+    interaction = DummyInteraction()
+    interaction.user = SimpleNamespace(id="u-1", guild_permissions=SimpleNamespace(administrator=False))
+    await discord_module.slash_event(interaction, "meteor shower")
+    event = await queue.get()
+    assert event.type == "control"
+    assert event.data["command"] == "inject_event"
+    assert event.data["text"] == "meteor shower"
+    assert event.data["scope"] == "global"
+    assert event.data["author"] == str(interaction.user)
+    interaction.response.send_message.assert_awaited_once_with("event injected", ephemeral=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_event_requires_authorization(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    ctx = SimpleNamespace(get_event_queue=lambda: queue)
+    bot = SimpleNamespace(context=ctx)
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=False))
+    interaction = DummyInteraction()
+    await discord_module.slash_event(interaction, "storm")
+    assert queue.empty()
+    interaction.response.send_message.assert_awaited_once_with("unauthorized", ephemeral=True)
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_slash_nudge_enqueues_event(

--- a/tests/unit/sim/test_simulation_inject_event.py
+++ b/tests/unit/sim/test_simulation_inject_event.py
@@ -1,0 +1,105 @@
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 0.0
+        self.du = 0.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+        self.is_alive = True
+        self.inheritance = 0.0
+        self.parent_id: str | None = None
+        self.genes: dict[str, float] = {}
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyAgentState:
+        return self._state
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_inject_event_enqueues_broadcast_and_world_event_kb_entry() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    sim.event_kernel.emit_environment_event = AsyncMock()
+
+    await sim.handle_control_command(
+        {
+            "command": "inject_event",
+            "text": "aurora visible",
+            "scope": "global",
+            "author": "gm",
+        }
+    )
+
+    assert sim.pending_messages_for_next_round
+    message = sim.pending_messages_for_next_round[-1]
+    assert message["sender_id"] == "gm"
+    assert message["recipient_id"] is None
+    assert "aurora visible" in message["content"]
+
+    assert sim.messages_to_perceive_this_round[-1] == message
+
+    sim.event_kernel.emit_environment_event.assert_awaited_once()
+    payload = sim.event_kernel.emit_environment_event.await_args.args[0]
+    assert payload["type"] == "world_event"
+    assert payload["author"] == "gm"
+    assert payload["text"] == "aurora visible"
+    assert payload["scope"] == "global"
+
+    latest_entry = sim.knowledge_board.entries[-1]
+    assert latest_entry["entry_type"] == "world_event"
+    assert latest_entry["content_full"] == "aurora visible"
+
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_inject_event_is_visible_to_all_agents_next_cycle() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A"), DummyAgent("B")])
+
+    await sim.handle_control_command(
+        {
+            "command": "inject_event",
+            "text": "market crash",
+            "scope": "global",
+            "author": "narrator",
+        }
+    )
+
+    sim.messages_to_perceive_this_round = list(sim.pending_messages_for_next_round)
+    perceived = sim.messages_to_perceive_this_round
+    assert len(perceived) == 1
+    assert perceived[0]["recipient_id"] is None
+    assert "market crash" in perceived[0]["content"]
+
+    await sim.stop_event_listener()
+    sim.close()


### PR DESCRIPTION
### Motivation
- Provide a way for operators to inject global world events via Discord that are delivered to all agents and mirrored to the Knowledge Board.
- Route operator input through the existing simulation control path so events are processed consistently with other control actions.

### Description
- Added a new slash command `event` in `src/interfaces/discord_bot.py` that enqueues `SimulationEvent(type="control", data={"command": "inject_event", "text": ..., "scope": "global", "author": ...})` after authorization checks in both the per-client command tree and the global slash handler. (See added `_tree_event` and `slash_event` handlers.)
- Extended `Simulation.handle_control_command` in `src/sim/simulation.py` to handle `command == "inject_event"` by building a structured `world_event` payload (including `type`, `author`, `step`, `timestamp`, `scope`, `text`), creating a `SimulationMessage` broadcast for agent perception, appending it to `pending_messages_for_next_round` and `messages_to_perceive_this_round`, emitting the environment event via `event_kernel.emit_environment_event`, and mirroring to the Knowledge Board with `entry_type="world_event"`.
- Added unit tests for interface and simulation behavior: updated `tests/unit/interfaces/test_discord_commands.py` and `tests/unit/interfaces/test_discord_bot_moderation_commands.py` to cover command parsing and authorization, and added `tests/unit/sim/test_simulation_inject_event.py` to validate event enqueueing, environment emit, KB mirroring, and that agents will perceive the injected event next cycle.

### Testing
- Ran targeted unit tests: `pytest tests/unit/interfaces/test_discord_commands.py tests/unit/interfaces/test_discord_bot_moderation_commands.py tests/unit/sim/test_simulation_inject_event.py`, and all targeted tests passed (16 passed, with unrelated async task teardown warnings from existing listeners). 
- Ran linter checks with `ruff` on the changed files and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989df34539c83268ff37f9ed220be98)