### PR TITLE
Add canonical governance workflow APIs and integrate pre-action checks into Simulation

### DIFF
--- a/src/governance/rules_engine.py
+++ b/src/governance/rules_engine.py
@@ -49,6 +49,20 @@ class RuleEvaluationResult:
     penalties: list[dict[str, Any]] = field(default_factory=list)
 
 
+@dataclass(slots=True)
+class GovernanceDecisionOutcome:
+    """Structured governance decision returned for agent action execution."""
+
+    outcome: str
+    decision: str
+    allowed: bool
+    action_intent: str
+    rule_ids: list[str] = field(default_factory=list)
+    reason: str | None = None
+    penalties: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 class RulesEngine:
     """Materializes accepted proposals into executable action constraints."""
 
@@ -61,9 +75,19 @@ class RulesEngine:
         r"(?P<amount>[0-9]+(?:\.[0-9]+)?)\s*(?P<unit>ip|du)",
         flags=re.IGNORECASE,
     )
+    _REQUIRE_VOTE_PATTERN = re.compile(
+        r"(?:^|\b)(?:require\s+vote|vote\s+required|regulate)\s+(?:for\s+)?(?P<action>[a-z_\-\s]+)",
+        flags=re.IGNORECASE,
+    )
 
     def __init__(self) -> None:
         self._active_rules: dict[str, GovernanceRule] = {}
+        self._governance_state: dict[str, Any] = {
+            "passed_laws": [],
+            "pending_votes": [],
+            "active_offices": [],
+            "sanctions": [],
+        }
 
     @staticmethod
     def _normalize_action(action: str) -> str:
@@ -123,6 +147,19 @@ class RulesEngine:
             )
             materialized.append(rule)
 
+        vote_match = self._REQUIRE_VOTE_PATTERN.search(text)
+        if vote_match:
+            action = self._normalize_action(vote_match.group("action"))
+            rule = GovernanceRule(
+                rule_id=self._rule_id(f"vote:{text}", decided_at),
+                source_text=text,
+                action_intent=action,
+                effective_date=decided_at,
+                decision_mode="vote_required",
+                provenance=provenance,
+            )
+            materialized.append(rule)
+
         ban_match = self._BAN_PATTERN.search(text)
         if ban_match:
             action = self._normalize_action(ban_match.group("action"))
@@ -160,6 +197,7 @@ class RulesEngine:
         """Evaluate ``action_intent`` against active executable rules."""
         normalized_action = self._normalize_action(action_intent or "idle")
         denials: list[str] = []
+        vote_required: list[str] = []
         penalties: list[dict[str, Any]] = []
 
         for rule in self._active_rules.values():
@@ -170,6 +208,10 @@ class RulesEngine:
             if rule.decision_mode == "deny":
                 rule.enforcement_stats["rejected"] += 1
                 denials.append(rule.rule_id)
+                continue
+
+            if rule.decision_mode == "vote_required":
+                vote_required.append(rule.rule_id)
                 continue
 
             if rule.decision_mode == "penalize":
@@ -192,6 +234,14 @@ class RulesEngine:
                 reason="blocked_by_governance_rule",
             )
 
+        if vote_required:
+            return RuleEvaluationResult(
+                allowed=False,
+                decision="vote_required",
+                violated_rules=vote_required,
+                reason="action_requires_governance_vote",
+            )
+
         if penalties:
             return RuleEvaluationResult(
                 allowed=True,
@@ -209,6 +259,140 @@ class RulesEngine:
             decision="accepted",
             violated_rules=[],
         )
