### PR TITLE
Decouple world time from per-turn progression (tick-indexed world clock)

### DIFF
--- a/docs/replay_snapshot_world_time_migration.md
+++ b/docs/replay_snapshot_world_time_migration.md
@@ -1,0 +1,34 @@
+# Replay and Snapshot Migration Notes: Tick-Indexed World Time
+
+## What changed
+
+Simulation world time is now advanced on a **world tick boundary** (`world_tick`) instead of advancing once per agent turn. A configurable turn quantum (`WORLD_TICK_TURN_QUANTUM`) determines how many agent turns map to one world tick.
+
+Agent action events now include both:
+
+- `turn_index`: the per-agent-turn progression index (legacy `step` semantics), and
+- `world_time`: a snapshot object (`world_tick`, `world_hour`, `world_day`, `world_season`, `formatted`).
+
+Snapshots now persist:
+
+- `world_tick`, and
+- `turns_per_world_tick`.
+
+## Backward compatibility behavior
+
+Historical traces and snapshots remain readable:
+
+1. **Legacy snapshots without `world_tick`**
+   - Replay derives `world_tick` from `step` using configured or snapshot-derived `turns_per_world_tick`.
+2. **Legacy events without `world_time` object**
+   - Replay falls back to legacy top-level `world_hour/world_day/world_season` fields when present.
+3. **Legacy action payloads without `turn_index`**
+   - `step` continues to be accepted as the turn index.
+
+## Interpreting mixed-era traces
+
+When inspecting old and new events together:
+
+- Use `turn_index` if present, otherwise fall back to `step`.
+- Use `world_time.world_tick` if present for cadence and day-boundary logic.
+- If `world_time` is absent, interpret time using the old top-level world fields and treat cadence assumptions as turn-based for those events.

--- a/src/agents/core/agent_graph_types.py
+++ b/src/agents/core/agent_graph_types.py
@@ -117,6 +117,8 @@ class AgentTurnState(TypedDict):
     simulation_step: int  # The current step number from the simulation
     previous_thought: str | None  # The thought from the *last* turn
     environment_perception: dict[str, object]  # Perception data from the environment
+    world_time: NotRequired[dict[str, object]]
+    turn_index: NotRequired[int]
     perceived_messages: list[SimulationMessage]  # Messages perceived from last step
     memory_history_list: list[dict[str, Any]]  # Field for memory history list
     turn_sentiment_score: float  # Field for aggregated sentiment score.

--- a/src/agents/core/base_agent.py
+++ b/src/agents/core/base_agent.py
@@ -560,6 +560,8 @@ class Agent:
             "simulation_step": simulation_step,
             "previous_thought": self._state.last_thought,
             "environment_perception": environment_perception,
+            "world_time": copy.deepcopy(environment_perception.get("world_time", {})),
+            "turn_index": int(environment_perception.get("turn_index", simulation_step)),
             "perceived_messages": copy.deepcopy(
                 environment_perception.get("perceived_messages", [])
             ),

--- a/src/agents/graphs/basic_agent_graph.py
+++ b/src/agents/graphs/basic_agent_graph.py
@@ -446,10 +446,12 @@ def route_action_intent(state: AgentTurnState) -> str:
 def _maybe_consolidate_memories(state: AgentTurnState) -> dict[str, Any]:
     manager = state.get("memory_service")
     step = int(state.get("simulation_step", 0))
+    world_time = cast(dict[str, Any], state.get("world_time") or {})
+    world_tick = int(world_time.get("world_tick", step))
     interval = int(
         config.get_config_value_with_override("SEMANTIC_MEMORY_CONSOLIDATION_INTERVAL_STEPS", 24)
     )
