### PR TITLE
Add KnowledgeBoardService to centralize knowledge board mediation

### DIFF
--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -19,7 +19,6 @@ from src.interfaces.interaction_schema import (
     InteractionResult,
 )
 from src.shared.typing import SimulationMessage
-from src.sim.knowledge_board import BoardEntry
 
 if TYPE_CHECKING:
     from src.sim.simulation import Simulation
@@ -175,7 +174,11 @@ class SimulationCommandService:
         elif action == "inject_event":
             await self._inject_world_event(envelope)
 
-        return {"paused": sim.paused, "speed": sim.speed, "simulation_complete": sim.simulation_complete}
+        return {
+            "paused": sim.paused,
+            "speed": sim.speed,
+            "simulation_complete": sim.simulation_complete,
+        }
 
     async def _spawn_agent(self, envelope: InteractionEnvelope) -> None:
         sim = self.simulation
@@ -186,7 +189,11 @@ class SimulationCommandService:
             await emit_event(
                 SimulationEvent(
                     type="spawn_rejected",
-                    data={"reason": "duplicate_agent_id", "agent_id": agent_id, "step": sim.current_step},
+                    data={
+                        "reason": "duplicate_agent_id",
+                        "agent_id": agent_id,
+                        "step": sim.current_step,
+                    },
                 )
             )
             return
@@ -213,13 +220,12 @@ class SimulationCommandService:
         text = envelope.text
         author = envelope.agent_id or "human"
         if text and sim.knowledge_board:
