### PR TITLE
Add environment subsystem for deterministic temporal progression

### DIFF
--- a/src/sim/environment.py
+++ b/src/sim/environment.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class EnvironmentState:
+    world_tick: int = 0
+    world_hour: int = 0
+    world_day: int = 0
+    world_season: int | None = None
+    weather: str = "clear"
+    season_effects: dict[str, Any] = field(default_factory=dict)
+    active_global_modifiers: list[str] = field(default_factory=list)
+    council_window_active: bool = False
+
+
+class EnvironmentSystem:
+    """Owns temporal progression and environment context generation."""
+
+    _WEATHER_CYCLE = ("clear", "rain", "windy", "storm")
+    _SEASON_NAMES = ("spring", "summer", "autumn", "winter")
+
+    def __init__(
+        self,
+        *,
+        state: EnvironmentState,
+        world_ticks_per_day: int,
+        turns_per_world_tick: int,
+        world_season_length_days: int | None,
+        weather_shift_interval_ticks: int = 6,
+        council_window_days: int = 7,
+        council_window_start_hour: int = 9,
+        council_window_duration_hours: int = 3,
+        world_time_broadcast_cadence_ticks: int = 24,
+    ) -> None:
+        self.state = state
+        self.world_ticks_per_day = max(1, int(world_ticks_per_day))
+        self.turns_per_world_tick = max(1, int(turns_per_world_tick))
+        self.world_season_length_days = (
+            int(world_season_length_days) if world_season_length_days is not None else None
+        )
+        self.weather_shift_interval_ticks = max(1, int(weather_shift_interval_ticks))
+        self.council_window_days = max(1, int(council_window_days))
+        self.council_window_start_hour = max(0, int(council_window_start_hour))
+        self.council_window_duration_hours = max(1, int(council_window_duration_hours))
+        self.world_time_broadcast_cadence_ticks = max(1, int(world_time_broadcast_cadence_ticks))
+
+    def _format_world_time(self) -> str:
+        time_str = f"Day {self.state.world_day}, {self.state.world_hour:02d}:00"
+        if self.state.world_season is not None:
+            time_str += f" (Season {self.state.world_season})"
+        return time_str
+
+    def _season_name(self) -> str | None:
+        if self.state.world_season is None:
+            return None
+        return self._SEASON_NAMES[self.state.world_season % len(self._SEASON_NAMES)]
+
+    def _condition_hooks(self) -> dict[str, Any]:
+        weather_hooks: dict[str, dict[str, Any]] = {
+            "clear": {
+                "resource_multipliers": {"gather": 1.0, "build": 1.0},
+                "allowed_actions": ["*"],
+                "mood_modifiers": {"baseline": 0.05},
+            },
+            "rain": {
+                "resource_multipliers": {"gather": 0.9, "build": 0.95},
+                "allowed_actions": ["*"],
+                "mood_modifiers": {"baseline": -0.02},
+            },
+            "windy": {
+                "resource_multipliers": {"gather": 0.95, "build": 0.9},
+                "allowed_actions": ["*"],
+                "mood_modifiers": {"baseline": 0.0},
+            },
+            "storm": {
+                "resource_multipliers": {"gather": 0.75, "build": 0.8},
+                "allowed_actions": ["idle", "propose_idea", "request_role_change"],
+                "mood_modifiers": {"baseline": -0.1},
+            },
+        }
+        season_hooks: dict[str, dict[str, Any]] = {
+            "spring": {
+                "resource_multipliers": {"gather": 1.1},
+                "mood_modifiers": {"baseline": 0.05},
+            },
+            "summer": {
+                "resource_multipliers": {"build": 1.05},
+                "mood_modifiers": {"baseline": 0.02},
+            },
+            "autumn": {
+                "resource_multipliers": {"gather": 1.0},
+                "mood_modifiers": {"baseline": 0.0},
+            },
+            "winter": {
+                "resource_multipliers": {"gather": 0.8, "build": 0.9},
+                "mood_modifiers": {"baseline": -0.06},
+            },
+        }
+        weather = weather_hooks.get(self.state.weather, weather_hooks["clear"])
+        season = season_hooks.get(self._season_name() or "spring", {})
+        resource = {
+            **weather.get("resource_multipliers", {}),
+            **season.get("resource_multipliers", {}),
+        }
+        mood = {**weather.get("mood_modifiers", {}), **season.get("mood_modifiers", {})}
+        return {
+            "resource_multipliers": resource,
+            "allowed_actions": list(weather.get("allowed_actions", ["*"])),
+            "mood_modifiers": mood,
+        }
+
+    def world_time_snapshot(self) -> dict[str, Any]:
+        return {
+            "world_tick": self.state.world_tick,
+            "world_hour": self.state.world_hour,
+            "world_day": self.state.world_day,
+            "world_season": self.state.world_season,
+            "formatted": self._format_world_time(),
+        }
+
+    def build_perception_context(self, *, turn_index: int) -> dict[str, Any]:
+        return {
+            "turn_index": turn_index,
+            "time": self.world_time_snapshot(),
+            "weather": self.state.weather,
+            "season": self._season_name(),
+            "season_effects": dict(self.state.season_effects),
+            "active_global_modifiers": list(self.state.active_global_modifiers),
+            "council_window_active": self.state.council_window_active,
+            "effect_hooks": self._condition_hooks(),
+        }
+
+    def tick(self, turn_index: int) -> list[dict[str, Any]]:
+        if turn_index <= 0:
+            return []
+
+        target_tick = (turn_index - 1) // self.turns_per_world_tick
+        events: list[dict[str, Any]] = []
+        while self.state.world_tick < target_tick:
+            self.state.world_tick += 1
+            self.state.world_hour += 1
+            if self.state.world_hour >= self.world_ticks_per_day:
+                self.state.world_hour = 0
+                self.state.world_day += 1
+                events.append(self._event("daily_reset", turn_index))
+
+            if self.state.world_tick % self.weather_shift_interval_ticks == 0:
+                idx = (self.state.world_tick // self.weather_shift_interval_ticks) % len(
+                    self._WEATHER_CYCLE
+                )
+                self.state.weather = self._WEATHER_CYCLE[idx]
+                events.append(self._event("weather_shift", turn_index))
+
+            if self.world_season_length_days and self.state.world_day > 0:
+                new_season = self.state.world_day // self.world_season_length_days
+                if new_season != self.state.world_season:
+                    self.state.world_season = new_season
+                    self.state.season_effects = {
+                        "season": self._season_name(),
+                        "hooks": self._condition_hooks(),
+                    }
+                    events.append(self._event("season_transition", turn_index))
+
+            is_council_day = (self.state.world_day % self.council_window_days) == 0
+            in_hour_window = (
+                self.council_window_start_hour
+                <= self.state.world_hour
+                < self.council_window_start_hour + self.council_window_duration_hours
+            )
+            council_active = is_council_day and in_hour_window
+            if council_active != self.state.council_window_active:
+                self.state.council_window_active = council_active
+                events.append(self._event("council_meeting_window", turn_index))
+
+            if self.state.world_tick % self.world_time_broadcast_cadence_ticks == 0:
+                events.append(self._event("world_time", turn_index))
+
+        return events
+
+    def _event(self, event_name: str, turn_index: int) -> dict[str, Any]:
+        return {
+            "type": "environment",
+            "event_name": event_name,
+            "turn_index": turn_index,
+            "world_time": self.world_time_snapshot(),
+            "weather": self.state.weather,
+            "season": self._season_name(),
+            "council_window_active": self.state.council_window_active,
+            "active_global_modifiers": list(self.state.active_global_modifiers),
+            "effect_hooks": self._condition_hooks(),
+        }

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -58,6 +58,7 @@ from src.interfaces.metrics import (
 )
 from src.shared.telemetry import trace_agent_action
 from src.shared.typing import SimulationMessage
