### PR TITLE
Align Discord message precheck costs with DM/broadcast routing

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -644,16 +644,28 @@ class SimulationDiscordBot:
                     if user_id and sender is None:
                         self.user_agents[str(user_id)] = agent_id
                     is_broadcast = explicit_broadcast or recipient is None
-                    ip_cost = float(
-                        config.get_config("IP_COST_BROADCAST_MESSAGE")
-                        or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                        or 0.0
-                    )
-                    du_cost = float(
-                        config.get_config("DU_COST_BROADCAST_ACTION")
-                        or config.get_config("DU_COST_PER_ACTION")
-                        or 0.0
-                    )
+                    if is_broadcast:
+                        ip_cost = float(
+                            config.get_config("IP_COST_BROADCAST_MESSAGE")
+                            or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                            or 0.0
+                        )
+                        du_cost = float(
+                            config.get_config("DU_COST_BROADCAST_ACTION")
+                            or config.get_config("DU_COST_PER_ACTION")
+                            or 0.0
+                        )
+                    else:
+                        ip_cost = float(
+                            config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                            or config.get_config("IP_COST_BROADCAST_MESSAGE")
+                            or 0.0
+                        )
+                        du_cost = float(
+                            config.get_config("DU_COST_PER_ACTION")
+                            or config.get_config("DU_COST_BROADCAST_ACTION")
+                            or 0.0
+                        )
                     ip_bal, du_bal = await ledger.get_balance_async(agent_id)
                     if ip_bal < ip_cost or du_bal < du_cost:
                         await send_channel_message(channel, content="Insufficient IP/DU")

--- a/tests/unit/interfaces/test_discord_human_messages.py
+++ b/tests/unit/interfaces/test_discord_human_messages.py
@@ -153,3 +153,74 @@ async def test_on_message_parses_explicit_dm_target(discord_module, monkeypatch)
     assert evt.data["target_agent_id"] == "agent-z"
     assert evt.data["broadcast"] is False
     assert evt.data["content"] == "hi there"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected_broadcast"),
+    [
+        ("@agent-z: hi mention", False),
+        ("/dm agent-z hi slash", False),
+        ("plain message", True),
+    ],
+)
+async def test_on_message_precheck_costs_align_with_routing(
+    discord_module,
+    monkeypatch,
+    content,
+    expected_broadcast,
+):
+    monkeypatch.setattr(discord_module, "allow_message", lambda _: True)
+
+    async def _eval(raw: str):
+        return True, raw
+
+    def _config_lookup(key: str):
+        values = {
+            "IP_COST_BROADCAST_MESSAGE": 6.0,
+            "IP_COST_SEND_DIRECT_MESSAGE": 2.0,
+            "DU_COST_BROADCAST_ACTION": 7.0,
+            "DU_COST_PER_ACTION": 3.0,
+        }
+        return values.get(key)
+
+    balance_checks: list[str] = []
+
+    async def _bal(agent_id: str):
+        balance_checks.append(agent_id)
+        return (4.0, 4.0)
+
+    sent_messages: list[str] = []
+
+    async def _send_channel_message(channel, *, content=None, embed=None):
+        if content:
+            sent_messages.append(content)
+
+    monkeypatch.setattr(discord_module, "evaluate_with_opa", _eval)
+    monkeypatch.setattr(discord_module.config, "get_config", _config_lookup)
+    monkeypatch.setattr(discord_module.ledger, "get_balance_async", _bal)
+    monkeypatch.setattr(discord_module, "send_channel_message", _send_channel_message)
+
+    from src.sim.context import SimulationContext
+
+    bot = discord_module.SimulationDiscordBot(
+        "token", 123, context=SimulationContext(), channel_map={"agent-z": 999}
+    )
+    bot.event_queue = asyncio.Queue()
+
+    message = SimpleNamespace(
+        content=content,
+        author=SimpleNamespace(id="human-1"),
+        channel=SimpleNamespace(id=123),
+    )
+    await bot.client.on_message(message)
+
+    assert balance_checks == ["agent-z"]
+    if expected_broadcast:
+        assert sent_messages == ["Insufficient IP/DU"]
+        assert bot.event_queue.empty()
+    else:
+        assert sent_messages == []
+        evt = await bot.event_queue.get()
+        assert evt.data["broadcast"] is False


### PR DESCRIPTION
### Motivation
- Ensure the Discord `on_message` precheck charging uses the same DM vs broadcast distinction as `Simulation._handle_human_command` so routing decisions and precheck ledger checks are consistent.
- Use separate primary config keys for DM vs broadcast while preserving existing fallback behavior when config values are missing.

### Description
- Updated `src/interfaces/discord_bot.py` so `on_message` computes `ip_cost` and `du_cost` by branching on `is_broadcast`, using `IP_COST_BROADCAST_MESSAGE`/`DU_COST_BROADCAST_ACTION` as the primary keys for broadcasts and `IP_COST_SEND_DIRECT_MESSAGE`/`DU_COST_PER_ACTION` as the primary keys for direct messages, with fallbacks preserved.
- Added a new parametrized unit test in `tests/unit/interfaces/test_discord_human_messages.py` to cover `@agent` mention routing, `/dm` routing, and plain messages and to verify precheck behavior (allow/reject) aligns with DM vs broadcast costing.

### Testing
- Ran linting with `ruff check src/interfaces/discord_bot.py tests/unit/interfaces/test_discord_human_messages.py` and it passed.
- Ran `pytest -q tests/unit/interfaces/test_discord_human_messages.py` and all tests passed (`6 passed`).
- Ran `pytest -q tests/unit/sim/test_human_command_costs.py` and tests passed (`2 passed`) (test output included existing async teardown/logging warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b409b883883268a98c1ccd581f030)