### PR TITLE
Use backend-agnostic knowledge board restore in replay

### DIFF
--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -91,6 +91,30 @@ class GraphKnowledgeBoard:
     def to_dict(self: Self) -> dict[str, Any]:
         return {"entries": self.get_full_entries()}
 
+    def replace_entries(self: Self, entries: list[dict[str, Any]]) -> None:
+        """Replace graph-backed KB entries from a serialized snapshot."""
+        self.clear_board()
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            props = dict(entry)
+            agent_id = str(props.get("agent_id", "unknown"))
+            entry_type = str(props.get("entry_type", "note"))
+            self._run(
+                """
+                MERGE (a:Agent {agent_id: $agent_id})
+                CREATE (e:KBEntry)
+                SET e = $props
+                SET e.entry_type = $entry_type
+                MERGE (a)-[:AUTHORED]->(e)
+                """,
+                agent_id=agent_id,
+                props=props,
+                entry_type=entry_type,
+            )
+            self._create_reference_links(str(props.get("entry_id", "")), props.get("reference_metadata"))
+        metrics.KNOWLEDGE_BOARD_SIZE.set(self._count_entries())
+
     def get_recent_entries_for_prompt(
         self: Self,
         max_entries: int = 5,

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -216,6 +216,11 @@ class KnowledgeBoard:
         """Serialize the knowledge board to a dictionary."""
         return {"entries": self.get_full_entries(), "vector": self.vector.to_dict()}
 
+    def replace_entries(self: Self, entries: list[dict[str, Any]]) -> None:
+        """Replace the board contents with precomputed entries."""
+        self.entries = LoggingList(list(entries))
+        metrics.KNOWLEDGE_BOARD_SIZE.set(len(self.entries))
+
     def get_recent_entries_for_prompt(self: Self, max_entries: int = 5) -> list[str]:
         """
         Returns a list of formatted strings for the most recent entries,

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -1732,9 +1732,9 @@ class Simulation:
                     break
             kb = event.get("knowledge_board")
             if isinstance(kb, dict):
-                from .knowledge_board import LoggingList
-
-                self.knowledge_board.entries = LoggingList(kb.get("entries", []))
+                entries = kb.get("entries", [])
+                if isinstance(entries, list):
+                    self.knowledge_board.replace_entries(entries)
             wm = event.get("world_map")
             if isinstance(wm, dict):
                 self.world_map.width = int(wm.get("width", self.world_map.width))

--- a/tests/unit/sim/test_simulation_inject_event.py
+++ b/tests/unit/sim/test_simulation_inject_event.py
@@ -149,3 +149,71 @@ async def test_graph_backend_kb_write_commands_use_lock(monkeypatch: pytest.Monk
 
     await sim.stop_event_listener()
     sim.close()
+
+
+@pytest.mark.unit
+def test_apply_event_replaces_memory_backend_kb_state() -> None:
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    event = {
+        "type": "agent_action",
+        "agent_id": "A",
+        "knowledge_board": {
+            "entries": [
+                {
+                    "entry_id": "e1",
+                    "step": 1,
+                    "agent_id": "A",
+                    "entry_type": "note",
+                    "tags": [],
+                    "reference_metadata": None,
+                    "content_full": "hello",
+                    "content_display": "Step 1 (Agent: A): hello",
+                    "content_summary": "hello",
+                }
+            ]
+        },
+    }
+
+    sim.apply_event(event)
+
+    assert sim.knowledge_board.to_dict()["entries"] == event["knowledge_board"]["entries"]
+    assert sim.knowledge_board.get_state() == ["Step 1 (Agent: A): hello"]
+
+
+@pytest.mark.unit
+def test_apply_event_replaces_graph_backend_kb_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.infra import config
+    from src.sim.graph_knowledge_board import GraphKnowledgeBoard
+    from src.sim.simulation import Simulation
+    from tests.integration.knowledge_board.test_graph_backend import DummyDriver
+
+    monkeypatch.setattr(config, "KNOWLEDGE_BOARD_BACKEND", "graph")
+    monkeypatch.setattr("src.sim.simulation.GraphKnowledgeBoard", lambda: GraphKnowledgeBoard(driver=DummyDriver()))
+
+    sim = Simulation([DummyAgent("A")])
+    event = {
+        "type": "agent_action",
+        "agent_id": "A",
+        "knowledge_board": {
+            "entries": [
+                {
+                    "entry_id": "g1",
+                    "step": 2,
+                    "agent_id": "A",
+                    "entry_type": "note",
+                    "tags": [],
+                    "reference_metadata": None,
+                    "content_full": "graph hello",
+                    "content_display": "Step 2 (Agent: A): graph hello",
+                    "content_summary": "graph hello",
+                }
+            ]
+        },
+    }
+
+    sim.apply_event(event)
+
+    assert sim.knowledge_board.to_dict()["entries"] == event["knowledge_board"]["entries"]
+    assert sim.knowledge_board.get_state() == ["Step 2 (Agent: A): graph hello"]


### PR DESCRIPTION
### Motivation

- Replay previously restored KB state by directly assigning `self.knowledge_board.entries`, which bypassed graph-backed write APIs and could break invariants/metrics for non-memory backends. 
- Introduce a single, backend-agnostic restore mechanism so replay reliably reconstructs KB state for both in-memory and graph backends.

### Description

- Added `replace_entries(entries: list[dict])` to `KnowledgeBoard` to safely replace the in-memory `LoggingList` and update metrics. 
- Added `replace_entries(entries: list[dict])` to `GraphKnowledgeBoard` to clear and repopulate graph entries via graph write queries and recreate reference links. 
- Updated `Simulation.apply_event` to call `self.knowledge_board.replace_entries(entries)` when replaying `knowledge_board` instead of assigning to `.entries`. 
- Added unit tests `test_apply_event_replaces_memory_backend_kb_state` and `test_apply_event_replaces_graph_backend_kb_state` to `tests/unit/sim/test_simulation_inject_event.py` to validate that `to_dict()` and `get_state()` are equivalent after `apply_event` for both backends.

### Testing

- Ran linter checks with `ruff check src/sim/knowledge_board.py src/sim/graph_knowledge_board.py src/sim/simulation.py tests/unit/sim/test_simulation_inject_event.py` which passed. 
- Ran unit tests with `pytest -q tests/unit/sim/test_simulation_inject_event.py` and the test suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e7d0fa8c832690c727bf8b46985f)