+from src.sim.environment import EnvironmentState, EnvironmentSystem
 from src.sim.event_kernel import EventKernel
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import BoardEntry, KnowledgeBoard
@@ -163,19 +164,33 @@ class Simulation:
         ACTIVE_AGENT_COUNT.set(len(self.agents))
         self.current_step: int = 0
         self.current_agent_index: int = 0
-        self.world_hour: int = 0
-        self.world_day: int = 0
-        self.world_season: int | None = None
         self.world_ticks_per_day: int = max(1, int(config.get_config("WORLD_TICKS_PER_DAY") or 24))
         self.turns_per_world_tick: int = max(
             1,
             int(config.get_config("WORLD_TICK_TURN_QUANTUM") or len(self.agents) or 1),
         )
-        self.world_tick_index: int = 0
         season_len = int(config.get_config("WORLD_SEASON_LENGTH_DAYS") or 0)
         self.world_season_length_days: int | None = season_len if season_len > 0 else None
-        self.world_season = 0 if self.world_season_length_days else None
-        self._last_time_update_tick = -1
+        self.environment_state = EnvironmentState(
+            world_season=0 if self.world_season_length_days else None
+        )
+        self.environment_system = EnvironmentSystem(
+            state=self.environment_state,
+            world_ticks_per_day=self.world_ticks_per_day,
+            turns_per_world_tick=self.turns_per_world_tick,
+            world_season_length_days=self.world_season_length_days,
+            weather_shift_interval_ticks=int(config.get_config("WORLD_WEATHER_SHIFT_TICKS") or 6),
+            council_window_days=int(config.get_config("WORLD_COUNCIL_WINDOW_DAYS") or 7),
+            council_window_start_hour=int(
+                config.get_config("WORLD_COUNCIL_WINDOW_START_HOUR") or 9
+            ),
+            council_window_duration_hours=int(
+                config.get_config("WORLD_COUNCIL_WINDOW_DURATION_HOURS") or 3
+            ),
+            world_time_broadcast_cadence_ticks=int(
+                config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS") or self.world_ticks_per_day
+            ),
+        )
         self._last_consolidation_day = -1
         self.last_completed_agent_index: int | None = None
         self.steps_to_run: int = 0  # Number of steps to run, set externally
