### PR TITLE
Scope human command relay cooldown by sender and channel

### DIFF
--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -181,7 +181,7 @@ class Simulation:
         # Lock for concurrent access to message queues
         self._msg_lock = asyncio.Lock()
         self._last_kb_time = 0.0
-        self._last_relay_time = 0.0
+        self._last_relay_times: dict[str, float] = {}
         self._kb_cooldown = float(config.get_config("DISCORD_KB_RATE_LIMIT_SECONDS") or 1.0)
         self._relay_cooldown = float(
             config.get_config("DISCORD_MESSAGE_RATE_LIMIT_SECONDS") or 1.0
@@ -366,6 +366,7 @@ class Simulation:
     ) -> None:
         """Handle a human-issued command or prompt."""
         now = time.monotonic()
+        routing = metadata or {}
         if text.startswith("/kb ") and self.knowledge_board:
             if now - self._last_kb_time < self._kb_cooldown:
                 return
@@ -385,15 +386,48 @@ class Simulation:
                     )
             return
 
-        if now - self._last_relay_time < self._relay_cooldown:
+        sender_id = str(routing.get("sender_id", "human"))
+        raw_channel_id = (
+            routing.get("channel_id")
+            or routing.get("source_channel_id")
+            or routing.get("target_channel_id")
+        )
+        channel_id = str(raw_channel_id) if raw_channel_id is not None else None
+        relay_scope_key = sender_id if channel_id is None else f"{sender_id}:{channel_id}"
+
+        last_relay_time = self._last_relay_times.get(relay_scope_key, 0.0)
+        if now - last_relay_time < self._relay_cooldown:
+            retry_after = max(0.0, self._relay_cooldown - (now - last_relay_time))
+            await emit_event(
+                SimulationEvent(
+                    type="human_command_rate_limited",
+                    data={
+                        "sender_id": sender_id,
+                        "scope": relay_scope_key,
+                        "retry_after_seconds": retry_after,
+                        "step": self.current_step,
+                    },
+                )
+            )
+            if self.discord_bot:
+                await self.discord_bot.send_simulation_update(
+                    (
+                        "Rate limited: please wait "
+                        f"{retry_after:.1f}s before sending another message."
+                    ),
+                    agent_id=sender_id,
+                    target_channel_id=(
+                        int(channel_id)
+                        if channel_id is not None and channel_id.isdigit()
+                        else self.discord_bot.last_channel_id
+                    ),
+                )
             return
-        self._last_relay_time = now
+        self._last_relay_times[relay_scope_key] = now
 
         if not self.agents:
             return
 
-        routing = metadata or {}
-        sender_id = str(routing.get("sender_id", "human"))
         raw_recipient = routing.get("recipient_id")
         recipient_id = str(raw_recipient) if isinstance(raw_recipient, str) else None
         broadcast = bool(routing.get("broadcast", False))

