### PR TITLE
Centralize trait updates through PersonalityEngine with audit and invariants

### DIFF
--- a/src/agents/core/agent_actions.py
+++ b/src/agents/core/agent_actions.py
@@ -105,28 +105,15 @@ def change_role(state: AgentState, new_role: str, current_step: int) -> bool:
         ledger.log_change(state.agent_id, state.ip - start_ip, 0.0, "role_change")
     except Exception:  # pragma: no cover - ledger optional
         logger.debug("Ledger logging failed", exc_info=True)
+    previous_role = state.current_role.name
     state.current_role = create_role_profile(new_role)
     state.role_embedding = list(state.current_role.embedding)
-    template = state.traits.__class__(**get_role_trait_template(new_role))
-    state.apply_trait_drift(
-        {
-            "openness": (template.openness - state.traits.openness) * 0.25,
-            "analytical_focus": (
-                template.analytical_focus - state.traits.analytical_focus
-            )
-            * 0.25,
-            "empathy": (template.empathy - state.traits.empathy) * 0.25,
-            "assertiveness": (template.assertiveness - state.traits.assertiveness) * 0.25,
-            "emotional_sensitivity": (
-                template.emotional_sensitivity - state.traits.emotional_sensitivity
-            )
-            * 0.25,
-            "resilience": (template.resilience - state.traits.resilience) * 0.25,
-            "trust_baseline": (template.trust_baseline - state.traits.trust_baseline)
-            * 0.25,
-            "adaptability": (template.adaptability - state.traits.adaptability) * 0.25,
-        },
+    _ENGINE.apply_role_transition_blend(
+        state,
+        target_traits=get_role_trait_template(new_role),
+        blend_ratio=0.25,
         max_step=0.03,
+        source=f"role_change:{previous_role}->{new_role}",
     )
     state.reputation_score = state.current_role.reputation
     state.steps_in_current_role = 0

--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -525,7 +525,14 @@ class AgentState(AgentStateData):  # Keep AgentState for now if BaseAgent uses i
         return self.traits.summarize()
 
     def apply_trait_drift(self, signals: dict[str, float] | None = None, max_step: float = 0.03) -> None:
-        """Apply bounded, small trait updates from interaction/reflection signals."""
+        """Deprecated helper kept for tests/legacy serialization compatibility only."""
+        from warnings import warn
+
+        warn(
+            "AgentState.apply_trait_drift is deprecated for production flows; use PersonalityEngine APIs.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         updates = signals or {}
         if not updates:
             return

--- a/src/agents/core/personality_engine.py
+++ b/src/agents/core/personality_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import cast
+from warnings import warn
 
 from pydantic import BaseModel
 
@@ -27,6 +28,44 @@ class ExperienceSignal(BaseModel):
 
 class PersonalityEngine:
     """Sole owner of personality-dependent strategy and trait drift updates."""
+
+    def _apply_trait_adjustments(
+        self,
+        state: AgentState,
+        deltas: dict[str, float],
+        *,
+        max_step: float,
+        cause: str,
+        source: str,
+        context: dict[str, float | str] | None = None,
+    ) -> list[dict[str, float | str | int]]:
+        records: list[dict[str, float | str | int]] = []
+        for trait, proposed_delta in deltas.items():
+            if not hasattr(state.traits, trait):
+                continue
+            before = float(getattr(state.traits, trait))
+            bounded_delta = max(-max_step, min(max_step, float(proposed_delta)))
+            after = max(0.0, min(1.0, before + bounded_delta))
+            applied_delta = after - before
+            if abs(applied_delta) < 1e-12:
+                continue
+            setattr(state.traits, trait, after)
+            record: dict[str, float | str | int] = {
+                "step": int(state.step_counter),
+                "trait": trait,
+                "before": before,
+                "delta": applied_delta,
+                "after": after,
+                "cause": cause,
+                "source": source,
+            }
+            if context:
+                record.update(context)
+            records.append(record)
+
+        if records:
+            state.trait_change_audit.extend(records)
+        return records
 
     def _coefficients(self, state: AgentState) -> dict[str, float]:
         coefficients = merge_trait_policy_coefficients(state.trait_policy_coefficients)
@@ -54,14 +93,15 @@ class PersonalityEngine:
             )
         )
 
