### PR TITLE
Introduce KnowledgeBoard protocol and backend-owned snapshot APIs; add conformance tests

### DIFF
--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -89,7 +89,21 @@ class GraphKnowledgeBoard:
         return [dict(record["e"]) for record in records]
 
     def to_dict(self: Self) -> dict[str, Any]:
+        return self.to_snapshot()
+
+    def to_snapshot(self: Self) -> dict[str, Any]:
+        """Serialize backend state required to restore this board."""
+
         return {"entries": self.get_full_entries()}
+
+    def from_snapshot(self: Self, snapshot: dict[str, Any]) -> None:
+        """Restore board state from a serialized snapshot."""
+
+        entries = snapshot.get("entries", [])
+        if isinstance(entries, list):
+            self.replace_entries([entry for entry in entries if isinstance(entry, dict)])
+        else:
+            self.replace_entries([])
 
     def replace_entries(self: Self, entries: list[dict[str, Any]]) -> None:
         """Replace graph-backed KB entries from a serialized snapshot."""

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -240,7 +240,23 @@ class KnowledgeBoard:
 
     def to_dict(self: Self) -> dict[str, Any]:
         """Serialize the knowledge board to a dictionary."""
+        return self.to_snapshot()
+
+    def to_snapshot(self: Self) -> dict[str, Any]:
+        """Serialize backend state required to restore this board."""
+
         return {"entries": self.get_full_entries(), "vector": self.vector.to_dict()}
+
+    def from_snapshot(self: Self, snapshot: dict[str, Any]) -> None:
+        """Restore board state from a serialized snapshot."""
+
+        entries = snapshot.get("entries", [])
+        if isinstance(entries, list):
+            self.replace_entries([entry for entry in entries if isinstance(entry, dict)])
+        else:
+            self.replace_entries([])
+        if isinstance(snapshot.get("vector"), dict):
+            self.vector.clock.update(snapshot["vector"])
 
     def replace_entries(self: Self, entries: list[dict[str, Any]]) -> None:
         """Replace the board contents with precomputed entries."""

