### PR TITLE
Extend GraphKnowledgeBoard with node/relationship writes, query helpers, and tests

### DIFF
--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -89,7 +89,12 @@ class GraphKnowledgeBoard:
     def to_dict(self: Self) -> dict[str, Any]:
         return {"entries": self.get_full_entries()}
 
-    def get_recent_entries_for_prompt(self: Self, max_entries: int = 5) -> list[str]:
+    def get_recent_entries_for_prompt(
+        self: Self,
+        max_entries: int = 5,
+        *,
+        include_relationship_summaries: bool = False,
+    ) -> list[str]:
         records = self._run(
             "MATCH (e:KBEntry) RETURN e ORDER BY e.step DESC LIMIT $limit",
             limit=max_entries,
@@ -106,7 +111,13 @@ class GraphKnowledgeBoard:
             max_content_len = 150
             if len(content_summary) > max_content_len:
                 content_summary = content_summary[:max_content_len] + "..."
-            formatted_entries.append(f"[Step {step}, {agent_id}]: {content_summary}")
+            relationship_summary = ""
+            if include_relationship_summaries:
+                endorsement_count = self._get_endorsement_count(entry.get("entry_id", ""))
+                relationship_summary = f" (endorsements: {endorsement_count})"
+            formatted_entries.append(
+                f"[Step {step}, {agent_id}]: {content_summary}{relationship_summary}"
+            )
         return formatted_entries
 
     def add_entry(
@@ -116,8 +127,20 @@ class GraphKnowledgeBoard:
         step: int,
         vector: dict[str, int] | None = None,
     ) -> bool:
-        _, props = prepare_entry_payload(entry, agent_id, step)
-        self._run("CREATE (e:KBEntry $props)", props=props)
+        entry_id, props = prepare_entry_payload(entry, agent_id, step)
+        self._run(
+            """
+            MERGE (a:Agent {agent_id: $agent_id})
+            CREATE (e:KBEntry)
+            SET e = $props
+            SET e.entry_type = $entry_type
+            MERGE (a)-[:AUTHORED]->(e)
+            """,
+            agent_id=agent_id,
+            props=props,
+            entry_type=props["entry_type"],
+        )
+        self._create_reference_links(entry_id, props.get("reference_metadata"))
         metrics.KNOWLEDGE_BOARD_SIZE.set(self._count_entries())
         logger.info(
             "GraphKnowledgeBoard: Added entry %s by %s at step %s",
@@ -126,6 +149,110 @@ class GraphKnowledgeBoard:
             step,
         )
         return True
+
+    def record_vote(
+        self: Self,
+        *,
+        voter_agent_id: str,
+        proposal_id: str,
+        approve: bool,
+    ) -> None:
+        self._run(
+            """
+            MERGE (a:Agent {agent_id: $voter_agent_id})
+            MATCH (p:KBEntry {entry_id: $proposal_id})
+            MERGE (a)-[v:VOTED {proposal_id: $proposal_id}]->(p)
+            SET v.approve = $approve
+            """,
+            voter_agent_id=voter_agent_id,
+            proposal_id=proposal_id,
+            approve=approve,
+        )
+
+    def get_proposal_support_counts(self: Self, proposal_ids: list[str] | None = None) -> dict[str, int]:
+        records = self._run(
+            """
+            MATCH (p:KBEntry)
+            WHERE p.entry_type = 'proposal'
+            AND ($proposal_ids IS NULL OR p.entry_id IN $proposal_ids)
+            OPTIONAL MATCH (:Agent)-[v:VOTED {approve: true}]->(p)
+            RETURN p.entry_id AS proposal_id, count(v) AS support_count
+            """,
+            proposal_ids=proposal_ids,
+        )
+        return {record["proposal_id"]: int(record["support_count"]) for record in records}
+
+    def get_endorsed_ideas(
+        self: Self,
+        *,
+        min_endorsements: int = 1,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        records = self._run(
+            """
+            MATCH (i:KBEntry {entry_type: 'idea'})
+            OPTIONAL MATCH (:Agent)-[v:VOTED {approve: true}]->(i)
+            WITH i, count(v) AS endorsements
+            WHERE endorsements >= $min_endorsements
+            RETURN i AS entry, endorsements
+            ORDER BY endorsements DESC, i.step DESC
+            LIMIT $limit
+            """,
+            min_endorsements=min_endorsements,
+            limit=limit,
+        )
+        return [
+            {
+                **dict(record["entry"]),
+                "endorsement_count": int(record["endorsements"]),
+            }
+            for record in records
+        ]
+
+    def get_agent_contribution_graph(self: Self, agent_id: str | None = None) -> list[dict[str, Any]]:
+        records = self._run(
+            """
+            MATCH (a:Agent)-[:AUTHORED]->(e:KBEntry)
+            WHERE $agent_id IS NULL OR a.agent_id = $agent_id
+            RETURN a.agent_id AS agent_id, e.entry_id AS entry_id, e.entry_type AS entry_type, e.step AS step
+            ORDER BY e.step ASC
+            """,
+            agent_id=agent_id,
+        )
+        return [dict(record) for record in records]
+
+    def _create_reference_links(self: Self, entry_id: str, reference_metadata: Any) -> None:
+        if not isinstance(reference_metadata, dict):
+            return
+        references = reference_metadata.get("references")
+        if not isinstance(references, list):
+            return
+        normalized_references = [str(reference_id) for reference_id in references if reference_id]
+        if not normalized_references:
+            return
+        self._run(
+            """
+            MATCH (source:KBEntry {entry_id: $entry_id})
+            UNWIND $references AS target_id
+            MATCH (target:KBEntry {entry_id: target_id})
+            MERGE (source)-[:REFERENCES]->(target)
+            """,
+            entry_id=entry_id,
+            references=normalized_references,
+        )
+
+    def _get_endorsement_count(self: Self, entry_id: str) -> int:
+        if not entry_id:
+            return 0
+        records = self._run(
+            """
+            MATCH (e:KBEntry {entry_id: $entry_id})
+            OPTIONAL MATCH (:Agent)-[v:VOTED {approve: true}]->(e)
+            RETURN count(v) AS endorsements
+            """,
+            entry_id=entry_id,
+        )
+        return int(records[0]["endorsements"]) if records else 0
 
     def add_law_proposal(
         self: Self,
@@ -146,7 +273,7 @@ class GraphKnowledgeBoard:
         )
 
     def clear_board(self: Self) -> None:
-        self._run("MATCH (e:KBEntry) DETACH DELETE e")
+        self._run("MATCH (n) WHERE n:KBEntry OR n:Agent DETACH DELETE n")
         metrics.KNOWLEDGE_BOARD_SIZE.set(0)
 
     def close(self: Self) -> None:

--- a/tests/integration/knowledge_board/test_graph_backend.py
+++ b/tests/integration/knowledge_board/test_graph_backend.py
@@ -20,7 +20,7 @@ class DummySession:
         self.store = store
 
     def run(self, query: str, **params: Any) -> Iterable[Any]:
-        if query.startswith("CREATE"):
+        if "SET e = $props" in query or query.startswith("CREATE"):
             self.store.append(params.get("props", params))
             return []
         if "count" in query:

--- a/tests/unit/sim/test_graph_knowledge_board.py
+++ b/tests/unit/sim/test_graph_knowledge_board.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+
+from src.sim.graph_knowledge_board import GraphKnowledgeBoard
+from src.sim.knowledge_board import BoardEntry
+
+pytestmark = pytest.mark.unit
+
+
+class DummyResult(list):
+    def single(self) -> Any:
+        return self[0]
+
+
+class MockSession:
+    def __init__(self, driver: MockDriver) -> None:
+        self.driver = driver
+
+    def run(self, query: str, **params: Any) -> Iterable[Any]:
+        self.driver.calls.append((query, params))
+        if "RETURN count(e) AS cnt" in query:
+            return DummyResult([{"cnt": self.driver.entry_count}])
+        if "ORDER BY e.step DESC" in query:
+            limit = params["limit"]
+            entries = list(reversed(self.driver.entries))[:limit]
+            return DummyResult([{"e": e} for e in entries])
+        if "OPTIONAL MATCH (:Agent)-[v:VOTED {approve: true}]->(e)" in query:
+            return DummyResult([{"endorsements": self.driver.endorsements.get(params["entry_id"], 0)}])
+        if "RETURN p.entry_id AS proposal_id, count(v) AS support_count" in query:
+            return DummyResult(
+                [
+                    {"proposal_id": proposal_id, "support_count": support_count}
+                    for proposal_id, support_count in self.driver.proposal_support.items()
+                ]
+            )
+        if "RETURN i AS entry, endorsements" in query:
+            return DummyResult(
+                [
+                    {"entry": entry, "endorsements": endorsements}
+                    for entry, endorsements in self.driver.idea_endorsements
+                ]
+            )
+        if "RETURN a.agent_id AS agent_id" in query:
+            return DummyResult(self.driver.contribution_rows)
+        if "DETACH DELETE" in query:
+            self.driver.entries.clear()
+            self.driver.entry_count = 0
+            return DummyResult([])
+        if "SET e = $props" in query:
+            self.driver.entries.append(dict(params["props"]))
+            self.driver.entry_count += 1
+            return DummyResult([])
+        return DummyResult([])
+
+    def __enter__(self) -> MockSession:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class MockDriver:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.entries: list[dict[str, Any]] = []
+        self.entry_count = 0
+        self.endorsements: dict[str, int] = {}
+        self.proposal_support: dict[str, int] = {}
+        self.idea_endorsements: list[tuple[dict[str, Any], int]] = []
+        self.contribution_rows: list[dict[str, Any]] = []
+        self.closed = False
+
+    def session(self) -> MockSession:
+        return MockSession(self)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_add_entry_creates_agent_authorship_and_reference_links() -> None:
+    driver = MockDriver()
+    board = GraphKnowledgeBoard(driver=driver)
+
+    board.add_entry(
+        BoardEntry(
+            content_full="new idea",
+            entry_type="idea",
+            reference_metadata={"references": ["proposal-1"]},
+        ),
+        agent_id="agent-1",
+        step=2,
+    )
+
+    queries = [query for query, _ in driver.calls]
+    assert any("MERGE (a:Agent" in query and "[:AUTHORED]" in query for query in queries)
+    assert any("MERGE (source)-[:REFERENCES]->(target)" in query for query in queries)
+
+
+def test_query_helpers_and_prompt_relationship_summary() -> None:
+    driver = MockDriver()
+    board = GraphKnowledgeBoard(driver=driver)
+
+    board.add_entry(BoardEntry(content_full="proposal", entry_type="proposal"), "agent-1", 1)
+    proposal_id = driver.entries[0]["entry_id"]
+
+    driver.proposal_support = {proposal_id: 3}
+    driver.idea_endorsements = [({"entry_id": "idea-1", "entry_type": "idea", "step": 4}, 2)]
+    driver.contribution_rows = [
+        {"agent_id": "agent-1", "entry_id": proposal_id, "entry_type": "proposal", "step": 1}
+    ]
+    driver.endorsements[proposal_id] = 3
+
+    board.record_vote(voter_agent_id="agent-2", proposal_id=proposal_id, approve=True)
+
+    assert board.get_proposal_support_counts() == {proposal_id: 3}
+    assert board.get_endorsed_ideas(min_endorsements=2) == [
+        {"entry_id": "idea-1", "entry_type": "idea", "step": 4, "endorsement_count": 2}
+    ]
+    assert board.get_agent_contribution_graph() == [
+        {"agent_id": "agent-1", "entry_id": proposal_id, "entry_type": "proposal", "step": 1}
+    ]
+
+    prompt_entries = board.get_recent_entries_for_prompt(
+        max_entries=1,
+        include_relationship_summaries=True,
+    )
+    assert prompt_entries == ["[Step 1, agent-1]: proposal (endorsements: 3)"]
+    assert any("MERGE (a)-[v:VOTED" in query for query, _ in driver.calls)


### PR DESCRIPTION
### Motivation
- Enable the graph-backed knowledge board to record richer graph semantics so entries, agents, authorship, votes, and reference links are first-class nodes/relationships for later analysis.
- Provide query helpers to surface proposal support, highly endorsed ideas, and per-agent contribution graphs to support higher-level features and prompt enrichment.
- Ensure the new graph write/read behavior is covered by unit tests that mock the Neo4j driver and keep integration dummies compatible.

### Description
- Update `GraphKnowledgeBoard.add_entry` to use `prepare_entry_payload`'s stable `entry_id` and `props`, `MERGE` an `(:Agent)` node, create a `(:KBEntry)` node with an explicit `entry_type`, and create `(:Agent)-[:AUTHORED]->(:KBEntry)` edges; reference links are created from `reference_metadata.references` via `_create_reference_links`.
- Add vote writing via `record_vote` which creates `[:VOTED {proposal_id, approve}]` relationships, and add helpers `get_proposal_support_counts`, `get_endorsed_ideas`, and `get_agent_contribution_graph` that run Cypher reads returning structured results.
- Extend `get_recent_entries_for_prompt` with an `include_relationship_summaries` option that appends endorsement counts (via `_get_endorsement_count`) to formatted prompt entries.
- Adjust `clear_board` to remove both `KBEntry` and `Agent` nodes, and add unit tests in `tests/unit/sim/test_graph_knowledge_board.py` that mock a driver/session to validate authored edges, reference writes, vote recording, helper queries, and prompt enrichment; also adapt the existing integration dummy to accept the new `SET e = $props` write path.

### Testing
- Ran linter: `python -m ruff check src/sim/graph_knowledge_board.py tests/unit/sim/test_graph_knowledge_board.py tests/integration/knowledge_board/test_graph_backend.py` and it passed without issues.
- Ran targeted tests: `python -m pytest -o addopts='' tests/unit/sim/test_graph_knowledge_board.py tests/integration/knowledge_board/test_graph_backend.py` and all tests in those files passed (6 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e1a4b61c832693035cd7e61f51ee)