@@ -817,75 +832,63 @@ class Simulation:
                     )
         return other_agents_info
 
-    def _format_world_time(self: Self) -> str:
-        """Return human-readable world time for prompts/events."""
-        time_str = f"Day {self.world_day}, {self.world_hour:02d}:00"
-        if self.world_season is not None:
-            time_str += f" (Season {self.world_season})"
-        return time_str
+    @property
+    def world_tick_index(self: Self) -> int:
+        return self.environment_state.world_tick
+
+    @world_tick_index.setter
+    def world_tick_index(self: Self, value: int) -> None:
+        self.environment_state.world_tick = int(value)
+
+    @property
+    def world_hour(self: Self) -> int:
+        return self.environment_state.world_hour
+
+    @world_hour.setter
+    def world_hour(self: Self, value: int) -> None:
+        self.environment_state.world_hour = int(value)
+
+    @property
+    def world_day(self: Self) -> int:
+        return self.environment_state.world_day
+
+    @world_day.setter
+    def world_day(self: Self, value: int) -> None:
+        self.environment_state.world_day = int(value)
+
+    @property
+    def world_season(self: Self) -> int | None:
+        return self.environment_state.world_season
+
+    @world_season.setter
+    def world_season(self: Self, value: int | None) -> None:
+        self.environment_state.world_season = int(value) if value is not None else None
 
     def _world_time_snapshot(self: Self) -> dict[str, Any]:
         """Return the structured world-time payload used in events and perception."""
-        return {
-            "world_tick": self.world_tick_index,
-            "world_hour": self.world_hour,
-            "world_day": self.world_day,
-            "world_season": self.world_season,
-            "formatted": self._format_world_time(),
-        }
+        return self.environment_system.world_time_snapshot()
 