--- a/src/sim/knowledge_board_protocol.py
+++ b/src/sim/knowledge_board_protocol.py
@@ -1,0 +1,68 @@
+"""Protocol definitions for knowledge board backends."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from src.sim.knowledge_board import BoardEntry
+
+
+@runtime_checkable
+class KnowledgeBoardProtocol(Protocol):
+    """Core interface required by simulation knowledge board backends."""
+
+    def add_entry(
+        self,
+        entry: str | BoardEntry,
+        agent_id: str,
+        step: int,
+        vector: dict[str, int] | None = None,
+    ) -> bool: ...
+
+    def replace_entries(self, entries: list[dict[str, Any]]) -> None: ...
+
+    def to_snapshot(self) -> dict[str, Any]: ...
+
+    def from_snapshot(self, snapshot: dict[str, Any]) -> None: ...
+
+    def get_recent_entries_for_prompt(self, max_entries: int = 5) -> list[str]: ...
+
+
+@runtime_checkable
+class KnowledgeBoardVoteProtocol(Protocol):
+    """Optional voting extension supported by graph-backed boards."""
+
+    def record_vote(self, *, voter_agent_id: str, proposal_id: str, approve: bool) -> None: ...
+
+    def get_proposal_support_counts(
+        self, proposal_ids: list[str] | None = None
+    ) -> dict[str, int]: ...
+
+
+@runtime_checkable
+class KnowledgeBoardGraphProtocol(Protocol):
+    """Optional graph query extension supported by graph-backed boards."""
+
+    def get_endorsed_ideas(
+        self,
+        *,
+        min_endorsements: int = 1,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]: ...
+
+    def get_agent_contribution_graph(
+        self, agent_id: str | None = None
+    ) -> list[dict[str, Any]]: ...
+
+
+def supports_voting(board: object) -> bool:
+    """Return ``True`` when the board supports voting extension APIs."""
+
+    return isinstance(board, KnowledgeBoardVoteProtocol)
+
+
+def supports_graph_queries(board: object) -> bool:
+    """Return ``True`` when the board supports graph query extension APIs."""
+
+    return isinstance(board, KnowledgeBoardGraphProtocol)
+

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -52,6 +52,7 @@ from src.shared.typing import SimulationMessage
 from src.sim.event_kernel import EventKernel
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import BoardEntry, KnowledgeBoard
+from src.sim.knowledge_board_protocol import KnowledgeBoardProtocol
 from src.sim.quests import generate_quest
 from src.sim.resource_manager import get_resource_manager
 from src.sim.version_vector import VersionVector
@@ -208,7 +209,7 @@ class Simulation:
             logger.warning("Simulation initialized without a scenario description.")
 
         # --- NEW: Initialize Knowledge Board ---
-        self.knowledge_board: GraphKnowledgeBoard | KnowledgeBoard
+        self.knowledge_board: KnowledgeBoardProtocol
         if config.KNOWLEDGE_BOARD_BACKEND == "graph":
             self.knowledge_board = GraphKnowledgeBoard()
             logger.info("Simulation initialized with Graph Knowledge Board.")
@@ -1073,7 +1074,7 @@ class Simulation:
             start = time.perf_counter()
             try:
                 kb_state = {
-                    k: v for k, v in self.knowledge_board.to_dict().items() if k != "vector"
+                    k: v for k, v in self.knowledge_board.to_snapshot().items() if k != "vector"
                 }
                 wm_state = {k: v for k, v in self.world_map.to_dict().items() if k != "vector"}
                 payload = {
@@ -1105,7 +1106,7 @@ class Simulation:
                 "step": self.current_step,
                 "collective_ip": self.collective_ip,
                 "collective_du": self.collective_du,
-                "knowledge_board": self.knowledge_board.to_dict(),
+                "knowledge_board": self.knowledge_board.to_snapshot(),
                 "world_map": self.world_map.to_dict(),
                 "agents": [
                     {
@@ -1923,20 +1924,8 @@ class Simulation:
                     break
 
         kb = snapshot.get("knowledge_board", {})
-        for entry in kb.get("entries", []):
-            sim.knowledge_board.add_entry(
-                BoardEntry(
-                    content_full=entry.get("content_full", ""),
-                    entry_type=entry.get("entry_type", "note"),
-                    content_summary=entry.get("content_summary"),
-                    tags=entry.get("tags"),
-                    reference_metadata=entry.get("reference_metadata"),
-                ),
-                entry.get("agent_id", "unknown"),
-                int(entry.get("step", 0)),
-            )
-        if isinstance(kb.get("vector"), dict):
-            sim.knowledge_board.vector.clock.update(kb["vector"])
+        if isinstance(kb, dict):
+            sim.knowledge_board.from_snapshot(kb)
 
         wm = snapshot.get("world_map", {})
         if wm:

--- a/tests/unit/sim/test_knowledge_board_conformance.py
+++ b/tests/unit/sim/test_knowledge_board_conformance.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import pytest
+
+from src.sim.graph_knowledge_board import GraphKnowledgeBoard
+from src.sim.knowledge_board import BoardEntry, KnowledgeBoard
+from src.sim.knowledge_board_protocol import (
+    KnowledgeBoardProtocol,
+    supports_graph_queries,
+    supports_voting,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class DummyResult(list):
+    def single(self) -> Any:
+        return self[0]
+
+
+class MockSession:
+    def __init__(self, driver: MockDriver) -> None:
+        self.driver = driver
+
+    def run(self, query: str, **params: Any) -> Iterable[Any]:
+        if "RETURN count(e) AS cnt" in query:
+            return DummyResult([{"cnt": len(self.driver.entries)}])
+        if "ORDER BY e.step DESC" in query:
+            limit = params["limit"]
+            rows = sorted(self.driver.entries, key=lambda entry: entry["step"], reverse=True)[:limit]
+            return DummyResult([{"e": row} for row in rows])
+        if "ORDER BY e.step ASC" in query:
+            rows = sorted(self.driver.entries, key=lambda entry: entry["step"])
+            return DummyResult([{"e": row} for row in rows])
+        if "DETACH DELETE" in query:
+            self.driver.entries.clear()
+            return DummyResult([])
+        if "SET e = $props" in query:
+            self.driver.entries.append(dict(params["props"]))
+            return DummyResult([])
+        return DummyResult([])
+
+    def __enter__(self) -> MockSession:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class MockDriver:
+    def __init__(self) -> None:
+        self.entries: list[dict[str, Any]] = []
+
+    def session(self) -> MockSession:
+        return MockSession(self)
+
+
+def _memory_factory() -> KnowledgeBoardProtocol:
+    return KnowledgeBoard()
+
+
+def _graph_factory() -> KnowledgeBoardProtocol:
+    return GraphKnowledgeBoard(driver=MockDriver())
+
+
+@pytest.mark.parametrize("factory", [_memory_factory, _graph_factory])
+def test_core_operations_match_backend_contract(
+    factory: Callable[[], KnowledgeBoardProtocol],
+) -> None:
+    board = factory()
+
+    board.add_entry("alpha", agent_id="agent-1", step=1)
+    board.add_entry(
+        BoardEntry(content_full="beta", entry_type="idea", content_summary="summary-beta"),
+        agent_id="agent-2",
+        step=2,
+    )
+
+    assert board.get_recent_entries_for_prompt(2) == [
+        "[Step 1, agent-1]: alpha",
+        "[Step 2, agent-2]: summary-beta",
+    ]
+
+    snapshot = board.to_snapshot()
+    board.replace_entries(snapshot["entries"][:1])
+    assert board.get_recent_entries_for_prompt(5) == ["[Step 1, agent-1]: alpha"]
+
+    board.from_snapshot(snapshot)
+    assert board.get_recent_entries_for_prompt(5) == [
+        "[Step 1, agent-1]: alpha",
+        "[Step 2, agent-2]: summary-beta",
+    ]
+
+
+@pytest.mark.parametrize("factory", [_memory_factory, _graph_factory])
+def test_snapshot_replay_invariants(
+    factory: Callable[[], KnowledgeBoardProtocol],
+) -> None:
+    source = factory()
+    source.add_entry(
+        BoardEntry(
+            content_full="proposal text",
+            entry_type="proposal",
+            tags=["governance", "proposal"],
+            reference_metadata={"proposal_id": "p-1"},
+        ),
+        agent_id="agent-3",
+        step=5,
+    )
+    source.add_entry("follow up", agent_id="agent-4", step=6)
+
+    restored = factory()
+    restored.from_snapshot(source.to_snapshot())
+
+    assert restored.get_recent_entries_for_prompt(5) == source.get_recent_entries_for_prompt(5)
+
+    restored_snapshot = restored.to_snapshot()
+    source_snapshot = source.to_snapshot()
+    assert restored_snapshot["entries"] == source_snapshot["entries"]
+
+
+@pytest.mark.parametrize(
+    ("factory", "expects_extensions"),
+    [(_memory_factory, False), (_graph_factory, True)],
+)
+def test_optional_feature_checks(
+    factory: Callable[[], KnowledgeBoardProtocol],
+    expects_extensions: bool,
+) -> None:
+    board = factory()
+
+    assert supports_voting(board) is expects_extensions
+    assert supports_graph_queries(board) is expects_extensions


### PR DESCRIPTION
### Motivation
- Define a stable protocol/interface so both in-memory and graph-backed knowledge boards implement the same core API for add/replace/snapshot/replay operations.
- Move snapshot serialization/deserialization out of `Simulation` to backend-owned methods so `Simulation` no longer mutates backend-private fields like `vector`.
- Add automated conformance tests to ensure both `KnowledgeBoard` and `GraphKnowledgeBoard` behave identically for core operations and replay invariants.

### Description
- Add `src/sim/knowledge_board_protocol.py` declaring `KnowledgeBoardProtocol` and optional vote/graph extension protocols plus `supports_voting`/`supports_graph_queries` helpers.
- Implement `to_snapshot` and `from_snapshot` on `KnowledgeBoard` and `GraphKnowledgeBoard`, and make existing `to_dict` delegate to `to_snapshot` for compatibility.
- Update `Simulation` to type `self.knowledge_board` as `KnowledgeBoardProtocol`, use `knowledge_board.to_snapshot()` when emitting/saving snapshots, and call `knowledge_board.from_snapshot(...)` to restore board state.
- Add `tests/unit/sim/test_knowledge_board_conformance.py` which parametrizes the same conformance and replay-invariant tests against both memory and graph backends and asserts optional feature checks.

### Testing
- Ran linter checks with `ruff` on the modified modules and related tests, and the lint run completed successfully.
- Executed targeted unit tests with `pytest -q` for `tests/unit/sim/test_knowledge_board.py`, `tests/unit/sim/test_graph_knowledge_board.py`, `tests/unit/sim/test_knowledge_board_conformance.py` and `tests/unit/infra/test_checkpoint.py`, and all selected tests passed.
- The change preserves existing knowledge-board behavior and snapshot/replay invariants as validated by the new conformance suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb87ac0cc8326881c9fdcee90503d)