### PR TITLE
Add unified InteractionService command dispatch across adapters

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -5,9 +5,9 @@ import asyncio
 # Skip self argument annotation warnings in stub classes
 import json
 import logging
-from collections.abc import AsyncGenerator, Awaitable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from opentelemetry import trace
 from pydantic import BaseModel
@@ -946,7 +946,27 @@ async def websocket_events(websocket: WebSocket) -> None:
 async def handle_control_command(
     cmd: dict[str, Any], ctx: SimulationContext = DEFAULT_CONTEXT
 ) -> dict[str, Any]:
-    """Process a control command and update simulation state."""
+    """Process a control command via the interaction service when available."""
+    simulation = ctx.sim_state.get("simulation")
+    service = getattr(simulation, "interaction_service", None)
+    if service is not None:
+        from src.interfaces.interaction_commands import InteractionContext
+
+        result = await service.execute_from_payload(
+            cmd,
+            context=InteractionContext(
+                sender_id="dashboard",
+                source="dashboard",
+                permissions={"admin", "moderator"},
+            ),
+        )
+        return {
+            "status": result.status,
+            "message": result.user_message,
+            "reason_code": result.reason_code,
+            "data": result.data,
+        }
+
     action = cmd.get("command")
     if action == "pause":
         ctx.sim_state["paused"] = True

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -27,6 +27,11 @@ from src.infra import config, event_log
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
 from src.interfaces import metrics
+from src.interfaces.interaction_commands import (
+    BroadcastCommand,
+    DirectMessageCommand,
+    InteractionContext,
+)
 from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
 
@@ -714,44 +719,70 @@ class SimulationDiscordBot:
                     is_broadcast = explicit_broadcast or (
                         recipient is None and _default_human_message_broadcast()
                     )
-                    if is_broadcast:
-                        ip_cost = float(
-                            config.get_config("IP_COST_BROADCAST_MESSAGE")
-                            or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                            or 0.0
-                        )
-                        du_cost = float(
-                            config.get_config("DU_COST_BROADCAST_ACTION")
-                            or config.get_config("DU_COST_PER_ACTION")
-                            or 0.0
-                        )
-                    else:
-                        ip_cost = float(
-                            config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                            or config.get_config("IP_COST_BROADCAST_MESSAGE")
-                            or 0.0
-                        )
-                        du_cost = float(
-                            config.get_config("DU_COST_PER_ACTION")
-                            or config.get_config("DU_COST_BROADCAST_ACTION")
-                            or 0.0
-                        )
-                    ip_bal, du_bal = await ledger.get_balance_async(agent_id)
-                    if ip_bal < ip_cost or du_bal < du_cost:
-                        await send_channel_message(channel, content="Insufficient IP/DU")
-                        return
                     self.last_agent_id = agent_id
                     self.last_channel_id = channel_id
