### PR TITLE
Add executable governance rules engine, enforcement in Simulation, and /gov read model

### DIFF
--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -2,6 +2,7 @@
 
 from .law_board import law_board
 from .policy import evaluate_policy, load_policy
+from .rules_engine import governance_rules_engine
 from .service import GovernanceService, governance
 from .voting import propose_law
 
@@ -9,6 +10,7 @@ __all__ = [
     "GovernanceService",
     "evaluate_policy",
     "governance",
+    "governance_rules_engine",
     "law_board",
     "load_policy",
     "propose_law",

--- a/src/governance/rules_engine.py
+++ b/src/governance/rules_engine.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from hashlib import sha1
+from typing import Any
+
+
+@dataclass(slots=True)
+class RulePenalty:
+    """Penalty to apply when a rule violation is overridden instead of denied."""
+
+    ip: float = 0.0
+    du: float = 0.0
+    reason: str = "rule_violation"
+
+
+@dataclass(slots=True)
+class GovernanceRule:
+    """Executable rule materialized from an accepted governance proposal."""
+
+    rule_id: str
+    source_text: str
+    action_intent: str
+    effective_date: str
+    decision_mode: str = "deny"
+    penalty: RulePenalty = field(default_factory=RulePenalty)
+    provenance: dict[str, Any] = field(default_factory=dict)
+    enforcement_stats: dict[str, int] = field(
+        default_factory=lambda: {
+            "checked": 0,
+            "accepted": 0,
+            "rejected": 0,
+            "overridden": 0,
+            "penalties_applied": 0,
+        }
+    )
+
+
+@dataclass(slots=True)
+class RuleEvaluationResult:
+    """Result of evaluating an action against active governance rules."""
+
+    allowed: bool
+    decision: str
+    violated_rules: list[str]
+    reason: str | None = None
+    penalties: list[dict[str, Any]] = field(default_factory=list)
+
+
+class RulesEngine:
+    """Materializes accepted proposals into executable action constraints."""
+
+    _BAN_PATTERN = re.compile(
+        r"(?:^|\b)(?:no|ban|forbid)\s+(?P<action>[a-z_\-\s]+)",
+        flags=re.IGNORECASE,
+    )
+    _PENALIZE_PATTERN = re.compile(
+        r"(?:^|\b)(?:penalize|penalty)\s+(?P<action>[a-z_\-\s]+)\s+(?:by|with)\s+"
+        r"(?P<amount>[0-9]+(?:\.[0-9]+)?)\s*(?P<unit>ip|du)",
+        flags=re.IGNORECASE,
+    )
+
+    def __init__(self) -> None:
+        self._active_rules: dict[str, GovernanceRule] = {}
+
+    @staticmethod
+    def _normalize_action(action: str) -> str:
+        return action.strip().lower().replace(" ", "_").replace("-", "_")
+
+    @staticmethod
+    def _rule_id(text: str, effective_date: str) -> str:
+        digest = sha1(f"{text}:{effective_date}".encode()).hexdigest()[:12]
+        return f"rule_{digest}"
+
+    def materialize_from_proposal(
+        self,
+        proposal_text: str,
+        *,
+        proposer_id: str,
+        approved: bool,
+        proposal_record: dict[str, Any] | None = None,
+        effective_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Build and register executable rules from a governance proposal."""
+        decided_at = effective_date or datetime.now(timezone.utc).isoformat()
+        provenance: dict[str, Any] = {
+            "proposer_id": proposer_id,
+            "proposal_text": proposal_text,
+            "approved": bool(approved),
+            "decided_at": decided_at,
+        }
+        if isinstance(proposal_record, dict):
+            provenance.update(proposal_record)
+
+        if not approved:
+            return {
+                "decision": "rejected",
+                "rule_ids": [],
+                "effective_date": decided_at,
+                "provenance": provenance,
+                "reason": "proposal_rejected_by_vote",
+            }
+
+        materialized: list[GovernanceRule] = []
+        text = proposal_text.strip()
+
+        penalize_match = self._PENALIZE_PATTERN.search(text)
+        if penalize_match:
+            action = self._normalize_action(penalize_match.group("action"))
+            amount = float(penalize_match.group("amount"))
+            unit = penalize_match.group("unit").lower()
+            penalty = RulePenalty(ip=amount if unit == "ip" else 0.0, du=amount if unit == "du" else 0.0)
+            rule = GovernanceRule(
+                rule_id=self._rule_id(text, decided_at),
+                source_text=text,
+                action_intent=action,
+                effective_date=decided_at,
+                decision_mode="penalize",
+                penalty=penalty,
+                provenance=provenance,
+            )
+            materialized.append(rule)
+
+        ban_match = self._BAN_PATTERN.search(text)
+        if ban_match:
+            action = self._normalize_action(ban_match.group("action"))
+            action = action.split("_", 1)[0] if "_" in action else action
+            rule = GovernanceRule(
+                rule_id=self._rule_id(f"deny:{text}", decided_at),
+                source_text=text,
+                action_intent=action,
+                effective_date=decided_at,
+                decision_mode="deny",
+                provenance=provenance,
+            )
+            materialized.append(rule)
+
+        if not materialized:
+            return {
+                "decision": "accepted",
+                "rule_ids": [],
+                "effective_date": decided_at,
+                "provenance": provenance,
+                "reason": "no_executable_constraint_materialized",
+            }
+
+        for rule in materialized:
+            self._active_rules[rule.rule_id] = rule
+
+        return {
+            "decision": "accepted",
+            "rule_ids": [rule.rule_id for rule in materialized],
+            "effective_date": decided_at,
+            "provenance": provenance,
+        }
+
+    def evaluate_action(self, action_intent: str) -> RuleEvaluationResult:
+        """Evaluate ``action_intent`` against active executable rules."""
+        normalized_action = self._normalize_action(action_intent or "idle")
+        denials: list[str] = []
+        penalties: list[dict[str, Any]] = []
+
+        for rule in self._active_rules.values():
+            rule.enforcement_stats["checked"] += 1
+            if rule.action_intent != normalized_action:
+                continue
+
+            if rule.decision_mode == "deny":
+                rule.enforcement_stats["rejected"] += 1
+                denials.append(rule.rule_id)
+                continue
+
+            if rule.decision_mode == "penalize":
+                rule.enforcement_stats["overridden"] += 1
+                rule.enforcement_stats["penalties_applied"] += 1
+                penalties.append(
+                    {
+                        "rule_id": rule.rule_id,
+                        "ip": rule.penalty.ip,
+                        "du": rule.penalty.du,
+                        "reason": rule.penalty.reason,
+                    }
+                )
+
+        if denials:
+            return RuleEvaluationResult(
+                allowed=False,
+                decision="rejected",
+                violated_rules=denials,
+                reason="blocked_by_governance_rule",
+            )
+
+        if penalties:
+            return RuleEvaluationResult(
+                allowed=True,
+                decision="overridden",
+                violated_rules=[p["rule_id"] for p in penalties],
+                penalties=penalties,
+                reason="action_allowed_with_penalty",
+            )
+
+        for rule in self._active_rules.values():
+            rule.enforcement_stats["accepted"] += 1
+
+        return RuleEvaluationResult(
+            allowed=True,
+            decision="accepted",
+            violated_rules=[],
+        )
+
+    def active_rules_read_model(self) -> list[dict[str, Any]]:
+        """Return active rules and their enforcement statistics."""
+        return [
+            {
+                "rule_id": rule.rule_id,
+                "source_text": rule.source_text,
+                "action_intent": rule.action_intent,
+                "decision_mode": rule.decision_mode,
+                "effective_date": rule.effective_date,
+                "provenance": rule.provenance,
+                "enforcement_stats": dict(rule.enforcement_stats),
+            }
+            for rule in self._active_rules.values()
+        ]
+
+
+governance_rules_engine = RulesEngine()
+
+__all__ = [
+    "GovernanceRule",
+    "RuleEvaluationResult",
+    "RulePenalty",
+    "RulesEngine",
+    "governance_rules_engine",
+]

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -12,6 +12,7 @@ from src.infra.ledger import ledger
 from src.utils.policy import evaluate_with_opa
 
 from .law_board import law_board
+from .rules_engine import governance_rules_engine
 
 
 def quadratic_vote_weight(ip_balance: float, staked_ip: float = 0.0) -> float:
@@ -140,6 +141,13 @@ class GovernanceService:
             "no_weight": no_weight,
             "ip_spent": ip_spent,
         }
+        rule_materialization = governance_rules_engine.materialize_from_proposal(
+            text,
+            proposer_id=proposer.agent_id,
+            approved=approved,
+            proposal_record=outcome,
+        )
+        outcome["rule_materialization"] = rule_materialization
         try:
             ledger.record_law_proposal(
                 proposer.agent_id,

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -13,6 +13,7 @@ from opentelemetry import trace
 from pydantic import BaseModel
 
 from src.governance.law_board import law_board
+from src.governance.rules_engine import governance_rules_engine
 from src.governance.service import governance
 from src.infra import event_log
 from src.infra import metrics as infra_metrics
@@ -226,6 +227,10 @@ class VotesResponse(BaseModel):
 
 class ProposalsResponse(BaseModel):
     proposals: list[ProposalRecord]
+
+
+class GovernanceReadModelResponse(BaseModel):
+    rules: list[dict[str, Any]]
 
 
 class VoteRequest(BaseModel):
@@ -659,6 +664,17 @@ async def api_recent_proposals(limit: int = 5) -> Response:
     """Return the most recent law proposals."""
     proposals = governance.get_proposals(limit)
     return JSONResponse({"proposals": proposals})
+
+
+@app.get("/gov", response_model=GovernanceReadModelResponse)
+@app.get("/api/gov", response_model=GovernanceReadModelResponse)
+async def api_get_gov() -> Response:
+    """Return active governance rules and enforcement stats."""
+    sim = SIM_STATE.get("simulation")
+    if sim is not None and hasattr(sim, "get_governance_read_model"):
+        model = cast(dict[str, Any], sim.get_governance_read_model())
+        return JSONResponse(model)
+    return JSONResponse({"rules": governance_rules_engine.active_rules_read_model()})
 
 
 @app.get("/api/laws", response_model=LawsResponse)
@@ -1132,6 +1148,7 @@ __all__ = [
     "api_agent_stats",
     "api_auctions",
     "api_flagged_messages",
+    "api_get_gov",
     "api_get_laws",
     "api_get_proposals",
     "api_get_votes",

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -1941,6 +1941,44 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
         )
 
 
+async def slash_gov(interaction: Any) -> None:
+    """Show active governance rules and enforcement stats."""
+    with command_span("gov", interaction):
+        sim = _governance_simulation_from_interaction(interaction)
+        rules: list[dict[str, Any]] = []
+        if sim is not None and hasattr(sim, "get_governance_read_model"):
+            try:
+                model = cast(dict[str, Any], sim.get_governance_read_model())
+                rules = cast(list[dict[str, Any]], model.get("rules", []))
+            except Exception:
+                rules = []
+        if not rules:
+            endpoint = f"{_dashboard_api_base_url()}/api/gov"
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(endpoint)
+                    resp.raise_for_status()
+                    payload = cast(dict[str, Any], resp.json())
+                    rules = cast(list[dict[str, Any]], payload.get("rules", []))
+            except Exception:
+                await send_interaction_response(interaction, "No active governance rules.", ephemeral=True)
+                return
+
+        if not rules:
+            await send_interaction_response(interaction, "No active governance rules.", ephemeral=True)
+            return
+
+        lines = []
+        for rule in rules[:8]:
+            stats = cast(dict[str, Any], rule.get("enforcement_stats", {}))
+            lines.append(
+                f"{rule.get('rule_id')}: {rule.get('action_intent')} ({rule.get('decision_mode')}) "
+                f"effective={rule.get('effective_date')} rejected={stats.get('rejected', 0)} "
+                f"overridden={stats.get('overridden', 0)}"
+            )
+        await send_interaction_response(interaction, "\n".join(lines), ephemeral=True)
+
+
 async def slash_misbehavior_log(interaction: Any, limit: int = 20) -> None:
     """Return last ``limit`` misbehavior events."""
     events = await asyncio.to_thread(event_log.fetch_events, event_type="misbehavior")
@@ -2024,6 +2062,7 @@ def register_slash_commands(tree: Any) -> dict[str, Callable[..., Any]]:
     _register("propose", slash_propose)
     _register("propose_law", slash_propose_law)
     _register("vote", slash_vote)
+    _register("gov", slash_gov)
     _register("misbehavior_log", slash_misbehavior_log)
 
     return commands

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -24,6 +24,7 @@ from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaDBException
 from src.governance import evaluate_policy
+from src.governance.rules_engine import governance_rules_engine
 from src.infra import config  # Import to access MAX_PROJECT_MEMBERS
 from src.infra.event_log import log_event
 from src.infra.ledger import ledger
@@ -952,6 +953,7 @@ class Simulation:
         message_content = agent_output.get("message_content")
         message_recipient_id = agent_output.get("message_recipient_id")
         action_intent_str = agent_output.get("action_intent", "idle")
+        requested_action_intent = action_intent_str
         map_action = agent_output.get("map_action")
 
         explain_why_payload = (
@@ -971,11 +973,46 @@ class Simulation:
             explain_why_payload["rag_summary"] = None
 
         allowed = await evaluate_policy(action_intent_str)
-        if not allowed:
+        rule_evaluation = governance_rules_engine.evaluate_action(action_intent_str)
+        if not allowed or not rule_evaluation.allowed:
             action_intent_str = AgentActionIntent.IDLE.value
             message_content = None
             message_recipient_id = None
             map_action = None
+
+        if rule_evaluation.penalties:
+            for penalty in rule_evaluation.penalties:
+                current_agent_state.ip = max(0.0, float(current_agent_state.ip) - float(penalty.get("ip", 0.0)))
+                current_agent_state.du = max(0.0, float(current_agent_state.du) - float(penalty.get("du", 0.0)))
+
+        if self.knowledge_board:
+            governance_decision = "rejected" if not allowed or not rule_evaluation.allowed else rule_evaluation.decision
+            rule_ids = rule_evaluation.violated_rules
+            async with self.knowledge_board.lock:
+                self.knowledge_board.add_entry(
+                    BoardEntry(
+                        content_full=(
+                            f"Governance enforcement {governance_decision} for action "
+                            f"'{requested_action_intent}' by {agent_id}"
+                        ),
+                        entry_type="governance_decision",
+                        tags=["governance", governance_decision],
+                        reference_metadata={
+                            "decision": governance_decision,
+                            "rule_ids": rule_ids,
+                            "provenance": {
+                                "agent_id": agent_id,
+                                "step": self.current_step,
+                                "policy_allowed": allowed,
+                                "rule_reason": rule_evaluation.reason,
+                                "penalties": rule_evaluation.penalties,
+                            },
+                        },
+                    ),
+                    agent_id,
+                    self.current_step,
+                    self.vector.to_dict(),
+                )
 
         if message_content:
             msg_data = cast(
@@ -1084,6 +1121,12 @@ class Simulation:
                     "turn_index": self.current_step,
                     "world_time": self._world_time_snapshot(),
                     "action_intent": action_intent_str,
+                    "governance_enforcement": {
+                        "decision": "rejected" if not allowed or not rule_evaluation.allowed else rule_evaluation.decision,
+                        "reason": rule_evaluation.reason,
+                        "violated_rules": rule_evaluation.violated_rules,
+                        "penalties": rule_evaluation.penalties,
+                    },
                     "ip": current_agent_state.ip,
                     "du": current_agent_state.du,
                     "knowledge_board": kb_state,
@@ -2061,6 +2104,10 @@ class Simulation:
 
         return _get_project_details(self)
 
+    def get_governance_read_model(self: Self) -> dict[str, Any]:
+        """Return active rules with enforcement statistics for governance audits."""
+        return {"rules": governance_rules_engine.active_rules_read_model()}
+
     async def propose_law(
         self: Self, proposer_id: str, text: str, vote_weights: dict[str, int] | None = None
     ) -> bool:
@@ -2087,13 +2134,21 @@ class Simulation:
             vote_weights,
         )
         approved = bool(result.get("approved"))
-        if approved and self.knowledge_board:
+        rule_materialization = result.get("rule_materialization", {})
+        if self.knowledge_board:
+            decision = str(rule_materialization.get("decision", "accepted" if approved else "rejected"))
+            rule_ids = rule_materialization.get("rule_ids", [])
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(
                     BoardEntry(
-                        content_full=f"Law approved: {text}",
+                        content_full=f"Law {'approved' if approved else 'rejected'}: {text}",
                         entry_type="proposal_result",
-                        tags=["governance", "result"],
+                        tags=["governance", "result", decision],
+                        reference_metadata={
+                            "decision": decision,
+                            "rule_ids": rule_ids,
+                            "provenance": rule_materialization.get("provenance", {}),
+                        },
                     ),
                     proposer_id,
                     self.current_step,

--- a/tests/unit/governance/test_rules_engine.py
+++ b/tests/unit/governance/test_rules_engine.py
@@ -1,0 +1,37 @@
+import pytest
+
+from src.governance.rules_engine import RulesEngine
+
+pytestmark = pytest.mark.unit
+
+
+def test_materialize_rejected_proposal() -> None:
+    engine = RulesEngine()
+    result = engine.materialize_from_proposal(
+        "no move",
+        proposer_id="a1",
+        approved=False,
+    )
+    assert result["decision"] == "rejected"
+    assert result["rule_ids"] == []
+
+
+def test_materialize_and_enforce_deny_and_penalty() -> None:
+    engine = RulesEngine()
+    deny = engine.materialize_from_proposal("no move", proposer_id="a1", approved=True)
+    penalize = engine.materialize_from_proposal(
+        "penalize talk by 2 ip", proposer_id="a1", approved=True
+    )
+
+    assert deny["decision"] == "accepted"
+    assert penalize["decision"] == "accepted"
+
+    denied = engine.evaluate_action("move")
+    assert denied.allowed is False
+    assert denied.decision == "rejected"
+    assert denied.violated_rules
+
+    overridden = engine.evaluate_action("talk")
+    assert overridden.allowed is True
+    assert overridden.decision == "overridden"
+    assert overridden.penalties and overridden.penalties[0]["ip"] == 2.0

--- a/tests/unit/interfaces/test_dashboard_backend_gov.py
+++ b/tests/unit/interfaces/test_dashboard_backend_gov.py
@@ -1,0 +1,22 @@
+import json
+
+import pytest
+
+pytest.importorskip("pytest_asyncio")
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_get_gov_without_sim(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(db.SIM_STATE, "simulation", None)
+    monkeypatch.setattr(
+        db.governance_rules_engine,
+        "active_rules_read_model",
+        lambda: [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}],
+    )
+    resp = await db.api_get_gov()
+    assert json.loads(resp.body) == {
+        "rules": [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}]
+    }

--- a/tests/unit/sim/test_simulation_governance_rules.py
+++ b/tests/unit/sim/test_simulation_governance_rules.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+
+from src.agents.core.agent_state import AgentActionIntent
+from src.governance.rules_engine import governance_rules_engine
+from src.sim.simulation import Simulation
+
+
+class DummyState(SimpleNamespace):
+    ip: float = 5.0
+    du: float = 5.0
+    age: int = 0
+    is_alive: bool = True
+    inheritance: float = 0.0
+    short_term_memory: ClassVar[list] = []
+    messages_sent_count: int = 0
+    last_message_step: int = 0
+    relationships: ClassVar[dict] = {}
+    current_role: str = "dummy"
+    steps_in_current_role: int = 0
+
+    def update_collective_metrics(self, ip: float, du: float) -> None:
+        return None
+
+
+class MoveAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager: object | None = None,
+        memory_service: object | None = None,
+        knowledge_board: object | None = None,
+    ) -> dict:
+        return {
+            "action_intent": AgentActionIntent.MOVE.value,
+            "map_action": {"action": "move", "dx": 1, "dy": 0},
+        }
+
+    def update_state(self, new_state: DummyState) -> None:
+        self.state = new_state
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_governance_rule_blocks_side_effects() -> None:
+    governance_rules_engine._active_rules.clear()
+    governance_rules_engine.materialize_from_proposal("no move", proposer_id="a1", approved=True)
+    agent = MoveAgent("a1")
+    sim = Simulation(agents=[agent])
+
+    await sim.run_step(max_turns=1)
+
+    assert sim.world_map.agent_positions.get("a1") == (0, 0)
+    entries = sim.knowledge_board.get_full_entries()
+    decision_entries = [e for e in entries if e.get("entry_type") == "governance_decision"]
+    assert decision_entries
+    metadata = decision_entries[-1].get("reference_metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("decision") == "rejected"


### PR DESCRIPTION
### Motivation
- Provide a mechanism to materialize accepted governance proposals into executable constraints so simulation actions can be enforced or penalized at runtime.
- Ensure governance decisions are auditable by recording decisions, rule IDs, and provenance back to the Knowledge Board.
- Expose a read model and operator UX so active rules and enforcement statistics can be inspected via HTTP and Discord.

### Description
- Added a rules subsystem at `src/governance/rules_engine.py` that parses simple natural-language patterns (deny / penalize), materializes `GovernanceRule` objects with stable `rule_id`, provenance, effective date, and enforcement counters, and exposes `evaluate_action` and `active_rules_read_model` APIs.
- Integrated rule materialization into governance outcomes by attaching `rule_materialization` metadata to proposal results in `src/governance/service.py` after vote tallying.
- Enforced governance at the Simulation action boundary in `src/sim/simulation.py` by evaluating active rules before side effects, blocking disallowed actions, applying penalties for overridden rules (deducting IP/DU), emitting structured `governance_enforcement` in action events, and writing per-action enforcement decisions to the Knowledge Board as `governance_decision` entries.
- Added a governance read model endpoint and surface in `src/interfaces/dashboard_backend.py` (`/gov` and `/api/gov`) that returns active rules and enforcement stats, and a Discord slash command `gov` in `src/interfaces/discord_bot.py` to display active rules.
- Exported the shared engine in `src/governance/__init__.py` and added unit tests under `tests/unit/` for the rules engine, dashboard read-model fallback, and simulation enforcement.

### Testing
- Ran unit tests covering the new features with `python -m pytest tests/unit/governance/test_rules_engine.py tests/unit/interfaces/test_dashboard_backend_gov.py tests/unit/sim/test_simulation_governance_rules.py tests/unit/interfaces/test_dashboard_backend_propose_law.py`, and all selected tests passed (test run reported passing tests).
- Ran `ruff` checks over changed files with `ruff check` and fixed issues introduced during development; linter checks passed.
- Added automated unit tests: `tests/unit/governance/test_rules_engine.py`, `tests/unit/interfaces/test_dashboard_backend_gov.py`, and `tests/unit/sim/test_simulation_governance_rules.py`, which exercise materialization, evaluation, read-model fallback, and simulation-side enforcement and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cba251e54832696a65873e0396567)