### PR TITLE
Add Discord `/help` command, onboarding embed, and unit tests

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -148,6 +148,66 @@ def embed_from_payload(payload: dict[str, Any]) -> Any:
     return embed
 
 
+def build_help_text() -> str:
+    """Render stable help text for Discord slash commands."""
+    return "\n".join(
+        [
+            "## 👋 Culture Bot Help",
+            "### Public commands",
+            "- `/dm <agent_id> <message>` — send a direct message to one agent.",
+            "- `/broadcast <message>` — send a message to all agents.",
+            "- `/kb <text>` — add a note to the Knowledge Board.",
+            "- `/status`, `/stats` — view current state/metrics.",
+            "- `/propose`, `/propose_law`, `/vote` — governance interactions.",
+            "",
+            "### Moderator/Admin commands",
+            "- `/nudge <prompt>` — steer agent behavior *(moderator/admin)*.",
+            "- `/event <text>` — inject world events *(moderator/admin)*.",
+            "- `/start`, `/stop`, `/pause`, `/resume` — sim lifecycle *(moderator/admin)*.",
+            "- `/spawn`, `/kill_agent`, `/pause_all`, `/kill` — high-impact controls *(admin required for kill/pause_all/kill_agent)*.",
+            "- `/set_speed`, `/speed`, `/set_max_rate` — tuning controls *(admin required for set_max_rate)*.",
+            "",
+            "### Quick examples",
+            "- `/dm agent-2 What's your latest plan?`",
+            "- `/broadcast Team sync in 2 minutes.`",
+            "- `/kb Rule: cite data source before proposing policy.`",
+            "- `/nudge Consider long-term coalition outcomes.`",
+            "",
+            "### Permission + rate-limit notes",
+            "- Public commands are usable by all channel users unless noted.",
+            "- Admin-only commands require Discord administrator privileges.",
+            "- Slash commands are globally rate-limited per user (default: 5 commands / 60s).",
+            "- Some moderation actions also have cooldowns to reduce spam.",
+        ]
+    )
+
+
+def create_onboarding_embed(channel_id: int) -> Any:
+    """Create a lightweight onboarding embed for startup."""
+    embed = discord.Embed(
+        title="🧭 How to interact",
+        description="Use slash commands to talk to agents and moderate the simulation.",
+        color=discord.Color.blue(),
+    )
+    embed.add_field(
+        name="Start with these",
+        value="`/help`, `/dm`, `/broadcast`, `/kb`, `/status`",
+        inline=False,
+    )
+    embed.add_field(
+        name="Permissions",
+        value="Public commands are open. Moderation/admin commands are labeled in `/help`.",
+        inline=False,
+    )
+    embed.add_field(
+        name="Rate limits",
+        value="Global command limit applies per user (default: 5 commands per 60s).",
+        inline=False,
+    )
+    embed.set_footer(text=f"Channel ID: {channel_id}")
+    return embed
+
+
 MAX_EMBED_DESCRIPTION_LENGTH = 4096
 _MENTION_TARGET_RE = re.compile(r"^@(?P<agent>[\w.-]+)\s*:\s*(?P<content>.+)$", re.DOTALL)
 _DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.DOTALL)
@@ -738,6 +798,13 @@ class SimulationDiscordBot:
                         )
                         await interaction.response.send_message("event injected", ephemeral=True)
 
+                @tree.command(name="help")
+                async def _tree_help(interaction: "discord.Interaction") -> None:
+                    with command_span("help", interaction) as span:
+                        help_text = build_help_text()
+                        span.set_attribute("discord.message.length", len(help_text))
+                        await interaction.response.send_message(help_text, ephemeral=True)
+
                 @tree.command(name="nudge")
                 @app_commands.describe(prompt="Prompt to nudge the simulation")
                 @moderation_rate_limit("nudge")
@@ -767,6 +834,7 @@ class SimulationDiscordBot:
                     )
                     embed.set_footer(text=f"Channel ID: {self.channel_id}")
                     await send_channel_message(channel, embed=embed)
+                    await send_channel_message(channel, embed=create_onboarding_embed(self.channel_id))
                 else:
                     logger.warning(f"Could not find Discord channel with ID: {self.channel_id}")
 
@@ -1804,6 +1872,15 @@ async def slash_speed(interaction: Any, value: float) -> None:
     with command_span("speed", interaction) as span:
         callback = cast(Callable[[Any, float], Awaitable[None]], slash_set_speed.callback)
         await callback(interaction, value)
+
+
+@bot.tree.command(name="help")
+async def slash_help(interaction: Any) -> None:
+    """Show command catalog, permission hints, and examples."""
+    with command_span("help", interaction) as span:
+        help_text = build_help_text()
+        span.set_attribute("discord.message.length", len(help_text))
+        await send_interaction_response(interaction, help_text, ephemeral=True)
 
 
 @bot.tree.command(name="kb")

