### PR TITLE
Introduce PolicyDecisionService and route interactions through a shared decision kernel

### DIFF
--- a/src/governance/decision_kernel.py
+++ b/src/governance/decision_kernel.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class DecisionProvenance(BaseModel):
+    policy_id: str
+    rule_id: str
+    vote_reference: str | None = None
+
+
+class PolicyDecision(BaseModel):
+    decision: Literal["allow", "deny", "transform", "requires_vote"]
+    reason_code: str
+    user_message: str | None = None
+    provenance: DecisionProvenance
+    transformed_updates: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PolicyDecisionService:
+    """Evaluates canonical interaction envelopes into typed policy decisions."""
+
+    policy_id = "interaction-policy-v1"
+
+    def decide(
+        self,
+        *,
+        envelope: Any,
+        context: Any,
+        simulation: Any,
+        stage: Literal["entry", "message", "knowledge_board", "control", "moderation"] = "entry",
+    ) -> PolicyDecision:
+        if stage == "entry":
+            return self._entry_decision(envelope=envelope, context=context)
+        if stage == "knowledge_board":
+            return self._knowledge_board_decision(simulation=simulation)
+        if stage == "message":
+            return self._message_decision(envelope=envelope, context=context, simulation=simulation)
+        if stage in {"control", "moderation"}:
+            return self._control_decision(envelope=envelope, context=context)
+        return self._allow("policy.default", "policy_allowed")
+
+    def _entry_decision(self, *, envelope: Any, context: Any) -> PolicyDecision:
+        if envelope.intent == "spawn":
+            if not ({"admin", "moderator"} & set(context.permissions)):
+                return self._deny("policy.auth.spawn", "unauthorized", "You are not authorized to spawn agents.")
+            return self._allow("policy.auth.spawn", "authorized")
+        if envelope.intent in {"moderation", "control", "inject_event"}:
+            return self._control_decision(envelope=envelope, context=context)
+        if envelope.intent == "human_message":
+            content = str(envelope.content or "").strip()
+            if content == "/broadcast":
+                return self._transform(
+                    "policy.normalize.human_message",
+                    "normalized_human_command",
+                    {"intent": "broadcast", "content": ""},
+                )
+            if content.startswith("/broadcast "):
+                return self._transform(
+                    "policy.normalize.human_message",
+                    "normalized_human_command",
+                    {"intent": "broadcast", "content": content[len("/broadcast ") :]},
+                )
+            if content.startswith("/kb "):
+                return self._transform(
+                    "policy.normalize.human_message",
+                    "normalized_human_command",
+                    {"intent": "knowledge_board", "content": content[4:]},
+                )
+            return self._transform(
+                "policy.normalize.human_message",
+                "normalized_human_command",
+                {"intent": "direct_message", "content": content},
+            )
+        return self._allow("policy.entry", "policy_allowed")
+
+    def _knowledge_board_decision(self, *, simulation: Any) -> PolicyDecision:
+        now = time.monotonic()
+        last_seen = simulation._last_kb_time
+        elapsed = now - last_seen
+        cooldown = simulation._kb_cooldown
+        if elapsed < cooldown:
+            retry = max(0.0, cooldown - elapsed)
+            return self._deny(
+                "policy.cooldown.knowledge_board",
+                "kb_rate_limited",
+                "Knowledge Board is cooling down. Please try again shortly.",
+                metadata={"retry_after_seconds": retry},
+            )
+        simulation._last_kb_time = now
+        return self._allow("policy.cooldown.knowledge_board", "cooldown_ok")
+
+    def _message_decision(self, *, envelope: Any, context: Any, simulation: Any) -> PolicyDecision:
+        now = time.monotonic()
+        channel_id = context.channel_id
+        relay_scope = context.sender_id if channel_id is None else f"{context.sender_id}:{channel_id}"
+        last_seen = simulation._last_relay_times.get(relay_scope, 0.0)
+        elapsed = now - last_seen
+        if elapsed < simulation._relay_cooldown:
+            retry = max(0.0, simulation._relay_cooldown - elapsed)
+            return self._deny(
+                "policy.cooldown.message",
+                "rate_limited",
+                f"Rate limited: please wait {retry:.1f}s before sending another message.",
+                metadata={"retry_after_seconds": retry, "scope": relay_scope},
+            )
+        simulation._last_relay_times[relay_scope] = now
+
+        if not simulation.agents:
+            return self._deny(
+                "policy.message.availability",
+                "no_agents",
+                "No agents are available to receive messages.",
+            )
+
+        if envelope.metadata.get("requires_vote") is True:
+            return PolicyDecision(
+                decision="requires_vote",
+                reason_code="requires_vote",
+                user_message="Action requires governance vote.",
+                provenance=DecisionProvenance(
+                    policy_id=self.policy_id,
+                    rule_id="policy.governance.vote_gate",
+                    vote_reference=str(envelope.metadata.get("vote_reference") or "pending"),
+                ),
+            )
+
+        return self._allow("policy.message.availability", "policy_allowed")
+
+    def _control_decision(self, *, envelope: Any, context: Any) -> PolicyDecision:
+        if not ({"admin", "moderator"} & set(context.permissions)):
+            return self._deny(
+                "policy.auth.control",
+                "unauthorized",
+                "You are not authorized to run moderation commands.",
+            )
+        if envelope.metadata.get("requires_vote") is True:
+            return PolicyDecision(
+                decision="requires_vote",
+                reason_code="requires_vote",
+                user_message="Command requires governance vote.",
+                provenance=DecisionProvenance(
+                    policy_id=self.policy_id,
+                    rule_id="policy.governance.control_vote",
+                    vote_reference=str(envelope.metadata.get("vote_reference") or "pending"),
+                ),
+            )
+        return self._allow("policy.auth.control", "authorized")
+
+    def _allow(self, rule_id: str, reason_code: str) -> PolicyDecision:
+        return PolicyDecision(
+            decision="allow",
+            reason_code=reason_code,
+            provenance=DecisionProvenance(policy_id=self.policy_id, rule_id=rule_id),
+        )
+
+    def _deny(
+        self,
+        rule_id: str,
+        reason_code: str,
+        user_message: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> PolicyDecision:
+        return PolicyDecision(
+            decision="deny",
+            reason_code=reason_code,
+            user_message=user_message,
+            provenance=DecisionProvenance(policy_id=self.policy_id, rule_id=rule_id),
+            metadata=metadata or {},
+        )
+
+    def _transform(self, rule_id: str, reason_code: str, updates: dict[str, Any]) -> PolicyDecision:
+        return PolicyDecision(
+            decision="transform",
+            reason_code=reason_code,
+            provenance=DecisionProvenance(policy_id=self.policy_id, rule_id=rule_id),
+            transformed_updates=updates,
+        )

--- a/src/interfaces/command_bus.py
+++ b/src/interfaces/command_bus.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
+from src.governance.decision_kernel import DecisionProvenance
 from src.interfaces.interaction_commands import (
     InteractionContext,
     InteractionEnvelope,
@@ -42,6 +43,10 @@ class CommandBus:
                 status="rejected",
                 user_message=f"Invalid command payload: {exc}",
                 reason_code="invalid_payload",
+                decision_provenance=DecisionProvenance(
+                    policy_id="interaction-policy-v1",
+                    rule_id="policy.validation.payload",
+                ),
             )
         return await self.dispatch(envelope, context=context)
 

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 from opentelemetry import trace
 from pydantic import BaseModel
 
+from src.governance.decision_kernel import PolicyDecisionService
 from src.governance.rules_engine import governance_rules_engine
 from src.governance.service import governance
 from src.infra import event_log
@@ -36,6 +37,7 @@ SEMANTIC_SUMMARIES_ERROR: Final[dict[str, str]] = {"error": "summary retrieval f
 DEFAULT_CONTEXT = SimulationContext()
 
 API_TOKEN: str | None = None
+DECISION_KERNEL = PolicyDecisionService()
 
 
 def configure_api_token(token: str | None) -> None:
@@ -1013,6 +1015,37 @@ async def handle_control_command(
             "message": result.user_message,
             "reason_code": result.reason_code,
             "data": result.data,
+            "decision_provenance": result.decision_provenance.model_dump(),
+        }
+
+    from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+
+    fallback_envelope = InteractionEnvelope.model_validate(
+        {
+            "intent": "control",
+            "action": str(cmd.get("command") or ""),
+            "value": cmd.get("value"),
+            "tags": cmd.get("tags"),
+            "metadata": dict(cmd),
+        }
+    )
+    decision = DECISION_KERNEL.decide(
+        envelope=fallback_envelope,
+        context=InteractionContext(
+            sender_id="dashboard",
+            source="dashboard",
+            permissions={"admin", "moderator"},
+        ),
+        simulation=simulation,
+        stage="control",
+    )
+    if decision.decision != "allow":
+        return {
+            "status": "rejected",
+            "message": decision.user_message or "Command rejected.",
+            "reason_code": decision.reason_code,
+            "decision_provenance": decision.provenance.model_dump(),
+            "data": decision.metadata or None,
         }
 
     action = cmd.get("command")
@@ -1030,7 +1063,11 @@ async def handle_control_command(
         if isinstance(tags, list):
             BREAKPOINT_TAGS.clear()
             BREAKPOINT_TAGS.update(str(t) for t in tags)
-    return {**ctx.sim_state, "breakpoints": list(BREAKPOINT_TAGS)}
+    return {
+        **ctx.sim_state,
+        "breakpoints": list(BREAKPOINT_TAGS),
+        "decision_provenance": decision.provenance.model_dump(),
+    }
 
 
 try:

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 import logging
-import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
 from src.agents.core.agent_state import AgentActionIntent
+from src.governance.decision_kernel import DecisionProvenance, PolicyDecisionService
 from src.infra import config
 from src.infra import ledger as infra_ledger
 from src.infra.event_log import log_event
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
-from src.interfaces.interaction_policy import check_cooldown, context_is_authorized
 from src.sim.knowledge_board import BoardEntry
 
 if TYPE_CHECKING:
@@ -37,6 +36,7 @@ class InteractionResult(BaseModel):
     user_message: str
     reason_code: str
     data: dict[str, Any] | None = None
+    decision_provenance: DecisionProvenance
 
 
 class InteractionContext(BaseModel):
@@ -97,6 +97,7 @@ class InteractionService:
 
     def __init__(self, simulation: Simulation) -> None:
         self.simulation = simulation
+        self.decision_service = PolicyDecisionService()
 
     async def execute(
         self,
@@ -117,18 +118,38 @@ class InteractionService:
             )
         )
 
-        envelope = self._normalize_human_message(command)
+        entry_decision = self.decision_service.decide(
+            envelope=command,
+            context=ctx,
+            simulation=self.simulation,
+            stage="entry",
+        )
+        if entry_decision.decision == "transform":
+            envelope = command.model_copy(update=entry_decision.transformed_updates)
+        else:
+            envelope = command
+
+        if entry_decision.decision == "deny":
+            return InteractionResult(
+                status="rejected",
+                user_message=entry_decision.user_message or "Command rejected.",
+                reason_code=entry_decision.reason_code,
+                data=entry_decision.metadata or None,
+                decision_provenance=entry_decision.provenance,
+            )
+        if entry_decision.decision == "requires_vote":
+            return InteractionResult(
+                status="rejected",
+                user_message=entry_decision.user_message or "Command requires vote.",
+                reason_code=entry_decision.reason_code,
+                decision_provenance=entry_decision.provenance,
+            )
+
         if envelope.intent == "knowledge_board":
             return await self._dispatch_knowledge_board(envelope, context=ctx)
         if envelope.intent in {"broadcast", "direct_message"}:
             return await self._dispatch_message(envelope, context=ctx)
         if envelope.intent == "spawn":
-            if not context_is_authorized(ctx, required={"admin", "moderator"}):
-                return InteractionResult(
-                    status="rejected",
-                    user_message="You are not authorized to spawn agents.",
-                    reason_code="unauthorized",
-                )
             await self.simulation.handle_control_command(
                 {
                     "command": "spawn",
@@ -143,14 +164,9 @@ class InteractionService:
                 status="ok",
                 user_message=f"Spawn request submitted for {envelope.agent_id}.",
                 reason_code="spawn_submitted",
+                decision_provenance=entry_decision.provenance,
             )
         if envelope.intent in {"moderation", "control", "inject_event"}:
-            if not context_is_authorized(ctx, required={"admin", "moderator"}):
-                return InteractionResult(
-                    status="rejected",
-                    user_message="You are not authorized to run moderation commands.",
-                    reason_code="unauthorized",
-                )
             payload: dict[str, Any] = {"command": envelope.action}
             if envelope.value is not None:
                 payload["value"] = envelope.value
@@ -172,11 +188,13 @@ class InteractionService:
                 user_message="Command accepted.",
                 reason_code="moderation_applied",
                 data=state if isinstance(state, dict) else None,
+                decision_provenance=entry_decision.provenance,
             )
         return InteractionResult(
             status="error",
             user_message="Unknown command.",
             reason_code="unsupported_command",
+            decision_provenance=entry_decision.provenance,
         )
 
     async def _dispatch_knowledge_board(
@@ -191,6 +209,10 @@ class InteractionService:
                 status="rejected",
                 user_message="Knowledge Board entry cannot be empty.",
                 reason_code="empty_message",
+                decision_provenance=DecisionProvenance(
+                    policy_id="interaction-policy-v1",
+                    rule_id="policy.validation.knowledge_board.empty",
+                ),
             )
         board = self.simulation.knowledge_board
         if board is None:
@@ -198,22 +220,25 @@ class InteractionService:
                 status="rejected",
                 user_message="Knowledge Board is not available.",
                 reason_code="kb_unavailable",
+                decision_provenance=DecisionProvenance(
+                    policy_id="interaction-policy-v1",
+                    rule_id="policy.validation.knowledge_board.unavailable",
+                ),
             )
-        now = time.monotonic()
-        retry_after = check_cooldown(
-            key="knowledge_board",
-            now=now,
-            cooldown=self.simulation._kb_cooldown,
-            state={"knowledge_board": self.simulation._last_kb_time},
+        decision = self.decision_service.decide(
+            envelope=command,
+            context=context,
+            simulation=self.simulation,
+            stage="knowledge_board",
         )
-        if retry_after is not None:
+        if decision.decision != "allow":
             return InteractionResult(
                 status="rejected",
-                user_message="Knowledge Board is cooling down. Please try again shortly.",
-                reason_code="kb_rate_limited",
+                user_message=decision.user_message or "Knowledge board command rejected.",
+                reason_code=decision.reason_code,
+                data=decision.metadata or None,
+                decision_provenance=decision.provenance,
             )
-
-        self.simulation._last_kb_time = now
         async with board.lock:
             board.add_entry(
                 BoardEntry(
@@ -229,6 +254,7 @@ class InteractionService:
             status="ok",
             user_message="Posted to Knowledge Board.",
             reason_code="kb_posted",
+            decision_provenance=decision.provenance,
         )
 
     async def _dispatch_message(
@@ -243,20 +269,29 @@ class InteractionService:
                 status="rejected",
                 user_message="Message cannot be empty.",
                 reason_code="empty_message",
+                decision_provenance=DecisionProvenance(
+                    policy_id="interaction-policy-v1",
+                    rule_id="policy.validation.message.empty",
+                ),
             )
 
-        now = time.monotonic()
-        channel_id = context.channel_id
-        relay_scope = (
-            context.sender_id if channel_id is None else f"{context.sender_id}:{channel_id}"
+        decision = self.decision_service.decide(
+            envelope=command,
+            context=context,
+            simulation=self.simulation,
+            stage="message",
         )
-        retry_after = check_cooldown(
-            key=relay_scope,
-            now=now,
-            cooldown=self.simulation._relay_cooldown,
-            state=self.simulation._last_relay_times,
-        )
-        if retry_after is not None:
+        if decision.decision == "requires_vote":
+            return InteractionResult(
+                status="rejected",
+                user_message=decision.user_message or "Command requires vote.",
+                reason_code=decision.reason_code,
+                decision_provenance=decision.provenance,
+            )
+
+        if decision.decision != "allow":
+            retry_after = float(decision.metadata.get("retry_after_seconds") or 0.0)
+            relay_scope = str(decision.metadata.get("scope") or context.sender_id)
             await emit_event(
                 SimulationEvent(
                     type="human_command_rate_limited",
@@ -270,17 +305,10 @@ class InteractionService:
             )
             return InteractionResult(
                 status="rejected",
-                user_message=(
-                    f"Rate limited: please wait {retry_after:.1f}s before sending another message."
-                ),
-                reason_code="rate_limited",
-                data={"retry_after_seconds": retry_after},
-            )
-        if not self.simulation.agents:
-            return InteractionResult(
-                status="rejected",
-                user_message="No agents are available to receive messages.",
-                reason_code="no_agents",
+                user_message=decision.user_message or "Command rejected.",
+                reason_code=decision.reason_code,
+                data=decision.metadata or None,
+                decision_provenance=decision.provenance,
             )
 
         broadcast = command.intent == "broadcast"
@@ -317,6 +345,7 @@ class InteractionService:
                 status="rejected",
                 user_message=str(exc),
                 reason_code="du_budget_exceeded",
+                decision_provenance=decision.provenance,
             )
 
         if state is not None and (state.ip < ip_cost or state.du < du_cost):
@@ -324,6 +353,7 @@ class InteractionService:
                 status="rejected",
                 user_message="Insufficient IP/DU",
                 reason_code="insufficient_resources",
+                decision_provenance=decision.provenance,
             )
 
         if state is not None:
@@ -392,6 +422,7 @@ class InteractionService:
                 "du_cost": du_cost,
                 "messages": [dict(msg) for msg in msgs],
                 "reason_code": "message_dispatched",
+                "decision_provenance": decision.provenance.model_dump(),
             }
         )
 
@@ -405,6 +436,7 @@ class InteractionService:
             user_message="Broadcast sent." if broadcast else "Message sent.",
             reason_code="message_dispatched",
             data={"target_agent_id": target.agent_id, "budget_agent_id": budget_agent_id},
+            decision_provenance=decision.provenance,
         )
 
     def _resolve_target(self, command: InteractionEnvelope) -> Any:
@@ -512,20 +544,6 @@ class InteractionService:
             )
         except Exception as exc:
             raise ValueError(f"Invalid command payload: {exc}") from exc
-
-    def _normalize_human_message(self, command: InteractionEnvelope) -> InteractionEnvelope:
-        if command.intent != "human_message":
-            return command
-        message = str(command.content or "").strip()
-        if message.startswith("/kb "):
-            return command.model_copy(update={"intent": "knowledge_board", "content": message[4:]})
-        if message == "/broadcast":
-            return command.model_copy(update={"intent": "broadcast", "content": ""})
-        if message.startswith("/broadcast "):
-            return command.model_copy(
-                update={"intent": "broadcast", "content": message[len("/broadcast ") :]}
-            )
-        return command.model_copy(update={"intent": "direct_message", "content": message})
 
     @staticmethod
     def _optional_str(value: Any) -> str | None:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -28,6 +28,7 @@ from src.agents.memory.memory_service import MemoryService
 from src.agents.memory.semantic_memory_manager import SemanticMemoryManager
 from src.agents.memory.vector_store import ChromaDBException
 from src.governance import evaluate_policy
+from src.governance.decision_kernel import PolicyDecisionService
 from src.governance.rules_engine import governance_rules_engine
 from src.governance.service import governance
 from src.infra import config  # Import to access MAX_PROJECT_MEMBERS