-            async with sim.knowledge_board.lock:
-                sim.knowledge_board.add_entry(
-                    BoardEntry(content_full=text, entry_type="human_message", tags=["human", "moderation"]),
-                    str(author),
-                    sim.current_step,
-                    sim.vector.to_dict(),
-                )
+            await sim.knowledge_board_service.post_human_message(
+                actor_id=str(author),
+                content=text,
+                tags=["moderation"],
+                causal_source="command_service.post_knowledge_board",
+            )
             await emit_event(
                 SimulationEvent(
                     type="knowledge_board",
@@ -255,15 +261,17 @@ class SimulationCommandService:
             sim.messages_to_perceive_this_round.append(msg)
         await sim.event_kernel.emit_environment_event(event_payload)
         if sim.knowledge_board:
-            async with sim.knowledge_board.lock:
-                sim.knowledge_board.add_entry(
-                    BoardEntry(content_full=text, entry_type="world_event", tags=["event", scope]),
-                    author,
-                    sim.current_step,
-                    sim.vector.to_dict(),
-                )
+            await sim.knowledge_board_service.post_event(
+                actor_id=author,
+                content=text,
+                event_type="world_event",
+                tags=[scope],
+                causal_source="command_service.inject_world_event",
+            )
 
-    async def _dispatch_knowledge_board(self, command: InteractionEnvelope, *, context: InteractionContext) -> InteractionResult:
+    async def _dispatch_knowledge_board(
+        self, command: InteractionEnvelope, *, context: InteractionContext
+    ) -> InteractionResult:
         content = str(command.content or "").strip()
         if not content:
             return InteractionResult(
@@ -300,13 +308,12 @@ class SimulationCommandService:
                 data=decision.metadata or None,
                 decision_provenance=decision.provenance,
             )
-        async with board.lock:
-            board.add_entry(
-                BoardEntry(content_full=content, entry_type="human_message", tags=["human", "knowledge_board"]),
-                context.sender_id,
-                self.simulation.current_step,
-                self.simulation.vector.to_dict(),
-            )
+        await self.simulation.knowledge_board_service.post_human_message(
+            actor_id=context.sender_id,
+            content=content,
+            tags=["knowledge_board"],
+            causal_source="command_service.dispatch_knowledge_board",
+        )
         return InteractionResult(
             status="ok",
             user_message="Posted to Knowledge Board.",
@@ -314,7 +321,9 @@ class SimulationCommandService:
             decision_provenance=decision.provenance,
         )
 
-    async def _dispatch_message(self, command: InteractionEnvelope, *, context: InteractionContext) -> InteractionResult:
+    async def _dispatch_message(
+        self, command: InteractionEnvelope, *, context: InteractionContext
+    ) -> InteractionResult:
         text = str(command.content or "").strip()
         if not text:
             return InteractionResult(
@@ -364,12 +373,22 @@ class SimulationCommandService:
         broadcast = command.intent == "broadcast"
         target = self._resolve_target(command)
         budget_agent_id = self._resolve_budget_agent_id(command, target.agent_id)
-        budget_agent = next((a for a in self.simulation.agents if a.agent_id == budget_agent_id), None)
+        budget_agent = next(
+            (a for a in self.simulation.agents if a.agent_id == budget_agent_id), None
+        )
         state = budget_agent.state if budget_agent is not None else None
 
         if broadcast:
-            ip_cost = float(config.get_config("IP_COST_BROADCAST_MESSAGE") or config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
-            du_cost = float(config.get_config("DU_COST_BROADCAST_ACTION") or config.get_config("DU_COST_PER_ACTION") or 0.0)
+            ip_cost = float(
+                config.get_config("IP_COST_BROADCAST_MESSAGE")
+                or config.get_config("IP_COST_SEND_DIRECT_MESSAGE")
+                or 0.0
+            )
+            du_cost = float(
+                config.get_config("DU_COST_BROADCAST_ACTION")
+                or config.get_config("DU_COST_PER_ACTION")
+                or 0.0
+            )
         else:
             ip_cost = float(config.get_config("IP_COST_SEND_DIRECT_MESSAGE") or 0.0)
             du_cost = float(config.get_config("DU_COST_PER_ACTION") or 0.0)
@@ -462,11 +481,32 @@ class SimulationCommandService:
     def _resolve_target(self, command: InteractionEnvelope) -> Any:
         target = None
         if command.routing.target_agent_id:
-            target = next((a for a in self.simulation.agents if a.agent_id == command.routing.target_agent_id), None)
+            target = next(
+                (
+                    a
+                    for a in self.simulation.agents
+                    if a.agent_id == command.routing.target_agent_id
+                ),
+                None,
+            )
         if target is None and command.routing.recipient_id:
-            target = next((a for a in self.simulation.agents if a.agent_id == command.routing.recipient_id), None)
-        if target is None and self.simulation.discord_bot and self.simulation.discord_bot.last_agent_id:
-            target = next((a for a in self.simulation.agents if a.agent_id == self.simulation.discord_bot.last_agent_id), None)
+            target = next(
+                (a for a in self.simulation.agents if a.agent_id == command.routing.recipient_id),
+                None,
+            )
+        if (
+            target is None
+            and self.simulation.discord_bot
+            and self.simulation.discord_bot.last_agent_id
+        ):
+            target = next(
+                (
+                    a
+                    for a in self.simulation.agents
+                    if a.agent_id == self.simulation.discord_bot.last_agent_id
+                ),
+                None,
+            )
         return target or self.simulation.agents[self.simulation.current_agent_index]
 
     def _resolve_budget_agent_id(self, command: InteractionEnvelope, fallback: str) -> str:

--- a/src/sim/knowledge_board_service.py
+++ b/src/sim/knowledge_board_service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from src.sim.knowledge_board_protocol import KnowledgeBoardProtocol
+from src.sim.knowledge_entry import KnowledgeEntry, KnowledgeEntryType
+
+
+class KnowledgeBoardService:
+    """Backend-agnostic mediator for knowledge board reads/writes."""
+
+    def __init__(
+        self,
+        board: KnowledgeBoardProtocol,
+        *,
+        step_provider: Callable[[], int],
+        vector_provider: Callable[[], dict[str, int]],
+    ) -> None:
+        self._board = board
+        self._step_provider = step_provider
+        self._vector_provider = vector_provider
+
+    def get_recent_entries_for_prompt(self, max_entries: int = 5) -> list[str]:
+        return self._board.get_recent_entries_for_prompt(max_entries=max_entries)
+
+    async def post_idea(
+        self,
+        *,
+        actor_id: str,
+        content: str,
+        causal_source: str,
+        tags: list[str] | None = None,
+        reference_metadata: dict[str, Any] | None = None,
+        governance_rule_id: str | None = None,
+    ) -> bool:
+        return await self._post_entry(
+            actor_id=actor_id,
+            entry=KnowledgeEntry(
+                content_full=content,
+                entry_type=KnowledgeEntryType.IDEA,
+                tags=self._merge_tags(["idea", "proposal"], tags),
+                reference_metadata=self._with_required_metadata(
+                    reference_metadata,
+                    actor_id=actor_id,
+                    causal_source=causal_source,
+                    governance_rule_id=governance_rule_id,
+                ),
+                governance_rule_id=governance_rule_id,
+            ),
+        )
+
+    async def post_vote(
+        self,
+        *,
+        actor_id: str,
+        proposal_id: str,
+        approve: bool,
+        causal_source: str,
+        tags: list[str] | None = None,
+        reference_metadata: dict[str, Any] | None = None,
+        governance_rule_id: str | None = None,
+    ) -> bool:
+        metadata = dict(reference_metadata or {})
+        metadata["approve"] = bool(approve)
+        metadata["proposal_id"] = proposal_id
+        return await self._post_entry(
+            actor_id=actor_id,
+            entry=KnowledgeEntry(
+                content_full=(
+                    f"Vote by {actor_id} on proposal {proposal_id}: {'approve' if approve else 'reject'}"
+                ),
+                entry_type=KnowledgeEntryType.VOTE,
+                parent_entry_id=proposal_id,
+                tags=self._merge_tags(["governance", "vote"], tags),
+                reference_metadata=self._with_required_metadata(
+                    metadata,
+                    actor_id=actor_id,
+                    causal_source=causal_source,
+                    governance_rule_id=governance_rule_id,
+                ),
+                governance_rule_id=governance_rule_id,
+            ),
+        )
+
+    async def post_event(
+        self,
+        *,
+        actor_id: str,
+        content: str,
+        causal_source: str,
+        event_type: KnowledgeEntryType | str = KnowledgeEntryType.EVENT,
+        tags: list[str] | None = None,
+        reference_metadata: dict[str, Any] | None = None,
+        governance_rule_id: str | None = None,
+    ) -> bool:
+        return await self._post_entry(
+            actor_id=actor_id,
+            entry=KnowledgeEntry(
+                content_full=content,
+                entry_type=event_type,
+                tags=self._merge_tags(["event"], tags),
+                reference_metadata=self._with_required_metadata(
+                    reference_metadata,
+                    actor_id=actor_id,
+                    causal_source=causal_source,
+                    governance_rule_id=governance_rule_id,
+                ),
+                governance_rule_id=governance_rule_id,
+            ),
+        )
+
+    async def post_lifecycle_transition(
+        self,
+        *,
+        actor_id: str,
+        from_state: str,
+        to_state: str,
+        reason: str,
+        legacy_artifacts: list[str] | None,
+        causal_source: str,
+        tags: list[str] | None = None,
+        reference_metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        metadata = dict(reference_metadata or {})
+        metadata.update(
+            {
+                "from_state": from_state,
+                "to_state": to_state,
+                "reason": reason,
+                "legacy_artifacts": legacy_artifacts or [],
+            }
+        )
+        return await self._post_entry(
+            actor_id=actor_id,
+            entry=KnowledgeEntry(
+                content_full=f"Agent {actor_id} transitioned lifecycle {from_state} -> {to_state}",
+                entry_type=KnowledgeEntryType.RETIREMENT,
+                tags=self._merge_tags(["population", "retirement", to_state], tags),
+                reference_metadata=self._with_required_metadata(
+                    metadata,
+                    actor_id=actor_id,
+                    causal_source=causal_source,
+                ),
+            ),
+        )
+
+    async def post_human_message(
+        self,
+        *,
+        actor_id: str,
+        content: str,
+        causal_source: str,
+        tags: list[str] | None = None,
+        reference_metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        return await self._post_entry(
+            actor_id=actor_id,
+            entry=KnowledgeEntry(
+                content_full=content,
+                entry_type=KnowledgeEntryType.HUMAN_MESSAGE,
+                tags=self._merge_tags(["human"], tags),
+                reference_metadata=self._with_required_metadata(
+                    reference_metadata,
+                    actor_id=actor_id,
+                    causal_source=causal_source,
+                ),
+            ),
+        )
+
+    async def _post_entry(self, *, actor_id: str, entry: KnowledgeEntry) -> bool:
+        step = self._step_provider()
+        lock = getattr(self._board, "lock", None)
+        if lock is not None:
+            async with lock:
+                return self._board.add_entry(entry, actor_id, step, self._vector_provider())
+        return self._board.add_entry(entry, actor_id, step, self._vector_provider())
+
+    def _with_required_metadata(
+        self,
+        metadata: dict[str, Any] | None,
+        *,
+        actor_id: str,
+        causal_source: str,
+        governance_rule_id: str | None = None,
+    ) -> dict[str, Any]:
+        base = dict(metadata or {})
+        provenance_raw = base.get("provenance")
+        provenance: dict[str, Any] = (
+            dict(provenance_raw) if isinstance(provenance_raw, dict) else {}
+        )
+        base["provenance"] = {
+            **provenance,
+            "step": self._step_provider(),
+            "actor": actor_id,
+            "causal_source": causal_source,
+        }
+        if governance_rule_id:
+            governance_raw = base.get("governance")
+            governance: dict[str, Any] = (
+                dict(governance_raw) if isinstance(governance_raw, dict) else {}
+            )
+            base["governance"] = {
+                **governance,
+                "rule_id": governance_rule_id,
+            }
+        return base
+
+    @staticmethod
+    def _merge_tags(default_tags: list[str], tags: list[str] | None) -> list[str]:
+        merged: list[str] = []
+        for tag in [*default_tags, *(tags or [])]:
+            if tag and tag not in merged:
+                merged.append(tag)
+        return merged

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -56,12 +56,13 @@ from src.sim.engine import SimulationEngine
 from src.sim.environment import EnvironmentState, EnvironmentSystem
 from src.sim.event_kernel import EventKernel
 from src.sim.graph_knowledge_board import GraphKnowledgeBoard
-from src.sim.knowledge_board import BoardEntry, KnowledgeBoard
+from src.sim.knowledge_board import KnowledgeBoard
 from src.sim.knowledge_board_protocol import (
     KnowledgeBoardProtocol,
     UnsupportedKnowledgeBoardCapabilityError,
     as_semantic_query_store,
 )
+from src.sim.knowledge_board_service import KnowledgeBoardService
 from src.sim.knowledge_entry import KnowledgeEntryType
 from src.sim.lifecycle_service import LifecycleService
 from src.sim.persistence.snapshot_migrations import (
@@ -257,6 +258,12 @@ class Simulation:
             step_provider=lambda: int(self.current_step),
         )
 
+        self.knowledge_board_service = KnowledgeBoardService(
+            self.knowledge_board,
+            step_provider=lambda: int(self.current_step),
+            vector_provider=lambda: self.vector.to_dict(),
+        )
+
         # Initialize world map and place agents
         self.world_map = WorldMap()
         self._init_tasks: list[asyncio.Task[Any]] = []
@@ -271,9 +278,9 @@ class Simulation:
         logger.info("Simulation initialized with world map.")
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -336,9 +343,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -582,18 +589,14 @@ class Simulation:
             except Exception:
                 pass
             if self.knowledge_board:
-                async with self.knowledge_board.lock:
-                    self.knowledge_board.add_entry(
-                        BoardEntry(
-                            content_full=f"Agent {parent.agent_id} spawned child {agent.agent_id}",
-                            entry_type="spawn_event",
-                            tags=["population", "spawn"],
-                            reference_metadata={"child_id": agent.agent_id},
-                        ),
-                        parent.agent_id,
-                        self.current_step,
-                        self.vector.to_dict(),
-                    )
+                await self.knowledge_board_service.post_event(
+                    actor_id=parent.agent_id,
+                    content=f"Agent {parent.agent_id} spawned child {agent.agent_id}",
+                    event_type=KnowledgeEntryType.SPAWN_EVENT,
+                    tags=["population", "spawn"],
+                    reference_metadata={"child_id": agent.agent_id},
+                    causal_source="simulation.spawn_agent.parent",
+                )
         else:
             if hasattr(agent.state, "mutate_genes"):
                 agent.state.mutate_genes(mutation_rate)
@@ -606,21 +609,16 @@ class Simulation:
                 inherit_context=inherit_context,
             )
             if self.knowledge_board:
-                async with self.knowledge_board.lock:
-                    self.knowledge_board.add_entry(
-                        BoardEntry(
-                            content_full=(
-                                f"Agent {agent.agent_id} designated successor of "
-                                f"{predecessor.agent_id}"
-                            ),
-                            entry_type="spawn_event",
-                            tags=["population", "succession"],
-                            reference_metadata=succession,
-                        ),
-                        predecessor.agent_id,
-                        self.current_step,
-                        self.vector.to_dict(),
-                    )
+                await self.knowledge_board_service.post_event(
+                    actor_id=predecessor.agent_id,
+                    content=(
+                        f"Agent {agent.agent_id} designated successor of {predecessor.agent_id}"
+                    ),
+                    event_type=KnowledgeEntryType.SPAWN_EVENT,
+                    tags=["population", "succession"],
+                    reference_metadata=succession,
+                    causal_source="simulation.spawn_agent.successor",
+                )
 
         self.agents.append(agent)
         await self.world_map.add_agent(agent.agent_id, x=len(self.agents) - 1, y=0)
@@ -661,26 +659,14 @@ class Simulation:
             )
 
         if self.knowledge_board:
-            async with self.knowledge_board.lock:
-                self.knowledge_board.add_entry(
-                    BoardEntry(
-                        content_full=(
-                            f"Agent {agent.agent_id} transitioned lifecycle "
-                            f"{transition.from_state.value} -> {transition.to_state.value}"
-                        ),
-                        entry_type="retirement",
-                        tags=["population", "retirement", transition.to_state.value],
-                        reference_metadata={
-                            "from_state": transition.from_state.value,
-                            "to_state": transition.to_state.value,
-                            "reason": reason,
-                            "legacy_artifacts": transition.artifacts,
-                        },
-                    ),
-                    agent.agent_id,
-                    self.current_step,
-                    self.vector.to_dict(),
-                )
+            await self.knowledge_board_service.post_lifecycle_transition(
+                actor_id=agent.agent_id,
+                from_state=transition.from_state.value,
+                to_state=transition.to_state.value,
+                reason=reason,
+                legacy_artifacts=transition.artifacts,
+                causal_source="lifecycle_service.transition",
+            )
         agent.update_state(agent.state)
         await self.world_map.remove_agent(agent.agent_id)
         if remove_from_simulation:
@@ -896,9 +882,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -989,37 +973,28 @@ class Simulation:
         )
 
         if self.knowledge_board:
-            async with self.knowledge_board.lock:
-                self.knowledge_board.add_entry(
-                    BoardEntry(
-                        content_full=(
-                            f"Governance enforcement {governance_outcome.outcome} for action "
-                            f"'{requested_action_intent}' by {agent_id}"
-                        ),
-                        entry_type=KnowledgeEntryType.GOVERNANCE_DECISION.value,
-                        tags=[
-                            "governance",
-                            governance_outcome.outcome,
-                            governance_outcome.decision,
-                        ],
-                        reference_metadata={
-                            "decision": governance_outcome.decision,
-                            "outcome": governance_outcome.outcome,
-                            "rule_ids": governance_outcome.rule_ids,
-                            "provenance": {
-                                "agent_id": agent_id,
-                                "step": self.current_step,
-                                "policy_allowed": policy_allowed,
-                                "rule_reason": governance_outcome.reason,
-                                "penalties": governance_outcome.penalties,
-                                "audit": governance_audit,
-                            },
-                        },
-                    ),
-                    agent_id,
-                    self.current_step,
-                    self.vector.to_dict(),
-                )
+            await self.knowledge_board_service.post_event(
+                actor_id=agent_id,
+                content=(
+                    f"Governance enforcement {governance_outcome.outcome} for action "
+                    f"'{requested_action_intent}' by {agent_id}"
+                ),
+                event_type=KnowledgeEntryType.GOVERNANCE_DECISION,
+                tags=["governance", governance_outcome.outcome, governance_outcome.decision],
+                governance_rule_id=(
+                    governance_outcome.rule_ids[0] if governance_outcome.rule_ids else None
+                ),
+                reference_metadata={
+                    "decision": governance_outcome.decision,
+                    "outcome": governance_outcome.outcome,
+                    "rule_ids": governance_outcome.rule_ids,
+                    "policy_allowed": policy_allowed,
+                    "rule_reason": governance_outcome.reason,
+                    "penalties": governance_outcome.penalties,
+                    "audit": governance_audit,
+                },
+                causal_source="governance_rules_engine.post_action_enforcement",
+            )
         if message_content:
             msg_data = cast(
                 SimulationMessage,
@@ -1047,17 +1022,12 @@ class Simulation:
                 and action_intent_str == AgentActionIntent.PROPOSE_IDEA.value
                 and message_recipient_id is None
             ):
-                async with self.knowledge_board.lock:
-                    self.knowledge_board.add_entry(
-                        BoardEntry(
-                            content_full=message_content,
-                            entry_type="idea",
-                            tags=["agent", "proposal"],
-                        ),
-                        agent_id,
-                        self.current_step,
-                        self.vector.to_dict(),
-                    )
+                await self.knowledge_board_service.post_idea(
+                    actor_id=agent_id,
+                    content=message_content,
+                    tags=["agent"],
+                    causal_source="agent_action.propose_idea",
+                )
 
         self.agents[agent_index] = agent
 

--- a/tests/unit/sim/test_knowledge_board_service.py
+++ b/tests/unit/sim/test_knowledge_board_service.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.sim.knowledge_board import KnowledgeBoard
+from src.sim.knowledge_board_service import KnowledgeBoardService
+from src.sim.knowledge_entry import KnowledgeEntryType
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_post_methods_add_minimal_provenance() -> None:
+    step = 12
+    board = KnowledgeBoard()
+    service = KnowledgeBoardService(
+        board,
+        step_provider=lambda: step,
+        vector_provider=lambda: {"sim": step},
+    )
+
+    await service.post_idea(actor_id="agent-1", content="idea", causal_source="test.idea")
+    await service.post_vote(
+        actor_id="agent-2",
+        proposal_id="proposal-1",
+        approve=True,
+        causal_source="test.vote",
+    )
+    await service.post_event(actor_id="agent-3", content="event", causal_source="test.event")
+    await service.post_lifecycle_transition(
+        actor_id="agent-4",
+        from_state="active",
+        to_state="retired",
+        reason="done",
+        legacy_artifacts=["artifact"],
+        causal_source="test.lifecycle",
+    )
+    await service.post_human_message(
+        actor_id="human",
+        content="hello",
+        causal_source="test.human",
+    )
+
+    assert len(board.entries) == 5
+    for entry in board.entries:
+        metadata = entry.get("reference_metadata") or {}
+        provenance = metadata.get("provenance") or {}
+        assert provenance.get("step") == step
+        assert provenance.get("actor") == entry["agent_id"]
+        assert isinstance(provenance.get("causal_source"), str)
+        assert provenance["causal_source"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_governance_linkage_is_attached_to_entry_and_metadata() -> None:
+    board = KnowledgeBoard()
+    service = KnowledgeBoardService(
+        board,
+        step_provider=lambda: 7,
+        vector_provider=lambda: {"sim": 7},
+    )
+
+    await service.post_event(
+        actor_id="agent-1",
+        content="governance event",
+        event_type=KnowledgeEntryType.GOVERNANCE_DECISION,
+        governance_rule_id="rule-123",
+        causal_source="test.governance",
+    )
+
+    entry = board.entries[-1]
+    assert entry["governance_rule_id"] == "rule-123"
+    metadata = entry.get("reference_metadata") or {}
+    governance = metadata.get("governance") or {}
+    assert governance.get("rule_id") == "rule-123"


### PR DESCRIPTION
### Motivation
- Centralize and standardize all Knowledge Board writes/reads behind a single, backend-agnostic service to enforce schema, provenance and governance metadata in one place.
- Remove scattered direct `add_entry(...)` calls from simulation/command paths so provenance, default tags, and governance linkage are applied consistently.

### Description
- Added `src/sim/knowledge_board_service.py` implementing `KnowledgeBoardService` with typed posting methods: `post_idea`, `post_vote`, `post_event`, `post_lifecycle_transition`, and `post_human_message`, plus `get_recent_entries_for_prompt`.
- The service mediates a `KnowledgeBoardProtocol` backend using provided `step_provider` and `vector_provider`, and enforces minimal provenance (`step`, `actor`, `causal_source`), default tags, and optional governance linkage (`governance.rule_id`).
- Replaced direct `knowledge_board.add_entry(...)` usages in `src/sim/simulation.py` and `src/sim/command_service.py` with calls to the new `knowledge_board_service`.
- Added audit-focused unit tests `tests/unit/sim/test_knowledge_board_service.py` validating that posted entries include minimal provenance and governance linkage where applicable.

### Testing
- Ran linter/format checks: `ruff check` and `ruff format` on modified files — all checks passed.
- Unit tests: `pytest -q tests/unit/sim/test_knowledge_board_service.py` — 2 passed.
- Sanity unit test: `pytest -q tests/unit/sim/test_human_command.py -k deducts_resources` — passed.
- Note: `mypy` reports pre-existing type issues in `src/sim/knowledge_board_protocol.py` (type-abstract concerns) which are unrelated to this change and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a196f7b92883268287c299919a62f3)