-    if manager and interval > 0 and step % interval == 0:
+    if manager and interval > 0 and world_tick > 0 and world_tick % interval == 0:
         try:
             cast(MemoryService, manager).consolidate_daily_memories(
                 state["agent_id"],

--- a/src/agents/graphs/basic_agent_types.py
+++ b/src/agents/graphs/basic_agent_types.py
@@ -99,6 +99,8 @@ class AgentTurnState(TypedDict):
     simulation_step: int
     previous_thought: str | None
     environment_perception: dict[str, object]
+    world_time: NotRequired[dict[str, object]]
+    turn_index: NotRequired[int]
     perceived_messages: list[dict[str, object]]
     memory_history_list: list[dict[str, Any]]
     memory_context: NotRequired[list[str]]

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -308,12 +308,16 @@ class InteractionService:
         except Exception:  # pragma: no cover - optional
             logger.debug("Ledger spend failed", exc_info=True)
 
+        world_time = self.simulation._world_time_snapshot()
+        turn_index = self.simulation.current_step
         msgs: list[dict[str, Any]] = []
         if broadcast:
             for agent in self.simulation.agents:
                 msgs.append(
                     {
                         "step": self.simulation.current_step,
+                        "turn_index": turn_index,
+                        "world_time": world_time,
                         "sender_id": context.sender_id,
                         "recipient_id": agent.agent_id,
                         "content": text,
@@ -325,6 +329,8 @@ class InteractionService:
             msgs.append(
                 {
                     "step": self.simulation.current_step,
+                    "turn_index": turn_index,
+                    "world_time": world_time,
                     "sender_id": context.sender_id,
                     "recipient_id": target.agent_id,
                     "content": text,
@@ -341,7 +347,9 @@ class InteractionService:
             {
                 "type": "human_command",
                 "step": self.simulation.current_step,
-                "tick": self.simulation.current_step + 1,
+                "turn_index": turn_index,
+                "world_time": world_time,
+                "tick": world_time.get("world_tick", 0),
                 "sender_id": context.sender_id,
                 "target_agent_id": target.agent_id,
                 "budget_agent_id": budget_agent_id,

--- a/src/shared/typing.py
+++ b/src/shared/typing.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from typing_extensions import NotRequired
+
 # Basic JSON-compatible types used throughout the codebase
 JSONValue = str | int | float | bool | None | dict[str, "JSONValue"] | list["JSONValue"]
 
@@ -69,6 +71,8 @@ class SimulationMessage(TypedDict):
     """Message exchanged between agents in the simulation."""
 
     step: int
+    turn_index: NotRequired[int]
+    world_time: NotRequired[JSONDict]
     sender_id: str
     recipient_id: str | None
     content: str

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -157,10 +157,16 @@ class Simulation:
         self.world_day: int = 0
         self.world_season: int | None = None
         self.world_ticks_per_day: int = max(1, int(config.get_config("WORLD_TICKS_PER_DAY") or 24))
+        self.turns_per_world_tick: int = max(
+            1,
+            int(config.get_config("WORLD_TICK_TURN_QUANTUM") or len(self.agents) or 1),
+        )
+        self.world_tick_index: int = 0
         season_len = int(config.get_config("WORLD_SEASON_LENGTH_DAYS") or 0)
         self.world_season_length_days: int | None = season_len if season_len > 0 else None
         self.world_season = 0 if self.world_season_length_days else None
-        self._last_time_update_step = 0
+        self._last_time_update_tick = -1
+        self._last_consolidation_day = -1
         self.last_completed_agent_index: int | None = None
         self.steps_to_run: int = 0  # Number of steps to run, set externally
         self.total_turns_executed = 0
@@ -265,7 +271,6 @@ class Simulation:
 
         self._last_semantic_job_step = 0
         self._last_memory_prune_step = 0
-        self._last_consolidation_step = 0
         self._last_quest_step = 0
         self._last_trace_hash = ""
 
@@ -774,36 +779,69 @@ class Simulation:
             time_str += f" (Season {self.world_season})"
         return time_str
 
-    async def _advance_world_time(self: Self) -> None:
-        """Advance world clock by one tick and broadcast periodic updates."""
-        self.world_hour += 1
-        if self.world_hour >= self.world_ticks_per_day:
-            self.world_hour = 0
-            self.world_day += 1
-            if self.world_season_length_days and self.world_day > 0:
-                self.world_season = self.world_day // self.world_season_length_days
+    def _world_time_snapshot(self: Self) -> dict[str, Any]:
+        """Return the structured world-time payload used in events and perception."""
+        return {
+            "world_tick": self.world_tick_index,
+            "world_hour": self.world_hour,
+            "world_day": self.world_day,
+            "world_season": self.world_season,
+            "formatted": self._format_world_time(),
+        }
 
-        cadence = max(1, int(config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS") or self.world_ticks_per_day))
+    async def _advance_world_time(self: Self, ticks: int = 1) -> None:
+        """Advance world clock by ``ticks`` and broadcast periodic updates."""
+        ticks_to_advance = max(0, int(ticks))
+        if ticks_to_advance == 0:
+            return
+
+        for _ in range(ticks_to_advance):
+            self.world_tick_index += 1
+            self.world_hour += 1
+            if self.world_hour >= self.world_ticks_per_day:
+                self.world_hour = 0
+                self.world_day += 1
+                if self.world_season_length_days and self.world_day > 0:
+                    self.world_season = self.world_day // self.world_season_length_days
+
+        cadence = max(
+            1,
+            int(
+                config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS")
+                or self.world_ticks_per_day
+            ),
+        )
         if (
-            self.current_step > 0
-            and self.current_step % cadence == 0
-            and self.current_step != self._last_time_update_step
+            self.world_tick_index > 0
+            and self.world_tick_index % cadence == 0
+            and self.world_tick_index != self._last_time_update_tick
         ):
-            self._last_time_update_step = self.current_step
+            self._last_time_update_tick = self.world_tick_index
+            world_time = self._world_time_snapshot()
             payload = {
                 "type": "world_time",
                 "step": self.current_step,
+                "turn_index": self.current_step,
+                "world_time": world_time,
+                "world_tick": self.world_tick_index,
                 "world_hour": self.world_hour,
                 "world_day": self.world_day,
                 "world_season": self.world_season,
-                "world_time": self._format_world_time(),
             }
             event = log_event(payload)
             if event is None:
                 event = {**payload}
                 event["trace_hash"] = compute_trace_hash(payload)
             await emit_event(SimulationEvent(type="world_time", data=event))
-            await self.send_discord_update(message=f"🕒 {payload['world_time']}")
+            await self.send_discord_update(message=f"🕒 {world_time['formatted']}")
+
+    async def _sync_world_time_for_turn(self: Self, turn_index: int) -> None:
+        """Advance world time based on the configured world-tick quantum."""
+        if turn_index <= 0:
+            return
+        target_tick = (turn_index - 1) // self.turns_per_world_tick
+        if target_tick > self.world_tick_index:
+            await self._advance_world_time(target_tick - self.world_tick_index)
 
     async def send_discord_update(
         self: Self,
@@ -833,9 +871,9 @@ class Simulation:
             logger.warning("No agents in simulation to run.")
             return
 
-        # Increment step and select agent
+        # Increment turn index, then sync world time to the configured tick boundary.
         self.current_step += 1
-        await self._advance_world_time()
+        await self._sync_world_time_for_turn(self.current_step)
         agent = self.agents[agent_index]
         agent_id = agent.agent_id
         if agent_id in self.muted_agents:
@@ -893,12 +931,8 @@ class Simulation:
             perception_data["knowledge_board_content"] = (
                 self.knowledge_board.get_recent_entries_for_prompt()
             )
-        perception_data["world_time"] = {
-            "world_hour": self.world_hour,
-            "world_day": self.world_day,
-            "world_season": self.world_season,
-            "formatted": self._format_world_time(),
-        }
+        perception_data["turn_index"] = self.current_step
+        perception_data["world_time"] = self._world_time_snapshot()
         with trace_agent_action("agent_activation", agent_id=agent_id, step=self.current_step):
             agent_output = await agent.run_turn(
                 simulation_step=self.current_step,
@@ -947,6 +981,8 @@ class Simulation:
                 SimulationMessage,
                 {
                     "step": self.current_step,
+                    "turn_index": self.current_step,
+                    "world_time": self._world_time_snapshot(),
                     "sender_id": agent_id,
                     "recipient_id": message_recipient_id,
                     "content": message_content,
@@ -1044,6 +1080,8 @@ class Simulation:
                     "type": "agent_action",
                     "agent_id": agent_id,
                     "step": self.current_step,
+                    "turn_index": self.current_step,
+                    "world_time": self._world_time_snapshot(),
                     "action_intent": action_intent_str,
                     "ip": current_agent_state.ip,
                     "du": current_agent_state.du,
@@ -1083,6 +1121,8 @@ class Simulation:
                 "world_hour": self.world_hour,
                 "world_day": self.world_day,
                 "world_season": self.world_season,
+                "world_tick": self.world_tick_index,
+                "turns_per_world_tick": self.turns_per_world_tick,
                 "trace_hash": self._last_trace_hash,
             }
             snapshot_no_vector = {
@@ -1119,15 +1159,15 @@ class Simulation:
         if (
             self.memory_service.vector_store
             and config.MEMORY_STORE_PRUNE_INTERVAL_STEPS > 0
-            and self.current_step % len(self.agents) == 0
-            and self.current_step > self._last_consolidation_step
+            and self.world_day > self._last_consolidation_day
         ):
-            start_step = self.current_step - len(self.agents) + 1
+            turns_per_world_day = self.turns_per_world_tick * self.world_ticks_per_day
+            start_step = max(1, self.current_step - turns_per_world_day + 1)
             await self.event_kernel.schedule_immediate(
                 lambda start=start_step: self._consolidate_memory_event(start),
                 vector=self.vector,
             )
-        self._last_consolidation_step = self.current_step
+            self._last_consolidation_day = self.world_day
 
         semantic_interval = int(
             config.get_config_value_with_override(
@@ -1327,6 +1367,8 @@ class Simulation:
         recipient = evt.data.get("recipient_id") if evt.type == "direct_message" else None
         msg: SimulationMessage = {
             "step": self.current_step,
+            "turn_index": self.current_step,
+            "world_time": self._world_time_snapshot(),
             "sender_id": sender,
             "recipient_id": recipient,
             "content": content,
@@ -1662,6 +1704,23 @@ class Simulation:
                     f" expected {expected_hash}, computed {actual_hash}"
                 )
         if event.get("type") == "agent_action":
+            world_time = event.get("world_time")
+            if isinstance(world_time, dict):
+                self.world_tick_index = int(world_time.get("world_tick", self.world_tick_index))
+                self.world_hour = int(world_time.get("world_hour", self.world_hour))
+                self.world_day = int(world_time.get("world_day", self.world_day))
+                if world_time.get("world_season") is not None:
+                    self.world_season = int(world_time["world_season"])
+                elif self.world_season_length_days is None:
+                    self.world_season = None
+            else:
+                if "world_hour" in event:
+                    self.world_hour = int(event.get("world_hour", self.world_hour))
+                if "world_day" in event:
+                    self.world_day = int(event.get("world_day", self.world_day))
+                if "world_season" in event:
+                    world_season = event.get("world_season")
+                    self.world_season = int(world_season) if world_season is not None else None
             aid = event.get("agent_id")
             for agent in self.agents:
                 if agent.agent_id == aid:
@@ -1758,6 +1817,8 @@ class Simulation:
                             SimulationMessage,
                             {
                                 "step": msg_step_int,
+                                "turn_index": int(msg.get("turn_index", msg_step_int)),
+                                "world_time": cast(dict[str, Any], msg.get("world_time") or {}),
                                 "sender_id": str(msg.get("sender_id", sender)),
                                 "recipient_id": msg.get("recipient_id"),
                                 "content": str(msg.get("content", "")),
@@ -1784,6 +1845,8 @@ class Simulation:
                         SimulationMessage,
                         {
                             "step": default_step,
+                            "turn_index": int(event.get("turn_index", default_step)),
+                            "world_time": cast(dict[str, Any], event.get("world_time") or {}),
                             "sender_id": sender,
                             "recipient_id": recipient,
                             "content": text,
@@ -1837,6 +1900,13 @@ class Simulation:
         sim.current_step = int(snapshot.get("step", 0))
         sim.world_hour = int(snapshot.get("world_hour", 0))
         sim.world_day = int(snapshot.get("world_day", 0))
+        snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
+        sim.turns_per_world_tick = max(1, snapshot_turn_quantum)
+        legacy_world_tick = int(snapshot.get("world_tick", -1))
+        if legacy_world_tick >= 0:
+            sim.world_tick_index = legacy_world_tick
+        elif sim.current_step > 0:
+            sim.world_tick_index = (sim.current_step - 1) // sim.turns_per_world_tick
         world_season = snapshot.get("world_season", 0 if sim.world_season_length_days else None)
         sim.world_season = int(world_season) if world_season is not None else None
         sim.collective_ip = float(snapshot.get("collective_ip", 0.0))

--- a/tests/unit/sim/test_simulation_world_time.py
+++ b/tests/unit/sim/test_simulation_world_time.py
@@ -128,3 +128,37 @@ async def test_run_turn_includes_world_time_perception(monkeypatch):
     assert world_time["world_day"] == sim.world_day
     assert "formatted" in world_time
     sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_agent_action_event_contains_turn_index_and_world_time(monkeypatch):
+    monkeypatch.setenv("WORLD_TICK_TURN_QUANTUM", "2")
+
+    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "src.sim.simulation.log_event", lambda data: {**data, "trace_hash": "hash"}
+    )
+    emit_event = AsyncMock()
+    monkeypatch.setattr("src.sim.simulation.emit_event", emit_event)
+    rm = SimpleNamespace(
+        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
+
+    agent = DummyAgent()
+    sim = Simulation(
+        [agent], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
+    )
+
+    await sim._run_agent_turn(0)
+
+    agent_action_events = [
+        call.args[0].data for call in emit_event.await_args_list if call.args[0].type == "agent_action"
+    ]
+    assert agent_action_events
+    payload = agent_action_events[-1]
+    assert payload["turn_index"] == sim.current_step
+    assert payload["world_time"]["world_tick"] == sim.world_tick_index
+    assert payload["world_time"]["world_day"] == sim.world_day
+    sim.close()


### PR DESCRIPTION
### Motivation
- Ensure world time advances on a deterministic tick boundary (a configurable turn quantum) rather than on every agent turn to make scheduling, daily consolidation, and broadcasts consistent with a global simulation clock. 
- Preserve replay/snapshot compatibility while introducing richer per-action time metadata so historical traces remain interpretable across schema versions.

### Description
- Introduced a world-tick model in `Simulation` via `turns_per_world_tick` (config `WORLD_TICK_TURN_QUANTUM`) and `world_tick_index`, and replaced per-turn `world_hour` increments with tick-driven advancement using `_sync_world_time_for_turn` and `_advance_world_time` in `src/sim/simulation.py`.
- Emit structured world-time snapshots (`world_time`) and include both `turn_index` and `world_time` in `agent_action` events, internal `SimulationMessage` payloads, and perception passed to agents, and added `Simulation._world_time_snapshot()` helper for consistent payloads.
- Move daily/semantic consolidation and time-broadcast cadence logic to use tick/day semantics derived from `world_tick` (daily consolidation now triggers on `world_day` transitions rather than per-turn modulo), and added `world_tick`/`turns_per_world_tick` to snapshots with replay compatibility handling in `apply_event`/`from_snapshot`.
- Propagated new time fields through interfaces and types: updated `src/shared/typing.py`, `src/agents/core/agent_graph_types.py`, `src/agents/graphs/basic_agent_types.py`, `src/agents/core/base_agent.py`, `src/agents/graphs/basic_agent_graph.py`, and `src/interfaces/interaction_commands.py` to accept and forward `turn_index` and `world_time` metadata, and added migration notes in `docs/replay_snapshot_world_time_migration.md`.

### Testing
- Ran `ruff check` against modified files with `ruff check src/sim/simulation.py src/interfaces/interaction_commands.py src/shared/typing.py src/agents/core/base_agent.py src/agents/core/agent_graph_types.py src/agents/graphs/basic_agent_graph.py src/agents/graphs/basic_agent_types.py tests/unit/sim/test_simulation_world_time.py` and it passed.
- Ran unit tests `pytest -q tests/unit/sim/test_simulation_world_time.py tests/unit/sim/test_human_command.py tests/unit/sim/test_human_command_costs.py` and they passed (`11 passed, 4 warnings`), noting there are pre-existing repo-wide linter findings outside the modified scopes.
- Added `tests/unit/sim/test_simulation_world_time.py` coverage to assert `agent_action` events include `turn_index` and nested `world_time` snapshot and updated tests to validate perception includes `world_time`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb32073b8832693ee56b1c375e36e)