@@ -372,6 +373,7 @@ class Simulation:
         self._event_loop_thread = None
         self.interaction_service = InteractionService(self)
         self.command_bus = CommandBus(self.interaction_service)
+        self.decision_service = PolicyDecisionService()
         self.control_service = SimulationControlService(self)
         self.engine = SimulationEngine(self)
 
@@ -496,6 +498,29 @@ class Simulation:
 
     async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process moderation actions like muting or penalties."""
+        from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+
+        envelope = InteractionEnvelope.model_validate(
+            {
+                "intent": "moderation",
+                "action": cmd.get("command"),
+                "agent_id": cmd.get("agent_id"),
+                "metadata": cmd,
+            }
+        )
+        decision = self.decision_service.decide(
+            envelope=envelope,
+            context=InteractionContext(
+                sender_id="simulation",
+                source="simulation",
+                permissions={"admin", "moderator"},
+            ),
+            simulation=self,
+            stage="moderation",
+        )
+        if decision.decision != "allow":
+            return
+
         action = cmd.get("command")
         agent_id = cmd.get("agent_id")
         if action == "mute" and agent_id:

--- a/tests/integration/interfaces/test_policy_decision_kernel_integration.py
+++ b/tests/integration/interfaces/test_policy_decision_kernel_integration.py
@@ -1,0 +1,104 @@
+import pytest
+
+from src.interfaces import dashboard_backend as db
+from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+from src.sim.simulation import Simulation
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 10.0
+        self.du = 10.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self.state = state
+
+    async def run_turn(self, *args: object, **kwargs: object) -> dict:
+        return {}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_equivalent_human_message_has_identical_policy_outcome() -> None:
+    sim = Simulation([DummyAgent("alpha"), DummyAgent("beta")])
+    try:
+        envelope = InteractionEnvelope(
+            intent="human_message",
+            content="hello kernel",
+            routing={"sender_id": "user-1", "source": "discord"},
+            metadata={"request_id": "equiv-1"},
+        )
+
+        discord_result = await sim.command_bus.dispatch(
+            envelope,
+            context=InteractionContext(sender_id="user-1", source="discord"),
+        )
+        dashboard_result = await sim.command_bus.dispatch_payload(
+            {
+                "command_type": "human_message",
+                "content": "hello kernel",
+                "sender_id": "user-1",
+                "source": "dashboard",
+                "request_id": "equiv-1",
+            },
+            context=InteractionContext(sender_id="user-1", source="dashboard"),
+        )
+
+        assert discord_result.status == dashboard_result.status == "ok"
+        assert discord_result.reason_code == dashboard_result.reason_code == "message_dispatched"
+        assert discord_result.decision_provenance == dashboard_result.decision_provenance
+    finally:
+        await sim.stop_event_listener()
+        sim.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_equivalent_control_request_has_identical_policy_outcome() -> None:
+    sim = Simulation([DummyAgent("alpha")])
+    try:
+        db.DEFAULT_CONTEXT.sim_state["simulation"] = sim
+
+        bus_result = await sim.command_bus.dispatch_payload(
+            {
+                "command": "set_speed",
+                "value": 2.0,
+                "sender_id": "moderator-1",
+                "source": "discord",
+                "permissions": ["admin"],
+            },
+            context=InteractionContext(
+                sender_id="moderator-1",
+                source="discord",
+                permissions={"admin"},
+            ),
+        )
+        endpoint_result = await db.handle_control_command(
+            {"command": "set_speed", "value": 2.0},
+            ctx=db.DEFAULT_CONTEXT,
+        )
+
+        assert bus_result.status == endpoint_result["status"] == "ok"
+        assert bus_result.reason_code == endpoint_result["reason_code"] == "moderation_applied"
+        assert (
+            bus_result.decision_provenance.model_dump()
+            == endpoint_result["decision_provenance"]
+        )
+    finally:
+        db.DEFAULT_CONTEXT.sim_state.pop("simulation", None)
+        await sim.stop_event_listener()
+        sim.close()


### PR DESCRIPTION
### Motivation

- Centralize permission, cooldown, and governance gating logic into a single policy component so behavior is consistent across transports and easier to audit. 
- Replace scattered local auth/rate-limit/business checks with typed policy outcomes to ensure deterministic replay and machine-readable provenance. 
- Provide explicit, machine-readable decision provenance (policy id / rule id / vote reference) with every command outcome for auditability and replay determinism.

### Description

- Added a new policy kernel `PolicyDecisionService` in `src/governance/decision_kernel.py` that returns typed `PolicyDecision` results (`allow`, `deny`, `transform`, `requires_vote`) and structured provenance via `DecisionProvenance`.
- Refactored `InteractionService` (`src/interfaces/interaction_commands.py`) to call the decision kernel for entry normalization, cooldown/availability checks, vote-gating, and authorization, and to attach `decision_provenance` to all `InteractionResult` responses and event logs.
- Updated `CommandBus` (`src/interfaces/command_bus.py`) to return provenance on payload validation failures and to forward canonical envelopes unchanged to the refactored `InteractionService`.
- Updated dashboard control handling (`src/interfaces/dashboard_backend.py`) to use the decision kernel for fallback control processing and to return decision provenance in control endpoint responses.
- Refactored simulation moderation handling (`src/sim/simulation.py`) to consult the decision kernel before executing moderation actions.
- Added integration tests `tests/integration/interfaces/test_policy_decision_kernel_integration.py` that assert equivalent requests across Discord/dashboard/control paths produce identical policy outcomes and provenance, and updated test cleanup to stop background listeners.

### Testing

- Linting/format checks: `ruff` checks on modified files (`src/governance/decision_kernel.py`, `src/interfaces/interaction_commands.py`, `src/interfaces/command_bus.py`, `src/interfaces/dashboard_backend.py`, `src/sim/simulation.py`, and new test file) completed with no reported issues.
- Automated tests: ran `pytest` for the interaction contract and the new integration policy test (`tests/unit/interfaces/test_interaction_contract.py` and `tests/integration/interfaces/test_policy_decision_kernel_integration.py`), and the tests passed (2 passed, 2 deselected).
- Note: test run emitted existing async task cleanup warnings in this environment (a pending `EventKernel.forward_external_events` task log), but these are non-blocking warnings and did not cause test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997408554488326b7a8e36fcb30fd17)