-    async def _advance_world_time(self: Self, ticks: int = 1) -> None:
-        """Advance world clock by ``ticks`` and broadcast periodic updates."""
-        ticks_to_advance = max(0, int(ticks))
-        if ticks_to_advance == 0:
-            return
-
-        for _ in range(ticks_to_advance):
-            self.world_tick_index += 1
-            self.world_hour += 1
-            if self.world_hour >= self.world_ticks_per_day:
-                self.world_hour = 0
-                self.world_day += 1
-                if self.world_season_length_days and self.world_day > 0:
-                    self.world_season = self.world_day // self.world_season_length_days
-
-        cadence = max(
-            1,
-            int(
-                config.get_config("WORLD_TIME_BROADCAST_CADENCE_TICKS") or self.world_ticks_per_day
-            ),
-        )
-        if (
-            self.world_tick_index > 0
-            and self.world_tick_index % cadence == 0
-            and self.world_tick_index != self._last_time_update_tick
-        ):
-            self._last_time_update_tick = self.world_tick_index
-            world_time = self._world_time_snapshot()
+    async def _emit_environment_observability_events(
+        self: Self, events: Sequence[Mapping[str, Any]], *, step: int
+    ) -> None:
+        for raw_event in events:
             payload = {
-                "type": "world_time",
-                "step": self.current_step,
-                "turn_index": self.current_step,
-                "world_time": world_time,
-                "world_tick": self.world_tick_index,
-                "world_hour": self.world_hour,
-                "world_day": self.world_day,
-                "world_season": self.world_season,
+                **dict(raw_event),
+                "step": step,
+                "environment_context": self.environment_system.build_perception_context(
+                    turn_index=step
+                ),
             }
             event = log_event(payload)
             if event is None:
                 event = {**payload}
                 event["trace_hash"] = compute_trace_hash(payload)
-            await emit_event(SimulationEvent(type="world_time", data=event))
-            await self.send_discord_update(message=f"🕒 {world_time['formatted']}")
-
-    async def _sync_world_time_for_turn(self: Self, turn_index: int) -> None:
-        """Advance world time based on the configured world-tick quantum."""
-        if turn_index <= 0:
-            return
-        target_tick = (turn_index - 1) // self.turns_per_world_tick
-        if target_tick > self.world_tick_index:
-            await self._advance_world_time(target_tick - self.world_tick_index)
+            event_name = str(payload.get("event_name", "environment"))
+            await emit_event(SimulationEvent(type="environment", data=event))
+            if event_name == "world_time":
+                await self.send_discord_update(
+                    message=f"🕒 {self._world_time_snapshot()['formatted']}"
+                )
 
     async def send_discord_update(
         self: Self,
@@ -961,7 +964,10 @@ class Simulation:
 
         # Increment turn index, then sync world time to the configured tick boundary.
         self.current_step += 1
-        await self._sync_world_time_for_turn(self.current_step)
+        environment_events = self.environment_system.tick(self.current_step)
+        await self._emit_environment_observability_events(
+            environment_events, step=self.current_step
+        )
         agent = self.agents[agent_index]
         agent_id = agent.agent_id
         if agent_id in self.muted_agents:
@@ -1020,8 +1026,9 @@ class Simulation:
             perception_data["knowledge_board_content"] = (
                 self.knowledge_board.get_recent_entries_for_prompt()
             )
-        perception_data["turn_index"] = self.current_step
-        perception_data["world_time"] = self._world_time_snapshot()
+        perception_data["environment_context"] = self.environment_system.build_perception_context(
+            turn_index=self.current_step
+        )
         mood_before = float(current_agent_state.mood_level)
 
         # decide
@@ -1119,6 +1126,9 @@ class Simulation:
                 {
                     "step": self.current_step,
                     "turn_index": self.current_step,
+                    "environment_context": self.environment_system.build_perception_context(
+                        turn_index=self.current_step
+                    ),
                     "world_time": self._world_time_snapshot(),
                     "sender_id": agent_id,
                     "recipient_id": message_recipient_id,
@@ -1229,6 +1239,9 @@ class Simulation:
                     "agent_id": agent_id,
                     "step": self.current_step,
                     "turn_index": self.current_step,
+                    "environment_context": self.environment_system.build_perception_context(
+                        turn_index=self.current_step
+                    ),
                     "world_time": self._world_time_snapshot(),
                     "action_intent": action_intent_str,
                     "governance_enforcement": {
@@ -1279,6 +1292,16 @@ class Simulation:
                 "world_season": self.world_season,
                 "world_tick": self.world_tick_index,
                 "turns_per_world_tick": self.turns_per_world_tick,
+                "environment_state": {
+                    "world_tick": self.environment_state.world_tick,
+                    "world_hour": self.environment_state.world_hour,
+                    "world_day": self.environment_state.world_day,
+                    "world_season": self.environment_state.world_season,
+                    "weather": self.environment_state.weather,
+                    "season_effects": self.environment_state.season_effects,
+                    "active_global_modifiers": self.environment_state.active_global_modifiers,
+                    "council_window_active": self.environment_state.council_window_active,
+                },
                 "trace_hash": self._last_trace_hash,
             }
             snapshot_no_vector = {
@@ -1865,7 +1888,9 @@ class Simulation:
                 else []
             ),
             "turn_index": turn_index,
-            "world_time": copy.deepcopy(self._world_time_snapshot()),
+            "environment_context": copy.deepcopy(
+                self.environment_system.build_perception_context(turn_index=turn_index)
+            ),
         }
         return MappingProxyType(snapshot)
 
@@ -1995,7 +2020,12 @@ class Simulation:
                     f" expected {expected_hash}, computed {actual_hash}"
                 )
         if event.get("type") == "agent_action":
