### PR TITLE
Strengthen graph backend KB write-command regression coverage

### DIFF
--- a/tests/unit/sim/test_simulation_inject_event.py
+++ b/tests/unit/sim/test_simulation_inject_event.py
@@ -1,6 +1,6 @@
 import asyncio
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -112,14 +112,13 @@ async def test_graph_backend_kb_write_commands_use_lock(monkeypatch: pytest.Monk
     from src.infra import config
     from src.sim.graph_knowledge_board import GraphKnowledgeBoard
     from src.sim.simulation import Simulation
-
-    class DummyGraphBoard(GraphKnowledgeBoard):
-        def __init__(self) -> None:
-            self.lock = asyncio.Lock()
-            self.add_entry = MagicMock()
+    from tests.integration.knowledge_board.test_graph_backend import DummyDriver
 
     monkeypatch.setattr(config, "KNOWLEDGE_BOARD_BACKEND", "graph")
-    monkeypatch.setattr("src.sim.simulation.GraphKnowledgeBoard", DummyGraphBoard)
+    monkeypatch.setattr(
+        "src.sim.simulation.GraphKnowledgeBoard",
+        lambda: GraphKnowledgeBoard(driver=DummyDriver()),
+    )
 
     sim = Simulation([DummyAgent("A")])
     sim.event_kernel.emit_environment_event = AsyncMock()
@@ -141,11 +140,19 @@ async def test_graph_backend_kb_write_commands_use_lock(monkeypatch: pytest.Monk
         }
     )
 
-    assert sim.knowledge_board.add_entry.call_count == 3
-    call_args = sim.knowledge_board.add_entry.call_args_list
-    assert call_args[0].args[1] == "human"
-    assert call_args[1].args[1] == "mod"
-    assert call_args[2].args[1] == "gm"
+    entries = sim.knowledge_board.get_full_entries()
+    assert [entry["agent_id"] for entry in entries] == ["human", "mod", "gm"]
+    assert [entry["entry_type"] for entry in entries] == [
+        "human_message",
+        "human_message",
+        "world_event",
+    ]
+    assert [entry["content_full"] for entry in entries] == [
+        "graph path",
+        "moderator entry",
+        "storm warning",
+    ]
+    assert isinstance(sim.knowledge_board.lock, asyncio.Lock)
 
     await sim.stop_event_listener()
     sim.close()


### PR DESCRIPTION
### Motivation
- Ensure the graph-backed `KnowledgeBoard` conforms to the simulation contract (exposes an `asyncio.Lock`) and that all KB write command paths (`/kb`, `post_kb`, `inject_event`) work when the graph backend is active. 

### Description
- Audited `Simulation` command paths that use `async with self.knowledge_board.lock` and confirmed they use a single backend-agnostic lock path, so no backend-specific branching was required. 
- Strengthened the unit test `test_graph_backend_kb_write_commands_use_lock` in `tests/unit/sim/test_simulation_inject_event.py` to instantiate a real `GraphKnowledgeBoard` backed by the existing in-memory `DummyDriver` and to assert persisted KB entries and their metadata (author, type, content) rather than relying on a MagicMock. 
- Added an explicit assertion that the graph board exposes `self.lock` as an `asyncio.Lock` to validate the interface contract. 

### Testing
- Ran `ruff check tests/unit/sim/test_simulation_inject_event.py` which passed. 
- Ran `pytest -q tests/unit/sim/test_simulation_inject_event.py tests/unit/sim/test_graph_knowledge_board.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9e685ffc8326b7c092082946d2a7)