+
+    def pre_action_check(self, action_intent: str, *, policy_allowed: bool = True) -> GovernanceDecisionOutcome:
+        """Return structured governance eligibility before side effects are committed."""
+        normalized_action = self._normalize_action(action_intent or "idle")
+        if not policy_allowed:
+            return GovernanceDecisionOutcome(
+                outcome="blocked",
+                decision="policy_denied",
+                allowed=False,
+                action_intent=normalized_action,
+                reason="blocked_by_policy",
+            )
+
+        evaluation = self.evaluate_action(normalized_action)
+        if not evaluation.allowed:
+            mapped_outcome = "needs_vote" if evaluation.decision == "vote_required" else "blocked"
+            return GovernanceDecisionOutcome(
+                outcome=mapped_outcome,
+                decision=evaluation.decision,
+                allowed=False,
+                action_intent=normalized_action,
+                rule_ids=evaluation.violated_rules,
+                reason=evaluation.reason,
+                penalties=evaluation.penalties,
+            )
+
+        if evaluation.penalties:
+            return GovernanceDecisionOutcome(
+                outcome="allowed_with_cost",
+                decision=evaluation.decision,
+                allowed=True,
+                action_intent=normalized_action,
+                rule_ids=evaluation.violated_rules,
+                reason=evaluation.reason,
+                penalties=evaluation.penalties,
+            )
+
+        return GovernanceDecisionOutcome(
+            outcome="allowed",
+            decision=evaluation.decision,
+            allowed=True,
+            action_intent=normalized_action,
+            reason=evaluation.reason,
+        )
+
+    def proposal_workflow(
+        self,
+        proposal_text: str,
+        *,
+        proposer_id: str,
+        approved: bool,
+        proposal_record: dict[str, Any] | None = None,
+        effective_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Canonical governance proposal workflow including state store updates."""
+        materialization = self.materialize_from_proposal(
+            proposal_text,
+            proposer_id=proposer_id,
+            approved=approved,
+            proposal_record=proposal_record,
+            effective_date=effective_date,
+        )
+        decided_at = str(materialization.get("effective_date") or datetime.now(timezone.utc).isoformat())
+        if approved:
+            self.record_passed_law(
+                proposal_text,
+                proposer_id=proposer_id,
+                effective_date=decided_at,
+                proposal_record=proposal_record,
+            )
+        else:
+            self._governance_state["pending_votes"].append(
+                {
+                    "proposal_text": proposal_text,
+                    "proposer_id": proposer_id,
+                    "status": "rejected",
+                    "effective_date": decided_at,
+                }
+            )
+        return materialization
+
+    def post_action_enforcement(
+        self,
+        outcome: GovernanceDecisionOutcome,
+        *,
+        agent_id: str,
+        step: int,
+    ) -> dict[str, Any]:
+        """Apply post-action consequences and return an audit record."""
+        record = {
+            "agent_id": agent_id,
+            "step": int(step),
+            "action_intent": outcome.action_intent,
+            "outcome": outcome.outcome,
+            "decision": outcome.decision,
+            "rule_ids": list(outcome.rule_ids),
+            "reason": outcome.reason,
+            "penalties": list(outcome.penalties),
+        }
+        if outcome.outcome in {"blocked", "needs_vote", "allowed_with_cost"}:
+            self._governance_state["sanctions"].append(record)
+        return record
+
+    def record_passed_law(
+        self,
+        text: str,
+        *,
+        proposer_id: str,
+        effective_date: str,
+        proposal_record: dict[str, Any] | None = None,
+    ) -> None:
+        entry = {
+            "text": text,
+            "proposer_id": proposer_id,
+            "effective_date": effective_date,
+        }
+        if proposal_record:
+            entry["proposal_record"] = proposal_record
+        self._governance_state["passed_laws"].append(entry)
+
+    def current_rules(self) -> list[dict[str, Any]]:
+        return self.active_rules_read_model()
+
+    def pending_votes(self) -> list[dict[str, Any]]:
+        return list(self._governance_state["pending_votes"])
+
+    def active_offices(self) -> list[dict[str, Any]]:
+        return list(self._governance_state["active_offices"])
+
+    def sanctions(self) -> list[dict[str, Any]]:
+        return list(self._governance_state["sanctions"])
+
+    def passed_laws(self) -> list[str]:
+        return [str(item.get("text", "")) for item in self._governance_state["passed_laws"]]
 
     def active_rules_read_model(self) -> list[dict[str, Any]]:
         """Return active rules and their enforcement statistics."""
@@ -229,6 +413,7 @@ class RulesEngine:
 governance_rules_engine = RulesEngine()
 
 __all__ = [
+    "GovernanceDecisionOutcome",
     "GovernanceRule",
     "RuleEvaluationResult",
     "RulePenalty",

--- a/src/governance/service.py
+++ b/src/governance/service.py
@@ -196,6 +196,7 @@ class GovernanceService:
         no_weight = sum(w for w, v in zip(weights, votes) if not v)
         approved = yes_weight > no_weight
         if approved:
+            # Keep legacy law board synced while canonical state lives in governance_rules_engine.
             law_board.add_law(text)
         outcome: dict[str, float | bool | dict[str, Any] | str] = {
             "approved": approved,
@@ -204,7 +205,7 @@ class GovernanceService:
             "ip_spent": ip_spent,
             "proposal_entry_id": proposal_entry_id,
         }
-        rule_materialization = governance_rules_engine.materialize_from_proposal(
+        rule_materialization = governance_rules_engine.proposal_workflow(
             text,
             proposer_id=proposer.agent_id,
             approved=approved,

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any, Final, cast
 from opentelemetry import trace
 from pydantic import BaseModel
 
-from src.governance.law_board import law_board
 from src.governance.rules_engine import governance_rules_engine
 from src.governance.service import governance
 from src.infra import event_log
@@ -231,6 +230,10 @@ class ProposalsResponse(BaseModel):
 
 class GovernanceReadModelResponse(BaseModel):
     rules: list[dict[str, Any]]
+    current_rules: list[dict[str, Any]] = []
+    pending_votes: list[dict[str, Any]] = []
+    active_offices: list[dict[str, Any]] = []
+    sanctions: list[dict[str, Any]] = []
 
 
 class VoteRequest(BaseModel):
@@ -674,15 +677,46 @@ async def api_get_gov() -> Response:
     if sim is not None and hasattr(sim, "get_governance_read_model"):
         model = cast(dict[str, Any], sim.get_governance_read_model())
         return JSONResponse(model)
-    return JSONResponse({"rules": governance_rules_engine.active_rules_read_model()})
+    return JSONResponse({
+        "rules": governance_rules_engine.current_rules(),
+        "current_rules": governance_rules_engine.current_rules(),
+        "pending_votes": governance_rules_engine.pending_votes(),
+        "active_offices": governance_rules_engine.active_offices(),
+        "sanctions": governance_rules_engine.sanctions(),
+    })
 
 
 @app.get("/api/laws", response_model=LawsResponse)
 async def api_get_laws() -> Response:
-    """Return passed laws from the law board."""
+    """Return passed laws from the canonical governance state store."""
 
-    laws = law_board.get_laws()
-    return JSONResponse({"laws": laws})
+    return JSONResponse({"laws": governance_rules_engine.passed_laws()})
+
+
+
+
+@app.get("/api/gov/current_rules")
+async def api_current_rules() -> Response:
+    """Return current executable governance rules."""
+    return JSONResponse({"current_rules": governance_rules_engine.current_rules()})
+
+
+@app.get("/api/gov/pending_votes")
+async def api_pending_votes() -> Response:
+    """Return pending governance vote records."""
+    return JSONResponse({"pending_votes": governance_rules_engine.pending_votes()})
+
+
+@app.get("/api/gov/active_offices")
+async def api_active_offices() -> Response:
+    """Return currently active governance offices."""
+    return JSONResponse({"active_offices": governance_rules_engine.active_offices()})
+
+
+@app.get("/api/gov/sanctions")
+async def api_sanctions() -> Response:
+    """Return active sanctions and post-action enforcement records."""
+    return JSONResponse({"sanctions": governance_rules_engine.sanctions()})
 
 
 @app.get("/api/votes", response_model=VotesResponse)
@@ -1143,8 +1177,10 @@ __all__ = [
     "VoteRecord",
     "VoteRequest",
     "VotesResponse",
+    "api_active_offices",
     "api_agent_stats",
     "api_auctions",
+    "api_current_rules",
     "api_flagged_messages",
     "api_get_gov",
     "api_get_laws",
@@ -1155,8 +1191,10 @@ __all__ = [
     "api_memory_snapshot",
     "api_memory_snapshots",
     "api_misbehavior",
+    "api_pending_votes",
     "api_propose_law",
     "api_recent_proposals",
+    "api_sanctions",
     "api_stake_ip",
     "api_token_balances",
     "api_vote",

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -67,6 +67,7 @@ from src.sim.event_kernel import EventKernel
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
 from src.sim.knowledge_board import BoardEntry, KnowledgeBoard
 from src.sim.knowledge_board_protocol import KnowledgeBoardProtocol
+from src.sim.knowledge_entry import KnowledgeEntryType
 from src.sim.lifecycle_service import LifecycleService
 from src.sim.quests import generate_quest
 from src.sim.resource_manager import get_resource_manager
@@ -1151,16 +1152,20 @@ class Simulation:
             explain_why_payload["rag_summary"] = None
 
         # act
-        allowed = await evaluate_policy(action_intent_str)
-        rule_evaluation = governance_rules_engine.evaluate_action(action_intent_str)
-        if not allowed or not rule_evaluation.allowed:
+        policy_allowed = await evaluate_policy(action_intent_str)
+        governance_outcome = governance_rules_engine.pre_action_check(
+            action_intent_str,
+            policy_allowed=policy_allowed,
+        )
+
+        if not governance_outcome.allowed:
             action_intent_str = AgentActionIntent.IDLE.value
             message_content = None
             message_recipient_id = None
             map_action = None
 
-        if rule_evaluation.penalties:
-            for penalty in rule_evaluation.penalties:
+        if governance_outcome.penalties:
+            for penalty in governance_outcome.penalties:
                 current_agent_state.ip = max(
                     0.0, float(current_agent_state.ip) - float(penalty.get("ip", 0.0))
                 )
@@ -1168,31 +1173,33 @@ class Simulation:
                     0.0, float(current_agent_state.du) - float(penalty.get("du", 0.0))
                 )
 
+        governance_audit = governance_rules_engine.post_action_enforcement(
+            governance_outcome,
+            agent_id=agent_id,
+            step=self.current_step,
+        )
+
         if self.knowledge_board:
-            governance_decision = (
-                "rejected"
-                if not allowed or not rule_evaluation.allowed
-                else rule_evaluation.decision
-            )
-            rule_ids = rule_evaluation.violated_rules
             async with self.knowledge_board.lock:
                 self.knowledge_board.add_entry(
                     BoardEntry(
                         content_full=(
-                            f"Governance enforcement {governance_decision} for action "
+                            f"Governance enforcement {governance_outcome.outcome} for action "
                             f"'{requested_action_intent}' by {agent_id}"
                         ),
-                        entry_type="governance_decision",
-                        tags=["governance", governance_decision],
+                        entry_type=KnowledgeEntryType.GOVERNANCE_DECISION.value,
+                        tags=["governance", governance_outcome.outcome, governance_outcome.decision],
                         reference_metadata={
-                            "decision": governance_decision,
-                            "rule_ids": rule_ids,
+                            "decision": governance_outcome.decision,
+                            "outcome": governance_outcome.outcome,
+                            "rule_ids": governance_outcome.rule_ids,
                             "provenance": {
                                 "agent_id": agent_id,
                                 "step": self.current_step,
-                                "policy_allowed": allowed,
-                                "rule_reason": rule_evaluation.reason,
-                                "penalties": rule_evaluation.penalties,
+                                "policy_allowed": policy_allowed,
+                                "rule_reason": governance_outcome.reason,
+                                "penalties": governance_outcome.penalties,
+                                "audit": governance_audit,
                             },
                         },
                     ),
@@ -1200,7 +1207,6 @@ class Simulation:
                     self.current_step,
                     self.vector.to_dict(),
                 )
-
         if message_content:
             msg_data = cast(
                 SimulationMessage,
@@ -1278,7 +1284,7 @@ class Simulation:
             message_recipient_id=message_recipient_id,
             mood_before=mood_before,
             mood_after=float(current_agent_state.mood_level),
-            rule_allowed=bool(allowed and rule_evaluation.allowed),
+            rule_allowed=bool(governance_outcome.allowed),
         )
         self.personality_engine.update_traits(current_agent_state, experience_signals)
         self.agents[agent_index].update_state(current_agent_state)
@@ -1326,12 +1332,11 @@ class Simulation:
                     "world_time": self._world_time_snapshot(),
                     "action_intent": action_intent_str,
                     "governance_enforcement": {
-                        "decision": "rejected"
-                        if not allowed or not rule_evaluation.allowed
-                        else rule_evaluation.decision,
-                        "reason": rule_evaluation.reason,
-                        "violated_rules": rule_evaluation.violated_rules,
-                        "penalties": rule_evaluation.penalties,
+                        "decision": governance_outcome.decision,
+                        "outcome": governance_outcome.outcome,
+                        "reason": governance_outcome.reason,
+                        "violated_rules": governance_outcome.rule_ids,
+                        "penalties": governance_outcome.penalties,
                     },
                     "ip": current_agent_state.ip,
                     "du": current_agent_state.du,
@@ -2520,9 +2525,31 @@ class Simulation:
 
         return _get_project_details(self)
 
+    def current_rules(self: Self) -> list[dict[str, Any]]:
+        """Read API for agents/UI: current executable governance rules."""
+        return governance_rules_engine.current_rules()
+
+    def pending_votes(self: Self) -> list[dict[str, Any]]:
+        """Read API for agents/UI: pending governance votes."""
+        return governance_rules_engine.pending_votes()
+
+    def active_offices(self: Self) -> list[dict[str, Any]]:
+        """Read API for agents/UI: active governance offices."""
+        return governance_rules_engine.active_offices()
+
+    def sanctions(self: Self) -> list[dict[str, Any]]:
+        """Read API for agents/UI: sanctions and enforcement records."""
+        return governance_rules_engine.sanctions()
+
     def get_governance_read_model(self: Self) -> dict[str, Any]:
-        """Return governance read models for rules, proposals, consensus, and stances."""
-        read_model: dict[str, Any] = {"rules": governance_rules_engine.active_rules_read_model()}
+        """Return governance read models for rules, voting, offices, sanctions, and stances."""
+        read_model: dict[str, Any] = {
+            "rules": governance_rules_engine.current_rules(),
+            "current_rules": governance_rules_engine.current_rules(),
+            "pending_votes": governance_rules_engine.pending_votes(),
+            "active_offices": governance_rules_engine.active_offices(),
+            "sanctions": governance_rules_engine.sanctions(),
+        }
         board = self.knowledge_board
         if hasattr(board, "get_active_proposals"):
             proposals = board.get_active_proposals(limit=20)
@@ -2538,7 +2565,6 @@ class Simulation:
                 for agent in self.agents
             }
         return read_model
-
     async def propose_law(
         self: Self, proposer_id: str, text: str, vote_weights: dict[str, int] | None = None
     ) -> bool:

--- a/tests/unit/governance/test_rules_engine_governance_api.py
+++ b/tests/unit/governance/test_rules_engine_governance_api.py
@@ -1,0 +1,42 @@
+from src.governance.rules_engine import RulesEngine
+
+
+def test_pre_action_check_maps_blocked_and_cost_outcomes() -> None:
+    engine = RulesEngine()
+    engine.materialize_from_proposal("ban move", proposer_id="a1", approved=True)
+    engine.materialize_from_proposal("penalize gather by 2 ip", proposer_id="a1", approved=True)
+
+    blocked = engine.pre_action_check("move")
+    assert blocked.outcome == "blocked"
+    assert blocked.allowed is False
+
+    with_cost = engine.pre_action_check("gather")
+    assert with_cost.outcome == "allowed_with_cost"
+    assert with_cost.allowed is True
+    assert with_cost.penalties
+
+
+def test_pre_action_check_maps_vote_required_outcome() -> None:
+    engine = RulesEngine()
+    engine.materialize_from_proposal("require vote for build", proposer_id="a1", approved=True)
+
+    outcome = engine.pre_action_check("build")
+    assert outcome.outcome == "needs_vote"
+    assert outcome.allowed is False
+
+
+def test_proposal_workflow_and_read_apis() -> None:
+    engine = RulesEngine()
+    engine.proposal_workflow("ban dance", proposer_id="a1", approved=True)
+
+    assert engine.current_rules()
+    assert engine.passed_laws() == ["ban dance"]
+    assert engine.pending_votes() == []
+
+    record = engine.post_action_enforcement(
+        engine.pre_action_check("dance"),
+        agent_id="a2",
+        step=3,
+    )
+    assert record["outcome"] == "blocked"
+    assert engine.sanctions()

--- a/tests/unit/interfaces/test_dashboard_backend_gov.py
+++ b/tests/unit/interfaces/test_dashboard_backend_gov.py
@@ -13,10 +13,18 @@ async def test_api_get_gov_without_sim(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(db.SIM_STATE, "simulation", None)
     monkeypatch.setattr(
         db.governance_rules_engine,
-        "active_rules_read_model",
+        "current_rules",
         lambda: [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}],
     )
+    monkeypatch.setattr(db.governance_rules_engine, "pending_votes", lambda: [{"id": "p1"}])
+    monkeypatch.setattr(db.governance_rules_engine, "active_offices", lambda: [{"office": "council"}])
+    monkeypatch.setattr(db.governance_rules_engine, "sanctions", lambda: [{"agent_id": "a1"}])
+
     resp = await db.api_get_gov()
     assert json.loads(resp.body) == {
-        "rules": [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}]
+        "rules": [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}],
+        "current_rules": [{"rule_id": "r1", "effective_date": "now", "enforcement_stats": {}}],
+        "pending_votes": [{"id": "p1"}],
+        "active_offices": [{"office": "council"}],
+        "sanctions": [{"agent_id": "a1"}],
     }


### PR DESCRIPTION
### Motivation
- Make governance an explicit layer in action proposal, validation, and post-action consequences so agent actions are checked against a canonical rules store before side effects commit. 
- Replace ad hoc law interactions with a single governance state store and expose clear read/write APIs for agents and the UI. 
- Provide structured action-to-rule outcomes (blocked / needs_vote / allowed_with_cost / allowed) and persist transparent governance decisions to the Knowledge Board.

### Description
- Added structured governance artifacts and APIs in `src/governance/rules_engine.py`: a `GovernanceDecisionOutcome` dataclass, `_REQUIRE_VOTE_PATTERN`, a canonical `_governance_state` store, and new methods `pre_action_check`, `proposal_workflow`, `post_action_enforcement`, plus read APIs `current_rules`, `pending_votes`, `active_offices`, `sanctions`, and `passed_laws`.
- Extended rule materialization to recognize vote-required and penalize rules and to return structured outcomes mapping actions to rule IDs and penalties via `pre_action_check`/`RuleEvaluationResult`.
- Integrated governance checks into the simulation execution path in `src/sim/simulation.py` by calling `governance_rules_engine.pre_action_check` before committing side effects, applying penalties to agent balances, calling `post_action_enforcement`, and writing typed governance decision entries to the Knowledge Board using `KnowledgeEntryType.GOVERNANCE_DECISION` for transparency; event payloads now include the structured `governance_enforcement` read model.
- Switched proposal handling in `src/governance/service.py` to use the canonical `proposal_workflow` (while keeping the legacy `LawBoard` synced for compatibility) so proposals update the central governance state store.
- Added dashboard and HTTP read surfaces in `src/interfaces/dashboard_backend.py`: enriched `/api/gov` response and added explicit endpoints `/api/gov/current_rules`, `/api/gov/pending_votes`, `/api/gov/active_offices`, and `/api/gov/sanctions`, and made `/api/laws` read from the canonical governance engine state.
- Added unit tests under `tests/unit/governance/test_rules_engine_governance_api.py` to verify `pre_action_check`, `proposal_workflow`, and read APIs; updated the dashboard unit test `tests/unit/interfaces/test_dashboard_backend_gov.py` to expect the expanded gov read model.

### Testing
- Ran the linter: `ruff check src/governance/rules_engine.py src/governance/service.py src/sim/simulation.py src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_gov.py tests/unit/governance/test_rules_engine_governance_api.py` and it reported all checks passed.
- Ran unit tests: `pytest -q tests/unit/governance/test_rules_engine_governance_api.py tests/unit/interfaces/test_dashboard_backend_gov.py` and the added/updated unit tests passed.
- Performed bytecode checks: `python -m py_compile src/governance/rules_engine.py src/governance/service.py src/sim/simulation.py src/interfaces/dashboard_backend.py tests/unit/interfaces/test_dashboard_backend_gov.py tests/unit/governance/test_rules_engine_governance_api.py` which succeeded.
- Attempted to run a few integration targets but the exact node IDs supplied were not found / deselected in this environment, so full integration-suite validation was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997336027148326bf04086ebc25ad16)