-    def update_traits(
+    def apply_experience_drift(
         self,
         state: AgentState,
         signals: ExperienceSignal,
         *,
         max_step: float = 0.01,
+        source: str = "simulation.turn",
     ) -> list[dict[str, float | str | int]]:
-        """Apply bounded drift updates and persist an audit trail on ``state``."""
+        """Apply bounded per-turn drift updates and persist an audit trail on ``state``."""
 
         drift = trait_drift_from_experience(
             {
@@ -75,31 +115,80 @@ class PersonalityEngine:
         drift["adaptability"] += 0.003 * signals.governance_participation
         drift["assertiveness"] += 0.002 * signals.conflict_outcome
 
-        records: list[dict[str, float | str | int]] = []
-        for trait, proposed_delta in drift.items():
-            if not hasattr(state.traits, trait):
-                continue
-            before = float(getattr(state.traits, trait))
-            bounded_delta = max(-max_step, min(max_step, float(proposed_delta)))
-            after = max(0.0, min(1.0, before + bounded_delta))
-            applied_delta = after - before
-            if abs(applied_delta) < 1e-12:
-                continue
-            setattr(state.traits, trait, after)
-            record = {
-                "step": int(state.step_counter),
-                "trait": trait,
-                "before": before,
-                "delta": applied_delta,
-                "after": after,
+        return self._apply_trait_adjustments(
+            state,
+            drift,
+            max_step=max_step,
+            cause="experience_drift",
+            source=source,
+            context={
                 "social_outcome": signals.social_outcome,
                 "conflict_outcome": signals.conflict_outcome,
                 "task_outcome": signals.task_outcome,
                 "mood_trajectory": signals.mood_trajectory,
                 "governance_participation": signals.governance_participation,
-            }
-            records.append(record)
+            },
+        )
 
-        if records:
-            state.trait_change_audit.extend(records)
-        return records
+    def apply_role_transition_blend(
+        self,
+        state: AgentState,
+        *,
+        target_traits: dict[str, float],
+        blend_ratio: float = 0.25,
+        max_step: float = 0.03,
+        source: str = "role_transition",
+    ) -> list[dict[str, float | str | int]]:
+        """Blend current traits toward a target template when transitioning roles."""
+
+        deltas = {
+            trait: (float(target) - float(getattr(state.traits, trait))) * blend_ratio
+            for trait, target in target_traits.items()
+            if hasattr(state.traits, trait)
+        }
+        return self._apply_trait_adjustments(
+            state,
+            deltas,
+            max_step=max_step,
+            cause="role_transition_blend",
+            source=source,
+            context={"blend_ratio": blend_ratio},
+        )
+
+    def apply_exogenous_trait_intervention(
+        self,
+        state: AgentState,
+        trait_updates: dict[str, float],
+        *,
+        max_step: float = 0.05,
+        source: str,
+        cause: str = "exogenous_intervention",
+    ) -> list[dict[str, float | str | int]]:
+        """Apply external/admin trait edits through the same bounded/audited engine path."""
+
+        return self._apply_trait_adjustments(
+            state,
+            trait_updates,
+            max_step=max_step,
+            cause=cause,
+            source=source,
+        )
+
+    def update_traits(
+        self,
+        state: AgentState,
+        signals: ExperienceSignal,
+        *,
+        max_step: float = 0.01,
+    ) -> list[dict[str, float | str | int]]:
+        warn(
+            "PersonalityEngine.update_traits is deprecated; use apply_experience_drift instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.apply_experience_drift(
+            state,
+            signals,
+            max_step=max_step,
+            source="legacy.update_traits",
+        )

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -430,6 +430,25 @@ class Simulation:
 
         # current_round = (self.current_step -1) // len(self.agents) # Not clearly used, commenting out
 
+    def _assert_trait_update_invariants(
+        self,
+        state: Any,
+        trait_records: Sequence[dict[str, float | str | int]],
+        *,
+        max_step: float,
+    ) -> None:
+        trait_values = state.traits.model_dump()
+        for trait, value in trait_values.items():
+            if not 0.0 <= float(value) <= 1.0:
+                raise AssertionError(f"Trait '{trait}' out of bounds: {value}")
+
+        for record in trait_records:
+            delta = float(record.get("delta", 0.0))
+            if abs(delta) > (max_step + 1e-9):
+                raise AssertionError(f"Trait drift exceeded per-step max: {record}")
+            if not record.get("cause") or not record.get("source"):
+                raise AssertionError(f"Trait audit record missing cause/source: {record}")
+
     async def _handle_human_command(
         self: Self, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
@@ -1069,7 +1088,16 @@ class Simulation:
             mood_after=float(current_agent_state.mood_level),
             rule_allowed=bool(governance_outcome.allowed),
         )
-        self.personality_engine.update_traits(current_agent_state, experience_signals)
+        trait_records = self.personality_engine.apply_experience_drift(
+            current_agent_state,
+            experience_signals,
+            source="simulation.turn",
+        )
+        self._assert_trait_update_invariants(
+            current_agent_state,
+            trait_records,
+            max_step=0.01,
+        )
         self.agents[agent_index].update_state(current_agent_state)
 
         async with self._msg_lock:

--- a/tests/unit/core/test_personality_engine.py
+++ b/tests/unit/core/test_personality_engine.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from src.agents.core.agent_state import AgentState, PersonalityTraits
@@ -38,7 +39,7 @@ def test_personality_engine_produces_deterministic_trajectory() -> None:
             traits=PersonalityTraits(),
         )
         for signal in sequence:
-            engine.update_traits(state, signal)
+            engine.apply_experience_drift(state, signal)
         return (
             state.traits.trust_baseline,
             state.traits.empathy,
@@ -55,7 +56,7 @@ def test_personality_engine_appends_trait_audit_records() -> None:
     state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits())
     engine = PersonalityEngine()
 
-    records = engine.update_traits(
+    records = engine.apply_experience_drift(
         state,
         ExperienceSignal(social_outcome=0.5, governance_participation=0.5),
     )
@@ -65,5 +66,85 @@ def test_personality_engine_appends_trait_audit_records() -> None:
     first = state.trait_change_audit[0]
     assert first["step"] == state.step_counter
     assert first["trait"]
-    assert "social_outcome" in first
-    assert "governance_participation" in first
+    assert first["cause"] == "experience_drift"
+    assert first["source"] == "simulation.turn"
+
+
+@pytest.mark.unit
+def test_role_transition_blend_uses_engine_audit_and_bounds() -> None:
+    state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits(openness=0.1))
+    engine = PersonalityEngine()
+
+    records = engine.apply_role_transition_blend(
+        state,
+        target_traits={"openness": 1.0},
+        blend_ratio=1.0,
+        max_step=0.03,
+        source="test.role_transition",
+    )
+
+    assert records
+    assert state.traits.openness == pytest.approx(0.13)
+    assert records[0]["cause"] == "role_transition_blend"
+    assert records[0]["source"] == "test.role_transition"
+
+
+@pytest.mark.unit
+def test_exogenous_intervention_uses_same_constraints() -> None:
+    state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits(assertiveness=0.5))
+    engine = PersonalityEngine()
+
+    records = engine.apply_exogenous_trait_intervention(
+        state,
+        {"assertiveness": 0.8},
+        source="admin.console",
+        max_step=0.05,
+        cause="admin_edit",
+    )
+
+    assert state.traits.assertiveness == pytest.approx(0.55)
+    assert records[0]["cause"] == "admin_edit"
+    assert records[0]["source"] == "admin.console"
+
+
+@pytest.mark.unit
+def test_same_role_different_traits_diverge_action_distribution_over_many_turns() -> None:
+    engine = PersonalityEngine()
+    available_actions = [
+        "propose_idea",
+        "ask_clarification",
+        "continue_collaboration",
+        "idle",
+    ]
+    high_empathy = AgentState(
+        agent_id="a",
+        name="A",
+        current_role="Facilitator",
+        traits=PersonalityTraits(empathy=0.9, assertiveness=0.2),
+    )
+    low_empathy = AgentState(
+        agent_id="b",
+        name="B",
+        current_role="Facilitator",
+        traits=PersonalityTraits(empathy=0.2, assertiveness=0.9),
+    )
+
+    rng = np.random.default_rng(7)
+
+    def sample_distribution(state: AgentState) -> dict[str, float]:
+        counts = {action: 0 for action in available_actions}
+        for _ in range(2000):
+            bias = engine.action_biases(state, available_actions)
+            logits = np.array([bias[action] for action in available_actions], dtype=float)
+            probs = np.exp(logits) / np.exp(logits).sum()
+            picked = rng.choice(available_actions, p=probs)
+            counts[str(picked)] += 1
+        return {action: count / 2000.0 for action, count in counts.items()}
+
+    high_empathy_dist = sample_distribution(high_empathy)
+    low_empathy_dist = sample_distribution(low_empathy)
+
+    assert high_empathy_dist["continue_collaboration"] > low_empathy_dist[
+        "continue_collaboration"
+    ]
+    assert low_empathy_dist["propose_idea"] > high_empathy_dist["propose_idea"]

--- a/tests/unit/core/test_personality_traits.py
+++ b/tests/unit/core/test_personality_traits.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.agents.core.agent_controller import AgentController
 from src.agents.core.agent_state import AgentState, PersonalityTraits
+from src.agents.core.personality_engine import ExperienceSignal, PersonalityEngine
 from src.agents.core.roles import ROLE_ANALYZER, ROLE_FACILITATOR, get_role_trait_template
 
 
@@ -45,5 +46,10 @@ def test_traits_modulate_mood_response() -> None:
 def test_trait_drift_is_bounded() -> None:
     state = AgentState(agent_id="a3", name="drift")
     before = state.traits.trust_baseline
-    state.apply_trait_drift({"trust_baseline": 1.0}, max_step=0.01)
+    PersonalityEngine().apply_experience_drift(
+        state,
+        ExperienceSignal(social_outcome=100.0),
+        max_step=0.01,
+        source="test.bound",
+    )
     assert state.traits.trust_baseline == pytest.approx(before + 0.01)

--- a/tests/unit/sim/test_trait_invariants.py
+++ b/tests/unit/sim/test_trait_invariants.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.agents.core.agent_state import PersonalityTraits
+from src.sim.simulation import Simulation
+
+
+class SeedAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = SimpleNamespace(ip=0.0, du=0.0)
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> SimpleNamespace:
+        return self._state
+
+
+@pytest.mark.unit
+def test_trait_update_invariants_accept_valid_records() -> None:
+    sim = Simulation([SeedAgent("seed")])
+    state = SimpleNamespace(traits=PersonalityTraits())
+    sim._assert_trait_update_invariants(
+        state,
+        [{"delta": 0.01, "cause": "experience_drift", "source": "simulation.turn"}],
+        max_step=0.01,
+    )
+    sim.close()
+
+
+@pytest.mark.unit
+def test_trait_update_invariants_reject_missing_audit_source() -> None:
+    sim = Simulation([SeedAgent("seed")])
+    state = SimpleNamespace(traits=PersonalityTraits())
+
+    with pytest.raises(AssertionError, match="cause/source"):
+        sim._assert_trait_update_invariants(
+            state,
+            [{"delta": 0.01, "cause": "experience_drift"}],
+            max_step=0.01,
+        )
+    sim.close()


### PR DESCRIPTION
### Motivation
- Centralize all production trait mutation flows to ensure consistent clamping, rate-limiting and audit logging. 
- Ensure role transitions, per-turn drift, and external/admin edits use the same audited engine path so trait changes are observable and verifiable. 
- Deprecate ad-hoc direct trait mutation helpers on `AgentState` for runtime code while keeping them for backward compatibility in tests/serialization. 
- Add simulation-level invariants to catch out-of-bounds or excessive per-step drift and to require audit metadata on trait edits.

### Description
- Added a shared internal engine path `_apply_trait_adjustments` on `PersonalityEngine` that enforces per-step `max_step` bounds, clamps traits to `[0,1]`, writes standardized audit records including `cause` and `source`, and returns the audit records. 
- Exposed three production APIs on `PersonalityEngine`: `apply_experience_drift` (per-turn drift), `apply_role_transition_blend` (role-transition blending), and `apply_exogenous_trait_intervention` (admin/deity/external edits), all of which route through `_apply_trait_adjustments`. 
- Deprecated `AgentState.apply_trait_drift` with a `DeprecationWarning` and retained it for tests/legacy serialization paths only. 
- Updated role-change code to call `PersonalityEngine.apply_role_transition_blend` (instead of directly mutating traits) and changed the simulation loop to call `apply_experience_drift` and then run `_assert_trait_update_invariants` to enforce trait bounds, per-step max-drift, and audit metadata presence. 
- Added/updated unit tests to validate the new engine APIs, audit metadata, bounded updates, simulation invariants, and a differential statistical test that two agents with the same role but different traits exhibit divergent action distributions over many turns.

### Testing
- Ran linting: `ruff check ...` across modified files and there were no remaining issues. 
- Ran unit tests: `pytest tests/unit/core/test_personality_engine.py tests/unit/core/test_personality_traits.py tests/unit/core/test_agent_controller_updates.py tests/unit/sim/test_trait_invariants.py` and all tests passed (`13 passed`). 
- The new/updated tests exercise deterministic drift, audit record contents (`cause`/`source`), role-transition blending bounds, exogenous intervention bounds, simulation invariant checks, and the long-run differential action-distribution property.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19b2233648326b4f92d2792c51977)