### PR TITLE
docs: add structured feature templates to blueprint_memo.md

### DIFF
--- a/docs/blueprint_memo.md
+++ b/docs/blueprint_memo.md
@@ -26,21 +26,92 @@ The strategy below now reflects a repository-grounded audit of capabilities that
 
 Agents in Culture.ai adopt **free-form roles**, allowing for highly flexible persona creation and dynamic roleplay interactions. This layer enables emergent behaviors and diverse agent personalities that go beyond rigid predefined job classes.
 
+### Feature Template
+
+1. **Existing behavior (current module/function references)**
+   - `src/interfaces/discord_bot.py::on_message` parses operator text and recipient metadata before forwarding directives.
+   - `src/sim/simulation.py::_handle_human_command` validates delivery constraints and dispatches role-affecting directives into the simulation.
+2. **Gap/limitation**
+   - Role assignment and role changes are inferred from ad hoc command wording, and rejection feedback is not yet standardized for operators.
+3. **Planned change (API/schema/UX deltas only)**
+   - Add a lightweight command intent schema (for example: explicit role action + target fields) at the interface boundary.
+   - Return structured rejection reasons and next-step hints in Discord replies for failed role updates.
+
+**Out of scope**
+- Rewriting persona-generation internals or replacing the agent identity model.
+- Replacing Discord transport or introducing a new control channel.
+
 ## Discrete-Event Kernel
 
 A **discrete-event kernel** orchestrates agent actions and environmental changes over simulated time. Rather than relying on continuous loops, events are processed in discrete steps, enabling consistent state updates and easier integration of new simulation modules.
+
+### Feature Template
+
+1. **Existing behavior (current module/function references)**
+   - `src/sim/simulation.py::handle_control_command`, `spawn_agent`, `retire_agent`, and `_advance_world_time` provide the current control-plane lifecycle.
+2. **Gap/limitation**
+   - Burst control traffic can be difficult to replay deterministically, and operator visibility into scheduling outcomes is limited.
+3. **Planned change (API/schema/UX deltas only)**
+   - Introduce deterministic control-command envelope metadata (sequence/time annotations) for replay and diagnostics.
+   - Expand control-command acknowledgements with concise execution-state details (accepted, queued, rejected).
+
+**Out of scope**
+- Replacing the discrete-event model with a continuous simulation loop.
+- Re-architecting scheduler ownership across unrelated modules.
 
 ## Memory V2
 
 The next generation of agent memory, **Memory V2**, builds on the hierarchical summaries described in the [Hierarchical Memory System Overview](hierarchical_memory_README.md) and the more detailed [Advanced Memory Pruning Design Proposal](advanced_memory_pruning_design_proposal.md). Memory V2 aims to integrate retrieval frequency, relevance scoring, and context-aware pruning directly into the core agent workflow.
 
+### Feature Template
+
+1. **Existing behavior (current module/function references)**
+   - Memory retrieval and board-state hooks are partially represented through simulation and shared-memory touchpoints (`src/sim/simulation.py`, `src/sim/knowledge_board.py`).
+2. **Gap/limitation**
+   - No end-to-end Memory V2 lifecycle contract (ingest, relevance decay, pruning, replay) is currently formalized.
+3. **Planned change (API/schema/UX deltas only)**
+   - Define a versioned memory-item schema with retrieval counters and relevance timestamps.
+   - Publish explicit API boundaries for memory ingest/query/prune operations before implementation expansion.
+
+**Out of scope**
+- Full algorithmic implementation of Memory V2 scoring/pruning in this planning phase.
+- Bulk migration of existing memory records without a staged rollout plan.
+
 ## Ledger Service
 
 A dedicated **ledger service** records significant agent and system events for auditing and cross-agent synchronization. The ledger acts as a source of truth for inter-agent communication and can be used to replay or analyze past simulations.
 
