### PR TITLE
Add dependency-layer ADR map and must-not-change interface contracts

### DIFF
--- a/docs/implementation_dependency_map.md
+++ b/docs/implementation_dependency_map.md
@@ -1,0 +1,82 @@
+# Implementation Dependency Map and ADR Checkpoints
+
+This document defines the required implementation order for high-impact platform work
+so multiple teams can ship in parallel without creating incompatible behavior.
+
+## Prerequisite Layers
+
+The architecture must be implemented in this order:
+
+1. **Interaction bus**
+2. **State consistency**
+3. **Memory/query semantics**
+4. **Governance rules**
+5. **Scale-out**
+
+Downstream layers may not be merged until upstream layer checkpoints are accepted.
+
+## Phase-by-Phase ADR Checkpoints (required before coding)
+
+For each phase below, open and approve an ADR before any high-impact code changes begin.
+
+### 1) Interaction bus
+
+**Goal:** Define event envelope, step dispatch boundaries, and ordering guarantees.
+
+**ADR checkpoints:**
+- Event envelope schema (required fields, optional extensions, versioning strategy).
+- Delivery semantics (at-most-once / at-least-once expectations for each event type).
+- Event lifecycle boundaries for producer/consumer ownership.
+- Backward-compatibility and migration strategy for event names/payloads.
+
+### 2) State consistency
+
+**Goal:** Ensure all replicated state transitions are deterministic and replayable.
+
+**ADR checkpoints:**
+- Canonical state transition rules and idempotency expectations.
+- Conflict handling strategy (merge policy, last-write-wins exceptions, vector clocks).
+- Snapshot/replay compatibility requirements and minimum validation checks.
+- Rollback/failure handling rules for partially applied changes.
+
+### 3) Memory/query semantics
+
+**Goal:** Lock read/write semantics so memory behavior is stable across implementations.
+
+**ADR checkpoints:**
+- Query contract (inputs, ranking expectations, token caps, fallback behavior).
+- Write contract (normalization, deduplication, summarization, retention rules).
+- Schema compatibility rules for memory payload evolution.
+- Observability requirements for memory correctness (metrics + traces).
+
+### 4) Governance rules
+
+**Goal:** Apply policy controls on top of stable interaction/state/memory layers.
+
+**ADR checkpoints:**
+- Policy evaluation boundaries (what is governed, where decisions are enforced).
+- Conflict resolution between policy outcomes and simulation progression.
+- Auditability requirements (decision logs, policy versions, replayability).
+- Exception/override model and who can authorize it.
+
+### 5) Scale-out
+
+**Goal:** Scale throughput and topology without changing layer contracts.
+
+**ADR checkpoints:**
+- Partitioning/sharding strategy and routing rules.
+- Cross-partition consistency model and acceptable staleness.
+- Load-shedding/backpressure controls and SLO-based safeguards.
+- Upgrade/rollout strategy that preserves compatibility with existing contracts.
+
+## Change Control Rule
+
+Before implementing high-impact changes, teams must verify:
+
+- The current phase ADR exists and is approved.
+- All prerequisite phase ADRs are approved.
+- The change does not violate any must-not-change contracts in:
+  - `src/sim/simulation.py`
+  - `src/sim/knowledge_board.py`
+  - `src/agents/core/agent_state.py`
+

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -184,6 +184,38 @@ else:
         class LLMClientInitError(RuntimeError):
             pass
 
