### PR TITLE
Unify Discord outbound text moderation and add blocked-output metric

### DIFF
--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -794,14 +794,23 @@ class SimulationDiscordBot:
             if not self.is_ready:
                 logger.warning("Discord bot not ready yet, message not sent")
                 return False
-            if not allow_message(content):
-                logger.debug("Message blocked by policy")
-                return False
-            if content is not None and agent_id is None:
+            if content:
+                if not allow_message(content):
+                    span.set_attribute("discord.message.blocked", True)
+                    span.set_attribute("discord.message.block_reason", "allow_message")
+                    if agent_id is not None:
+                        metrics.DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL.inc()
+                    logger.debug("Message blocked by policy")
+                    return False
                 allowed, content = await evaluate_with_opa(content)
                 if not allowed:
+                    span.set_attribute("discord.message.blocked", True)
+                    span.set_attribute("discord.message.block_reason", "opa")
+                    if agent_id is not None:
+                        metrics.DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL.inc()
                     logger.debug("Message blocked by OPA policy")
                     return False
+            # NOTE: embed-only updates preserve current behavior (no embed text moderation yet).
             try:
                 client = await self._select_client(agent_id)
                 chan_id = target_channel_id

--- a/src/interfaces/metrics.py
+++ b/src/interfaces/metrics.py
@@ -79,6 +79,10 @@ HUMAN_MESSAGES_TOTAL = Counter(
     "human_messages_total",
     "Total number of human messages received",
 )
+DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL = Counter(
+    "discord_agent_outputs_blocked_total",
+    "Total number of agent outbound Discord messages blocked by moderation or policy",
+)
 
 # Simulation state metrics
 COALITION_COUNT = Gauge("coalition_count", "Number of active coalitions")
@@ -237,6 +241,11 @@ def get_human_messages() -> int:
     return int(HUMAN_MESSAGES_TOTAL._value.get())
 
 
+def get_discord_agent_outputs_blocked_total() -> int:
+    """Return the total blocked outbound agent messages to Discord."""
+    return int(DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL._value.get())
+
+
 def get_coalition_count() -> int:
     """Return the current number of coalitions."""
     return int(COALITION_COUNT._value.get())
@@ -262,6 +271,7 @@ __all__ = [
     "COUNCIL_LATENCY_P95_MS",
     "COUNCIL_RUNS_TOTAL",
     "COUNCIL_WIN_RATE",
+    "DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL",
     "GAS_PRICE_PER_CALL",
     "GAS_PRICE_PER_TOKEN",
     "HUMAN_MESSAGES_TOTAL",
@@ -283,6 +293,7 @@ __all__ = [
     "Gauge",
     "get_average_sentiment",
     "get_coalition_count",
+    "get_discord_agent_outputs_blocked_total",
     "get_du_per_1k_tokens",
     "get_gas_price_per_call",
     "get_gas_price_per_token",

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -99,6 +99,27 @@ async def test_multi_token_start_and_send() -> None:
     assert sent_by_token == ["tok2"]
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_agent_update_blocked_content_not_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    with (
+        patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient),
+        patch(
+            "src.interfaces.discord_bot.evaluate_with_opa",
+            AsyncMock(return_value=(False, "blocked")),
+        ),
+    ):
+        bot = await SimulationDiscordBot.create("token", 123, context=SimulationContext())
+        bot.is_ready = True
+        bot.client.get_channel = MagicMock()
+
+        before = metrics.get_discord_agent_outputs_blocked_total()
+        result = await bot.send_simulation_update(content="blocked payload", agent_id="agent-a")
+
+        assert result is False
+        assert metrics.get_discord_agent_outputs_blocked_total() == before + 1
+        bot.client.get_channel.assert_not_called()
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_multi_token_message_forwarding() -> None:


### PR DESCRIPTION
### Motivation

- Ensure outbound text posted to Discord is consistently evaluated by moderation/policy regardless of `agent_id` so agent-generated text cannot bypass checks.
- Make blocked agent outputs observable via tracing and metrics so moderation events are measurable and debuggable.

### Description

- Run `allow_message` and `evaluate_with_opa` for any non-empty `content` in `SimulationDiscordBot.send_simulation_update`, and short-circuit sending when blocked. 
- Record tracing attributes `discord.message.blocked` and `discord.message.block_reason` when content is blocked, and increment `metrics.DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL` for blocked agent-originated outputs.
- Preserve existing embed-only behavior (no embed description/field moderation yet) and add a comment for future embed moderation.
- Add a new Prometheus counter `DISCORD_AGENT_OUTPUTS_BLOCKED_TOTAL` and accessor `get_discord_agent_outputs_blocked_total` in `src/interfaces/metrics.py`.
- Add an integration test `tests/integration/interfaces/test_discord_bot.py::test_agent_update_blocked_content_not_sent` that simulates an OPA block and verifies the message is not sent and the blocked-output metric increments.

### Testing

- Ran `ruff check src/interfaces/discord_bot.py src/interfaces/metrics.py tests/integration/interfaces/test_discord_bot.py` and it passed.
- Ran `pytest tests/integration/interfaces/test_discord_bot.py -m integration -k test_agent_update_blocked_content_not_sent` and the new integration test passed.
- Ran `pytest tests/unit/interfaces/test_discord_errors.py -m unit` and it passed.
- Note: `pytest` targeting `tests/unit/interfaces/test_discord_policy.py` surfaced failures due to the existing test's OPA mock shape and not due to this change; that test was not modified by this PR and appears unrelated to the integration behavior introduced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698caa9018708326bc4f8ef69ec48c6c)