### PR TITLE
Normalize broadcast command parsing and empty command handling

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -259,25 +259,35 @@ _DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.D
 
 
 
-def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str]:
+def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str, str | None]:
     """Parse optional routing directives from plain Discord messages."""
     cleaned = content.strip()
     if not cleaned:
-        return None, False, ""
+        return None, False, "", None
 
-    if cleaned.startswith("/broadcast"):
-        payload = cleaned[len("/broadcast") :].strip()
-        return None, True, payload
+    if cleaned == "/broadcast":
+        return None, True, "", "Broadcast message cannot be empty. Use /broadcast <message>."
+
+    if cleaned.startswith("/broadcast "):
+        payload = cleaned[len("/broadcast ") :].strip()
+        if not payload:
+            return (
+                None,
+                True,
+                "",
+                "Broadcast message cannot be empty. Use /broadcast <message>.",
+            )
+        return None, True, payload, None
 
     mention_match = _MENTION_TARGET_RE.match(cleaned)
     if mention_match:
-        return mention_match.group("agent"), False, mention_match.group("content").strip()
+        return mention_match.group("agent"), False, mention_match.group("content").strip(), None
 
     dm_match = _DM_TARGET_RE.match(cleaned)
     if dm_match:
-        return dm_match.group("agent"), False, dm_match.group("content").strip()
+        return dm_match.group("agent"), False, dm_match.group("content").strip(), None
 
-    return None, False, cleaned
+    return None, False, cleaned, None
 
 
 
@@ -679,9 +689,12 @@ class SimulationDiscordBot:
                     if user_id and channel_id:
                         self.user_channels[str(user_id)] = channel_id
                         self.last_user_id = str(user_id)
-                    explicit_recipient, explicit_broadcast, parsed_content = (
+                    explicit_recipient, explicit_broadcast, parsed_content, validation_error = (
                         _parse_human_message_routing(content)
                     )
+                    if validation_error:
+                        await send_channel_message(channel, content=validation_error)
+                        return
                     if not parsed_content:
                         return
                     recipient = explicit_recipient or self.channel_to_agent.get(channel_id)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -365,6 +365,7 @@ class Simulation:
         self: Self, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
         """Handle a human-issued command or prompt."""
+        text = text or ""
         now = time.monotonic()
         routing = metadata or {}
         if text.startswith("/kb ") and self.knowledge_board:
@@ -384,6 +385,15 @@ class Simulation:
                         self.current_step,
                         self.vector.to_dict(),
                     )
+            return
+
+        if not text.strip():
+            if self.discord_bot:
+                await self.discord_bot.send_simulation_update(
+                    "Message cannot be empty.",
+                    agent_id=str(routing.get("sender_id", "human")),
+                    target_channel_id=self.discord_bot.last_channel_id,
+                )
             return
 
         sender_id = str(routing.get("sender_id", "human"))
@@ -434,6 +444,14 @@ class Simulation:
         if text.startswith("/broadcast "):
             broadcast = True
             text = text[len("/broadcast ") :].strip()
+            if not text:
+                if self.discord_bot:
+                    await self.discord_bot.send_simulation_update(
+                        "Broadcast message cannot be empty.",
+                        agent_id=sender_id,
+                        target_channel_id=self.discord_bot.last_channel_id,
+                    )
+                return
 
         raw_target = routing.get("target_agent_id")
         target_agent_id = str(raw_target) if isinstance(raw_target, str) else None