--- a/tests/unit/interfaces/test_discord_help.py
+++ b/tests/unit/interfaces/test_discord_help.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.interfaces import discord_bot
+
+EXPECTED_HELP_TEXT = "\n".join(
+    [
+        "## 👋 Culture Bot Help",
+        "### Public commands",
+        "- `/dm <agent_id> <message>` — send a direct message to one agent.",
+        "- `/broadcast <message>` — send a message to all agents.",
+        "- `/kb <text>` — add a note to the Knowledge Board.",
+        "- `/status`, `/stats` — view current state/metrics.",
+        "- `/propose`, `/propose_law`, `/vote` — governance interactions.",
+        "",
+        "### Moderator/Admin commands",
+        "- `/nudge <prompt>` — steer agent behavior *(moderator/admin)*.",
+        "- `/event <text>` — inject world events *(moderator/admin)*.",
+        "- `/start`, `/stop`, `/pause`, `/resume` — sim lifecycle *(moderator/admin)*.",
+        "- `/spawn`, `/kill_agent`, `/pause_all`, `/kill` — high-impact controls *(admin required for kill/pause_all/kill_agent)*.",
+        "- `/set_speed`, `/speed`, `/set_max_rate` — tuning controls *(admin required for set_max_rate)*.",
+        "",
+        "### Quick examples",
+        "- `/dm agent-2 What's your latest plan?`",
+        "- `/broadcast Team sync in 2 minutes.`",
+        "- `/kb Rule: cite data source before proposing policy.`",
+        "- `/nudge Consider long-term coalition outcomes.`",
+        "",
+        "### Permission + rate-limit notes",
+        "- Public commands are usable by all channel users unless noted.",
+        "- Admin-only commands require Discord administrator privileges.",
+        "- Slash commands are globally rate-limited per user (default: 5 commands / 60s).",
+        "- Some moderation actions also have cooldowns to reduce spam.",
+    ]
+)
+
+
+@pytest.mark.unit
+def test_build_help_text_is_stable() -> None:
+    assert discord_bot.build_help_text() == EXPECTED_HELP_TEXT
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_slash_help_returns_help_text() -> None:
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=AsyncMock()),
+        user=SimpleNamespace(id="user-1"),
+        channel=SimpleNamespace(id=123),
+    )
+
+    await discord_bot.slash_help.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once_with(
+        EXPECTED_HELP_TEXT,
+        ephemeral=True,
+    )
+
+
+@pytest.mark.unit
+def test_create_onboarding_embed_contains_interaction_guidance(monkeypatch: pytest.MonkeyPatch) -> None:
+    fields: list[tuple[str, str, bool]] = []
+
+    class DummyEmbed:
+        def __init__(self, title: str, description: str, color: int) -> None:
+            self.title = title
+            self.description = description
+            self.color = color
+            self.footer_text = ""
+
+        def add_field(self, name: str, value: str, inline: bool) -> None:
+            fields.append((name, value, inline))
+
+        def set_footer(self, text: str) -> None:
+            self.footer_text = text
+
+    monkeypatch.setattr(
+        discord_bot,
+        "discord",
+        SimpleNamespace(Embed=DummyEmbed, Color=SimpleNamespace(blue=lambda: 123)),
+    )
+
+    embed = discord_bot.create_onboarding_embed(99)
+
+    assert embed.title == "🧭 How to interact"
+    assert "slash commands" in embed.description
+    assert any(name == "Permissions" for name, _, _ in fields)
+    assert any(name == "Rate limits" for name, _, _ in fields)
+    assert embed.footer_text == "Channel ID: 99"


### PR DESCRIPTION
### Motivation
- Provide users and moderators with an in-channel reference describing available commands, permission hints, examples, and rate-limit guidance so interactions with the bot are clearer and less error-prone.
- Surface lightweight onboarding guidance on bot startup to reduce friction for new channels.
- Make help content deterministic and testable so UI regressions are caught by unit tests.

### Description
- Added a stable help renderer `build_help_text()` that returns a deterministic multi-line help string listing public commands, moderator/admin commands, examples, and permission/rate-limit notes.
- Added an onboarding embed builder `create_onboarding_embed(channel_id)` that summarizes how to interact, permissions, and rate limits.
- Registered a per-client slash command `help` inside the `SimulationDiscordBot` command tree and a module-level `slash_help` on the global bot tree that both return the same help text ephemerally via `send_interaction_response`.
- Updated `on_ready` to post the lightweight onboarding embed to the configured channel immediately after the existing startup embed.
- Added unit tests at `tests/unit/interfaces/test_discord_help.py` that assert the help text is stable, that `slash_help` returns the expected text, and that the onboarding embed contains the expected guidance.

### Testing
- Ran linter checks with `ruff check src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_help.py` and fixed issues; all checks passed.
- Ran unit tests with `pytest -q tests/unit/interfaces/test_discord_help.py tests/unit/interfaces/test_discord_commands.py` and observed the test suite pass (all tests passed, existing unrelated warnings from the project environment were emitted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e2b2c1b08326b3962f6a9a4b1078)