### PR TITLE
Add async lock to GraphKnowledgeBoard and cover KB write paths

### DIFF
--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -47,6 +48,7 @@ class GraphKnowledgeBoard:
                 uri or config.GRAPH_DB_URI,
                 auth=(user or config.GRAPH_DB_USER, password or config.GRAPH_DB_PASSWORD),
             )
+        self.lock = asyncio.Lock()
         metrics.KNOWLEDGE_BOARD_SIZE.set(self._count_entries())
 
     # Enable use as a context manager
@@ -169,7 +171,9 @@ class GraphKnowledgeBoard:
             approve=approve,
         )
 
-    def get_proposal_support_counts(self: Self, proposal_ids: list[str] | None = None) -> dict[str, int]:
+    def get_proposal_support_counts(
+        self: Self, proposal_ids: list[str] | None = None
+    ) -> dict[str, int]:
         records = self._run(
             """
             MATCH (p:KBEntry)
@@ -209,7 +213,9 @@ class GraphKnowledgeBoard:
             for record in records
         ]
 
-    def get_agent_contribution_graph(self: Self, agent_id: str | None = None) -> list[dict[str, Any]]:
+    def get_agent_contribution_graph(
+        self: Self, agent_id: str | None = None
+    ) -> list[dict[str, Any]]:
         records = self._run(
             """
             MATCH (a:Agent)-[:AUTHORED]->(e:KBEntry)

--- a/tests/unit/sim/test_graph_knowledge_board.py
+++ b/tests/unit/sim/test_graph_knowledge_board.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 from typing import Any
 
@@ -29,7 +30,9 @@ class MockSession:
             entries = list(reversed(self.driver.entries))[:limit]
             return DummyResult([{"e": e} for e in entries])
         if "OPTIONAL MATCH (:Agent)-[v:VOTED {approve: true}]->(e)" in query:
-            return DummyResult([{"endorsements": self.driver.endorsements.get(params["entry_id"], 0)}])
+            return DummyResult(
+                [{"endorsements": self.driver.endorsements.get(params["entry_id"], 0)}]
+            )
         if "RETURN p.entry_id AS proposal_id, count(v) AS support_count" in query:
             return DummyResult(
                 [
@@ -130,3 +133,9 @@ def test_query_helpers_and_prompt_relationship_summary() -> None:
     )
     assert prompt_entries == ["[Step 1, agent-1]: proposal (endorsements: 3)"]
     assert any("MERGE (a)-[v:VOTED" in query for query, _ in driver.calls)
+
+
+def test_graph_board_exposes_async_lock_for_simulation_interface() -> None:
+    board = GraphKnowledgeBoard(driver=MockDriver())
+
+    assert isinstance(board.lock, asyncio.Lock)

--- a/tests/unit/sim/test_simulation_inject_event.py
+++ b/tests/unit/sim/test_simulation_inject_event.py
@@ -1,5 +1,6 @@
+import asyncio
 import sys
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -100,6 +101,51 @@ async def test_inject_event_is_visible_to_all_agents_next_cycle() -> None:
     assert len(perceived) == 1
     assert perceived[0]["recipient_id"] is None
     assert "market crash" in perceived[0]["content"]
+
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_graph_backend_kb_write_commands_use_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.infra import config
+    from src.sim.graph_knowledge_board import GraphKnowledgeBoard
+    from src.sim.simulation import Simulation
+
+    class DummyGraphBoard(GraphKnowledgeBoard):
+        def __init__(self) -> None:
+            self.lock = asyncio.Lock()
+            self.add_entry = MagicMock()
+
+    monkeypatch.setattr(config, "KNOWLEDGE_BOARD_BACKEND", "graph")
+    monkeypatch.setattr("src.sim.simulation.GraphKnowledgeBoard", DummyGraphBoard)
+
+    sim = Simulation([DummyAgent("A")])
+    sim.event_kernel.emit_environment_event = AsyncMock()
+
+    await sim._handle_human_command("/kb graph path")
+    await sim.handle_control_command(
+        {
+            "command": "post_kb",
+            "text": "moderator entry",
+            "author": "mod",
+        }
+    )
+    await sim.handle_control_command(
+        {
+            "command": "inject_event",
+            "text": "storm warning",
+            "scope": "global",
+            "author": "gm",
+        }
+    )
+
+    assert sim.knowledge_board.add_entry.call_count == 3
+    call_args = sim.knowledge_board.add_entry.call_args_list
+    assert call_args[0].args[1] == "human"
+    assert call_args[1].args[1] == "mod"
+    assert call_args[2].args[1] == "gm"
 
     await sim.stop_event_listener()
     sim.close()


### PR DESCRIPTION
### Motivation
- The graph-backed knowledge board lacked an `asyncio` lock, causing interface mismatch with `KnowledgeBoard` and risking failures when `Simulation` used `async with self.knowledge_board.lock`.
- Ensure KB write command paths (`/kb`, `post_kb`, `inject_event`, proposals, spawn/retire flows) operate correctly when the graph backend is selected.

### Description
- Add `import asyncio` and `self.lock = asyncio.Lock()` to `GraphKnowledgeBoard.__init__` so the graph backend exposes the same lock-based API as the in-memory `KnowledgeBoard`.
- Audited all `async with self.knowledge_board.lock` callsites in `src/sim/simulation.py` and kept the existing backend-agnostic locking usage, so no backend-specific branching was required.
- Add a unit test asserting `GraphKnowledgeBoard.lock` is an `asyncio.Lock` and extend unit tests to exercise KB write commands (`/kb`, `post_kb`, `inject_event`) with a graph backend stub that tracks `add_entry` calls.

### Testing
- Ran `ruff` and `black` on the modified files and fixed formatting issues, all checks passed.
- Ran targeted `pytest` for updated unit and integration tests: `tests/unit/sim/test_graph_knowledge_board.py`, `tests/unit/sim/test_simulation_inject_event.py`, and `tests/integration/knowledge_board/test_graph_backend.py`, and all selected tests passed.
- Verified the new test confirms the KB write command paths invoke `add_entry` on the graph backend (3 calls for `/kb`, `post_kb`, `inject_event`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e5adee9483269350a7b08efc5b68)