--- a/tests/unit/interfaces/test_discord_human_messages.py
+++ b/tests/unit/interfaces/test_discord_human_messages.py
@@ -299,3 +299,84 @@ async def test_on_message_parses_explicit_mention_target(discord_module, monkeyp
     assert evt.data["target_agent_id"] == "agent-z"
     assert evt.data["broadcast"] is False
     assert evt.data["content"] == "hi there"
+
+
+@pytest.mark.unit
+def test_parse_human_message_routing_rejects_broadcast_without_payload(discord_module):
+    recipient, is_broadcast, parsed_content, validation_error = discord_module._parse_human_message_routing(
+        "/broadcast"
+    )
+
+    assert recipient is None
+    assert is_broadcast is True
+    assert parsed_content == ""
+    assert validation_error is not None
+
+
+@pytest.mark.unit
+def test_parse_human_message_routing_rejects_broadcast_whitespace_payload(discord_module):
+    recipient, is_broadcast, parsed_content, validation_error = discord_module._parse_human_message_routing(
+        "/broadcast   "
+    )
+
+    assert recipient is None
+    assert is_broadcast is True
+    assert parsed_content == ""
+    assert validation_error is not None
+
+
+@pytest.mark.unit
+def test_parse_human_message_routing_accepts_broadcast_payload(discord_module):
+    recipient, is_broadcast, parsed_content, validation_error = discord_module._parse_human_message_routing(
+        "/broadcast hello"
+    )
+
+    assert recipient is None
+    assert is_broadcast is True
+    assert parsed_content == "hello"
+    assert validation_error is None
+
+
+@pytest.mark.unit
+def test_parse_human_message_routing_treats_broadcasting_as_plain_text(discord_module):
+    recipient, is_broadcast, parsed_content, validation_error = discord_module._parse_human_message_routing(
+        "/broadcasting foo"
+    )
+
+    assert recipient is None
+    assert is_broadcast is False
+    assert parsed_content == "/broadcasting foo"
+    assert validation_error is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_message_replies_with_validation_error_for_empty_broadcast(discord_module, monkeypatch):
+    monkeypatch.setattr(discord_module, "allow_message", lambda _: True)
+
+    async def _eval(content: str):
+        return True, content
+
+    sent_messages: list[str] = []
+
+    async def _send_channel_message(channel, *, content=None, embed=None):
+        if content:
+            sent_messages.append(content)
+
+    monkeypatch.setattr(discord_module, "evaluate_with_opa", _eval)
+    monkeypatch.setattr(discord_module, "send_channel_message", _send_channel_message)
+
+    from src.sim.context import SimulationContext
+
+    bot = discord_module.SimulationDiscordBot("token", 123, context=SimulationContext())
+    bot.event_queue = asyncio.Queue()
+
+    message = SimpleNamespace(
+        content="/broadcast   ",
+        author=SimpleNamespace(id="human-1"),
+        channel=SimpleNamespace(id=123),
+    )
+    await bot.client.on_message(message)
+
+    assert sent_messages == ["Broadcast message cannot be empty. Use /broadcast <message>."]
+    assert bot.event_queue.empty()

--- a/tests/unit/sim/test_human_command.py
+++ b/tests/unit/sim/test_human_command.py
@@ -164,3 +164,30 @@ async def test_human_command_broadcast_falls_back_to_current_agent(
         recipients = [msg["recipient_id"] for msg in sim.pending_messages_for_next_round]
     assert recipients == ["alpha", "beta"]
     sim.close()
+
+
+@pytest.mark.asyncio
+async def test_human_command_ignores_empty_text_without_spending_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    monkeypatch.setattr("src.infra.ledger.ledger", ledger)
+    monkeypatch.setattr("src.sim.simulation.ledger", ledger)
+
+    agent = DummyAgent("A")
+    sim = Simulation([agent])
+
+    await sim._handle_human_command("   ")
+
+    assert agent.state.ip == pytest.approx(2.0)
+    assert agent.state.du == pytest.approx(2.0)
+    ip, du = ledger.get_balance(agent.agent_id)
+    assert ip == pytest.approx(2.0)
+    assert du == pytest.approx(2.0)
+    async with sim._msg_lock:
+        assert sim.pending_messages_for_next_round == []
+    sim.close()


### PR DESCRIPTION
### Motivation
- Ensure consistent command parsing between Discord input and simulation handling so `/broadcast` is only treated as a command when the proper delimiter is used. 
- Surface clear validation feedback for empty broadcast payloads instead of silently dropping them. 
- Prevent the simulation from spending agent resources or enqueueing messages for empty human input.

### Description
- Tightened `_parse_human_message_routing` to return a validation error field and to only treat `/broadcast` as a command when using the `/broadcast ` delimiter or when explicitly the exact `/broadcast` string (which now yields a validation error). 
- Updated Discord `on_message` flow to inspect the parse validation error and reply to the channel with a user-facing validation message when present. 
- Added defensive guards in `Simulation._handle_human_command` to early-return (and optionally send validation feedback) for empty text and to reject empty `/broadcast ` payloads before doing budget checks, ledger spends, or message enqueueing. 
- Added unit tests covering `/broadcast` (no payload) rejection with feedback, `/broadcast   ` rejection, `/broadcast hello` acceptance, `/broadcasting foo` treated as plain text, and that empty simulation human commands do not spend resources or enqueue messages.

### Testing
- Ran `pytest tests/unit/interfaces/test_discord_human_messages.py tests/unit/sim/test_human_command.py` and all tests passed (`18 passed`).
- Ran `ruff check src/interfaces/discord_bot.py src/sim/simulation.py tests/unit/interfaces/test_discord_human_messages.py tests/unit/sim/test_human_command.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca8ca1d308326913f09419206b6e0)