+# Must-not-change contract for persistence compatibility.
+#
+# Fields listed below are persisted and must remain backward compatible across
+# releases unless an ADR-approved migration plan is implemented.
+AGENT_STATE_PERSISTENCE_MUST_NOT_CHANGE: dict[str, tuple[str, ...]] = {
+    "identity_fields": (
+        "agent_id",
+        "name",
+    ),
+    "economic_fields": (
+        "ip",
+        "du",
+    ),
+    "role_and_mood_history_fields": (
+        "current_role",
+        "role_history",
+        "mood_level",
+        "mood_history",
+    ),
+    "memory_and_goal_fields": (
+        "short_term_memory",
+        "goals",
+        "projects",
+        "current_project_id",
+    ),
+    "step_fields": (
+        "step_counter",
+        "last_message_step",
+        "last_action_step",
+    ),
+}
+
 
 class AgentStateData(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra=Extra.allow)

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -24,6 +24,32 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+# Must-not-change contract for knowledge board entry compatibility.
+#
+# Team changes that affect entry payload shape must be versioned and gated by
+# an approved ADR before changing these fields or their meaning.
+KNOWLEDGE_BOARD_ENTRY_SCHEMA_MUST_NOT_CHANGE: dict[str, tuple[str, ...]] = {
+    "required_fields": (
+        "entry_id",
+        "step",
+        "agent_id",
+        "entry_type",
+        "content_full",
+        "content_display",
+        "content_summary",
+    ),
+    "field_semantics": (
+        "content_full stores normalized full text (length-capped)",
+        "content_display is UI-safe display text",
+        "content_summary is prompt-safe summary text",
+    ),
+    "metadata_fields": (
+        "tags",
+        "reference_metadata",
+    ),
+}
+
+
 @dataclass(slots=True)
 class BoardEntry:
     """Typed payload describing a knowledge board entry."""

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -65,6 +65,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Must-not-change contract for safe parallel development.
+#
+# Any high-impact change touching the event/step lifecycle must preserve these
+# guarantees unless an ADR explicitly approves a versioned migration path.
+EVENT_STEP_LIFECYCLE_MUST_NOT_CHANGE: dict[str, tuple[str, ...]] = {
+    "run_step_order": (
+        "start_event_listener must run before kernel dispatch",
+        "event_kernel.step is the step execution boundary",
+        "evaluation hooks execute after events are produced for a step",
+    ),
+    "bootstrap_semantics": (
+        "when kernel queue is empty, exactly one immediate agent event is seeded",
+        "seeded event uses current_agent_index and increments that agent vector clock",
+    ),
+    "metrics_event_semantics": (
+        "evaluation metrics are emitted as SimulationEvent(type='evaluation')",
+        "evaluation metrics include the current simulation step",
+    ),
+}
+
+
 class Simulation:
     """
     Manages the simulation environment, agents, and time steps.


### PR DESCRIPTION
### Motivation

- Prevent incompatible parallel changes by locking down prerequisite implementation order and requiring ADR approvals before high-impact work.  
- Provide explicit, discoverable contracts for critical interfaces that other teams must not change without an ADR-approved migration.

### Description

- Added `docs/implementation_dependency_map.md` that defines the layer ordering (interaction bus → state consistency → memory/query semantics → governance rules → scale-out) and per-phase ADR checkpoints.  
- Introduced `EVENT_STEP_LIFECYCLE_MUST_NOT_CHANGE` in `src/sim/simulation.py` to document event/step lifecycle guarantees that must remain stable.  
- Introduced `KNOWLEDGE_BOARD_ENTRY_SCHEMA_MUST_NOT_CHANGE` in `src/sim/knowledge_board.py` to lock the Knowledge Board entry payload shape and semantics.  
- Introduced `AGENT_STATE_PERSISTENCE_MUST_NOT_CHANGE` in `src/agents/core/agent_state.py` to enumerate persistence-compatible fields that require ADRs for migration.

### Testing

- Ran the linter: `ruff check src/sim/simulation.py src/sim/knowledge_board.py src/agents/core/agent_state.py`, which passed without errors.  
- Ran unit tests: `pytest -q tests/unit/sim/test_knowledge_board.py tests/unit/core/test_agent_state_serialization.py tests/unit/sim/test_simulation_spans.py`, yielding `15 passed` with warnings (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b56b583e88326a3af918b4ad65ee3)