### PR TITLE
Reject duplicate agent IDs in spawn control command

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -533,6 +533,26 @@ class Simulation:
         elif action == "spawn":
             agent_id = cmd.get("agent_id")
             if agent_id:
+                normalized_agent_id = str(agent_id)
+                if any(agent.agent_id == normalized_agent_id for agent in self.agents):
+                    warning_message = (
+                        "Rejected spawn request for duplicate agent_id "
+                        f"'{normalized_agent_id}'."
+                    )
+                    logger.warning(warning_message)
+                    await emit_event(
+                        SimulationEvent(
+                            type="spawn_rejected",
+                            data={
+                                "reason": "duplicate_agent_id",
+                                "agent_id": normalized_agent_id,
+                                "step": self.current_step,
+                            },
+                        )
+                    )
+                    if self.discord_bot:
+                        await self.discord_bot.send_simulation_update(content=warning_message)
+                    return
                 try:
                     from src.agents.core.base_agent import Agent
 
@@ -576,8 +596,8 @@ class Simulation:
                         initial_state["backstory"] = str(cmd.get("backstory"))
 
                     new_agent = Agent(
-                        agent_id=str(agent_id),
-                        name=str(agent_id),
+                        agent_id=normalized_agent_id,
+                        name=normalized_agent_id,
                         initial_state=initial_state or None,
                     )
                     await self.spawn_agent(new_agent)

--- a/tests/unit/sim/test_simulation_spawn_control.py
+++ b/tests/unit/sim/test_simulation_spawn_control.py
@@ -1,5 +1,6 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -114,4 +115,53 @@ async def test_spawn_control_rejects_invalid_trait_payload(monkeypatch: pytest.M
         }
     )
     assert len(sim.agents) == before
+    sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_spawn_control_rejects_duplicate_agent_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.interfaces.metrics import ACTIVE_AGENT_COUNT
+    from src.sim import simulation as simulation_module
+    from src.sim.simulation import Simulation
+
+    spawned: list[object] = []
+
+    class DummySpawnAgent:
+        def __init__(self, agent_id: str, name: str, initial_state: dict | None = None) -> None:
+            self.agent_id = agent_id
+            self.name = name
+            self._state = SimpleNamespace(ip=0.0, du=0.0, parent_id=None, genes={})
+            spawned.append(self)
+
+        def get_id(self) -> str:
+            return self.agent_id
+
+        @property
+        def state(self) -> SimpleNamespace:
+            return self._state
+
+    import src.agents.core.base_agent as base_agent_module
+
+    monkeypatch.setattr(base_agent_module, "Agent", DummySpawnAgent)
+    emit_event_mock = AsyncMock()
+    monkeypatch.setattr(simulation_module, "emit_event", emit_event_mock)
+
+    sim = Simulation([SeedAgent("seed")])
+    before = len(sim.agents)
+
+    await sim.handle_control_command({"command": "spawn", "agent_id": "child-1"})
+    after_first_spawn = len(sim.agents)
+    await sim.handle_control_command({"command": "spawn", "agent_id": "child-1"})
+
+    assert len(spawned) == 1
+    assert after_first_spawn == before + 1
+    assert len(sim.agents) == after_first_spawn
+    assert ACTIVE_AGENT_COUNT._value.get() == after_first_spawn
+    assert emit_event_mock.await_count == 1
+    event = emit_event_mock.await_args.args[0]
+    assert event.type == "spawn_rejected"
+    assert event.data["reason"] == "duplicate_agent_id"
+    assert event.data["agent_id"] == "child-1"
     sim.close()


### PR DESCRIPTION
### Motivation

- Prevent accidental creation of multiple agents with the same `agent_id` when processing `spawn` control commands.  
- Ensure operators and monitoring surfaces are informed when a spawn request is rejected.  
- Preserve simulation metrics such as `ACTIVE_AGENT_COUNT` and avoid inconsistent state by rejecting duplicates early.

### Description

- Normalize the incoming `agent_id` to a string and check `self.agents` for an existing agent before constructing an `Agent` in `handle_control_command` for the `spawn` branch.  
- When a duplicate is detected, log a warning and emit a `SimulationEvent` with `type="spawn_rejected"` and payload including `reason`, `agent_id`, and `step`.  
- If a `discord_bot` is available, send a human-readable update via `discord_bot.send_simulation_update`.  
- Use the normalized `agent_id` when constructing new `Agent(...)` in the successful spawn path; otherwise return early without creating an agent.

### Testing

- Ran linter: `ruff check src/sim/simulation.py tests/unit/sim/test_simulation_spawn_control.py` and it passed.  
- Added unit `test_spawn_control_rejects_duplicate_agent_id` and ran `pytest -q tests/unit/sim/test_simulation_spawn_control.py`; tests passed (3 passed) while pytest emitted unrelated asyncio teardown warnings.  
- The new test asserts a successful first spawn, rejection of the second spawn with the same ID, `ACTIVE_AGENT_COUNT` remains accurate, and a `spawn_rejected` event was emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b42eb96448326ab78188533fbc016)