### PR TITLE
Add snapshot schema versioning, migrations, and regression tests

### DIFF
--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
+from src.sim.persistence.snapshot_migrations import CURRENT_SNAPSHOT_SCHEMA_VERSION
 from src.sim.persistence.trace_hash_service import TraceHashService
 from src.utils.paths import ensure_dir
 
@@ -39,6 +40,17 @@ def compute_trace_hash(data: dict[str, Any]) -> str:
     """Backward-compatible trace hash helper; use sim persistence services for new code."""
 
     return TraceHashService.compute(data)
+
+
+def _validate_snapshot_schema_version(data: dict[str, Any]) -> None:
+    version = data.get("snapshot_schema_version")
+    if not isinstance(version, int):
+        raise ValueError("Snapshot schema version is missing or invalid")
+    if version < 1 or version > CURRENT_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported snapshot schema version {version}; "
+            f"supported range is [1, {CURRENT_SNAPSHOT_SCHEMA_VERSION}]"
+        )
 
 
 def _get_s3_client() -> boto3.client:
@@ -97,6 +109,7 @@ def save_snapshot(
         Folder where snapshots will be stored.
     """
     compress = SNAPSHOT_COMPRESS if compress is None else compress
+    _validate_snapshot_schema_version(data)
 
     path = ensure_dir(directory)
 
@@ -175,6 +188,8 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
+
+    _validate_snapshot_schema_version(data)
 
     expected = data.get("trace_hash")
     if expected is not None:

--- a/src/sim/persistence/snapshot_migrations.py
+++ b/src/sim/persistence/snapshot_migrations.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any
+
+CURRENT_SNAPSHOT_SCHEMA_VERSION = 3
+
+
+def _migrate_v1_to_v2(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Normalize world timing fields into ``environment_state``."""
+
+    migrated = deepcopy(snapshot)
+    env = migrated.get("environment_state")
+    if not isinstance(env, dict):
+        env = {}
+    env["world_tick"] = int(env.get("world_tick", migrated.get("world_tick", -1)))
+    env["world_hour"] = int(env.get("world_hour", migrated.get("world_hour", 0)))
+    env["world_day"] = int(env.get("world_day", migrated.get("world_day", 0)))
+    world_season = env.get("world_season", migrated.get("world_season"))
+    env["world_season"] = int(world_season) if world_season is not None else None
+    migrated["environment_state"] = env
+    migrated["snapshot_schema_version"] = 2
+    return migrated
+
+
+def _migrate_v2_to_v3(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Backfill environment/agent defaults required by the current schema."""
+
+    migrated = deepcopy(snapshot)
+
+    env = migrated.get("environment_state")
+    if not isinstance(env, dict):
+        env = {}
+    env.setdefault("weather", "clear")
+    env.setdefault("season_effects", {})
+    env.setdefault("active_global_modifiers", [])
+    env.setdefault("council_window_active", False)
+    migrated["environment_state"] = env
+
+    agents = migrated.get("agents")
+    if isinstance(agents, list):
+        for agent_data in agents:
+            if not isinstance(agent_data, dict):
+                continue
+            agent_data.setdefault("lifecycle_state", "active")
+            agent_data.setdefault("lifecycle_history", [])
+            agent_data.setdefault("legacy_artifacts", {})
+            agent_data.setdefault("memory_archival_policy", {})
+            agent_data.setdefault("predecessor_id", None)
+            agent_data.setdefault("successor_id", None)
+
+    if not isinstance(migrated.get("knowledge_board"), dict):
+        migrated["knowledge_board"] = {"entries": [], "vector": {}}
+    if not isinstance(migrated.get("world_map"), dict):
+        migrated["world_map"] = {"width": 10, "height": 10, "agents": {}, "vector": {}}
+
+    migrated["snapshot_schema_version"] = CURRENT_SNAPSHOT_SCHEMA_VERSION
+    return migrated
+
+
+SNAPSHOT_MIGRATIONS: dict[int, Callable[[dict[str, Any]], dict[str, Any]]] = {
+    1: _migrate_v1_to_v2,
+    2: _migrate_v2_to_v3,
+}
+
+
+def migrate_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Run ordered N->N+1 migrations to normalize snapshot payloads."""
+
+    version_raw = snapshot.get("snapshot_schema_version", 1)
+    if not isinstance(version_raw, int):
+        raise ValueError("snapshot_schema_version must be an integer")
+    if version_raw < 1:
+        raise ValueError("snapshot_schema_version must be >= 1")
+    if version_raw > CURRENT_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported snapshot schema version {version_raw}; "
+            f"maximum supported is {CURRENT_SNAPSHOT_SCHEMA_VERSION}"
+        )
+
+    migrated = deepcopy(snapshot)
+    version = version_raw
+    while version < CURRENT_SNAPSHOT_SCHEMA_VERSION:
+        migration = SNAPSHOT_MIGRATIONS.get(version)
+        if migration is None:
+            raise ValueError(f"Missing migration for snapshot schema version {version}")
+        migrated = migration(migrated)
+        next_version = migrated.get("snapshot_schema_version")
+        if next_version != version + 1:
+            raise ValueError(
+                "Snapshot migration contract violated: "
+                f"expected version {version + 1}, got {next_version}"
+            )
+        version = next_version
+
+    return migrated

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -62,6 +62,10 @@ from src.sim.knowledge_board_protocol import (
 )
 from src.sim.knowledge_entry import KnowledgeEntryType
 from src.sim.lifecycle_service import LifecycleService
+from src.sim.persistence.snapshot_migrations import (
+    CURRENT_SNAPSHOT_SCHEMA_VERSION,
+    migrate_snapshot,
+)
 from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 from src.sim.persistence.trace_hash_service import TraceHashService
 from src.sim.quests import generate_quest
@@ -1133,6 +1137,7 @@ class Simulation:
             from src.infra.checkpoint import capture_rng_state
 
             snapshot = {
+                "snapshot_schema_version": CURRENT_SNAPSHOT_SCHEMA_VERSION,
                 "step": self.current_step,
                 "collective_ip": self.collective_ip,
                 "collective_du": self.collective_du,
@@ -2059,6 +2064,8 @@ class Simulation:
         """Create a ``Simulation`` instance from a snapshot dictionary."""
         from src.agents.core.base_agent import Agent  # avoid circular import at module level
 
+        snapshot = migrate_snapshot(snapshot)
+
         agents_data = snapshot.get("agents", [])
         agents = [Agent(agent_id=a.get("agent_id", str(i))) for i, a in enumerate(agents_data)]
         sim_seed = seed if seed is not None else snapshot.get("seed")
@@ -2068,42 +2075,16 @@ class Simulation:
 
             restore_rng_state(snapshot["rng_state"])
         sim.current_step = int(snapshot.get("step", 0))
-        env_snapshot = snapshot.get("environment_state", {})
-        if isinstance(env_snapshot, dict) and env_snapshot:
-            sim.world_hour = int(env_snapshot.get("world_hour", snapshot.get("world_hour", 0)))
-            sim.world_day = int(env_snapshot.get("world_day", snapshot.get("world_day", 0)))
-            sim.world_tick_index = int(
-                env_snapshot.get("world_tick", snapshot.get("world_tick", -1))
-            )
-            world_season_value = env_snapshot.get(
-                "world_season",
-                snapshot.get("world_season", 0 if sim.world_season_length_days else None),
-            )
-            sim.world_season = int(world_season_value) if world_season_value is not None else None
-            sim.environment_state.weather = str(
-                env_snapshot.get("weather", sim.environment_state.weather)
-            )
-            sim.environment_state.season_effects = dict(
-                env_snapshot.get("season_effects", sim.environment_state.season_effects)
-            )
-            sim.environment_state.active_global_modifiers = list(
-                env_snapshot.get(
-                    "active_global_modifiers", sim.environment_state.active_global_modifiers
-                )
-            )
-            sim.environment_state.council_window_active = bool(
-                env_snapshot.get(
-                    "council_window_active", sim.environment_state.council_window_active
-                )
-            )
-        else:
-            sim.world_hour = int(snapshot.get("world_hour", 0))
-            sim.world_day = int(snapshot.get("world_day", 0))
-            sim.world_tick_index = int(snapshot.get("world_tick", -1))
-            world_season = snapshot.get(
-                "world_season", 0 if sim.world_season_length_days else None
-            )
-            sim.world_season = int(world_season) if world_season is not None else None
+        env_snapshot = snapshot["environment_state"]
+        sim.world_hour = int(env_snapshot["world_hour"])
+        sim.world_day = int(env_snapshot["world_day"])
+        sim.world_tick_index = int(env_snapshot["world_tick"])
+        world_season_value = env_snapshot.get("world_season")
+        sim.world_season = int(world_season_value) if world_season_value is not None else None
+        sim.environment_state.weather = str(env_snapshot["weather"])
+        sim.environment_state.season_effects = dict(env_snapshot["season_effects"])
+        sim.environment_state.active_global_modifiers = list(env_snapshot["active_global_modifiers"])
+        sim.environment_state.council_window_active = bool(env_snapshot["council_window_active"])
         snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
         sim.turns_per_world_tick = max(1, snapshot_turn_quantum)
         sim.environment_system.turns_per_world_tick = sim.turns_per_world_tick

--- a/tests/integration/sim/fixtures/historical_snapshot_v1.json
+++ b/tests/integration/sim/fixtures/historical_snapshot_v1.json
@@ -1,0 +1,20 @@
+{
+  "snapshot_schema_version": 1,
+  "step": 5,
+  "collective_ip": 3.5,
+  "collective_du": 1.25,
+  "agents": [
+    {
+      "agent_id": "agent-1",
+      "ip": 1.1,
+      "du": 0.3,
+      "mood": 0.9
+    }
+  ],
+  "seed": 17,
+  "world_hour": 9,
+  "world_day": 2,
+  "world_tick": 4,
+  "world_season": 1,
+  "turns_per_world_tick": 2
+}

--- a/tests/integration/sim/fixtures/historical_snapshot_v2.json
+++ b/tests/integration/sim/fixtures/historical_snapshot_v2.json
@@ -1,0 +1,32 @@
+{
+  "snapshot_schema_version": 2,
+  "step": 8,
+  "collective_ip": 7.0,
+  "collective_du": 2.0,
+  "agents": [
+    {
+      "agent_id": "agent-2",
+      "ip": 2.1,
+      "du": 0.8,
+      "mood": 0.2
+    }
+  ],
+  "seed": 23,
+  "turns_per_world_tick": 3,
+  "environment_state": {
+    "world_tick": 2,
+    "world_hour": 6,
+    "world_day": 3,
+    "world_season": 0
+  },
+  "knowledge_board": {
+    "entries": []
+  },
+  "world_map": {
+    "width": 12,
+    "height": 8,
+    "agents": {
+      "agent-2": [1, 1]
+    }
+  }
+}

--- a/tests/integration/sim/fixtures/normalized_from_v1_snapshot_v3.json
+++ b/tests/integration/sim/fixtures/normalized_from_v1_snapshot_v3.json
@@ -1,0 +1,46 @@
+{
+  "snapshot_schema_version": 3,
+  "step": 5,
+  "collective_ip": 3.5,
+  "collective_du": 1.25,
+  "agents": [
+    {
+      "agent_id": "agent-1",
+      "ip": 1.1,
+      "du": 0.3,
+      "mood": 0.9,
+      "lifecycle_state": "active",
+      "lifecycle_history": [],
+      "legacy_artifacts": {},
+      "memory_archival_policy": {},
+      "predecessor_id": null,
+      "successor_id": null
+    }
+  ],
+  "seed": 17,
+  "world_hour": 9,
+  "world_day": 2,
+  "world_tick": 4,
+  "world_season": 1,
+  "turns_per_world_tick": 2,
+  "environment_state": {
+    "world_tick": 4,
+    "world_hour": 9,
+    "world_day": 2,
+    "world_season": 1,
+    "weather": "clear",
+    "season_effects": {},
+    "active_global_modifiers": [],
+    "council_window_active": false
+  },
+  "knowledge_board": {
+    "entries": [],
+    "vector": {}
+  },
+  "world_map": {
+    "width": 10,
+    "height": 10,
+    "agents": {},
+    "vector": {}
+  }
+}

--- a/tests/integration/sim/fixtures/normalized_from_v2_snapshot_v3.json
+++ b/tests/integration/sim/fixtures/normalized_from_v2_snapshot_v3.json
@@ -1,0 +1,42 @@
+{
+  "snapshot_schema_version": 3,
+  "step": 8,
+  "collective_ip": 7.0,
+  "collective_du": 2.0,
+  "agents": [
+    {
+      "agent_id": "agent-2",
+      "ip": 2.1,
+      "du": 0.8,
+      "mood": 0.2,
+      "lifecycle_state": "active",
+      "lifecycle_history": [],
+      "legacy_artifacts": {},
+      "memory_archival_policy": {},
+      "predecessor_id": null,
+      "successor_id": null
+    }
+  ],
+  "seed": 23,
+  "turns_per_world_tick": 3,
+  "environment_state": {
+    "world_tick": 2,
+    "world_hour": 6,
+    "world_day": 3,
+    "world_season": 0,
+    "weather": "clear",
+    "season_effects": {},
+    "active_global_modifiers": [],
+    "council_window_active": false
+  },
+  "knowledge_board": {
+    "entries": []
+  },
+  "world_map": {
+    "width": 12,
+    "height": 8,
+    "agents": {
+      "agent-2": [1, 1]
+    }
+  }
+}

--- a/tests/integration/sim/test_snapshot_schema_migrations.py
+++ b/tests/integration/sim/test_snapshot_schema_migrations.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.sim.persistence.snapshot_migrations import (
+    CURRENT_SNAPSHOT_SCHEMA_VERSION,
+    migrate_snapshot,
+)
+from src.sim.simulation import Simulation
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    with (_FIXTURE_DIR / name).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.mark.parametrize(
+    ("historical_fixture", "normalized_fixture"),
+    [
+        ("historical_snapshot_v1.json", "normalized_from_v1_snapshot_v3.json"),
+        ("historical_snapshot_v2.json", "normalized_from_v2_snapshot_v3.json"),
+    ],
+)
+@pytest.mark.integration
+def test_historical_snapshot_normalization_is_deterministic(
+    historical_fixture: str,
+    normalized_fixture: str,
+) -> None:
+    historical_snapshot = _load_fixture(historical_fixture)
+    expected = _load_fixture(normalized_fixture)
+
+    normalized = migrate_snapshot(historical_snapshot)
+    normalized_again = migrate_snapshot(normalized)
+
+    assert normalized == expected
+    assert normalized_again == expected
+    assert normalized["snapshot_schema_version"] == CURRENT_SNAPSHOT_SCHEMA_VERSION
+
+
+@pytest.mark.parametrize("historical_fixture", ["historical_snapshot_v1.json", "historical_snapshot_v2.json"])
+@pytest.mark.integration
+def test_historical_snapshot_replay_compatibility(historical_fixture: str, tmp_path: Path) -> None:
+    raw_snapshot = _load_fixture(historical_fixture)
+    snapshot_path = tmp_path / "snapshot.json"
+    events_path = tmp_path / "events.jsonl"
+
+    snapshot_path.write_text(json.dumps(raw_snapshot), encoding="utf-8")
+    events_path.write_text(json.dumps({"type": "header", "seed": raw_snapshot.get("seed", 0)}) + "\n")
+
+    normalized = migrate_snapshot(raw_snapshot)
+    from_normalized = Simulation.from_snapshot(normalized)
+    replayed = Simulation.replay_from_snapshot(snapshot_path, events_path=events_path)
+
+    assert replayed.current_step == from_normalized.current_step
+    assert replayed.turns_per_world_tick == from_normalized.turns_per_world_tick
+    assert replayed.world_day == from_normalized.world_day
+    assert replayed.world_hour == from_normalized.world_hour
+    assert replayed.world_tick_index == from_normalized.world_tick_index
+    assert replayed.world_map.agent_positions == from_normalized.world_map.agent_positions
+    assert [agent.agent_id for agent in replayed.agents] == [
+        agent.agent_id for agent in from_normalized.agents
+    ]


### PR DESCRIPTION
### Motivation

- Ensure snapshots are explicitly versioned so older snapshots can be normalized to the current shape before replay or hydration.  
- Provide a deterministic, auditable migration path (N -> N+1) so replay and `Simulation.from_snapshot` operate on a single normalized schema.  
- Validate schema versions at persistence boundaries to avoid silently writing or loading unsupported snapshot shapes.  
- Add fixture-driven regression tests to lock-in normalization behavior for historical snapshots.

### Description

- Add `src/sim/persistence/snapshot_migrations.py` implementing `CURRENT_SNAPSHOT_SCHEMA_VERSION`, ordered migration functions (`_migrate_v1_to_v2`, `_migrate_v2_to_v3`), a `SNAPSHOT_MIGRATIONS` registry, and a `migrate_snapshot` normalizer.  
- Include `snapshot_schema_version` in snapshot payloads produced by `Simulation` at write time by adding `"snapshot_schema_version": CURRENT_SNAPSHOT_SCHEMA_VERSION` to the snapshot dict.  
- Refactor `Simulation.from_snapshot` to call `migrate_snapshot(snapshot)` up-front and then hydrate the `Simulation` only from the normalized (current) schema.  
- Add schema validation in `src/infra/snapshot.py` via `_validate_snapshot_schema_version` and call it before saving and after loading snapshots.  
- Add fixture files in `tests/integration/sim/fixtures/` for historical snapshots and their expected normalized forms and a regression test file `tests/integration/sim/test_snapshot_schema_migrations.py` that asserts deterministic normalization and replay compatibility.

### Testing

- Ran lint/type checks with `python -m ruff check src/infra/snapshot.py src/sim/simulation.py src/sim/persistence/snapshot_migrations.py tests/integration/sim/test_snapshot_schema_migrations.py` and it passed.  
- Ran the migration regression suite with `python -m pytest -m "integration" tests/integration/sim/test_snapshot_schema_migrations.py` and all tests passed.  
- Running a broader set of existing integration snapshot/world-map tests (`pytest -m "integration" tests/integration/sim/test_snapshot_schema_migrations.py tests/integration/sim/test_snapshot_replay.py tests/integration/sim/test_snapshot_rng_state.py tests/integration/sim/test_world_map.py`) surfaced unrelated pre-existing failures in the environment (e.g. test monkeypatch expectations for module-level symbols and an agent `run_turn` signature mismatch) that are not caused by the migration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973f2b77088326a26f1407fd2c99fb)