+### Feature Template
+
+1. **Existing behavior (current module/function references)**
+   - Snapshot and event-adjacent persistence exists in `src/infra/snapshot.py`, with simulation-level emit/load hooks in `src/sim/simulation.py`.
+2. **Gap/limitation**
+   - Ledger-specific event taxonomy, retention policy, and replay contracts are not yet unified under one API surface.
+3. **Planned change (API/schema/UX deltas only)**
+   - Define a ledger event envelope (actor, event_type, correlation_id, world_time, payload hash).
+   - Specify read APIs for audit/replay queries and operator-facing filtering conventions.
+
+**Out of scope**
+- Building a production distributed log backend in this phase.
+- Migrating all persistence paths to ledger-first storage immediately.
+
 ## Spatial World Fabric
 
 Culture.ai envisions a **spatial world fabric** that provides a virtual environment in which agents interact. This layer includes a grid or coordinate system, environmental rules, and mechanisms to attach memories or artifacts to specific locations. The spatial dimension enables richer world-building and more complex agent behaviors.
+
+### Feature Template
+
+1. **Existing behavior (current module/function references)**
+   - `src/sim/world_map.py` and `src/sim/world_map_actions.py` implement map state, movement, and resource/action effects.
+2. **Gap/limitation**
+   - Environmental systems and event hooks remain narrower than the target simulation depth, limiting downstream agent strategy variety.
+3. **Planned change (API/schema/UX deltas only)**
+   - Extend world-state schema to support additional terrain/economy/event dimensions.
+   - Add action result metadata for clearer downstream simulation and interface reporting.
+
+**Out of scope**
+- A full rendering/visualization client rewrite.
+- Large-scale pathfinding engine replacement during this increment.
 
 ## Additional Components
 
@@ -50,3 +121,29 @@ Other major components on the roadmap include:
 - **Agent Personality Evolution** supported by persistent artifacts on the knowledge board.
 
 These layers collectively define the blueprint for Culture.ai's future development.
+
+### Feature Template: LLM Call Monitoring
+
+1. **Existing behavior (current module/function references)**
+   - Monitoring signals are currently fragmented across runtime hooks rather than a dedicated monitoring contract.
+2. **Gap/limitation**
+   - No single schema guarantees consistent latency/error/token metrics across invocation paths.
+3. **Planned change (API/schema/UX deltas only)**
+   - Define a unified LLM invocation telemetry schema and dashboard-facing aggregation fields.
+
+**Out of scope**
+- Building a new external observability platform from scratch.
+
+### Feature Template: Agent Personality Evolution
+
+1. **Existing behavior (current module/function references)**
+   - `src/agents/core/agent_state.py::apply_trait_drift` provides trait drift mechanics, with shared-memory interactions via `src/sim/knowledge_board.py` and orchestration in `src/sim/simulation.py`.
+2. **Gap/limitation**
+   - Trait changes are not yet consistently surfaced as explainable, user-facing deltas across simulation and interface layers.
+3. **Planned change (API/schema/UX deltas only)**
+   - Add structured trait-change events emitted by simulation and consumable by interface adapters.
+   - Introduce a concise explanation schema for personality deltas presented to operators.
+
+**Out of scope**
+- Replacing the trait model with a wholly different psychological framework.
+- Retrofitting all historical agent state snapshots in a single migration step.


### PR DESCRIPTION
### Motivation

- Make feature planning consistent by adding a compact 3-part template (existing behavior, gap, planned change) to each roadmap section to reduce ambiguity. 
- Anchor planning text to concrete code touchpoints so follow-up work can map to implementation more easily. 
- Prioritize surface-area overlap with control/interface/shared-memory codepaths around simulation, Discord, and the knowledge board to avoid missed integration needs.

### Description

- Added a standardized "Feature Template" (1. Existing behavior with module/function references, 2. Gap/limitation, 3. Planned change (API/schema/UX deltas only)) to Free-Form Roles, Discrete-Event Kernel, Memory V2, Ledger Service, Spatial World Fabric, and Additional Components sections. 
- Each new template contains explicit module/function anchors (where applicable) and concrete planned deltas focused on API/schema/UX changes rather than implementation details. 
- Every template now includes an explicit **Out of scope** list to prevent accidental rewrites or scope creep. 
- Templates explicitly reference and prioritize overlap-heavy deltas tied to `src/sim/simulation.py`, `src/interfaces/discord_bot.py`, and `src/sim/knowledge_board.py` when relevant.

### Testing

- No automated tests or linters were run because this is a documentation-only change and repository guidance allows skipping tests/linters for changes that only modify documentation or comments; therefore there were no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5033f60083269b460772d448b907)