-                    data = {
-                        "author": str(user_id) if user_id is not None else "human",
-                        "content": parsed_content,
-                        "sender_id": str(user_id) if user_id is not None else "human",
-                        "target_agent_id": agent_id,
-                        "broadcast": is_broadcast,
-                    }
-                    if recipient is not None:
-                        data["recipient_id"] = recipient
-                    await self.event_queue.put(SimulationEvent(type="broadcast", data=data))
+                    simulation = self.context.sim_state.get("simulation")
+                    service = getattr(simulation, "interaction_service", None)
+                    if service is None:
+                        if is_broadcast:
+                            ip_cost = float(
+                                config.get_config("IP_COST_BROADCAST_MESSAGE")
+                                or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                                or 0.0
+                            )
+                            du_cost = float(
+                                config.get_config("DU_COST_BROADCAST_ACTION")
+                                or config.get_config("DU_COST_PER_ACTION")
+                                or 0.0
+                            )
+                        else:
+                            ip_cost = float(
+                                config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                                or config.get_config("IP_COST_BROADCAST_MESSAGE")
+                                or 0.0
+                            )
+                            du_cost = float(
+                                config.get_config("DU_COST_PER_ACTION")
+                                or config.get_config("DU_COST_BROADCAST_ACTION")
+                                or 0.0
+                            )
+                        ip_bal, du_bal = await ledger.get_balance_async(agent_id)
+                        if ip_bal < ip_cost or du_bal < du_cost:
+                            await send_channel_message(channel, content="Insufficient IP/DU")
+                            return
+                        data = {
+                            "author": str(user_id) if user_id is not None else "human",
+                            "content": parsed_content,
+                            "sender_id": str(user_id) if user_id is not None else "human",
+                            "target_agent_id": agent_id,
+                            "broadcast": is_broadcast,
+                        }
+                        if recipient is not None:
+                            data["recipient_id"] = recipient
+                        await self.event_queue.put(SimulationEvent(type="broadcast", data=data))
+                        return
+                    if is_broadcast:
+                        command = BroadcastCommand(
+                            content=parsed_content,
+                            target_agent_id=agent_id,
+                            recipient_id=recipient,
+                        )
+                    else:
+                        command = DirectMessageCommand(
+                            content=parsed_content,
+                            target_agent_id=agent_id,
+                            recipient_id=recipient,
+                        )
+                    result = await service.execute(
+                        command,
+                        context=InteractionContext(
+                            sender_id=str(user_id) if user_id is not None else "human",
+                            channel_id=str(channel_id) if channel_id is not None else None,
+                            source="discord",
+                        ),
+                    )
+                    if result.status != "ok":
+                        await send_channel_message(channel, content=result.user_message)
 
     async def _select_client(self: Self, agent_id: str | None) -> Any:
         """Return the Discord client for the given agent."""

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -1,0 +1,469 @@
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from src.agents.core.agent_state import AgentActionIntent
+from src.infra import config
+from src.infra import ledger as infra_ledger
+from src.infra.event_log import log_event
+from src.interfaces.dashboard_backend import SimulationEvent, emit_event
+from src.sim.knowledge_board import BoardEntry
+
+if TYPE_CHECKING:
+    from src.sim.simulation import Simulation
+
+logger = logging.getLogger(__name__)
+
+
+class InteractionResult(BaseModel):
+    status: Literal["ok", "rejected", "error"]
+    user_message: str
+    reason_code: str
+    data: dict[str, Any] | None = None
+
+
+class InteractionContext(BaseModel):
+    sender_id: str = "human"
+    channel_id: str | None = None
+    source: str = "unknown"
+    permissions: set[str] = Field(default_factory=set)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class BroadcastCommand(BaseModel):
+    command_type: Literal["broadcast"] = "broadcast"
+    content: str
+    budget_agent_id: str | None = None
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+
+
+class DirectMessageCommand(BaseModel):
+    command_type: Literal["direct_message"] = "direct_message"
+    content: str
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+    budget_agent_id: str | None = None
+
+
+class SpawnAgentCommand(BaseModel):
+    command_type: Literal["spawn"] = "spawn"
+    agent_id: str
+    role: str | dict[str, Any] | None = None
+    persona: str | None = None
+    backstory: str | None = None
+    traits: dict[str, float] | None = None
+
+
+class ModerationCommand(BaseModel):
+    command_type: Literal["moderation"] = "moderation"
+    action: str
+    value: float | None = None
+    tags: list[str] | None = None
+    prompt: str | None = None
+    text: str | None = None
+    agent_id: str | None = None
+
+
+class KnowledgeBoardCommand(BaseModel):
+    command_type: Literal["knowledge_board"] = "knowledge_board"
+    content: str
+
+
+InteractionCommand = (
+    BroadcastCommand | DirectMessageCommand | SpawnAgentCommand | ModerationCommand | KnowledgeBoardCommand
+)
+
+
+class InteractionService:
+    """Validates, authorizes, and dispatches user interaction commands."""
+
+    def __init__(self, simulation: Simulation) -> None:
+        self.simulation = simulation
+
+    async def execute(
+        self,
+        command: InteractionCommand,
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        ctx = context or InteractionContext()
+
+        if isinstance(command, KnowledgeBoardCommand):
+            return await self._dispatch_knowledge_board(command, context=ctx)
+        if isinstance(command, (BroadcastCommand, DirectMessageCommand)):
+            return await self._dispatch_message(command, context=ctx)
+        if isinstance(command, SpawnAgentCommand):
+            if not self._is_authorized(ctx, required={"admin", "moderator"}):
+                return InteractionResult(
+                    status="rejected",
+                    user_message="You are not authorized to spawn agents.",
+                    reason_code="unauthorized",
+                )
+            await self.simulation.handle_control_command(
+                {
+                    "command": "spawn",
+                    "agent_id": command.agent_id,
+                    "role": command.role,
+                    "persona": command.persona,
+                    "backstory": command.backstory,
+                    "traits": command.traits,
+                }
+            )
+            return InteractionResult(
+                status="ok",
+                user_message=f"Spawn request submitted for {command.agent_id}.",
+                reason_code="spawn_submitted",
+            )
+        if isinstance(command, ModerationCommand):
+            if not self._is_authorized(ctx, required={"admin", "moderator"}):
+                return InteractionResult(
+                    status="rejected",
+                    user_message="You are not authorized to run moderation commands.",
+                    reason_code="unauthorized",
+                )
+            payload: dict[str, Any] = {"command": command.action}
+            if command.value is not None:
+                payload["value"] = command.value
+            if command.tags is not None:
+                payload["tags"] = command.tags
+            if command.prompt is not None:
+                payload["prompt"] = command.prompt
+            if command.text is not None:
+                payload["text"] = command.text
+            if command.agent_id is not None:
+                payload["agent_id"] = command.agent_id
+            state = await self.simulation.handle_control_command(payload)
+            return InteractionResult(
+                status="ok",
+                user_message="Command accepted.",
+                reason_code="moderation_applied",
+                data=state if isinstance(state, dict) else None,
+            )
+        return InteractionResult(
+            status="error",
+            user_message="Unknown command.",
+            reason_code="unsupported_command",
+        )
+
+    def _is_authorized(self, context: InteractionContext, required: set[str]) -> bool:
+        if not required:
+            return True
+        return bool(context.permissions & required)
+
+    async def _dispatch_knowledge_board(
+        self,
+        command: KnowledgeBoardCommand,
+        *,
+        context: InteractionContext,
+    ) -> InteractionResult:
+        content = command.content.strip()
+        if not content:
+            return InteractionResult(
+                status="rejected",
+                user_message="Knowledge Board entry cannot be empty.",
+                reason_code="empty_message",
+            )
+        board = self.simulation.knowledge_board
+        if board is None:
+            return InteractionResult(
+                status="rejected",
+                user_message="Knowledge Board is not available.",
+                reason_code="kb_unavailable",
+            )
+        now = time.monotonic()
+        if now - self.simulation._last_kb_time < self.simulation._kb_cooldown:
+            return InteractionResult(
+                status="rejected",
+                user_message="Knowledge Board is cooling down. Please try again shortly.",
+                reason_code="kb_rate_limited",
+            )
+
+        self.simulation._last_kb_time = now
+        async with board.lock:
+            board.add_entry(
+                BoardEntry(
+                    content_full=content,
+                    entry_type="human_message",
+                    tags=["human", "knowledge_board"],
+                ),
+                context.sender_id,
+                self.simulation.current_step,
+                self.simulation.vector.to_dict(),
+            )
+        return InteractionResult(
+            status="ok",
+            user_message="Posted to Knowledge Board.",
+            reason_code="kb_posted",
+        )
+
+    async def _dispatch_message(
+        self,
+        command: BroadcastCommand | DirectMessageCommand,
+        *,
+        context: InteractionContext,
+    ) -> InteractionResult:
+        text = command.content.strip()
+        if not text:
+            return InteractionResult(
+                status="rejected",
+                user_message="Message cannot be empty.",
+                reason_code="empty_message",
+            )
+
+        now = time.monotonic()
+        channel_id = context.channel_id
+        relay_scope = context.sender_id if channel_id is None else f"{context.sender_id}:{channel_id}"
+        last_relay_time = self.simulation._last_relay_times.get(relay_scope, 0.0)
+        if now - last_relay_time < self.simulation._relay_cooldown:
+            retry_after = max(0.0, self.simulation._relay_cooldown - (now - last_relay_time))
+            await emit_event(
+                SimulationEvent(
+                    type="human_command_rate_limited",
+                    data={
+                        "sender_id": context.sender_id,
+                        "scope": relay_scope,
+                        "retry_after_seconds": retry_after,
+                        "step": self.simulation.current_step,
+                    },
+                )
+            )
+            return InteractionResult(
+                status="rejected",
+                user_message=(
+                    "Rate limited: please wait "
+                    f"{retry_after:.1f}s before sending another message."
+                ),
+                reason_code="rate_limited",
+                data={"retry_after_seconds": retry_after},
+            )
+        self.simulation._last_relay_times[relay_scope] = now
+
+        if not self.simulation.agents:
+            return InteractionResult(
+                status="rejected",
+                user_message="No agents are available to receive messages.",
+                reason_code="no_agents",
+            )
+
+        broadcast = isinstance(command, BroadcastCommand)
+        target = self._resolve_target(command)
+        budget_agent_id = self._resolve_budget_agent_id(command, target.agent_id)
+        budget_agent = next(
+            (agent for agent in self.simulation.agents if agent.agent_id == budget_agent_id),
+            None,
+        )
+        state = budget_agent.state if budget_agent is not None else None
+
+        if broadcast:
+            ip_cost = float(
+                config.get_config("IP_COST_BROADCAST_MESSAGE")
+                or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                or 0.0
+            )
+            du_cost = float(
+                config.get_config("DU_COST_BROADCAST_ACTION")
+                or config.get_config("DU_COST_PER_ACTION")
+                or 0.0
+            )
+        else:
+            ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
+            du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
+
+        try:
+            from src.sim import simulation as simulation_module
+
+            simulation_module.get_resource_manager().ensure_du_budget(budget_agent_id, du_cost)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.info("Rejecting interaction for %s: %s", budget_agent_id, exc)
+            return InteractionResult(
+                status="rejected",
+                user_message=str(exc),
+                reason_code="du_budget_exceeded",
+            )
+
+        if state is not None and (state.ip < ip_cost or state.du < du_cost):
+            return InteractionResult(
+                status="rejected",
+                user_message="Insufficient IP/DU",
+                reason_code="insufficient_resources",
+            )
+
+        if state is not None:
+            state.ip -= ip_cost
+            state.du -= du_cost
+
+        try:
+            await infra_ledger.ledger.spend(
+                budget_agent_id,
+                ip=ip_cost,
+                du=du_cost,
+                reason="human_broadcast" if broadcast else "human_dm",
+            )
+        except Exception:  # pragma: no cover - optional
+            logger.debug("Ledger spend failed", exc_info=True)
+
+        msgs: list[dict[str, Any]] = []
+        if broadcast:
+            for agent in self.simulation.agents:
+                msgs.append(
+                    {
+                        "step": self.simulation.current_step,
+                        "sender_id": context.sender_id,
+                        "recipient_id": agent.agent_id,
+                        "content": text,
+                        "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
+                        "sentiment_score": None,
+                    }
+                )
+        else:
+            msgs.append(
+                {
+                    "step": self.simulation.current_step,
+                    "sender_id": context.sender_id,
+                    "recipient_id": target.agent_id,
+                    "content": text,
+                    "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
+                    "sentiment_score": None,
+                }
+            )
+
+        async with self.simulation._msg_lock:
+            self.simulation.pending_messages_for_next_round.extend(msgs)
+            self.simulation.messages_to_perceive_this_round.extend(msgs)
+
+        log_event(
+            {
+                "type": "human_command",
+                "step": self.simulation.current_step,
+                "tick": self.simulation.current_step + 1,
+                "sender_id": context.sender_id,
+                "target_agent_id": target.agent_id,
+                "budget_agent_id": budget_agent_id,
+                "broadcast": broadcast,
+                "recipient_id": command.recipient_id,
+                "text": text,
+                "ip_cost": ip_cost,
+                "du_cost": du_cost,
+                "messages": [dict(msg) for msg in msgs],
+                "reason_code": "message_dispatched",
+            }
+        )
+
+        if self.simulation.discord_bot and self.simulation.discord_bot.last_channel_id is not None:
+            chan = self.simulation.discord_bot.last_channel_id
+            self.simulation.discord_bot.channel_map[target.agent_id] = chan
+            self.simulation.discord_bot.channel_to_agent[chan] = target.agent_id
+
+        return InteractionResult(
+            status="ok",
+            user_message="Broadcast sent." if broadcast else "Message sent.",
+            reason_code="message_dispatched",
+            data={"target_agent_id": target.agent_id, "budget_agent_id": budget_agent_id},
+        )
+
+    def _resolve_target(self, command: BroadcastCommand | DirectMessageCommand) -> Any:
+        target: Any | None = None
+        if command.target_agent_id:
+            target = next(
+                (agent for agent in self.simulation.agents if agent.agent_id == command.target_agent_id),
+                None,
+            )
+        if target is None and command.recipient_id:
+            target = next(
+                (agent for agent in self.simulation.agents if agent.agent_id == command.recipient_id),
+                None,
+            )
+        if target is None and self.simulation.discord_bot and self.simulation.discord_bot.last_agent_id:
+            last_id = self.simulation.discord_bot.last_agent_id
+            target = next((agent for agent in self.simulation.agents if agent.agent_id == last_id), None)
+        if target is None:
+            target = self.simulation.agents[self.simulation.current_agent_index]
+        return target
+
+    def _resolve_budget_agent_id(
+        self,
+        command: BroadcastCommand | DirectMessageCommand,
+        fallback: str,
+    ) -> str:
+        configured_budget_id = config.get_config("HUMAN_COMMAND_BUDGET_AGENT_ID")
+        if command.budget_agent_id:
+            return command.budget_agent_id
+        if isinstance(configured_budget_id, str) and configured_budget_id:
+            return configured_budget_id
+        return fallback
+
+    async def execute_from_payload(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        cmd_type = str(payload.get("command") or payload.get("command_type") or "").strip()
+        try:
+            if cmd_type == "broadcast":
+                command = BroadcastCommand(
+                    content=str(payload.get("content", "")),
+                    recipient_id=self._optional_str(payload.get("recipient_id")),
+                    target_agent_id=self._optional_str(payload.get("target_agent_id")),
+                    budget_agent_id=self._optional_str(payload.get("budget_agent_id")),
+                )
+            elif cmd_type in {"direct_message", "dm"}:
+                command = DirectMessageCommand(
+                    content=str(payload.get("content", "")),
+                    recipient_id=self._optional_str(payload.get("recipient_id")),
+                    target_agent_id=self._optional_str(payload.get("target_agent_id")),
+                    budget_agent_id=self._optional_str(payload.get("budget_agent_id")),
+                )
+            elif cmd_type in {"kb", "knowledge_board"}:
+                command = KnowledgeBoardCommand(content=str(payload.get("content", "")))
+            elif cmd_type == "spawn":
+                command = SpawnAgentCommand(
+                    agent_id=str(payload.get("agent_id", "")).strip(),
+                    role=payload.get("role"),
+                    persona=self._optional_str(payload.get("persona")),
+                    backstory=self._optional_str(payload.get("backstory")),
+                    traits=payload.get("traits"),
+                )
+            else:
+                command = ModerationCommand(
+                    action=cmd_type or str(payload.get("action", "")).strip(),
+                    value=self._optional_float(payload.get("value")),
+                    tags=self._optional_tags(payload.get("tags")),
+                    prompt=self._optional_str(payload.get("prompt")),
+                    text=self._optional_str(payload.get("text")),
+                    agent_id=self._optional_str(payload.get("agent_id")),
+                )
+        except Exception as exc:
+            return InteractionResult(
+                status="rejected",
+                user_message=f"Invalid command payload: {exc}",
+                reason_code="invalid_payload",
+            )
+        return await self.execute(command, context=context)
+
+    @staticmethod
+    def _optional_str(value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _optional_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        return float(value)
+
+    @staticmethod
+    def _optional_tags(value: Any) -> list[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return [str(tag) for tag in value]
+        return [str(value)]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -39,6 +39,13 @@ from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
 )
+from src.interfaces.interaction_commands import (
+    BroadcastCommand,
+    DirectMessageCommand,
+    InteractionContext,
+    InteractionService,
+    KnowledgeBoardCommand,
+)
 from src.interfaces.metrics import ACTIVE_AGENT_COUNT
 from src.shared.telemetry import trace_agent_action
 from src.shared.typing import SimulationMessage
@@ -318,6 +325,7 @@ class Simulation:
         self._event_task = None
         self._event_loop = None
         self._event_loop_thread = None
+        self.interaction_service = InteractionService(self)
 
         # Automatically start listening for external events when an event loop
         # is already running. This allows tests to enqueue events before calling
@@ -365,223 +373,62 @@ class Simulation:
         self: Self, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
         """Handle a human-issued command or prompt."""
-        text = text or ""
-        now = time.monotonic()
-        routing = metadata or {}
-        if text.startswith("/kb ") and self.knowledge_board:
-            if now - self._last_kb_time < self._kb_cooldown:
-                return
-            self._last_kb_time = now
-            entry = text[4:].strip()
-            if entry:
-                async with self.knowledge_board.lock:
-                    self.knowledge_board.add_entry(
-                        BoardEntry(
-                            content_full=entry,
-                            entry_type="human_message",
-                            tags=["human", "knowledge_board"],
-                        ),
-                        "human",
-                        self.current_step,
-                        self.vector.to_dict(),
-                    )
-            return
-
-        if not text.strip():
-            if self.discord_bot:
-                await self.discord_bot.send_simulation_update(
-                    "Message cannot be empty.",
-                    agent_id=str(routing.get("sender_id", "human")),
-                    target_channel_id=self.discord_bot.last_channel_id,
-                )
-            return
-
-        sender_id = str(routing.get("sender_id", "human"))
+        payload = metadata or {}
+        sender_id = str(payload.get("sender_id", "human"))
         raw_channel_id = (
-            routing.get("channel_id")
-            or routing.get("source_channel_id")
-            or routing.get("target_channel_id")
+            payload.get("channel_id")
+            or payload.get("source_channel_id")
+            or payload.get("target_channel_id")
         )
         channel_id = str(raw_channel_id) if raw_channel_id is not None else None
-        relay_scope_key = sender_id if channel_id is None else f"{sender_id}:{channel_id}"
-
-        last_relay_time = self._last_relay_times.get(relay_scope_key, 0.0)
-        if now - last_relay_time < self._relay_cooldown:
-            retry_after = max(0.0, self._relay_cooldown - (now - last_relay_time))
-            await emit_event(
-                SimulationEvent(
-                    type="human_command_rate_limited",
-                    data={
-                        "sender_id": sender_id,
-                        "scope": relay_scope_key,
-                        "retry_after_seconds": retry_after,
-                        "step": self.current_step,
-                    },
-                )
-            )
-            if self.discord_bot:
-                await self.discord_bot.send_simulation_update(
-                    (
-                        "Rate limited: please wait "
-                        f"{retry_after:.1f}s before sending another message."
-                    ),
-                    agent_id=sender_id,
-                    target_channel_id=(
-                        int(channel_id)
-                        if channel_id is not None and channel_id.isdigit()
-                        else self.discord_bot.last_channel_id
-                    ),
-                )
-            return
-        self._last_relay_times[relay_scope_key] = now
-
-        if not self.agents:
-            return
-
-        raw_recipient = routing.get("recipient_id")
-        recipient_id = str(raw_recipient) if isinstance(raw_recipient, str) else None
-        broadcast = bool(routing.get("broadcast", False))
-        if text.startswith("/broadcast "):
-            broadcast = True
-            text = text[len("/broadcast ") :].strip()
-            if not text:
-                if self.discord_bot:
-                    await self.discord_bot.send_simulation_update(
-                        "Broadcast message cannot be empty.",
-                        agent_id=sender_id,
-                        target_channel_id=self.discord_bot.last_channel_id,
-                    )
-                return
-
-        raw_target = routing.get("target_agent_id")
-        target_agent_id = str(raw_target) if isinstance(raw_target, str) else None
-        raw_budget = routing.get("budget_agent_id")
-        target = next((a for a in self.agents if a.agent_id == target_agent_id), None)
-        if target is None and recipient_id:
-            target = next((a for a in self.agents if a.agent_id == recipient_id), None)
-        if target is None and self.discord_bot and self.discord_bot.last_agent_id:
-            last_id = self.discord_bot.last_agent_id
-            target = next((a for a in self.agents if a.agent_id == last_id), None)
-        if target is None:
-            target = self.agents[self.current_agent_index]
-        configured_budget_id = config.get_config("HUMAN_COMMAND_BUDGET_AGENT_ID")
-        if isinstance(raw_budget, str) and raw_budget:
-            budget_agent_id = raw_budget
-        elif isinstance(configured_budget_id, str) and configured_budget_id:
-            budget_agent_id = configured_budget_id
-        else:
-            budget_agent_id = target.agent_id
-        budget_agent = next((a for a in self.agents if a.agent_id == budget_agent_id), None)
-        state = budget_agent.state if budget_agent is not None else None
-        if broadcast:
-            ip_cost = float(
-                config.get_config("IP_COST_BROADCAST_MESSAGE")
-                or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                or 0.0
-            )
-            du_cost = float(
-                config.get_config("DU_COST_BROADCAST_ACTION")
-                or config.get_config("DU_COST_PER_ACTION")
-                or 0.0
-            )
-        else:
-            ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
-            du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
-
-        try:
-            get_resource_manager().ensure_du_budget(budget_agent_id, du_cost)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.info(
-                "Rejecting human %s for %s: %s",
-                "broadcast" if broadcast else "command",
-                budget_agent_id,
-                exc,
-            )
-            if self.discord_bot:
-                await self.discord_bot.send_simulation_update(
-                    str(exc),
-                    agent_id=budget_agent_id,
-                    target_channel_id=self.discord_bot.last_channel_id,
-                )
-            return
-
-        if state is not None and (state.ip < ip_cost or state.du < du_cost):
-            logger.info(
-                "Rejecting human %s for %s: insufficient resources",
-                "broadcast" if broadcast else "command",
-                budget_agent_id,
-            )
-            if self.discord_bot:
-                await self.discord_bot.send_simulation_update(
-                    "Insufficient IP/DU",
-                    agent_id=budget_agent_id,
-                    target_channel_id=self.discord_bot.last_channel_id,
-                )
-            return
-
-        if state is not None:
-            state.ip -= ip_cost
-            state.du -= du_cost
-        try:
-            await ledger.spend(
-                budget_agent_id,
-                ip=ip_cost,
-                du=du_cost,
-                reason="human_broadcast" if broadcast else "human_dm",
-            )
-        except Exception:  # pragma: no cover - optional
-            logger.debug("Ledger spend failed", exc_info=True)
-
-        msgs = []
-        if broadcast:
-            for ag in self.agents:
-                msgs.append(
-                    {
-                        "step": self.current_step,
-                        "sender_id": sender_id,
-                        "recipient_id": ag.agent_id,
-                        "content": text,
-                        "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
-                        "sentiment_score": None,
-                    }
-                )
-        else:
-            msgs.append(
-                {
-                    "step": self.current_step,
-                    "sender_id": sender_id,
-                    "recipient_id": target.agent_id,
-                    "content": text,
-                    "action_intent": AgentActionIntent.SEND_DIRECT_MESSAGE.value,
-                    "sentiment_score": None,
-                }
-            )
-        async with self._msg_lock:
-            self.pending_messages_for_next_round.extend(msgs)
-            self.messages_to_perceive_this_round.extend(msgs)
-
-        log_event(
-            {
-                "type": "human_command",
-                "step": self.current_step,
-                "tick": self.current_step + 1,
-                "sender_id": sender_id,
-                "target_agent_id": target.agent_id,
-                "budget_agent_id": budget_agent_id,
-                "broadcast": broadcast,
-                "recipient_id": recipient_id,
-                "text": text,
-                "ip_cost": ip_cost,
-                "du_cost": du_cost,
-                "messages": [dict(msg) for msg in msgs],
-            }
+        permissions = payload.get("permissions")
+        permission_set = set(permissions) if isinstance(permissions, list | set | tuple) else set()
+        context = InteractionContext(
+            sender_id=sender_id,
+            channel_id=channel_id,
+            source=str(payload.get("source", "simulation")),
+            permissions=permission_set,
+            metadata={k: v for k, v in payload.items() if k not in {"permissions"}},
         )
 
-        if self.discord_bot and self.discord_bot.last_channel_id is not None:
-            chan = self.discord_bot.last_channel_id
-            aid = target.agent_id
-            self.discord_bot.channel_map[aid] = chan
-            self.discord_bot.channel_to_agent[chan] = aid
+        cleaned_text = (text or "").strip()
+        if cleaned_text.startswith("/kb "):
+            command = KnowledgeBoardCommand(content=cleaned_text[4:])
+        else:
+            is_broadcast = bool(payload.get("broadcast", False))
+            command_text = cleaned_text
+            if cleaned_text == "/broadcast":
+                is_broadcast = True
+                command_text = ""
+            elif cleaned_text.startswith("/broadcast "):
+                is_broadcast = True
+                command_text = cleaned_text[len("/broadcast ") :]
+            command_cls = BroadcastCommand if is_broadcast else DirectMessageCommand
+            command = command_cls(
+                content=command_text,
+                recipient_id=str(payload.get("recipient_id"))
+                if isinstance(payload.get("recipient_id"), str)
+                else None,
+                target_agent_id=str(payload.get("target_agent_id"))
+                if isinstance(payload.get("target_agent_id"), str)
+                else None,
+                budget_agent_id=str(payload.get("budget_agent_id"))
+                if isinstance(payload.get("budget_agent_id"), str)
+                else None,
+            )
+
+        result = await self.interaction_service.execute(command, context=context)
+        if result.status != "ok" and self.discord_bot:
+            target_channel_id = (
+                int(channel_id)
+                if channel_id is not None and channel_id.isdigit()
+                else self.discord_bot.last_channel_id
+            )
+            await self.discord_bot.send_simulation_update(
+                result.user_message,
+                agent_id=sender_id,
+                target_channel_id=target_channel_id,
+            )
 
     async def handle_control_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process a control command sent via the event queue."""


### PR DESCRIPTION
### Motivation
- Centralize human interaction handling (routing, budget checks, KB posting, authorization, and dispatch) into a single service to remove simulation mutation logic from transport adapters and make feedback consistent.
- Provide typed command models and a standardized result envelope so adapters (Discord, dashboard) can remain thin and only translate transport payloads into commands.

### Description
- Added `src/interfaces/interaction_commands.py` providing typed command models (`BroadcastCommand`, `DirectMessageCommand`, `SpawnAgentCommand`, `ModerationCommand`, `KnowledgeBoardCommand`), `InteractionContext`, `InteractionResult` envelope, and an `InteractionService` that validates, authorizes, and dispatches commands (including rate-limiting, DU/IP budget enforcement, knowledge-board posting, logging, and enqueueing of simulation messages).
- Refactored `Simulation` to instantiate `InteractionService` and updated `_handle_human_command` to parse transport-level text/metadata into typed commands and delegate execution to `InteractionService` (removing routing/budget/KB mutation logic from the adapter path).
- Refactored `src/interfaces/discord_bot.py` to translate Discord messages into `BroadcastCommand`/`DirectMessageCommand` and call `InteractionService.execute`; retained original event-queue fallback behavior when no active simulation/service is present.
- Refactored dashboard backend control handling in `src/interfaces/dashboard_backend.py` to call `InteractionService.execute_from_payload` when a simulation is available and return the standardized result envelope (`status`, `message`, `reason_code`, `data`).

### Testing
- Ran `ruff` on modified modules: `ruff check src/interfaces/interaction_commands.py src/sim/simulation.py src/interfaces/discord_bot.py src/interfaces/dashboard_backend.py` and fixed issues reported by the linter for these files (passed).
- Ran unit and integration tests relevant to message handling and human commands: `pytest tests/unit/sim/test_human_command.py tests/unit/sim/test_human_command_costs.py tests/unit/interfaces/test_discord_human_messages.py tests/unit/interfaces/test_discord_commands.py tests/integration/interfaces/test_discord_forwarding.py` and observed all selected tests passed (some broader repo lint issues remain outside this change set).
- Executed `pytest tests/integration/interfaces/test_dashboard_backend_api.py -k control -q` (no tests matched the `-k control` filter in that invocation). All other targeted test runs completed successfully; a full repo `ruff check .` surfaced pre-existing lint warnings unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698caf97cf6883268c61fcfa31de27ab)