### PR TITLE
Support optional role/persona/traits on spawn command (Discord + simulation)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -50,11 +50,28 @@ async def stop_simulation(ctx: SimulationContext | None = None) -> None:
     await context.get_event_queue().put(SimulationEvent(type="control", data={"command": "stop"}))
 
 
-async def spawn_agent_command(agent_id: str, ctx: SimulationContext | None = None) -> None:
+async def spawn_agent_command(
+    agent_id: str,
+    ctx: SimulationContext | None = None,
+    *,
+    role: str | dict[str, object] | None = None,
+    persona: str | None = None,
+    backstory: str | None = None,
+    traits: dict[str, float] | None = None,
+) -> None:
     """Request spawning of a new agent via the event queue."""
     context = ctx or DEFAULT_CONTEXT
+    payload: dict[str, object] = {"command": "spawn", "agent_id": agent_id}
+    if role is not None:
+        payload["role"] = role
+    if persona is not None:
+        payload["persona"] = persona
+    if backstory is not None:
+        payload["backstory"] = backstory
+    if traits is not None:
+        payload["traits"] = traits
     await context.get_event_queue().put(
-        SimulationEvent(type="control", data={"command": "spawn", "agent_id": agent_id})
+        SimulationEvent(type="control", data=payload)
     )
 
 
@@ -431,7 +448,7 @@ def main() -> None:
 
     if args.checkpoint and Path(args.checkpoint).exists():
         logging.info("Loading simulation from checkpoint %s", args.checkpoint)
-        sim, meta = load_checkpoint(args.checkpoint)
+        sim, _meta = load_checkpoint(args.checkpoint)
         sim.steps_to_run = args.steps
     else:
         sim_kwargs = {

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -176,6 +176,73 @@ def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str]:
     return None, False, cleaned
 
 
+
+
+def _parse_json_object_argument(raw: str | None, field_name: str) -> dict[str, Any] | None:
+    """Parse a JSON object argument from a slash-command string option."""
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid {field_name} JSON: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{field_name} must be a JSON object")
+    return cast(dict[str, Any], parsed)
+
+
+def _spawn_kwargs_from_inputs(
+    *,
+    role: str | None = None,
+    role_json: str | None = None,
+    persona: str | None = None,
+    backstory: str | None = None,
+    traits_json: str | None = None,
+    openness: float | None = None,
+    analytical_focus: float | None = None,
+    empathy: float | None = None,
+    assertiveness: float | None = None,
+    emotional_sensitivity: float | None = None,
+    resilience: float | None = None,
+    trust_baseline: float | None = None,
+    adaptability: float | None = None,
+) -> dict[str, Any]:
+    """Build spawn payload kwargs from slash-command optional inputs."""
+    role_payload = _parse_json_object_argument(role_json, "role") if role_json is not None else None
+    if role_payload is None and role is not None and role.strip():
+        role_payload = role.strip()
+
+    traits_payload = _parse_json_object_argument(traits_json, "traits") if traits_json is not None else None
+    explicit_traits = {
+        "openness": openness,
+        "analytical_focus": analytical_focus,
+        "empathy": empathy,
+        "assertiveness": assertiveness,
+        "emotional_sensitivity": emotional_sensitivity,
+        "resilience": resilience,
+        "trust_baseline": trust_baseline,
+        "adaptability": adaptability,
+    }
+    explicit_clean = {k: float(v) for k, v in explicit_traits.items() if v is not None}
+    if explicit_clean:
+        merged = dict(traits_payload or {})
+        merged.update(explicit_clean)
+        traits_payload = merged
+
+    kwargs: dict[str, Any] = {}
+    if role_payload is not None:
+        kwargs["role"] = role_payload
+    if persona is not None and persona.strip():
+        kwargs["persona"] = persona.strip()
+    if backstory is not None and backstory.strip():
+        kwargs["backstory"] = backstory.strip()
+    if traits_payload is not None:
+        kwargs["traits"] = traits_payload
+    return kwargs
+
 def _default_agent_for_channel(self: "SimulationDiscordBot", channel_id: int | None) -> str | None:
     """Resolve a deterministic fallback agent for an unmapped incoming message."""
     if channel_id is not None:
@@ -522,9 +589,40 @@ class SimulationDiscordBot:
                             )
 
                 @tree.command(name="spawn")
-                @app_commands.describe(agent_id="ID of the agent to spawn")
+                @app_commands.describe(
+                    agent_id="ID of the agent to spawn",
+                    role="Role name",
+                    role_json="Role profile JSON object",
+                    persona="Persona text",
+                    backstory="Backstory text",
+                    traits_json="Trait overrides JSON object",
+                    openness="Trait override",
+                    analytical_focus="Trait override",
+                    empathy="Trait override",
+                    assertiveness="Trait override",
+                    emotional_sensitivity="Trait override",
+                    resilience="Trait override",
+                    trust_baseline="Trait override",
+                    adaptability="Trait override",
+                )
                 @moderation_rate_limit("spawn")
-                async def _tree_spawn(interaction: "discord.Interaction", agent_id: str) -> None:
+                async def _tree_spawn(
+                    interaction: "discord.Interaction",
+                    agent_id: str,
+                    role: str | None = None,
+                    role_json: str | None = None,
+                    persona: str | None = None,
+                    backstory: str | None = None,
+                    traits_json: str | None = None,
+                    openness: float | None = None,
+                    analytical_focus: float | None = None,
+                    empathy: float | None = None,
+                    assertiveness: float | None = None,
+                    emotional_sensitivity: float | None = None,
+                    resilience: float | None = None,
+                    trust_baseline: float | None = None,
+                    adaptability: float | None = None,
+                ) -> None:
                     with command_span("spawn", interaction, agent_id=agent_id) as span:
                         if not await _has_control_command_permission(
                             getattr(interaction, "user", None),
@@ -534,7 +632,22 @@ class SimulationDiscordBot:
                             await interaction.response.send_message("unauthorized", ephemeral=True)
                             return
                         try:
-                            await spawn_agent_command(agent_id, self.context)
+                            spawn_kwargs = _spawn_kwargs_from_inputs(
+                                role=role,
+                                role_json=role_json,
+                                persona=persona,
+                                backstory=backstory,
+                                traits_json=traits_json,
+                                openness=openness,
+                                analytical_focus=analytical_focus,
+                                empathy=empathy,
+                                assertiveness=assertiveness,
+                                emotional_sensitivity=emotional_sensitivity,
+                                resilience=resilience,
+                                trust_baseline=trust_baseline,
+                                adaptability=adaptability,
+                            )
+                            await spawn_agent_command(agent_id, self.context, **spawn_kwargs)
                         except Exception as exc:
                             embed = self.create_spawn_embed(agent_id, False, str(exc))
                             await self.send_simulation_update(embed=embed)
@@ -1575,8 +1688,31 @@ async def slash_stop(interaction: Any) -> None:
 
 
 @bot.tree.command(name="spawn")
+@app_commands.describe(
+    role="Role name",
+    role_json="Role profile JSON object",
+    persona="Persona text",
+    backstory="Backstory text",
+    traits_json="Trait overrides JSON object",
+)
 @moderation_rate_limit("spawn")
-async def slash_spawn(interaction: Any, agent_id: str) -> None:
+async def slash_spawn(
+    interaction: Any,
+    agent_id: str,
+    role: str | None = None,
+    role_json: str | None = None,
+    persona: str | None = None,
+    backstory: str | None = None,
+    traits_json: str | None = None,
+    openness: float | None = None,
+    analytical_focus: float | None = None,
+    empathy: float | None = None,
+    assertiveness: float | None = None,
+    emotional_sensitivity: float | None = None,
+    resilience: float | None = None,
+    trust_baseline: float | None = None,
+    adaptability: float | None = None,
+) -> None:
     """Spawn a new agent in the simulation."""
     with command_span("spawn", interaction, agent_id=agent_id) as span:
         bot_instance = get_active_bot()
@@ -1589,7 +1725,22 @@ async def slash_spawn(interaction: Any, agent_id: str) -> None:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         try:
-            await spawn_agent_command(agent_id, ctx)
+            spawn_kwargs = _spawn_kwargs_from_inputs(
+                role=role,
+                role_json=role_json,
+                persona=persona,
+                backstory=backstory,
+                traits_json=traits_json,
+                openness=openness,
+                analytical_focus=analytical_focus,
+                empathy=empathy,
+                assertiveness=assertiveness,
+                emotional_sensitivity=emotional_sensitivity,
+                resilience=resilience,
+                trust_baseline=trust_baseline,
+                adaptability=adaptability,
+            )
+            await spawn_agent_command(agent_id, ctx, **spawn_kwargs)
         except Exception as exc:
             if bot_instance is not None:
                 embed = bot_instance.create_spawn_embed(agent_id, False, str(exc))

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -18,7 +18,8 @@ from pydantic import ValidationError
 from typing_extensions import Self
 
 from src.agents.core.agent_controller import AgentController
-from src.agents.core.agent_state import AgentActionIntent
+from src.agents.core.agent_state import AgentActionIntent, PersonalityTraits
+from src.agents.core.roles import ensure_profile, get_role_trait_template
 from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaDBException
@@ -535,7 +536,50 @@ class Simulation:
                 try:
                     from src.agents.core.base_agent import Agent
 
-                    new_agent = Agent(agent_id=str(agent_id), name=str(agent_id))
+                    role_value = cmd.get("role")
+                    role_profile = ensure_profile(role_value) if role_value is not None else None
+
+                    trait_overrides: dict[str, float] | None = None
+                    traits_payload = cmd.get("traits")
+                    if traits_payload is not None:
+                        if not isinstance(traits_payload, dict):
+                            raise ValueError("spawn traits must be an object")
+                        valid_traits = set(getattr(PersonalityTraits, "model_fields", {}).keys())
+                        if not valid_traits:
+                            valid_traits = set(getattr(PersonalityTraits, "__fields__", {}).keys())
+                        trait_overrides = {}
+                        for trait_name, raw_value in traits_payload.items():
+                            if str(trait_name) not in valid_traits:
+                                raise ValueError(f"Unknown trait: {trait_name}")
+                            try:
+                                trait_overrides[str(trait_name)] = float(raw_value)
+                            except (TypeError, ValueError) as exc:
+                                raise ValueError(
+                                    f"Invalid trait value for {trait_name}: {raw_value!r}"
+                                ) from exc
+
+                    initial_state: dict[str, Any] = {}
+                    if role_profile is not None:
+                        initial_state["current_role"] = role_profile
+
+                    if trait_overrides is not None:
+                        role_name_for_traits = (
+                            role_profile.name if role_profile is not None else "Innovator"
+                        )
+                        merged_traits = get_role_trait_template(role_name_for_traits)
+                        merged_traits.update(trait_overrides)
+                        initial_state["traits"] = PersonalityTraits(**merged_traits)
+
+                    if "persona" in cmd and cmd.get("persona") is not None:
+                        initial_state["persona"] = str(cmd.get("persona"))
+                    if "backstory" in cmd and cmd.get("backstory") is not None:
+                        initial_state["backstory"] = str(cmd.get("backstory"))
+
+                    new_agent = Agent(
+                        agent_id=str(agent_id),
+                        name=str(agent_id),
+                        initial_state=initial_state or None,
+                    )
                     await self.spawn_agent(new_agent)
                 except Exception:
                     logger.error("Failed to spawn agent %s", agent_id, exc_info=True)

--- a/tests/unit/core/test_agent_state_serialization.py
+++ b/tests/unit/core/test_agent_state_serialization.py
@@ -9,7 +9,12 @@ except IndentationError:
 
 @pytest.mark.unit
 def test_agent_state_serialization_roundtrip() -> None:
-    state = AgentState(agent_id="agent1", name="TestAgent")
+    state = AgentState(
+        agent_id="agent1",
+        name="TestAgent",
+        persona="Calm collaborator",
+        backstory="Grew up solving logistics puzzles",
+    )
     controller = AgentController(state)
     controller.update_mood(0.4)
     controller.update_relationship("agent2", sentiment_score=0.2)
@@ -20,3 +25,6 @@ def test_agent_state_serialization_roundtrip() -> None:
     assert serialized == restored.to_dict()
     assert restored.agent_id == "agent1"
     assert restored.name == "TestAgent"
+    assert restored.persona == "Calm collaborator"
+    assert restored.backstory == "Grew up solving logistics puzzles"
+    assert restored.traits.openness == pytest.approx(state.traits.openness)

--- a/tests/unit/interfaces/test_discord_commands.py
+++ b/tests/unit/interfaces/test_discord_commands.py
@@ -281,3 +281,38 @@ async def test_slash_nudge_enqueues_event(
     event = await queue.get()
     assert event.type == "nudge" and event.data == {"prompt": "hi there"}
     interaction.response.send_message.assert_awaited_once_with("nudge sent", ephemeral=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_spawn_forwards_optional_profile_fields(
+    discord_module: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bot = SimpleNamespace(
+        context=discord_module.DEFAULT_CONTEXT,
+        send_simulation_update=AsyncMock(),
+        create_spawn_embed=MagicMock(return_value={}),
+        channel_to_agent={},
+    )
+    monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
+    spawn_mock = AsyncMock()
+    monkeypatch.setattr(discord_module, "spawn_agent_command", spawn_mock)
+
+    interaction = DummyInteraction()
+    await discord_module.slash_spawn(
+        interaction,
+        "agent",
+        role="Analyzer",
+        persona="critical thinker",
+        backstory="former reviewer",
+        traits_json='{"openness": 0.4}',
+        empathy=0.7,
+    )
+
+    spawn_mock.assert_awaited_once()
+    args = spawn_mock.await_args
+    assert args.args[:2] == ("agent", bot.context)
+    assert args.kwargs["role"] == "Analyzer"
+    assert args.kwargs["persona"] == "critical thinker"
+    assert args.kwargs["backstory"] == "former reviewer"
+    assert args.kwargs["traits"] == {"openness": 0.4, "empathy": 0.7}

--- a/tests/unit/sim/test_simulation_spawn_control.py
+++ b/tests/unit/sim/test_simulation_spawn_control.py
@@ -1,0 +1,117 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class SeedAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = SimpleNamespace(ip=0.0, du=0.0)
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> SimpleNamespace:
+        return self._state
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_spawn_control_applies_role_traits_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    spawned: list[object] = []
+
+    class DummySpawnAgent:
+        def __init__(self, agent_id: str, name: str, initial_state: dict | None = None) -> None:
+            state = initial_state or {}
+            self.agent_id = agent_id
+            self.name = name
+            self._state = SimpleNamespace(
+                ip=0.0,
+                du=0.0,
+                current_role=state.get("current_role"),
+                traits=state.get("traits"),
+                persona=state.get("persona"),
+                backstory=state.get("backstory"),
+                parent_id=None,
+                genes={},
+            )
+            spawned.append(self)
+
+        def get_id(self) -> str:
+            return self.agent_id
+
+        @property
+        def state(self) -> SimpleNamespace:
+            return self._state
+
+    import src.agents.core.base_agent as base_agent_module
+
+    monkeypatch.setattr(base_agent_module, "Agent", DummySpawnAgent)
+
+    sim = Simulation([SeedAgent("seed")])
+    await sim.handle_control_command(
+        {
+            "command": "spawn",
+            "agent_id": "child-1",
+            "role": "Analyzer",
+            "persona": "Precise and skeptical",
+            "backstory": "Former auditor",
+            "traits": {"openness": 0.2, "resilience": "0.9"},
+        }
+    )
+
+    assert len(spawned) == 1
+    child = spawned[0]
+    assert child.state.current_role.name == "Analyzer"
+    assert child.state.traits.openness == pytest.approx(0.2)
+    assert child.state.traits.resilience == pytest.approx(0.9)
+    assert child.state.persona == "Precise and skeptical"
+    assert child.state.backstory == "Former auditor"
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_spawn_control_rejects_invalid_trait_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    class DummySpawnAgent:
+        def __init__(self, agent_id: str, name: str, initial_state: dict | None = None) -> None:
+            self.agent_id = agent_id
+            self._state = SimpleNamespace(ip=0.0, du=0.0, parent_id=None, genes={})
+
+        def get_id(self) -> str:
+            return self.agent_id
+
+        @property
+        def state(self) -> SimpleNamespace:
+            return self._state
+
+    import src.agents.core.base_agent as base_agent_module
+
+    monkeypatch.setattr(base_agent_module, "Agent", DummySpawnAgent)
+
+    sim = Simulation([SeedAgent("seed")])
+    before = len(sim.agents)
+    await sim.handle_control_command(
+        {
+            "command": "spawn",
+            "agent_id": "bad-child",
+            "traits": {"openness": 2.0},
+        }
+    )
+    assert len(sim.agents) == before
+    sim.close()

--- a/tests/unit/test_app_spawn_command.py
+++ b/tests/unit/test_app_spawn_command.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import pytest
+
+from src.app import spawn_agent_command
+from src.interfaces.dashboard_backend import SimulationEvent
+from src.sim.context import SimulationContext
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_spawn_agent_command_includes_optional_profile_fields() -> None:
+    queue: asyncio.Queue[SimulationEvent] = asyncio.Queue()
+    ctx = SimulationContext()
+    ctx.get_event_queue = lambda: queue  # type: ignore[method-assign]
+
+    await spawn_agent_command(
+        "agent-x",
+        ctx,
+        role="Analyzer",
+        persona="Careful planner",
+        backstory="Raised in a lab",
+        traits={"openness": 0.8},
+    )
+
+    event = await queue.get()
+    assert event.type == "control"
+    assert event.data == {
+        "command": "spawn",
+        "agent_id": "agent-x",
+        "role": "Analyzer",
+        "persona": "Careful planner",
+        "backstory": "Raised in a lab",
+        "traits": {"openness": 0.8},
+    }


### PR DESCRIPTION
### Motivation
- Allow external controllers (Discord slash commands and programmatic callers) to provide explicit role/profile, persona/backstory metadata and trait overrides when spawning agents.
- Ensure trait overrides are validated and clamped to the typed `PersonalityTraits` model so spawned agents start with safe, predictable trait values.

### Description
- Extended `spawn_agent_command` signature in `src/app.py` to accept `role`, `persona`, `backstory`, and `traits` and include them in the `SimulationEvent` control payload. 
- Added input-parsing helpers in `src/interfaces/discord_bot.py` to accept either JSON object payloads (`role_json`, `traits_json`) or explicit trait fields and to merge explicit trait overrides into a single `traits` dict forwarded to `spawn_agent_command`.
- Updated both command-tree and top-level `slash_spawn` handlers in `src/interfaces/discord_bot.py` to accept the new optional fields and forward merged kwargs to `spawn_agent_command`.
- Augmented `handle_control_command` spawn branch in `src/sim/simulation.py` to build `initial_state` for the new agent by constructing an explicit role profile (`ensure_profile`), validating/coercing incoming trait values against `PersonalityTraits` fields and bounds, merging trait overrides with role defaults (`get_role_trait_template`), and injecting optional `persona` and `backstory` into the agent's `initial_state` before instantiation.
- Minor imports and helper adjustments to support validation and merging logic.
- Added unit tests to cover: the app-level spawn payload (`tests/unit/test_app_spawn_command.py`), simulation spawn handling for valid/invalid trait payloads and metadata persistence (`tests/unit/sim/test_simulation_spawn_control.py`), trait/persona/backstory serialization persistence (`tests/unit/core/test_agent_state_serialization.py`), and Discord spawn forwarding of optional profile fields (`tests/unit/interfaces/test_discord_commands.py`).

### Testing
- Ran static checks with `ruff check` across modified modules and updated tests, and the checks passed.
- Ran unit tests with `pytest -q tests/unit/test_app_spawn_command.py tests/unit/sim/test_simulation_spawn_control.py tests/unit/core/test_agent_state_serialization.py tests/unit/interfaces/test_discord_commands.py` and they passed (tests completed successfully, with existing async-cleanup warnings from background event-loop teardown that predate these changes).
- The new tests exercise valid/invalid spawn payloads and verify trait merging and persistence via roundtrip serialization and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e0ec25a08326abf3e0f4051ee891)