--- a/tests/integration/interfaces/test_discord_forwarding.py
+++ b/tests/integration/interfaces/test_discord_forwarding.py
@@ -73,9 +73,11 @@ async def test_event_bus_forwarding(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     handled: list[str] = []
     original = Simulation._handle_human_command
 
-    async def wrapped(self: Simulation, text: str) -> None:
+    async def wrapped(
+        self: Simulation, text: str, metadata: dict | None = None
+    ) -> None:
         handled.append(text)
-        await original(self, text)
+        await original(self, text, metadata)
 
     monkeypatch.setattr(Simulation, "_handle_human_command", wrapped)
 
@@ -98,3 +100,86 @@ async def test_event_bus_forwarding(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
         sim.close()
         bus.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_human_command_rate_limit_scoped_by_sender(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    import src.sim.simulation as simulation_module
+    from src.infra import ledger as ledger_module
+    from src.infra.ledger import Ledger
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+    monkeypatch.setattr(
+        simulation_module,
+        "get_resource_manager",
+        lambda: type(
+            "ResourceManager",
+            (),
+            {
+                "ensure_du_budget": staticmethod(lambda *_a, **_k: None),
+                "set_du_budget": staticmethod(lambda *_a, **_k: None),
+                "cap_tick": staticmethod(lambda *_a, **_k: None),
+            },
+        )(),
+    )
+    spend_mock = AsyncMock()
+    monkeypatch.setattr(ledger_module.ledger, "spend", spend_mock)
+    emit_mock = AsyncMock()
+    monkeypatch.setattr(simulation_module, "emit_event", emit_mock)
+
+    sim = Simulation([DummyAgent("A")])
+
+    await sim._handle_human_command("hello from user 1", {"sender_id": "user-1"})
+    await sim._handle_human_command("hello from user 2", {"sender_id": "user-2"})
+
+    assert spend_mock.await_count == 2
+    assert emit_mock.await_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_human_command_rate_limit_sends_feedback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    import src.sim.simulation as simulation_module
+    from src.infra import ledger as ledger_module
+    from src.infra.ledger import Ledger
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+    monkeypatch.setattr(
+        simulation_module,
+        "get_resource_manager",
+        lambda: type(
+            "ResourceManager",
+            (),
+            {
+                "ensure_du_budget": staticmethod(lambda *_a, **_k: None),
+                "set_du_budget": staticmethod(lambda *_a, **_k: None),
+                "cap_tick": staticmethod(lambda *_a, **_k: None),
+            },
+        )(),
+    )
+    spend_mock = AsyncMock()
+    monkeypatch.setattr(ledger_module.ledger, "spend", spend_mock)
+    emit_mock = AsyncMock()
+    monkeypatch.setattr(simulation_module, "emit_event", emit_mock)
+
+    sim = Simulation([DummyAgent("A")])
+
+    await sim._handle_human_command("first", {"sender_id": "user-1"})
+    await sim._handle_human_command("second", {"sender_id": "user-1"})
+
+    assert spend_mock.await_count == 1
+    assert emit_mock.await_count == 1
+    throttled_event = emit_mock.await_args.args[0]
+    assert throttled_event.type == "human_command_rate_limited"
+    assert throttled_event.data["sender_id"] == "user-1"

--- a/tests/unit/sim/test_human_command_costs.py
+++ b/tests/unit/sim/test_human_command_costs.py
@@ -97,7 +97,7 @@ async def test_handle_human_command_missing_config(
         monkeypatch.setitem(config._CONFIG, key, None)
 
     await sim._handle_human_command("hello")
-    sim._last_relay_time = 0.0
+    sim._last_relay_times.clear()
     await sim._handle_human_command("/broadcast hi")
 
     assert agent.state.ip == pytest.approx(2.0)


### PR DESCRIPTION
### Motivation

- Prevent one global relay gate from blocking other users; cooldown should be scoped to the originating sender (and channel when available).  
- Provide explicit user feedback when a human relay is throttled so clients know why their message was dropped.  
- Add integration-level coverage to ensure near-simultaneous messages from distinct senders are not suppressed by each other.

### Description

- Replaced the single `self._last_relay_time` gate with an in-memory map `self._last_relay_times: dict[str, float]` keyed by a relay scope key built from `sender_id` and optional `channel_id`.  
- In `_handle_human_command`, compute `relay_scope_key` from metadata (`sender_id` and one of `channel_id` / `source_channel_id` / `target_channel_id`) and apply the configured `_relay_cooldown` against `self._last_relay_times[relay_scope_key]`.  
- On throttle, emit a `SimulationEvent(type="human_command_rate_limited")` containing `sender_id`, `scope`, `retry_after_seconds`, and `step`, and send an explicit Discord feedback message via `self.discord_bot.send_simulation_update(...)` when a bot is present.  
- Added integration tests in `tests/integration/interfaces/test_discord_forwarding.py` to verify that messages from two different senders sent near-simultaneously both pass and that repeated messages from the same sender are throttled with emitted feedback, and updated `tests/unit/sim/test_human_command_costs.py` to clear the new cooldown map (`sim._last_relay_times.clear()`).  

### Testing

- Ran linter/auto-fixes with `ruff check src/sim/simulation.py tests/integration/interfaces/test_discord_forwarding.py tests/unit/sim/test_human_command_costs.py` and the checks passed.  
- Executed unit tests with `pytest tests/unit/sim/test_human_command_costs.py` and they passed.  
- Executed the integration tests with `pytest -m integration tests/integration/interfaces/test_discord_forwarding.py` and they passed (integration tests: 3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca547cec88326871ac980b19f9195)