### PR TITLE
Unify simulation scheduling behind EventKernel protocol

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -526,6 +526,19 @@ The project-related components:
 5. **Environment Updates**: Update shared resources like the knowledge board
 6. **Observation**: Record metrics and state for analysis
 
+### Event Scheduler Ordering Contract
+
+The simulation uses a single source-of-truth scheduler (`EventKernel`) behind a narrow scheduler protocol consumed by `Simulation` and `SimulationEngine`.
+
+Event ordering is deterministic and uses the following tie-break rules:
+
+1. **Primary key: `step`** — lower simulated step executes first.
+2. **Secondary key: `count`** — for equal `step`, lower insertion count executes first (FIFO for same-step events).
+3. **Trace metadata** — every dispatched event carries stable metadata (`step`, `count`, `tokens`, `agent_id`, vector clock, and `trace_hash`) used for replay verification.
+
+Pause/resume behavior is also defined by the protocol: `pause()` prevents further dispatch, and `resume()` continues dispatching in the same deterministic order from the remaining queue.
+
+
 ## 9. Interfaces
 
 ### Overview

--- a/src/sim/engine.py
+++ b/src/sim/engine.py
@@ -29,7 +29,7 @@ class SimulationEngine:
 
         await sim.start_event_listener()
 
-        queue_depth = len(getattr(sim.event_kernel, "_queue", []))
+        queue_depth = sim.event_kernel.queue_depth()
         sim._set_labeled_gauge(STEP_PHASE_QUEUE_DEPTH, phase="queue_pre_step", value=queue_depth)
 
         if max_turns > 1:

--- a/src/sim/event_kernel.py
+++ b/src/sim/event_kernel.py
@@ -46,6 +46,7 @@ class EventKernel:
         self.current_step = 0
         self._budgets: dict[str, int] = {}
         self.vector = VersionVector()
+        self._paused = False
 
     def set_budget(self: Self, agent_id: str, tokens: int) -> None:
         """Set the token budget for an agent."""
@@ -211,7 +212,7 @@ class EventKernel:
     async def dispatch(self: Self, limit: int) -> list[Event]:
         """Dispatch up to ``limit`` queued events in sorted order."""
         executed: list[Event] = []
-        while len(executed) < limit and self._queue:
+        while len(executed) < limit and self._queue and not self._paused:
             event = heapq.heappop(self._queue)
             if event.step < self.current_step:
                 continue
@@ -234,8 +235,28 @@ class EventKernel:
         """Compatibility wrapper for old ``step`` API."""
         return await self.dispatch(limit)
 
+    def pause(self: Self) -> None:
+        self._paused = True
+
+    async def resume(self: Self) -> list[Event]:
+        self._paused = False
+        return await self.dispatch(limit=len(self._queue))
+
     def empty(self: Self) -> bool:
         return not self._queue
+
+    def queue_depth(self: Self) -> int:
+        return len(self._queue)
+
+    def event_metadata(self: Self, event: Event) -> dict[str, Any]:
+        return {
+            "step": event.step,
+            "count": event.count,
+            "tokens": event.tokens,
+            "agent_id": event.agent_id,
+            "vector": event.vector.to_dict(),
+            "trace_hash": event.trace_hash,
+        }
 
     async def emit_environment_event(self: Self, event: dict[str, Any]) -> None:
         """Log and forward an environment event."""

--- a/src/sim/kernel/kernel.py
+++ b/src/sim/kernel/kernel.py
@@ -1,108 +1,101 @@
-"""Priority-queue based discrete event scheduler."""
+"""Deprecated adapter over :class:`src.sim.event_kernel.EventKernel`."""
 
 from __future__ import annotations
 
-import heapq
+import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 from typing_extensions import Self
 
+from src.sim.event_kernel import EventKernel
+
 from .event import Event
 
 
 class DiscreteEventKernel:
-    """A minimal discrete-event simulation kernel."""
+    """Compatibility adapter retained for tests and fixtures only."""
 
     def __init__(self: Self) -> None:
-        self._queue: list[Event] = []
-        self._seq = 0
-        self.now: int = 0
-        self._paused = False
+        warnings.warn(
+            "DiscreteEventKernel is deprecated; use EventKernel directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._kernel = EventKernel()
 
-    # ------------------------------------------------------------------
-    # scheduling helpers
+    @property
+    def now(self: Self) -> int:
+        return self._kernel.current_step
+
+    def _to_legacy_event(self: Self, event: Any) -> Event:
+        return Event(ts=int(event.step), seq=int(event.count), callback=event.callback)
+
+    # scheduling helpers -------------------------------------------------
     def schedule_at_nowait(
-        self: Self, ts: int, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, ts: int, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        """Schedule ``callback`` to run at ``ts``."""
-        heapq.heappush(self._queue, Event(ts, self._seq, callback))
-        self._seq += 1
+        self._kernel.schedule_at_nowait(ts, callback, **kwargs)
 
     async def schedule_at(
-        self: Self, ts: int, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, ts: int, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        self.schedule_at_nowait(ts, callback, **_kwargs)
+        await self._kernel.schedule_at(ts, callback, **kwargs)
 
     def schedule_immediate_nowait(
-        self: Self, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        self.schedule_at_nowait(self.now, callback, **_kwargs)
+        self._kernel.schedule_immediate_nowait(callback, **kwargs)
 
     async def schedule_immediate(
-        self: Self, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        self.schedule_immediate_nowait(callback, **_kwargs)
+        await self._kernel.schedule_immediate(callback, **kwargs)
 
     def schedule_in_nowait(
-        self: Self, delay: int, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, delay: int, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        self.schedule_at_nowait(self.now + delay, callback, **_kwargs)
+        self._kernel.schedule_in_nowait(delay, callback, **kwargs)
 
     async def schedule_in(
-        self: Self, delay: int, callback: Callable[[], Awaitable[None]], **_kwargs: Any
+        self: Self, delay: int, callback: Callable[[], Awaitable[None]], **kwargs: Any
     ) -> None:
-        self.schedule_in_nowait(delay, callback, **_kwargs)
+        await self._kernel.schedule_in(delay, callback, **kwargs)
 
-    # ------------------------------------------------------------------
+    # run/flow control ---------------------------------------------------
     def empty(self: Self) -> bool:
-        return not self._queue
+        return self._kernel.empty()
 
     def pause(self: Self) -> None:
-        self._paused = True
+        self._kernel.pause()
 
     async def resume(self: Self) -> list[Event]:
-        self._paused = False
-        return await self.run()
+        return [self._to_legacy_event(event) for event in await self._kernel.resume()]
 
     async def run(self: Self) -> list[Event]:
-        """Run until the queue is empty or paused."""
-        executed: list[Event] = []
-        while self._queue and not self._paused:
-            executed.extend(await self.step(1))
-        return executed
+        events = await self._kernel.dispatch(limit=self._kernel.queue_depth())
+        return [self._to_legacy_event(event) for event in events]
 
     async def step(self: Self, n: int = 1) -> list[Event]:
-        """Execute up to ``n`` events."""
-        executed: list[Event] = []
-        for _ in range(n):
-            if not self._queue or self._paused:
-                break
-            event = heapq.heappop(self._queue)
-            self.now = max(self.now, event.ts)
-            await event.callback()
-            executed.append(event)
-        return executed
+        return [self._to_legacy_event(event) for event in await self._kernel.step(n)]
 
     async def fast_forward(self: Self, until_ts: int) -> list[Event]:
-        """Execute events with ``ts`` <= ``until_ts``."""
         executed: list[Event] = []
-        while self._queue and self._queue[0].ts <= until_ts and not self._paused:
-            event = heapq.heappop(self._queue)
-            self.now = event.ts
-            await event.callback()
-            executed.append(event)
+        while not self.empty() and self._kernel._queue[0].step <= until_ts:
+            next_events = await self.step(1)
+            if not next_events:
+                break
+            executed.extend(next_events)
         return executed
 
-    # Stubs to satisfy existing Simulation interface ---------------------------------
-    async def emit_environment_event(
-        self: Self, _event: dict[str, Any]
-    ) -> None:  # pragma: no cover
-        """Stub for compatibility with the older kernel."""
-        return None
+    # compatibility stubs ------------------------------------------------
+    async def emit_environment_event(self: Self, event: dict[str, Any]) -> None:
+        await self._kernel.emit_environment_event(event)
 
     async def forward_external_events(
-        self: Self, _handler: Callable[[str], Awaitable[None]]
-    ) -> None:  # pragma: no cover
-        """Stub for compatibility with the older kernel."""
-        return None
+        self: Self, handler: Callable[[str], Awaitable[None]]
+    ) -> None:
+        async def _adapted_handler(content: str, _metadata: dict[str, Any] | None) -> None:
+            await handler(content)
+
+        await self._kernel.forward_external_events(_adapted_handler)

--- a/src/sim/scheduler_protocol.py
+++ b/src/sim/scheduler_protocol.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, Protocol
+
+from src.sim.version_vector import VersionVector
+
+
+class SchedulerProtocol(Protocol):
+    """Narrow protocol for deterministic simulation scheduling."""
+
+    async def schedule_at(
+        self,
+        step: int,
+        callback: Callable[[], Awaitable[None]],
+        *,
+        agent_id: str | None = None,
+        tokens: int = 1,
+        vector: VersionVector | None = None,
+    ) -> None: ...
+
+    async def schedule_immediate(
+        self,
+        callback: Callable[[], Awaitable[None]],
+        *,
+        agent_id: str | None = None,
+        tokens: int = 1,
+        vector: VersionVector | None = None,
+    ) -> None: ...
+
+    def schedule_at_nowait(
+        self,
+        step: int,
+        callback: Callable[[], Awaitable[None]],
+        *,
+        agent_id: str | None = None,
+        tokens: int = 1,
+        vector: VersionVector | None = None,
+    ) -> None: ...
+
+    def schedule_immediate_nowait(
+        self,
+        callback: Callable[[], Awaitable[None]],
+        *,
+        agent_id: str | None = None,
+        tokens: int = 1,
+        vector: VersionVector | None = None,
+    ) -> None: ...
+
+    async def dispatch(self, limit: int) -> list[Any]: ...
+
+    async def step(self, limit: int) -> list[Any]: ...
+
+    def pause(self) -> None: ...
+
+    async def resume(self) -> list[Any]: ...
+
+    def empty(self) -> bool: ...
+
+    def queue_depth(self) -> int: ...
+
+    def event_metadata(self, event: Any) -> Mapping[str, Any]: ...
+

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -71,6 +71,7 @@ from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 from src.sim.persistence.trace_hash_service import TraceHashService
 from src.sim.quests import generate_quest
 from src.sim.resource_manager import get_resource_manager
+from src.sim.scheduler_protocol import SchedulerProtocol
 from src.sim.version_vector import VersionVector
 from src.sim.world_map import WorldMap
 
@@ -131,6 +132,7 @@ class Simulation:
         evaluation_hook_names: Sequence[str] | None = None,
         evaluation_targets: Mapping[str, Any] | None = None,
         success_metrics: Mapping[str, Any] | None = None,
+        scheduler: SchedulerProtocol | None = None,
     ) -> None:
         """
         Initializes the Simulation instance.
@@ -205,7 +207,7 @@ class Simulation:
         self.personality_engine = PersonalityEngine()
         self.lifecycle_service = LifecycleService()
         self.simulation_complete = False
-        self.event_kernel = EventKernel()
+        self.event_kernel: SchedulerProtocol = scheduler or EventKernel()
         self.vector = VersionVector()
         self.paused: bool = False
         self.speed: float = 1.0

--- a/tests/unit/sim/test_scheduler_replay.py
+++ b/tests/unit/sim/test_scheduler_replay.py
@@ -1,0 +1,71 @@
+import hashlib
+import random
+from typing import Any
+
+import pytest
+
+from src.sim.event_kernel import EventKernel
+
+pytestmark = pytest.mark.unit
+
+
+async def _noop() -> None:
+    return None
+
+
+def _command_stream(seed: int, size: int = 30) -> list[dict[str, Any]]:
+    rng = random.Random(seed)
+    commands: list[dict[str, Any]] = []
+    for idx in range(size):
+        commands.append(
+            {
+                "step": rng.randint(0, 6),
+                "agent_id": f"agent-{rng.randint(1, 3)}",
+                "tokens": rng.randint(1, 4),
+                "count": idx,
+            }
+        )
+    return commands
+
+
+async def _run_stream(seed: int) -> tuple[list[str], bytes]:
+    kernel = EventKernel()
+    stream = _command_stream(seed)
+    for command in stream:
+        kernel.set_budget(command["agent_id"], 1000)
+    for command in stream:
+        kernel.schedule_at_nowait(
+            command["step"],
+            _noop,
+            agent_id=command["agent_id"],
+            tokens=command["tokens"],
+        )
+    events = await kernel.dispatch(10_000)
+    trace_hashes = [kernel.event_metadata(event)["trace_hash"] for event in events]
+    trace_bytes = "\n".join(trace_hashes).encode("utf-8")
+    return trace_hashes, trace_bytes
+
+
+@pytest.mark.asyncio
+async def test_scheduler_replay_hashes_are_byte_identical() -> None:
+    left_hashes, left_bytes = await _run_stream(seed=1337)
+    right_hashes, right_bytes = await _run_stream(seed=1337)
+
+    assert left_hashes == right_hashes
+    assert left_bytes == right_bytes
+    assert hashlib.sha256(left_bytes).digest() == hashlib.sha256(right_bytes).digest()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_tie_break_uses_insertion_count() -> None:
+    kernel = EventKernel()
+
+    kernel.schedule_at_nowait(2, _noop)
+    kernel.schedule_at_nowait(2, _noop)
+    kernel.schedule_at_nowait(2, _noop)
+
+    events = await kernel.dispatch(10)
+    metadata = [kernel.event_metadata(event) for event in events]
+
+    assert [item["step"] for item in metadata] == [2, 2, 2]
+    assert [item["count"] for item in metadata] == [0, 1, 2]


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth scheduler and a narrow protocol so high-level simulation code depends on a small, stable API rather than kernel internals.
- Preserve deterministic event ordering and replayability while making it easy to adapt or test alternate scheduler implementations.
- Deprecate the older concrete kernel implementation while keeping backward-compatible adapter support for tests and fixtures.

### Description
- Add a `SchedulerProtocol` that defines the minimal scheduler surface (`schedule_at`, `schedule_immediate`, `schedule_at_nowait`, `schedule_immediate_nowait`, `dispatch`/`step`, `pause`/`resume`, `empty`, `queue_depth`, and `event_metadata`). (`src/sim/scheduler_protocol.py`).
- Extend `EventKernel` to implement protocol behaviors (pause/resume, `queue_depth`, and `event_metadata`) and continue to compute stable `trace_hash` metadata for each scheduled event. (`src/sim/event_kernel.py`).
- Refactor `Simulation` to accept/inject a `SchedulerProtocol` and use it as the scheduler dependency instead of touching kernel internals. (`src/sim/simulation.py`).
- Update `SimulationEngine` to query scheduler queue depth via the protocol (`queue_depth`) rather than accessing kernel private state. (`src/sim/engine.py`).
- Convert `DiscreteEventKernel` into a deprecated compatibility adapter that delegates to `EventKernel` and translates legacy event shapes for existing tests/fixtures. (`src/sim/kernel/kernel.py`).
- Add deterministic replay tests that assert identical trace-hash byte streams for the same seed+command stream and verify same-step tie-break semantics use insertion count. (`tests/unit/sim/test_scheduler_replay.py`).
- Document the scheduler ordering contract and tie-break rules in the architecture docs. (`docs/architecture.md`).

### Testing
- Ran linter checks with `python -m ruff check src/sim/scheduler_protocol.py src/sim/event_kernel.py src/sim/kernel/kernel.py src/sim/engine.py src/sim/simulation.py tests/unit/sim/test_scheduler_replay.py tests/unit/kernel/test_discrete_event_kernel.py` and the checks passed.
- Ran unit tests with `pytest -q tests/unit/sim/test_event_kernel.py tests/unit/sim/test_scheduler_replay.py tests/unit/kernel/test_discrete_event_kernel.py` and all tests passed (12 passed, with expected deprecation/warnings reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a192d623908326a99799a45514084e)