### PR TITLE
Introduce typed command bus and shared interaction policy

### DIFF
--- a/src/interfaces/command_bus.py
+++ b/src/interfaces/command_bus.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from src.interfaces.interaction_commands import (
+    BroadcastCommand,
+    DirectMessageCommand,
+    InteractionCommand,
+    InteractionContext,
+    InteractionResult,
+    KnowledgeBoardCommand,
+    ModerationCommand,
+    SpawnAgentCommand,
+)
+
+if TYPE_CHECKING:
+    from src.interfaces.interaction_commands import InteractionService
+
+
+class HumanMessage(BaseModel):
+    command_type: Literal["human_message"] = "human_message"
+    content: str
+    sender_id: str = "human"
+    source: str = "unknown"
+    channel_id: str | None = None
+    permissions: set[str] = Field(default_factory=set)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    broadcast: bool = False
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+    budget_agent_id: str | None = None
+
+
+class BroadcastRequest(BaseModel):
+    command_type: Literal["broadcast"] = "broadcast"
+    content: str
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+    budget_agent_id: str | None = None
+
+
+class DirectMessageRequest(BaseModel):
+    command_type: Literal["direct_message"] = "direct_message"
+    content: str
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+    budget_agent_id: str | None = None
+
+
+class SpawnAgentRequest(BaseModel):
+    command_type: Literal["spawn"] = "spawn"
+    agent_id: str
+    role: str | dict[str, Any] | None = None
+    persona: str | None = None
+    backstory: str | None = None
+    traits: dict[str, float] | None = None
+
+
+class InjectEventRequest(BaseModel):
+    command_type: Literal["inject_event"] = "inject_event"
+    text: str
+    author: str = "human"
+    scope: str = "global"
+
+
+class ModerationAction(BaseModel):
+    command_type: Literal["moderation"] = "moderation"
+    action: str
+    value: float | None = None
+    tags: list[str] | None = None
+    prompt: str | None = None
+    text: str | None = None
+    agent_id: str | None = None
+
+
+class ControlRequest(BaseModel):
+    command_type: Literal["control"] = "control"
+    action: Literal["pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"]
+    value: float | None = None
+    agent_id: str | None = None
+
+
+BusCommand = (
+    HumanMessage
+    | BroadcastRequest
+    | DirectMessageRequest
+    | SpawnAgentRequest
+    | InjectEventRequest
+    | ModerationAction
+    | ControlRequest
+)
+
+
+class CommandBus:
+    def __init__(self, interaction_service: InteractionService) -> None:
+        self.interaction_service = interaction_service
+
+    async def dispatch(
+        self,
+        command: BusCommand,
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        if isinstance(command, HumanMessage):
+            ctx = InteractionContext(
+                sender_id=command.sender_id,
+                channel_id=command.channel_id,
+                source=command.source,
+                permissions=command.permissions,
+                metadata=command.metadata,
+            )
+            message = command.content.strip()
+            if message.startswith("/kb "):
+                return await self.interaction_service.execute(
+                    KnowledgeBoardCommand(content=message[4:]),
+                    context=ctx,
+                )
+            if command.broadcast or message.startswith("/broadcast"):
+                content = (
+                    message[len("/broadcast ") :] if message.startswith("/broadcast ") else ""
+                )
+                req = BroadcastRequest(
+                    content=content if message.startswith("/broadcast") else message,
+                    recipient_id=command.recipient_id,
+                    target_agent_id=command.target_agent_id,
+                    budget_agent_id=command.budget_agent_id,
+                )
+                return await self.dispatch(req, context=ctx)
+            return await self.dispatch(
+                DirectMessageRequest(
+                    content=message,
+                    recipient_id=command.recipient_id,
+                    target_agent_id=command.target_agent_id,
+                    budget_agent_id=command.budget_agent_id,
+                ),
+                context=ctx,
+            )
+
+        typed_command: InteractionCommand
+        if isinstance(command, BroadcastRequest):
+            typed_command = BroadcastCommand(**command.model_dump(exclude={"command_type"}))
+        elif isinstance(command, DirectMessageRequest):
+            typed_command = DirectMessageCommand(**command.model_dump(exclude={"command_type"}))
+        elif isinstance(command, SpawnAgentRequest):
+            typed_command = SpawnAgentCommand(**command.model_dump(exclude={"command_type"}))
+        elif isinstance(command, InjectEventRequest):
+            typed_command = ModerationCommand(
+                action="inject_event",
+                text=command.text,
+                prompt=command.scope,
+                agent_id=command.author,
+            )
+        elif isinstance(command, ModerationAction):
+            typed_command = ModerationCommand(**command.model_dump(exclude={"command_type"}))
+        elif isinstance(command, ControlRequest):
+            typed_command = ModerationCommand(
+                action=command.action,
+                value=command.value,
+                agent_id=command.agent_id,
+            )
+        else:
+            return InteractionResult(
+                status="error",
+                user_message="Unknown command.",
+                reason_code="unsupported_command",
+            )
+        return await self.interaction_service.execute(typed_command, context=context)
+
+    async def dispatch_payload(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        command = parse_bus_command(payload)
+        return await self.dispatch(command, context=context)
+
+
+def parse_bus_command(payload: Mapping[str, Any]) -> BusCommand:
+    cmd_type = str(payload.get("command_type") or payload.get("command") or "").strip()
+    if cmd_type in {"human_message"}:
+        return HumanMessage(**dict(payload))
+    if cmd_type == "broadcast":
+        return BroadcastRequest(**dict(payload))
+    if cmd_type in {"direct_message", "dm"}:
+        data = dict(payload)
+        data["command_type"] = "direct_message"
+        return DirectMessageRequest(**data)
+    if cmd_type in {"spawn"}:
+        return SpawnAgentRequest(**dict(payload))
+    if cmd_type in {"inject_event"}:
+        data = dict(payload)
+        data["command_type"] = "inject_event"
+        if "author" not in data and "agent_id" in data:
+            data["author"] = data["agent_id"]
+        if "text" not in data and "content" in data:
+            data["text"] = data["content"]
+        return InjectEventRequest(**data)
+    if cmd_type in {"pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"}:
+        data = {
+            "command_type": "control",
+            "action": cmd_type,
+            "value": payload.get("value"),
+            "agent_id": payload.get("agent_id"),
+        }
+        return ControlRequest(**data)
+    if cmd_type in {"kb", "knowledge_board"}:
+        return HumanMessage(
+            content=f"/kb {payload.get('content', '')!s}",
+            sender_id=str(payload.get("sender_id", "human")),
+            source=str(payload.get("source", "unknown")),
+        )
+
+    return ModerationAction(
+        action=cmd_type or str(payload.get("action", "")).strip(),
+        value=float(payload["value"]) if payload.get("value") is not None else None,
+        tags=[str(tag) for tag in payload.get("tags", [])]
+        if isinstance(payload.get("tags"), list)
+        else None,
+        prompt=str(payload["prompt"]) if payload.get("prompt") is not None else None,
+        text=str(payload["text"]) if payload.get("text") is not None else None,
+        agent_id=str(payload["agent_id"]) if payload.get("agent_id") is not None else None,
+    )

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -822,9 +822,7 @@ async def api_memory_snapshot(step: int) -> Response:
 
 
 @app.get("/api/agent_actions/explain_why")
-async def api_agent_action_explain_why(
-    after_step: int = 0, limit: int = 20
-) -> Response:
+async def api_agent_action_explain_why(after_step: int = 0, limit: int = 20) -> Response:
     """Expose explain-why payloads for recent agent actions."""
 
     def _load_events() -> list[dict[str, Any]]:
@@ -964,11 +962,11 @@ async def handle_control_command(
 ) -> dict[str, Any]:
     """Process a control command via the interaction service when available."""
     simulation = ctx.sim_state.get("simulation")
-    service = getattr(simulation, "interaction_service", None)
-    if service is not None:
+    bus = getattr(simulation, "command_bus", None)
+    if bus is not None:
         from src.interfaces.interaction_commands import InteractionContext
 
-        result = await service.execute_from_payload(
+        result = await bus.dispatch_payload(
             cmd,
             context=InteractionContext(
                 sender_id="dashboard",

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -11,7 +11,6 @@ import json
 import logging
 import re
 import time
-from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -22,15 +21,22 @@ import httpx
 from opentelemetry import trace
 from typing_extensions import Self
 
-from src.app import spawn_agent_command, start_simulation, stop_simulation
 from src.infra import config, event_log
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
 from src.interfaces import metrics
-from src.interfaces.interaction_commands import (
-    BroadcastCommand,
-    DirectMessageCommand,
-    InteractionContext,
+from src.interfaces.command_bus import (
+    ControlRequest,
+    HumanMessage,
+    InjectEventRequest,
+    SpawnAgentRequest,
+)
+from src.interfaces.interaction_commands import InteractionContext
+from src.interfaces.interaction_policy import (
+    check_command_rate_limit,
+    has_admin_permission,
+    has_control_command_permission,
+    set_max_rate,
 )
 from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
@@ -74,9 +80,7 @@ _DEFAULT_DASHBOARD_API_BASE_URL = "http://localhost:8000"
 
 
 def _dashboard_api_base_url() -> str:
-    configured = str(
-        config.get("DASHBOARD_API_BASE_URL", _DEFAULT_DASHBOARD_API_BASE_URL)
-    ).strip()
+    configured = str(config.get("DASHBOARD_API_BASE_URL", _DEFAULT_DASHBOARD_API_BASE_URL)).strip()
     return configured.rstrip("/") or _DEFAULT_DASHBOARD_API_BASE_URL
 
 
@@ -111,7 +115,9 @@ def _governance_simulation_from_interaction(interaction: Any) -> Any | None:
 
 
 def _governance_agent_for_sim(sim: Any, agent_id: str) -> Any | None:
-    return next((agent for agent in getattr(sim, "agents", []) if agent.agent_id == agent_id), None)
+    return next(
+        (agent for agent in getattr(sim, "agents", []) if agent.agent_id == agent_id), None
+    )
 
 
 @contextmanager
@@ -262,8 +268,6 @@ _MENTION_TARGET_RE = re.compile(r"^@(?P<agent>[\w.-]+)\s*:\s*(?P<content>.+)$", 
 _DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.DOTALL)
 
 
-
-
 def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str, str | None]:
     """Parse optional routing directives from plain Discord messages."""
     cleaned = content.strip()
@@ -293,8 +297,6 @@ def _parse_human_message_routing(content: str) -> tuple[str | None, bool, str, s
         return dm_match.group("agent"), False, dm_match.group("content").strip(), None
 
     return None, False, cleaned, None
-
-
 
 
 def _parse_json_object_argument(raw: str | None, field_name: str) -> dict[str, Any] | None:
@@ -330,11 +332,15 @@ def _spawn_kwargs_from_inputs(
     adaptability: float | None = None,
 ) -> dict[str, Any]:
     """Build spawn payload kwargs from slash-command optional inputs."""
-    role_payload = _parse_json_object_argument(role_json, "role") if role_json is not None else None
+    role_payload = (
+        _parse_json_object_argument(role_json, "role") if role_json is not None else None
+    )
     if role_payload is None and role is not None and role.strip():
         role_payload = role.strip()
 
-    traits_payload = _parse_json_object_argument(traits_json, "traits") if traits_json is not None else None
+    traits_payload = (
+        _parse_json_object_argument(traits_json, "traits") if traits_json is not None else None
+    )
     explicit_traits = {
         "openness": openness,
         "analytical_focus": analytical_focus,
@@ -362,6 +368,7 @@ def _spawn_kwargs_from_inputs(
         kwargs["traits"] = traits_payload
     return kwargs
 
+
 def _default_agent_for_channel(self: "SimulationDiscordBot", channel_id: int | None) -> str | None:
     """Resolve a deterministic fallback agent for an unmapped incoming message."""
     if channel_id is not None:
@@ -384,7 +391,9 @@ def _default_human_message_broadcast() -> bool:
     value = overrides.get("DISCORD_DEFAULT_BROADCAST")
     if value is None:
         value = config.get_config("DISCORD_DEFAULT_BROADCAST")
-    return _coerce_to_bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
 
 
 def _truncate_for_code_block(content: str, max_length: int = MAX_EMBED_DESCRIPTION_LENGTH) -> str:
@@ -662,7 +671,9 @@ class SimulationDiscordBot:
                     )
                     embed.set_footer(text=f"Channel ID: {self.channel_id}")
                     await send_channel_message(channel, embed=embed)
-                    await send_channel_message(channel, embed=create_onboarding_embed(self.channel_id))
+                    await send_channel_message(
+                        channel, embed=create_onboarding_embed(self.channel_id)
+                    )
                 else:
                     logger.warning(f"Could not find Discord channel with ID: {self.channel_id}")
 
@@ -721,60 +732,19 @@ class SimulationDiscordBot:
                     )
                     self.last_agent_id = agent_id
                     self.last_channel_id = channel_id
-                    simulation = self.context.sim_state.get("simulation")
-                    service = getattr(simulation, "interaction_service", None)
-                    if service is None:
-                        if is_broadcast:
-                            ip_cost = float(
-                                config.get_config("IP_COST_BROADCAST_MESSAGE")
-                                or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                                or 0.0
-                            )
-                            du_cost = float(
-                                config.get_config("DU_COST_BROADCAST_ACTION")
-                                or config.get_config("DU_COST_PER_ACTION")
-                                or 0.0
-                            )
-                        else:
-                            ip_cost = float(
-                                config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
-                                or config.get_config("IP_COST_BROADCAST_MESSAGE")
-                                or 0.0
-                            )
-                            du_cost = float(
-                                config.get_config("DU_COST_PER_ACTION")
-                                or config.get_config("DU_COST_BROADCAST_ACTION")
-                                or 0.0
-                            )
-                        ip_bal, du_bal = await ledger.get_balance_async(agent_id)
-                        if ip_bal < ip_cost or du_bal < du_cost:
-                            await send_channel_message(channel, content="Insufficient IP/DU")
-                            return
-                        data = {
-                            "author": str(user_id) if user_id is not None else "human",
-                            "content": parsed_content,
-                            "sender_id": str(user_id) if user_id is not None else "human",
-                            "target_agent_id": agent_id,
-                            "broadcast": is_broadcast,
-                        }
-                        if recipient is not None:
-                            data["recipient_id"] = recipient
-                        await self.event_queue.put(SimulationEvent(type="broadcast", data=data))
+                    bus = get_command_bus(self.context)
+                    if bus is None:
                         return
-                    if is_broadcast:
-                        command = BroadcastCommand(
+                    result = await bus.dispatch(
+                        HumanMessage(
                             content=parsed_content,
-                            target_agent_id=agent_id,
+                            sender_id=str(user_id) if user_id is not None else "human",
+                            channel_id=str(channel_id) if channel_id is not None else None,
+                            source="discord",
+                            broadcast=is_broadcast,
                             recipient_id=recipient,
-                        )
-                    else:
-                        command = DirectMessageCommand(
-                            content=parsed_content,
                             target_agent_id=agent_id,
-                            recipient_id=recipient,
-                        )
-                    result = await service.execute(
-                        command,
+                        ),
                         context=InteractionContext(
                             sender_id=str(user_id) if user_id is not None else "human",
                             channel_id=str(channel_id) if channel_id is not None else None,
@@ -1258,6 +1228,11 @@ def get_active_bot(ctx: SimulationContext = DEFAULT_CONTEXT) -> "SimulationDisco
     return cast("SimulationDiscordBot | None", ctx.sim_state.get("discord_bot"))
 
 
+def get_command_bus(ctx: SimulationContext = DEFAULT_CONTEXT) -> Any | None:
+    simulation = ctx.sim_state.get("simulation")
+    return getattr(simulation, "command_bus", None)
+
+
 def _global_context_resolver() -> tuple[Any, Any]:
     """Resolve context and event queue for slash command registration."""
     bot_instance = get_active_bot()
@@ -1269,112 +1244,13 @@ def _global_context_resolver() -> tuple[Any, Any]:
 
 # --- Command rate limiting -------------------------------------------------
 
-_COMMAND_HISTORY: dict[str, deque[float]] = {}
-_COMMAND_LOCKS: dict[str, asyncio.Lock] = {}
-_MAX_RATE: int = 5
-_DEFAULT_RATE_LIMIT_WINDOW_SECONDS: float = 60.0
-
-
-def has_admin_permission(user: Any) -> bool:
-    """Return True if the Discord user has administrator permissions."""
-    perms = getattr(getattr(user, "guild_permissions", None), "administrator", False)
-    return bool(perms)
-
-
-_TRUE_BOOL_VALUES = {"1", "true", "yes", "on"}
-_FALSE_BOOL_VALUES = {"0", "false", "no", "off"}
-
-
-def _coerce_to_bool(value: object) -> bool:
-    """Normalize truthy and falsy values retrieved from configuration."""
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in _TRUE_BOOL_VALUES:
-            return True
-        if lowered in _FALSE_BOOL_VALUES:
-            return False
-    return bool(value)
-
-
-def _allow_control_via_opa() -> bool:
-    """Return True when control commands may defer authorization to OPA."""
-    overrides = getattr(config, "CONFIG_OVERRIDES", {})
-    value = overrides.get("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
-    if value is None:
-        value = config.get_config("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
-    return _coerce_to_bool(value)
-
-
-def _get_command_rate_limit_window() -> float:
-    """Return the configured rate limit window in seconds."""
-    overrides = getattr(config, "CONFIG_OVERRIDES", {})
-    value = overrides.get("DISCORD_COMMAND_RATE_LIMIT_SECONDS")
-    if value is None:
-        value = config.get_config("DISCORD_COMMAND_RATE_LIMIT_SECONDS")
-    try:
-        return max(0.0, float(value))
-    except (TypeError, ValueError):  # pragma: no cover - defensive
-        return _DEFAULT_RATE_LIMIT_WINDOW_SECONDS
-
 
 async def _has_control_command_permission(
     user: Any, command: str, *, agent_id: str | None = None
 ) -> bool:
     """Return True when the user may execute privileged control commands."""
 
-    if has_admin_permission(user):
-        return True
-    if not _allow_control_via_opa():
-        return False
-    payload = {
-        "command": command,
-        "user_id": str(getattr(user, "id", "")),
-    }
-    if agent_id is not None:
-        payload["agent_id"] = agent_id
-    allowed, _ = await evaluate_with_opa(json.dumps(payload))
-    return bool(allowed)
-
-
-async def check_command_rate_limit(user: Any) -> bool:
-    """Increment and check the rate limit for the given user."""
-    user_id = str(getattr(user, "id", ""))
-    if not user_id:
-        return True
-    lock = _COMMAND_LOCKS.setdefault(user_id, asyncio.Lock())
-    async with lock:
-        history = _COMMAND_HISTORY.setdefault(user_id, deque())
-        now = time.monotonic()
-        window_seconds = _get_command_rate_limit_window()
-        if window_seconds <= 0:
-            history.clear()
-        else:
-            cutoff = now - window_seconds
-            while history and history[0] <= cutoff:
-                history.popleft()
-        if len(history) >= _MAX_RATE:
-            logger.warning("Rate limit exceeded for user %s", user_id)
-            return False
-        history.append(now)
-    return True
-
-
-def reset_command_counts(user_id: str | None = None) -> None:
-    """Reset stored command counts for a user or all users."""
-    if user_id is not None:
-        history = _COMMAND_HISTORY.pop(user_id, None)
-        if history is not None:
-            history.clear()
-    else:
-        _COMMAND_HISTORY.clear()
-
-
-def set_max_rate(value: int) -> None:
-    """Set the maximum allowed commands per user."""
-    global _MAX_RATE
-    _MAX_RATE = max(1, int(value))
+    return await has_control_command_permission(user, command, agent_id=agent_id)
 
 
 async def _rate_limit_check(interaction: Any) -> bool:
@@ -1484,7 +1360,16 @@ async def slash_pause(interaction: Any) -> None:
     with command_span("pause", interaction) as span:
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(SimulationEvent(type="control", data={"command": "pause"}))
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                ControlRequest(action="pause"),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         await send_interaction_response(interaction, "pause", ephemeral=True)
 
 
@@ -1493,9 +1378,16 @@ async def slash_resume(interaction: Any) -> None:
     with command_span("resume", interaction) as span:
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(type="control", data={"command": "resume"})
-        )
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                ControlRequest(action="resume"),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         await send_interaction_response(interaction, "resume", ephemeral=True)
 
 
@@ -1507,9 +1399,16 @@ async def slash_pause_all(interaction: Any) -> None:
             return
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(type="control", data={"command": "pause_all"})
-        )
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                ControlRequest(action="pause_all"),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         await send_interaction_response(interaction, "pause all", ephemeral=True)
 
 
@@ -1521,9 +1420,16 @@ async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
             return
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(type="control", data={"command": "kill_agent", "agent_id": agent_id})
-        )
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                ControlRequest(action="kill_agent", agent_id=agent_id),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         await send_interaction_response(interaction, "killed", ephemeral=True)
 
 
@@ -1555,7 +1461,17 @@ async def slash_start(interaction: Any) -> None:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         try:
-            await start_simulation(ctx)
+            bus = get_command_bus(ctx)
+            if bus is None:
+                raise RuntimeError("command bus unavailable")
+            await bus.dispatch(
+                ControlRequest(action="start"),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         except Exception as exc:
             if bot_instance is not None:
                 embed = (
@@ -1602,7 +1518,17 @@ async def slash_stop(interaction: Any) -> None:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         try:
-            await stop_simulation(ctx)
+            bus = get_command_bus(ctx)
+            if bus is None:
+                raise RuntimeError("command bus unavailable")
+            await bus.dispatch(
+                ControlRequest(action="stop"),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         except Exception as exc:
             if bot_instance is not None:
                 embed = (
@@ -1629,6 +1555,7 @@ async def slash_stop(interaction: Any) -> None:
                 )
             else:
                 await send_interaction_response(interaction, "stop", ephemeral=True)
+
 
 async def slash_spawn(
     interaction: Any,
@@ -1674,7 +1601,17 @@ async def slash_spawn(
                 trust_baseline=trust_baseline,
                 adaptability=adaptability,
             )
-            await spawn_agent_command(agent_id, ctx, **spawn_kwargs)
+            bus = get_command_bus(ctx)
+            if bus is None:
+                raise RuntimeError("command bus unavailable")
+            await bus.dispatch(
+                SpawnAgentRequest(agent_id=agent_id, **spawn_kwargs),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         except Exception as exc:
             if bot_instance is not None:
                 embed = bot_instance.create_spawn_embed(agent_id, False, str(exc))
@@ -1723,9 +1660,16 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
         span.set_attribute("discord.speed", value)
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(type="control", data={"command": "set_speed", "value": value})
-        )
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                ControlRequest(action="set_speed", value=value),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "discord")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
+            )
         await send_interaction_response(interaction, f"speed {value}", ephemeral=True)
 
 
@@ -1749,16 +1693,15 @@ async def slash_kb(interaction: Any, text: str) -> None:
         span.set_attribute("discord.message.length", len(text))
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="control",
-                data={
-                    "command": "post_kb",
-                    "text": text,
-                    "author": str(getattr(interaction, "user", "human")),
-                },
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                HumanMessage(
+                    content=f"/kb {text}",
+                    sender_id=str(getattr(interaction, "user", "human")),
+                    source="discord",
+                )
             )
-        )
         await send_interaction_response(interaction, "KB entry created", ephemeral=True)
 
 
@@ -1774,17 +1717,20 @@ async def slash_event(interaction: Any, text: str) -> None:
             return
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(
-            SimulationEvent(
-                type="control",
-                data={
-                    "command": "inject_event",
-                    "text": text,
-                    "scope": "global",
-                    "author": str(getattr(interaction, "user", "human")),
-                },
+        bus = get_command_bus(ctx)
+        if bus is not None:
+            await bus.dispatch(
+                InjectEventRequest(
+                    text=text,
+                    scope="global",
+                    author=str(getattr(interaction, "user", "human")),
+                ),
+                context=InteractionContext(
+                    sender_id=str(getattr(interaction, "user", "human")),
+                    source="discord",
+                    permissions={"admin", "moderator"},
+                ),
             )
-        )
         await send_interaction_response(interaction, "event injected", ephemeral=True)
 
 
@@ -1961,11 +1907,15 @@ async def slash_gov(interaction: Any) -> None:
                     payload = cast(dict[str, Any], resp.json())
                     rules = cast(list[dict[str, Any]], payload.get("rules", []))
             except Exception:
-                await send_interaction_response(interaction, "No active governance rules.", ephemeral=True)
+                await send_interaction_response(
+                    interaction, "No active governance rules.", ephemeral=True
+                )
                 return
 
         if not rules:
-            await send_interaction_response(interaction, "No active governance rules.", ephemeral=True)
+            await send_interaction_response(
+                interaction, "No active governance rules.", ephemeral=True
+            )
             return
 
         lines = []
@@ -2015,7 +1965,9 @@ def register_slash_commands(tree: Any) -> dict[str, Callable[..., Any]]:
                 moderation_rate_limit(moderation_action)(handler),
             )
         if descriptions:
-            handler = cast(Callable[..., Awaitable[None]], app_commands.describe(**descriptions)(handler))
+            handler = cast(
+                Callable[..., Awaitable[None]], app_commands.describe(**descriptions)(handler)
+            )
         if not hasattr(callback, "callback"):
             setattr(callback, "callback", callback)
         registered = tree.command(name=name)(handler)
@@ -2028,7 +1980,12 @@ def register_slash_commands(tree: Any) -> dict[str, Callable[..., Any]]:
     _register("resume", slash_resume)
     _register("pause_all", slash_pause_all)
     _register("kill_agent", slash_kill_agent, descriptions={"agent_id": "ID of the agent to kill"})
-    _register("nudge", slash_nudge, descriptions={"prompt": "Prompt to nudge the simulation"}, moderation_action="nudge")
+    _register(
+        "nudge",
+        slash_nudge,
+        descriptions={"prompt": "Prompt to nudge the simulation"},
+        moderation_action="nudge",
+    )
     _register("start", slash_start, moderation_action="start")
     _register("stop", slash_stop, moderation_action="stop")
     _register(

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -12,6 +12,7 @@ from src.infra import config
 from src.infra import ledger as infra_ledger
 from src.infra.event_log import log_event
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
+from src.interfaces.interaction_policy import check_cooldown, context_is_authorized
 from src.sim.knowledge_board import BoardEntry
 
 if TYPE_CHECKING:
@@ -76,7 +77,11 @@ class KnowledgeBoardCommand(BaseModel):
 
 
 InteractionCommand = (
-    BroadcastCommand | DirectMessageCommand | SpawnAgentCommand | ModerationCommand | KnowledgeBoardCommand
+    BroadcastCommand
+    | DirectMessageCommand
+    | SpawnAgentCommand
+    | ModerationCommand
+    | KnowledgeBoardCommand
 )
 
 
@@ -93,13 +98,24 @@ class InteractionService:
         context: InteractionContext | None = None,
     ) -> InteractionResult:
         ctx = context or InteractionContext()
+        await emit_event(
+            SimulationEvent(
+                type="human_command",
+                data={
+                    "command_type": command.command_type,
+                    "sender_id": ctx.sender_id,
+                    "source": ctx.source,
+                    "step": self.simulation.current_step,
+                },
+            )
+        )
 
         if isinstance(command, KnowledgeBoardCommand):
             return await self._dispatch_knowledge_board(command, context=ctx)
         if isinstance(command, (BroadcastCommand, DirectMessageCommand)):
             return await self._dispatch_message(command, context=ctx)
         if isinstance(command, SpawnAgentCommand):
-            if not self._is_authorized(ctx, required={"admin", "moderator"}):
+            if not context_is_authorized(ctx, required={"admin", "moderator"}):
                 return InteractionResult(
                     status="rejected",
                     user_message="You are not authorized to spawn agents.",
@@ -121,7 +137,7 @@ class InteractionService:
                 reason_code="spawn_submitted",
             )
         if isinstance(command, ModerationCommand):
-            if not self._is_authorized(ctx, required={"admin", "moderator"}):
+            if not context_is_authorized(ctx, required={"admin", "moderator"}):
                 return InteractionResult(
                     status="rejected",
                     user_message="You are not authorized to run moderation commands.",
@@ -138,6 +154,10 @@ class InteractionService:
                 payload["text"] = command.text
             if command.agent_id is not None:
                 payload["agent_id"] = command.agent_id
+            if command.action == "inject_event" and command.prompt is not None:
+                payload["scope"] = command.prompt
+            if command.action == "inject_event" and command.agent_id is not None:
+                payload["author"] = command.agent_id
             state = await self.simulation.handle_control_command(payload)
             return InteractionResult(
                 status="ok",
@@ -150,11 +170,6 @@ class InteractionService:
             user_message="Unknown command.",
             reason_code="unsupported_command",
         )
-
-    def _is_authorized(self, context: InteractionContext, required: set[str]) -> bool:
-        if not required:
-            return True
-        return bool(context.permissions & required)
 
     async def _dispatch_knowledge_board(
         self,
@@ -177,7 +192,13 @@ class InteractionService:
                 reason_code="kb_unavailable",
             )
         now = time.monotonic()
-        if now - self.simulation._last_kb_time < self.simulation._kb_cooldown:
+        retry_after = check_cooldown(
+            key="knowledge_board",
+            now=now,
+            cooldown=self.simulation._kb_cooldown,
+            state={"knowledge_board": self.simulation._last_kb_time},
+        )
+        if retry_after is not None:
             return InteractionResult(
                 status="rejected",
                 user_message="Knowledge Board is cooling down. Please try again shortly.",
@@ -218,10 +239,16 @@ class InteractionService:
 
         now = time.monotonic()
         channel_id = context.channel_id
-        relay_scope = context.sender_id if channel_id is None else f"{context.sender_id}:{channel_id}"
-        last_relay_time = self.simulation._last_relay_times.get(relay_scope, 0.0)
-        if now - last_relay_time < self.simulation._relay_cooldown:
-            retry_after = max(0.0, self.simulation._relay_cooldown - (now - last_relay_time))
+        relay_scope = (
+            context.sender_id if channel_id is None else f"{context.sender_id}:{channel_id}"
+        )
+        retry_after = check_cooldown(
+            key=relay_scope,
+            now=now,
+            cooldown=self.simulation._relay_cooldown,
+            state=self.simulation._last_relay_times,
+        )
+        if retry_after is not None:
             await emit_event(
                 SimulationEvent(
                     type="human_command_rate_limited",
@@ -236,14 +263,11 @@ class InteractionService:
             return InteractionResult(
                 status="rejected",
                 user_message=(
-                    "Rate limited: please wait "
-                    f"{retry_after:.1f}s before sending another message."
+                    f"Rate limited: please wait {retry_after:.1f}s before sending another message."
                 ),
                 reason_code="rate_limited",
                 data={"retry_after_seconds": retry_after},
             )
-        self.simulation._last_relay_times[relay_scope] = now
-
         if not self.simulation.agents:
             return InteractionResult(
                 status="rejected",
@@ -379,17 +403,31 @@ class InteractionService:
         target: Any | None = None
         if command.target_agent_id:
             target = next(
-                (agent for agent in self.simulation.agents if agent.agent_id == command.target_agent_id),
+                (
+                    agent
+                    for agent in self.simulation.agents
+                    if agent.agent_id == command.target_agent_id
+                ),
                 None,
             )
         if target is None and command.recipient_id:
             target = next(
-                (agent for agent in self.simulation.agents if agent.agent_id == command.recipient_id),
+                (
+                    agent
+                    for agent in self.simulation.agents
+                    if agent.agent_id == command.recipient_id
+                ),
                 None,
             )
-        if target is None and self.simulation.discord_bot and self.simulation.discord_bot.last_agent_id:
+        if (
+            target is None
+            and self.simulation.discord_bot
+            and self.simulation.discord_bot.last_agent_id
+        ):
             last_id = self.simulation.discord_bot.last_agent_id
-            target = next((agent for agent in self.simulation.agents if agent.agent_id == last_id), None)
+            target = next(
+                (agent for agent in self.simulation.agents if agent.agent_id == last_id), None
+            )
         if target is None:
             target = self.simulation.agents[self.simulation.current_agent_index]
         return target

--- a/src/interfaces/interaction_policy.py
+++ b/src/interfaces/interaction_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from src.infra import config
+
+if TYPE_CHECKING:
+    from src.interfaces.interaction_commands import InteractionContext
+from src.utils.policy import evaluate_with_opa
+
+logger = logging.getLogger(__name__)
+
+_TRUE_BOOL_VALUES = {"1", "true", "yes", "on"}
+_FALSE_BOOL_VALUES = {"0", "false", "no", "off"}
+_DEFAULT_RATE_LIMIT_WINDOW_SECONDS: float = 60.0
+
+_COMMAND_HISTORY: dict[str, deque[float]] = {}
+_COMMAND_LOCKS: dict[str, asyncio.Lock] = {}
+_MAX_RATE: int = 5
+
+
+def has_admin_permission(user: Any) -> bool:
+    perms = getattr(getattr(user, "guild_permissions", None), "administrator", False)
+    return bool(perms)
+
+
+def _coerce_to_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in _TRUE_BOOL_VALUES:
+            return True
+        if lowered in _FALSE_BOOL_VALUES:
+            return False
+    return bool(value)
+
+
+def allow_control_via_opa() -> bool:
+    overrides = getattr(config, "CONFIG_OVERRIDES", {})
+    value = overrides.get("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
+    if value is None:
+        value = config.get_config("DISCORD_ALLOW_OPA_CONTROL_COMMANDS")
+    return _coerce_to_bool(value)
+
+
+def get_command_rate_limit_window() -> float:
+    overrides = getattr(config, "CONFIG_OVERRIDES", {})
+    value = overrides.get("DISCORD_COMMAND_RATE_LIMIT_SECONDS")
+    if value is None:
+        value = config.get_config("DISCORD_COMMAND_RATE_LIMIT_SECONDS")
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return _DEFAULT_RATE_LIMIT_WINDOW_SECONDS
+
+
+async def has_control_command_permission(
+    user: Any,
+    command: str,
+    *,
+    agent_id: str | None = None,
+) -> bool:
+    if has_admin_permission(user):
+        return True
+    if not allow_control_via_opa():
+        return False
+    payload = {
+        "command": command,
+        "user_id": str(getattr(user, "id", "")),
+    }
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    allowed, _ = await evaluate_with_opa(json.dumps(payload))
+    return bool(allowed)
+
+
+async def check_command_rate_limit(user: Any) -> bool:
+    user_id = str(getattr(user, "id", ""))
+    if not user_id:
+        return True
+    lock = _COMMAND_LOCKS.setdefault(user_id, asyncio.Lock())
+    async with lock:
+        history = _COMMAND_HISTORY.setdefault(user_id, deque())
+        now = time.monotonic()
+        window_seconds = get_command_rate_limit_window()
+        if window_seconds <= 0:
+            history.clear()
+        else:
+            cutoff = now - window_seconds
+            while history and history[0] <= cutoff:
+                history.popleft()
+        if len(history) >= _MAX_RATE:
+            logger.warning("Rate limit exceeded for user %s", user_id)
+            return False
+        history.append(now)
+    return True
+
+
+def reset_command_counts(user_id: str | None = None) -> None:
+    if user_id is not None:
+        history = _COMMAND_HISTORY.pop(user_id, None)
+        if history is not None:
+            history.clear()
+    else:
+        _COMMAND_HISTORY.clear()
+
+
+def set_max_rate(value: int) -> None:
+    global _MAX_RATE
+    _MAX_RATE = max(1, int(value))
+
+
+def context_is_authorized(context: InteractionContext, required: set[str]) -> bool:
+    if not required:
+        return True
+    return bool(context.permissions & required)
+
+
+def check_cooldown(
+    *,
+    key: str,
+    now: float,
+    cooldown: float,
+    state: dict[str, float],
+) -> float | None:
+    last_seen = state.get(key, 0.0)
+    elapsed = now - last_seen
+    if elapsed < cooldown:
+        return max(0.0, cooldown - elapsed)
+    state[key] = now
+    return None

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -37,6 +37,7 @@ from src.infra.snapshot import (
     save_snapshot,
     upload_snapshot,
 )
+from src.interfaces.command_bus import CommandBus, parse_bus_command
 from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
@@ -338,6 +339,7 @@ class Simulation:
         self._event_loop = None
         self._event_loop_thread = None
         self.interaction_service = InteractionService(self)
+        self.command_bus = CommandBus(self.interaction_service)
 
         # Automatically start listening for external events when an event loop
         # is already running. This allows tests to enqueue events before calling
@@ -442,9 +444,14 @@ class Simulation:
                 target_channel_id=target_channel_id,
             )
 
-    async def handle_control_command(self: Self, cmd: dict[str, Any]) -> None:
+    async def handle_control_command(self: Self, cmd: Mapping[str, Any]) -> dict[str, Any] | None:
         """Process a control command sent via the event queue."""
-        action = cmd.get("command")
+        try:
+            parsed = parse_bus_command(cmd)
+        except ValidationError:
+            logger.warning("Invalid control command payload: %s", cmd)
+            return None
+        action = getattr(parsed, "action", None) or str(cmd.get("command", ""))
         if action == "pause":
             self.paused = True
         elif action == "resume":
@@ -463,13 +470,12 @@ class Simulation:
             self.simulation_complete = True
             await self.stop_event_listener()
         elif action == "spawn":
-            agent_id = cmd.get("agent_id")
+            agent_id = getattr(parsed, "agent_id", None) or cmd.get("agent_id")
             if agent_id:
                 normalized_agent_id = str(agent_id)
                 if any(agent.agent_id == normalized_agent_id for agent in self.agents):
                     warning_message = (
-                        "Rejected spawn request for duplicate agent_id "
-                        f"'{normalized_agent_id}'."
+                        f"Rejected spawn request for duplicate agent_id '{normalized_agent_id}'."
                     )
                     logger.warning(warning_message)
                     await emit_event(
@@ -488,11 +494,19 @@ class Simulation:
                 try:
                     from src.agents.core.base_agent import Agent
 
-                    role_value = cmd.get("role")
+                    role_value = (
+                        getattr(parsed, "role", None)
+                        if hasattr(parsed, "role")
+                        else cmd.get("role")
+                    )
                     role_profile = ensure_profile(role_value) if role_value is not None else None
 
                     trait_overrides: dict[str, float] | None = None
-                    traits_payload = cmd.get("traits")
+                    traits_payload = (
+                        getattr(parsed, "traits", None)
+                        if hasattr(parsed, "traits")
+                        else cmd.get("traits")
+                    )
                     if traits_payload is not None:
                         if not isinstance(traits_payload, dict):
                             raise ValueError("spawn traits must be an object")
@@ -522,10 +536,20 @@ class Simulation:
                         merged_traits.update(trait_overrides)
                         initial_state["traits"] = PersonalityTraits(**merged_traits)
 
-                    if "persona" in cmd and cmd.get("persona") is not None:
-                        initial_state["persona"] = str(cmd.get("persona"))
-                    if "backstory" in cmd and cmd.get("backstory") is not None:
-                        initial_state["backstory"] = str(cmd.get("backstory"))
+                    persona = (
+                        getattr(parsed, "persona", None)
+                        if hasattr(parsed, "persona")
+                        else cmd.get("persona")
+                    )
+                    backstory = (
+                        getattr(parsed, "backstory", None)
+                        if hasattr(parsed, "backstory")
+                        else cmd.get("backstory")
+                    )
+                    if persona is not None:
+                        initial_state["persona"] = str(persona)
+                    if backstory is not None:
+                        initial_state["backstory"] = str(backstory)
 
                     new_agent = Agent(
                         agent_id=normalized_agent_id,
@@ -536,19 +560,19 @@ class Simulation:
                 except Exception:
                     logger.error("Failed to spawn agent %s", agent_id, exc_info=True)
         elif action == "kill_agent":
-            agent_id = cmd.get("agent_id")
+            agent_id = getattr(parsed, "agent_id", None) or cmd.get("agent_id")
             if agent_id:
                 agent = next((a for a in self.agents if a.agent_id == str(agent_id)), None)
                 if agent is not None:
                     await self.retire_agent(agent, remove_from_simulation=True)
         elif action == "set_speed":
             try:
-                self.speed = float(cmd.get("value", 1))
+                self.speed = float(getattr(parsed, "value", None) or cmd.get("value", 1))
             except (TypeError, ValueError):
                 pass
         elif action == "post_kb":
-            text = cmd.get("text")
-            author = cmd.get("author", "human")
+            text = getattr(parsed, "text", None) or cmd.get("text")
+            author = getattr(parsed, "author", None) or cmd.get("author", "human")
             if text and self.knowledge_board:
                 async with self.knowledge_board.lock:
                     self.knowledge_board.add_entry(
@@ -575,11 +599,11 @@ class Simulation:
                     )
                     _ = task
         elif action == "inject_event":
-            text = str(cmd.get("text", "")).strip()
+            text = str(getattr(parsed, "text", None) or cmd.get("text", "")).strip()
             if not text:
-                return
-            author = str(cmd.get("author", "human"))
-            scope = str(cmd.get("scope", "global"))
+                return None
+            author = str(getattr(parsed, "author", None) or cmd.get("author", "human"))
+            scope = str(getattr(parsed, "scope", None) or cmd.get("scope", "global"))
             event_payload = {
                 "type": "world_event",
                 "author": author,
@@ -612,6 +636,12 @@ class Simulation:
                         self.current_step,
                         self.vector.to_dict(),
                     )
+
+        return {
+            "paused": self.paused,
+            "speed": self.speed,
+            "simulation_complete": self.simulation_complete,
+        }
 
     async def mute_agent(self: Self, agent_id: str, *, emit_event: bool = True) -> None:
         from .resources import mute_agent as _mute_agent
@@ -814,8 +844,7 @@ class Simulation:
         cadence = max(
             1,
             int(
-                config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS")
-                or self.world_ticks_per_day
+                config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS") or self.world_ticks_per_day
             ),
         )
         if (
@@ -987,11 +1016,19 @@ class Simulation:
 
         if rule_evaluation.penalties:
             for penalty in rule_evaluation.penalties:
-                current_agent_state.ip = max(0.0, float(current_agent_state.ip) - float(penalty.get("ip", 0.0)))
-                current_agent_state.du = max(0.0, float(current_agent_state.du) - float(penalty.get("du", 0.0)))
+                current_agent_state.ip = max(
+                    0.0, float(current_agent_state.ip) - float(penalty.get("ip", 0.0))
+                )
+                current_agent_state.du = max(
+                    0.0, float(current_agent_state.du) - float(penalty.get("du", 0.0))
+                )
 
         if self.knowledge_board:
-            governance_decision = "rejected" if not allowed or not rule_evaluation.allowed else rule_evaluation.decision
+            governance_decision = (
+                "rejected"
+                if not allowed or not rule_evaluation.allowed
+                else rule_evaluation.decision
+            )
             rule_ids = rule_evaluation.violated_rules
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(
@@ -1127,7 +1164,9 @@ class Simulation:
                     "world_time": self._world_time_snapshot(),
                     "action_intent": action_intent_str,
                     "governance_enforcement": {
-                        "decision": "rejected" if not allowed or not rule_evaluation.allowed else rule_evaluation.decision,
+                        "decision": "rejected"
+                        if not allowed or not rule_evaluation.allowed
+                        else rule_evaluation.decision,
                         "reason": rule_evaluation.reason,
                         "violated_rules": rule_evaluation.violated_rules,
                         "penalties": rule_evaluation.penalties,
@@ -1404,10 +1443,25 @@ class Simulation:
         if not evt.data:
             return
         if evt.type == "control":
-            await self.handle_control_command(evt.data)
+            context = InteractionContext(
+                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
+                channel_id=str(evt.data.get("channel_id")) if evt.data.get("channel_id") else None,
+                source=str(evt.data.get("source", "event_bus")),
+                permissions=set(evt.data.get("permissions", []))
+                if isinstance(evt.data.get("permissions"), list)
+                else set(),
+                metadata={k: v for k, v in evt.data.items()},
+            )
+            await self.command_bus.dispatch(parse_bus_command(evt.data), context=context)
             return
         if evt.type == "moderation":
-            await self.handle_moderation_command(evt.data)
+            context = InteractionContext(
+                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
+                source=str(evt.data.get("source", "event_bus")),
+                permissions={"admin", "moderator"},
+                metadata={k: v for k, v in evt.data.items()},
+            )
+            await self.command_bus.dispatch(parse_bus_command(evt.data), context=context)
             return
         sender = str(evt.data.get("author", "external"))
         if sender in self.muted_agents:
@@ -1788,12 +1842,13 @@ class Simulation:
             phase="perception_snapshot",
             value=(time.perf_counter() - phase_start) * 1000,
         )
-        self._set_labeled_gauge(STEP_PHASE_QUEUE_DEPTH, phase="planning_batch_size", value=len(plans))
+        self._set_labeled_gauge(
+            STEP_PHASE_QUEUE_DEPTH, phase="planning_batch_size", value=len(plans)
+        )
 
         phase_start = time.perf_counter()
         planning_tasks = [
-            self.agents[int(plan["agent_index"])]
-            .run_turn(
+            self.agents[int(plan["agent_index"])].run_turn(
                 simulation_step=int(plan["simulation_step"]),
                 environment_perception=dict(cast(Mapping[str, Any], plan["snapshot"])),
                 memory_service=self.memory_service,
@@ -1827,7 +1882,9 @@ class Simulation:
             phase="deterministic_commit_apply",
             value=(time.perf_counter() - phase_start) * 1000,
         )
-        self._set_labeled_gauge(STEP_PHASE_QUEUE_DEPTH, phase="commit_batch_size", value=len(committed))
+        self._set_labeled_gauge(
+            STEP_PHASE_QUEUE_DEPTH, phase="commit_batch_size", value=len(committed)
+        )
         return committed
 
     async def async_run(self: Self, num_steps: int) -> None:
@@ -2241,7 +2298,9 @@ class Simulation:
         approved = bool(result.get("approved"))
         rule_materialization = result.get("rule_materialization", {})
         if self.knowledge_board:
-            decision = str(rule_materialization.get("decision", "accepted" if approved else "rejected"))
+            decision = str(
+                rule_materialization.get("decision", "accepted" if approved else "rejected")
+            )
             rule_ids = rule_materialization.get("rule_ids", [])
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(


### PR DESCRIPTION
### Motivation

- Consolidate disparate command handling paths (Discord, dashboard, event bus) behind a single typed dispatcher to avoid ad-hoc `dict` payload handling and duplicated routing logic.
- Provide canonical, validated command/event models so command parsing/validation is consistent and discoverable across interfaces.
- Centralize authorization and rate-limiting logic in a reusable policy layer to remove duplicated checks and make permission behavior testable.
- Emit a single normalized audit event for human-originated commands so external consumers (dashboard/event log) see a consistent record.

### Description

- Added `src/interfaces/command_bus.py` containing Pydantic models (`HumanMessage`, `BroadcastRequest`, `DirectMessageRequest`, `SpawnAgentRequest`, `InjectEventRequest`, `ModerationAction`, `ControlRequest`), a `parse_bus_command` helper, and a `CommandBus` class providing `dispatch`/`dispatch_payload` to translate typed bus commands into `InteractionCommand` and call `InteractionService`.
- Added `src/interfaces/interaction_policy.py` which centralizes admin checks, OPA delegation, per-user rate limiting, cooldown utilities, and `context_is_authorized` helper used by the service layer.
- Updated `src/interfaces/interaction_commands.py` so `InteractionService.execute` emits a normalized `SimulationEvent(type="human_command", data=...)` for all command sources and uses the shared policy helpers (`check_cooldown`, `context_is_authorized`) for KB and relay rate limiting and authorization.
- Refactored `src/sim/simulation.py` to instantiate `CommandBus`, parse control payloads with `parse_bus_command`, return a normalized state from `handle_control_command`, and route incoming `control`/`moderation` events through the `CommandBus` instead of duplicating routing logic.
- Refactored `src/interfaces/discord_bot.py` to only parse Discord input and forward typed commands (`HumanMessage`, `ControlRequest`, `SpawnAgentRequest`, `InjectEventRequest`, etc.) to the `CommandBus` with an `InteractionContext`, and to reuse the shared policy helpers for permission and rate checks.
- Updated `src/interfaces/dashboard_backend.py` to dispatch dashboard control payloads through `simulation.command_bus.dispatch_payload(...)` using an appropriate `InteractionContext`.

### Testing

- Ran linting and formatting checks with `ruff check` and `ruff format` and resolved issues (checks passed afterwards).
- Verified syntax by running `python -m py_compile` on modified modules, which succeeded without errors.
- Executed a smoke test `pytest -q tests/test_pytest_sanity.py`, which passed.
- Attempted targeted interface integration runs (`pytest` on a few dashboard/discord integration tests); collection in this environment deselected some of those tests, so full integration coverage was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995caa825cc832699ce9e8efca33a66)