-            world_time = event.get("world_time")
+            environment_context = event.get("environment_context")
+            world_time = None
+            if isinstance(environment_context, dict):
+                world_time = environment_context.get("time")
+            if world_time is None:
+                world_time = event.get("world_time")
             if isinstance(world_time, dict):
                 self.world_tick_index = int(world_time.get("world_tick", self.world_tick_index))
                 self.world_hour = int(world_time.get("world_hour", self.world_hour))
@@ -2189,17 +2219,47 @@ class Simulation:
 
             restore_rng_state(snapshot["rng_state"])
         sim.current_step = int(snapshot.get("step", 0))
-        sim.world_hour = int(snapshot.get("world_hour", 0))
-        sim.world_day = int(snapshot.get("world_day", 0))
+        env_snapshot = snapshot.get("environment_state", {})
+        if isinstance(env_snapshot, dict) and env_snapshot:
+            sim.world_hour = int(env_snapshot.get("world_hour", snapshot.get("world_hour", 0)))
+            sim.world_day = int(env_snapshot.get("world_day", snapshot.get("world_day", 0)))
+            sim.world_tick_index = int(
+                env_snapshot.get("world_tick", snapshot.get("world_tick", -1))
+            )
+            world_season_value = env_snapshot.get(
+                "world_season",
+                snapshot.get("world_season", 0 if sim.world_season_length_days else None),
+            )
+            sim.world_season = int(world_season_value) if world_season_value is not None else None
+            sim.environment_state.weather = str(
+                env_snapshot.get("weather", sim.environment_state.weather)
+            )
+            sim.environment_state.season_effects = dict(
+                env_snapshot.get("season_effects", sim.environment_state.season_effects)
+            )
+            sim.environment_state.active_global_modifiers = list(
+                env_snapshot.get(
+                    "active_global_modifiers", sim.environment_state.active_global_modifiers
+                )
+            )
+            sim.environment_state.council_window_active = bool(
+                env_snapshot.get(
+                    "council_window_active", sim.environment_state.council_window_active
+                )
+            )
+        else:
+            sim.world_hour = int(snapshot.get("world_hour", 0))
+            sim.world_day = int(snapshot.get("world_day", 0))
+            sim.world_tick_index = int(snapshot.get("world_tick", -1))
+            world_season = snapshot.get(
+                "world_season", 0 if sim.world_season_length_days else None
+            )
+            sim.world_season = int(world_season) if world_season is not None else None
         snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
         sim.turns_per_world_tick = max(1, snapshot_turn_quantum)
-        legacy_world_tick = int(snapshot.get("world_tick", -1))
-        if legacy_world_tick >= 0:
-            sim.world_tick_index = legacy_world_tick
-        elif sim.current_step > 0:
+        sim.environment_system.turns_per_world_tick = sim.turns_per_world_tick
+        if sim.world_tick_index < 0 and sim.current_step > 0:
             sim.world_tick_index = (sim.current_step - 1) // sim.turns_per_world_tick
