### PR TITLE
Unify snapshot hash validation in SnapshotPersistenceService

### DIFF
--- a/src/infra/snapshot.py
+++ b/src/infra/snapshot.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
-from src.sim.persistence.snapshot_migrations import CURRENT_SNAPSHOT_SCHEMA_VERSION
 from src.sim.persistence.trace_hash_service import TraceHashService
 from src.utils.paths import ensure_dir
 
@@ -37,20 +36,9 @@ _s3_client: boto3.client | None = None
 
 
 def compute_trace_hash(data: dict[str, Any]) -> str:
-    """Backward-compatible trace hash helper; use sim persistence services for new code."""
+    """Backward-compatible trace hash helper."""
 
     return TraceHashService.compute(data)
-
-
-def _validate_snapshot_schema_version(data: dict[str, Any]) -> None:
-    version = data.get("snapshot_schema_version")
-    if not isinstance(version, int):
-        raise ValueError("Snapshot schema version is missing or invalid")
-    if version < 1 or version > CURRENT_SNAPSHOT_SCHEMA_VERSION:
-        raise ValueError(
-            f"Unsupported snapshot schema version {version}; "
-            f"supported range is [1, {CURRENT_SNAPSHOT_SCHEMA_VERSION}]"
-        )
 
 
 def _get_s3_client() -> boto3.client:
@@ -61,7 +49,6 @@ def _get_s3_client() -> boto3.client:
             raise RuntimeError("boto3 is required for S3 operations")
         _s3_client = boto3.client("s3")
     return _s3_client
-
 
 
 def _s3_key(step: int, compress: bool) -> str:
@@ -109,8 +96,6 @@ def save_snapshot(
         Folder where snapshots will be stored.
     """
     compress = SNAPSHOT_COMPRESS if compress is None else compress
-    _validate_snapshot_schema_version(data)
-
     path = ensure_dir(directory)
 
     if compress:
@@ -133,13 +118,7 @@ def load_snapshot(
     directory: str | Path = "snapshots",
     compress: bool | None = None,
 ) -> dict[str, Any]:
-    """Load ``directory/snapshot_{step}.json`` or ``.json.zst`` and verify hash.
-
-    Raises
-    ------
-    ValueError
-        If the recomputed trace hash does not match the stored value.
-    """
+    """Load ``directory/snapshot_{step}.json`` or ``.json.zst``."""
 
     compress = SNAPSHOT_COMPRESS if compress is None else compress
 
@@ -188,24 +167,5 @@ def load_snapshot(
     else:
         with file_path.open("r", encoding="utf-8") as f:
             data = cast(dict[str, Any], json.load(f))
-
-    _validate_snapshot_schema_version(data)
-
-    expected = data.get("trace_hash")
-    if expected is not None:
-        data_no_vector = {k: v for k, v in data.items() if k != "trace_hash"}
-        if "knowledge_board" in data_no_vector:
-            data_no_vector["knowledge_board"] = {
-                k: v for k, v in data.get("knowledge_board", {}).items() if k != "vector"
-            }
-        if "world_map" in data_no_vector:
-            data_no_vector["world_map"] = {
-                k: v for k, v in data.get("world_map", {}).items() if k != "vector"
-            }
-        actual = TraceHashService.compute(data_no_vector)
-        if actual != expected:
-            raise ValueError(
-                f"Trace hash mismatch for snapshot {step}: expected {expected}, computed {actual}"
-            )
 
     return data

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -18,10 +18,10 @@ from src.governance.service import governance
 from src.infra import event_log
 from src.infra import metrics as infra_metrics
 from src.infra.ledger import ledger
-from src.infra.snapshot import load_snapshot
 from src.interfaces import metrics
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
+from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 
 from .widget_registry import WidgetRegistry
 
@@ -679,13 +679,15 @@ async def api_get_gov() -> Response:
     if sim is not None and hasattr(sim, "get_governance_read_model"):
         model = cast(dict[str, Any], sim.get_governance_read_model())
         return JSONResponse(model)
-    return JSONResponse({
-        "rules": governance_rules_engine.current_rules(),
-        "current_rules": governance_rules_engine.current_rules(),
-        "pending_votes": governance_rules_engine.pending_votes(),
-        "active_offices": governance_rules_engine.active_offices(),
-        "sanctions": governance_rules_engine.sanctions(),
-    })
+    return JSONResponse(
+        {
+            "rules": governance_rules_engine.current_rules(),
+            "current_rules": governance_rules_engine.current_rules(),
+            "pending_votes": governance_rules_engine.pending_votes(),
+            "active_offices": governance_rules_engine.active_offices(),
+            "sanctions": governance_rules_engine.sanctions(),
+        }
+    )
 
 
 @app.get("/api/laws", response_model=LawsResponse)
@@ -693,8 +695,6 @@ async def api_get_laws() -> Response:
     """Return passed laws from the canonical governance state store."""
 
     return JSONResponse({"laws": governance_rules_engine.passed_laws()})
-
-
 
 
 @app.get("/api/gov/current_rules")
@@ -845,7 +845,9 @@ async def api_memory_snapshot(step: int) -> Response:
     """Return memory snapshot data for the given step."""
 
     try:
-        data = await asyncio.to_thread(load_snapshot, step, directory=SNAPSHOT_DIR)
+        data = await asyncio.to_thread(
+            SnapshotPersistenceService.load, step, directory=SNAPSHOT_DIR
+        )
     except Exception:  # pragma: no cover - invalid or missing snapshot
         resp = JSONResponse({"error": "not_found"}, status_code=404)
         if not hasattr(resp, "status_code"):

--- a/src/sim/persistence/snapshot_service.py
+++ b/src/sim/persistence/snapshot_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from src.infra.snapshot import load_snapshot as _load_snapshot
 from src.infra.snapshot import save_snapshot as _save_snapshot
 from src.infra.snapshot import upload_snapshot as _upload_snapshot
+from src.sim.persistence.snapshot_migrations import CURRENT_SNAPSHOT_SCHEMA_VERSION
 
 from .trace_hash_service import TraceHashService
 
@@ -14,7 +15,49 @@ class SnapshotPersistenceService:
     """Snapshot/replay-oriented persistence service over infra storage primitives."""
 
     @staticmethod
+    def _validate_schema_version(data: dict[str, Any]) -> None:
+        version = data.get("snapshot_schema_version")
+        if not isinstance(version, int):
+            raise ValueError("Snapshot schema version is missing or invalid")
+        if version < 1 or version > CURRENT_SNAPSHOT_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported snapshot schema version {version}; "
+                f"supported range is [1, {CURRENT_SNAPSHOT_SCHEMA_VERSION}]"
+            )
+
+    @staticmethod
+    def normalize_for_hash(data: dict[str, Any]) -> dict[str, Any]:
+        normalized = {k: v for k, v in data.items() if k != "trace_hash"}
+        knowledge_board = normalized.get("knowledge_board")
+        if isinstance(knowledge_board, dict):
+            normalized["knowledge_board"] = {
+                k: v for k, v in knowledge_board.items() if k != "vector"
+            }
+        world_map = normalized.get("world_map")
+        if isinstance(world_map, dict):
+            normalized["world_map"] = {k: v for k, v in world_map.items() if k != "vector"}
+        return normalized
+
+    @classmethod
+    def compute_hash(cls, data: dict[str, Any]) -> str:
+        return TraceHashService.compute(cls.normalize_for_hash(data))
+
+    @classmethod
+    def validate(cls, step: int | str | Path, data: dict[str, Any]) -> dict[str, Any]:
+        cls._validate_schema_version(data)
+        expected = data.get("trace_hash")
+        if expected is None:
+            return data
+        actual = cls.compute_hash(data)
+        if actual != expected:
+            raise ValueError(
+                f"Trace hash mismatch for snapshot {step}: expected {expected}, computed {actual}"
+            )
+        return data
+
+    @staticmethod
     def save(step: int, data: dict[str, Any], directory: str | Path = "snapshots") -> None:
+        SnapshotPersistenceService._validate_schema_version(data)
         _save_snapshot(step, data, directory=directory)
 
     @staticmethod
@@ -24,21 +67,4 @@ class SnapshotPersistenceService:
     @staticmethod
     def load(step: int | str | Path, directory: str | Path = "snapshots") -> dict[str, Any]:
         data = _load_snapshot(step, directory=directory)
-        expected = data.get("trace_hash")
-        if expected is None:
-            return data
-        data_no_vector = {k: v for k, v in data.items() if k != "trace_hash"}
-        if "knowledge_board" in data_no_vector:
-            data_no_vector["knowledge_board"] = {
-                k: v for k, v in data.get("knowledge_board", {}).items() if k != "vector"
-            }
-        if "world_map" in data_no_vector:
-            data_no_vector["world_map"] = {
-                k: v for k, v in data.get("world_map", {}).items() if k != "vector"
-            }
-        actual = TraceHashService.compute(data_no_vector)
-        if actual != expected:
-            raise ValueError(
-                f"Trace hash mismatch for snapshot {step}: expected {expected}, computed {actual}"
-            )
-        return data
+        return SnapshotPersistenceService.validate(step, data)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -271,9 +271,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[
-            str, dict[str, Any]
-        ] = {}  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[str, dict[str, Any]] = (
+            {}
+        )  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -336,9 +336,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[
-            SimulationMessage
-        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[SimulationMessage] = (
+            []
+        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -437,9 +437,11 @@ class Simulation:
             sender_id=str(payload.get("sender_id", "human")),
             channel_id=str(raw_channel_id) if raw_channel_id is not None else None,
             source=str(payload.get("source", "simulation")),
-            permissions=set(payload.get("permissions", []))
-            if isinstance(payload.get("permissions"), list | set | tuple)
-            else set(),
+            permissions=(
+                set(payload.get("permissions", []))
+                if isinstance(payload.get("permissions"), list | set | tuple)
+                else set()
+            ),
             metadata={k: v for k, v in payload.items() if k not in {"permissions"}},
         )
         command_type = payload.get("command_type")
@@ -894,7 +896,9 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = (
+                    []
+                )  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -1210,14 +1214,7 @@ class Simulation:
                 },
                 "trace_hash": self._last_trace_hash,
             }
-            snapshot_no_vector = {
-                **{k: v for k, v in snapshot.items() if k != "trace_hash"},
-                "knowledge_board": {
-                    k: v for k, v in snapshot["knowledge_board"].items() if k != "vector"
-                },
-                "world_map": {k: v for k, v in snapshot["world_map"].items() if k != "vector"},
-            }
-            snapshot["trace_hash"] = TraceHashService.compute(snapshot_no_vector)
+            snapshot["trace_hash"] = SnapshotPersistenceService.compute_hash(snapshot)
             self._last_trace_hash = snapshot["trace_hash"]
             SnapshotPersistenceService.save(self.current_step, snapshot)
             SnapshotPersistenceService.upload(self.current_step)
@@ -1444,9 +1441,11 @@ class Simulation:
                 sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
                 channel_id=str(evt.data.get("channel_id")) if evt.data.get("channel_id") else None,
                 source=str(evt.data.get("source", "event_bus")),
-                permissions=set(evt.data.get("permissions", []))
-                if isinstance(evt.data.get("permissions"), list)
-                else set(),
+                permissions=(
+                    set(evt.data.get("permissions", []))
+                    if isinstance(evt.data.get("permissions"), list)
+                    else set()
+                ),
                 metadata={k: v for k, v in evt.data.items()},
             )
             await self.command_bus.dispatch(parse_bus_command(evt.data), context=context)
@@ -2112,7 +2111,9 @@ class Simulation:
         sim.world_season = int(world_season_value) if world_season_value is not None else None
         sim.environment_state.weather = str(env_snapshot["weather"])
         sim.environment_state.season_effects = dict(env_snapshot["season_effects"])
-        sim.environment_state.active_global_modifiers = list(env_snapshot["active_global_modifiers"])
+        sim.environment_state.active_global_modifiers = list(
+            env_snapshot["active_global_modifiers"]
+        )
         sim.environment_state.council_window_active = bool(env_snapshot["council_window_active"])
         snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
         sim.turns_per_world_tick = max(1, snapshot_turn_quantum)

--- a/tests/unit/infra/test_snapshot.py
+++ b/tests/unit/infra/test_snapshot.py
@@ -57,8 +57,8 @@ def test_load_snapshot_hash_mismatch(tmp_path: Path) -> None:
     with fname.open("w") as f:
         json.dump(data, f)
 
-    with pytest.raises(ValueError):
-        load_snapshot(1, directory=tmp_path)
+    loaded = load_snapshot(1, directory=tmp_path)
+    assert loaded["step"] == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
+++ b/tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py
@@ -3,8 +3,9 @@ from pathlib import Path
 
 import pytest
 
-from src.infra.snapshot import compute_trace_hash, save_snapshot
+from src.infra.snapshot import save_snapshot
 from src.interfaces import dashboard_backend as db
+from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 
 
 @pytest.mark.unit
@@ -13,8 +14,8 @@ async def test_api_memory_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     # create several snapshot files
     steps = [1, 2, 3]
     for step in steps:
-        data = {"step": step}
-        data["trace_hash"] = compute_trace_hash(data)
+        data = {"step": step, "snapshot_schema_version": 3}
+        data["trace_hash"] = SnapshotPersistenceService.compute_hash(data)
         save_snapshot(step, data, directory=tmp_path)
     monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
 
@@ -25,8 +26,8 @@ async def test_api_memory_snapshots(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_api_memory_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    data = {"step": 5}
-    data["trace_hash"] = compute_trace_hash(data)
+    data = {"step": 5, "snapshot_schema_version": 3}
+    data["trace_hash"] = SnapshotPersistenceService.compute_hash(data)
     save_snapshot(5, data, directory=tmp_path)
     monkeypatch.setattr(db, "SNAPSHOT_DIR", tmp_path)
 

--- a/tests/unit/sim/persistence/test_snapshot_service.py
+++ b/tests/unit/sim/persistence/test_snapshot_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.infra.snapshot import save_snapshot
+from src.sim.persistence.snapshot_migrations import CURRENT_SNAPSHOT_SCHEMA_VERSION
+from src.sim.persistence.snapshot_service import SnapshotPersistenceService
+
+pytestmark = pytest.mark.unit
+
+
+def _snapshot_payload(version: int) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "step": 7,
+        "snapshot_schema_version": version,
+        "knowledge_board": {"entries": [{"id": "k1"}], "vector": {"clock": 1}},
+        "world_map": {"width": 10, "height": 10, "agents": {}, "vector": {"clock": 2}},
+    }
+    payload["trace_hash"] = SnapshotPersistenceService.compute_hash(payload)
+    return payload
+
+
+def test_load_snapshot_validates_current_schema(tmp_path: Path) -> None:
+    payload = _snapshot_payload(CURRENT_SNAPSHOT_SCHEMA_VERSION)
+    save_snapshot(7, payload, directory=tmp_path)
+
+    loaded = SnapshotPersistenceService.load(7, directory=tmp_path)
+
+    assert loaded == payload
+
+
+def test_load_snapshot_accepts_previous_schema(tmp_path: Path) -> None:
+    payload = _snapshot_payload(CURRENT_SNAPSHOT_SCHEMA_VERSION - 1)
+    save_snapshot(7, payload, directory=tmp_path)
+
+    loaded = SnapshotPersistenceService.load(7, directory=tmp_path)
+
+    assert loaded["snapshot_schema_version"] == CURRENT_SNAPSHOT_SCHEMA_VERSION - 1
+
+
+def test_load_snapshot_rejects_tampered_hash(tmp_path: Path) -> None:
+    payload = _snapshot_payload(CURRENT_SNAPSHOT_SCHEMA_VERSION)
+    save_snapshot(7, payload, directory=tmp_path)
+
+    path = tmp_path / "snapshot_7.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["step"] = 8
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Trace hash mismatch"):
+        SnapshotPersistenceService.load(7, directory=tmp_path)


### PR DESCRIPTION
### Motivation
- Eliminate duplicated snapshot hash/schema validation across infra and sim code by centralizing semantic checks in one authoritative module.
- Make infra snapshot utilities responsible only for low-level I/O (read/write/upload/download) to keep responsibilities separated.
- Provide a single, testable API for normalization and hash computation so all callers compute/validate snapshots consistently.

### Description
- Added `SnapshotPersistenceService` helpers: schema version guard (`_validate_schema_version`), normalization (`normalize_for_hash`), `compute_hash`, and `validate`, and made `save`/`load`/`upload` use them; this centralizes trace-hash logic and vector exclusions (knowledge_board/world_map). 
- Removed semantic validation from `src/infra/snapshot.py` so it now only performs low-level serialization, compression and S3 upload/download, and exposes a backward-compatible `compute_trace_hash` that delegates to `TraceHashService`. 
- Updated callers to use the unified service: `src/interfaces/dashboard_backend.py` now uses `SnapshotPersistenceService.load` for API snapshot retrieval and `src/sim/simulation.py` uses `SnapshotPersistenceService.compute_hash` when generating snapshot `trace_hash`. 
- Added unit tests `tests/unit/sim/persistence/test_snapshot_service.py` covering current-schema acceptance, previous-schema acceptance, and tampered snapshot hash failure, and updated existing snapshot tests to align with the new validation boundary. 

### Testing
- Ran `ruff check` on the modified files which passed for the set of changed files. 
- Ran `black` to reformat affected files and verified formatting with `black --check` afterwards. 
- Ran unit tests `pytest -q tests/unit/sim/persistence/test_snapshot_service.py tests/unit/interfaces/test_dashboard_backend_memory_snapshots.py tests/unit/infra/test_snapshot.py` and they passed (11 passed, 1 skipped for optional S3 dependency). 
- Ran integration migration tests `pytest -q -m integration tests/integration/sim/test_snapshot_schema_migrations.py` and they passed (4 passed). 
- `bash scripts/lint.sh` surfaced unrelated, pre-existing repo-wide lint issues outside the modified modules, and `mypy` reported unrelated type issues elsewhere in the codebase; these do not affect the snapshot changes or the tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1948ad2048326a066f70a4d6484c5)