-        world_season = snapshot.get("world_season", 0 if sim.world_season_length_days else None)
-        sim.world_season = int(world_season) if world_season is not None else None
         sim.collective_ip = float(snapshot.get("collective_ip", 0.0))
         sim.collective_du = float(snapshot.get("collective_du", 0.0))
         sim._last_trace_hash = snapshot.get("trace_hash", "")

--- a/tests/unit/sim/test_simulation_world_time.py
+++ b/tests/unit/sim/test_simulation_world_time.py
@@ -35,42 +35,9 @@ class DummyAgent:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_world_time_rollover_hour_to_day(monkeypatch):
+async def test_environment_tick_rollover_and_daily_reset(monkeypatch):
     monkeypatch.setenv("WORLD_TICKS_PER_DAY", "2")
     monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "0")
-    monkeypatch.setenv("WORLD_TIME_BROADCAST_CADENCE_TICKS", "2")
-
-    monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
-    monkeypatch.setattr(
-        "src.sim.simulation.log_event", lambda data: {**data, "trace_hash": "hash"}
-    )
-    monkeypatch.setattr("src.sim.simulation.emit_event", AsyncMock())
-    rm = SimpleNamespace(
-        cap_tick=lambda **kwargs: None, set_du_budget=lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr("src.sim.simulation.get_resource_manager", lambda: rm)
-
-    sim = Simulation(
-        [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
-    )
-    sim.current_step = 1
-    await sim._advance_world_time()
-    assert sim.world_hour == 1
-    assert sim.world_day == 0
-
-    sim.current_step = 2
-    await sim._advance_world_time()
-    assert sim.world_hour == 0
-    assert sim.world_day == 1
-    assert sim.world_season is None
-    sim.close()
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_world_time_rollover_day_to_season(monkeypatch):
-    monkeypatch.setenv("WORLD_TICKS_PER_DAY", "2")
-    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "2")
     monkeypatch.setenv("WORLD_TIME_BROADCAST_CADENCE_TICKS", "2")
 
     monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
@@ -87,23 +54,35 @@ async def test_world_time_rollover_day_to_season(monkeypatch):
     sim = Simulation(
         [DummyAgent()], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
     )
+    sim.personality_engine.update_traits = lambda *args, **kwargs: []
+    await sim._run_agent_turn(0)
+    assert sim.world_hour == 0
+    assert sim.world_day == 0
 
-    for step in range(1, 5):
-        sim.current_step = step
-        await sim._advance_world_time()
+    await sim._run_agent_turn(0)
+    assert sim.world_hour == 1
+    assert sim.world_day == 0
 
-    assert sim.world_day == 2
-    assert sim.world_season == 1
-    assert any(call.args[0].type == "world_time" for call in emit_event.await_args_list)
+    await sim._run_agent_turn(0)
+    assert sim.world_hour == 0
+    assert sim.world_day == 1
+
+    env_events = [
+        call.args[0].data
+        for call in emit_event.await_args_list
+        if call.args[0].type == "environment"
+    ]
+    assert any(event.get("event_name") == "daily_reset" for event in env_events)
+    assert any(event.get("event_name") == "world_time" for event in env_events)
+    await sim.stop_event_listener()
     sim.close()
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_run_turn_includes_world_time_perception(monkeypatch):
+async def test_environment_context_in_perception(monkeypatch):
     monkeypatch.setenv("WORLD_TICKS_PER_DAY", "24")
-    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "0")
-    monkeypatch.setenv("WORLD_TIME_BROADCAST_CADENCE_TICKS", "24")
+    monkeypatch.setenv("WORLD_SEASON_LENGTH_DAYS", "2")
 
     monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
     monkeypatch.setattr(
@@ -119,20 +98,22 @@ async def test_run_turn_includes_world_time_perception(monkeypatch):
     sim = Simulation(
         [agent], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
     )
+    sim.personality_engine.update_traits = lambda *args, **kwargs: []
     await sim._run_agent_turn(0)
 
     assert agent.last_perception is not None
-    world_time = agent.last_perception.get("world_time")
-    assert world_time is not None
-    assert world_time["world_hour"] == sim.world_hour
-    assert world_time["world_day"] == sim.world_day
-    assert "formatted" in world_time
+    environment_context = agent.last_perception.get("environment_context")
+    assert environment_context is not None
+    assert "time" in environment_context
+    assert "effect_hooks" in environment_context
+    assert environment_context["time"]["world_hour"] == sim.world_hour
+    await sim.stop_event_listener()
     sim.close()
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_agent_action_event_contains_turn_index_and_world_time(monkeypatch):
+async def test_agent_action_event_contains_environment_context(monkeypatch):
     monkeypatch.setenv("WORLD_TICK_TURN_QUANTUM", "2")
 
     monkeypatch.setattr("src.sim.simulation.evaluate_policy", AsyncMock(return_value=True))
@@ -150,15 +131,19 @@ async def test_agent_action_event_contains_turn_index_and_world_time(monkeypatch
     sim = Simulation(
         [agent], memory_service=SimpleNamespace(vector_store=None, semantic_manager=None)
     )
+    sim.personality_engine.update_traits = lambda *args, **kwargs: []
 
     await sim._run_agent_turn(0)
 
     agent_action_events = [
-        call.args[0].data for call in emit_event.await_args_list if call.args[0].type == "agent_action"
+        call.args[0].data
+        for call in emit_event.await_args_list
+        if call.args[0].type == "agent_action"
     ]
     assert agent_action_events
     payload = agent_action_events[-1]
     assert payload["turn_index"] == sim.current_step
-    assert payload["world_time"]["world_tick"] == sim.world_tick_index
-    assert payload["world_time"]["world_day"] == sim.world_day
+    assert payload["environment_context"]["time"]["world_tick"] == sim.world_tick_index
+    assert payload["environment_context"]["time"]["world_day"] == sim.world_day
+    await sim.stop_event_listener()
     sim.close()


### PR DESCRIPTION
### Motivation
- Centralize world-time and environment logic into a single subsystem so temporal progression, condition effects, and observability are owned and deterministic. 
- Replace ad-hoc scattered time fields in perception with a single structured payload to simplify agent interfaces and make environment effects pluggable. 
- Emit normalized environment events for observability and include environment state in snapshots to preserve replay compatibility.

### Description
- Add `src/sim/environment.py` implementing `EnvironmentState` (world tick/hour/day/season, weather, season effects, modifiers, council windows) and `EnvironmentSystem` which provides `tick(turn_index)`, deterministic schedulers (daily reset, weather shift, season transition, council meeting windows), `build_perception_context(...)`, and condition effect hooks (`resource_multipliers`, `allowed_actions`, `mood_modifiers`).
- Refactor `Simulation` to use the new subsystem by importing `EnvironmentState`/`EnvironmentSystem`, storing `environment_state` and `environment_system`, exposing time fields via environment-backed properties (`world_tick_index`, `world_hour`, `world_day`, `world_season`), and delegating time advancement to `environment_system.tick(...)` during turn execution.
- Inject a single structured `environment_context` into agent perception snapshots and pipeline snapshots, include `environment_context` in `agent_action` events, and read time from `environment_context` during replay with fallback to legacy `world_time` fields.
- Emit normalized environment observability events via a new `_emit_environment_observability_events(...)` helper and persist full `environment_state` inside simulation snapshots while preserving legacy fields for backward compatibility.
- Update unit tests in `tests/unit/sim/test_simulation_world_time.py` to assert environment-driven rollover/events, `environment_context` presence in perception, and `environment_context` inclusion in agent action payloads.

### Testing
- Ran targeted lint/format checks: `ruff check src/sim/environment.py src/sim/simulation.py tests/unit/sim/test_simulation_world_time.py` (passed) and `ruff format` was applied to the changed files.
- Ran unit tests: `pytest tests/unit/sim/test_simulation_world_time.py -q` and the updated tests passed (3 tests, 0 failures).
- Ran `mypy` for the changed modules, but a pre-existing unrelated typing issue in `src/infra/settings.py` prevents a clean full-type pass; this is unrelated to the environment changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69972a786dcc8326b77c33dde304db94)