### PR TITLE
Introduce typed domain command dispatcher across transports

### DIFF
--- a/src/interfaces/command_bus.py
+++ b/src/interfaces/command_bus.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from src.governance.decision_kernel import DecisionProvenance
+from src.interfaces.domain_command_adapters import command_from_envelope, command_from_payload
 from src.interfaces.interaction_schema import (
     InteractionContext,
     InteractionEnvelope,
@@ -14,21 +15,23 @@ from src.interfaces.interaction_schema import (
 
 if TYPE_CHECKING:
     from src.interfaces.interaction_commands import InteractionService
+    from src.sim.commands.domain_commands import DomainCommandT
 
 
 class CommandBus:
-    """Thin adapter that normalizes payload shape and forwards canonical envelopes."""
+    """Thin adapter that converts external payloads into typed domain commands."""
 
     def __init__(self, interaction_service: InteractionService) -> None:
         self.interaction_service = interaction_service
 
     async def dispatch(
         self,
-        command: InteractionEnvelope,
+        command: DomainCommandT | InteractionEnvelope,
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        return await self.interaction_service.execute(command, context=context)
+        normalized = command_from_envelope(command) if isinstance(command, InteractionEnvelope) else command
+        return await self.interaction_service.execute(normalized, context=context)
 
     async def dispatch_payload(
         self,
@@ -37,7 +40,7 @@ class CommandBus:
         context: InteractionContext | None = None,
     ) -> InteractionResult:
         try:
-            envelope = parse_bus_command(payload, context=context)
+            command = command_from_payload(payload, context=context)
         except ValidationError as exc:
             return InteractionResult(
                 status="rejected",
@@ -48,57 +51,4 @@ class CommandBus:
                     rule_id="policy.validation.payload",
                 ),
             )
-        return await self.dispatch(envelope, context=context)
-
-
-def parse_bus_command(
-    payload: Mapping[str, Any],
-    *,
-    context: InteractionContext | None = None,
-) -> InteractionEnvelope:
-    """Validate transport payload and normalize aliases to canonical envelope fields."""
-    data = dict(payload)
-    command = str(data.get("command_type") or data.get("command") or "").strip()
-    if command == "dm":
-        data["command_type"] = "direct_message"
-    elif command == "kb":
-        data["command_type"] = "knowledge_board"
-    elif command in {"pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"}:
-        data["command_type"] = "control"
-    elif command == "inject_event":
-        data["command_type"] = "inject_event"
-    elif command:
-        data["command_type"] = command
-
-    ctx = context or InteractionContext()
-    permissions = data.get("permissions")
-    if isinstance(permissions, list | set | tuple):
-        normalized_permissions = set(str(item) for item in permissions)
-    else:
-        normalized_permissions = set(ctx.permissions)
-
-    envelope_payload: dict[str, Any] = {
-        "intent": data.get("command_type") or "moderation",
-        "content": data.get("content"),
-        "action": data.get("action") or command or data.get("command_type") or data.get("command"),
-        "value": data.get("value"),
-        "tags": data.get("tags"),
-        "prompt": data.get("prompt") or data.get("scope"),
-        "text": data.get("text") or data.get("content"),
-        "agent_id": data.get("agent_id") or data.get("author"),
-        "role": data.get("role"),
-        "persona": data.get("persona"),
-        "backstory": data.get("backstory"),
-        "traits": data.get("traits"),
-        "routing": {
-            "sender_id": str(data.get("sender_id", ctx.sender_id)),
-            "source": str(data.get("source", ctx.source)),
-            "channel_id": str(data.get("channel_id")) if data.get("channel_id") is not None else ctx.channel_id,
-            "recipient_id": data.get("recipient_id"),
-            "target_agent_id": data.get("target_agent_id"),
-        },
-        "auth": {"permissions": normalized_permissions},
-        "budget": {"budget_agent_id": data.get("budget_agent_id")},
-        "metadata": data,
-    }
-    return InteractionEnvelope.model_validate(envelope_payload)
+        return await self.dispatch(command, context=context)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -19,6 +19,7 @@ from src.infra import event_log
 from src.infra import metrics as infra_metrics
 from src.infra.ledger import ledger
 from src.interfaces import metrics
+from src.interfaces.domain_command_adapters import command_from_payload
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
 from src.sim.persistence.snapshot_service import SnapshotPersistenceService
@@ -1020,14 +1021,13 @@ async def handle_control_command(
 
     from src.interfaces.interaction_schema import InteractionContext
 
-    result = await simulation.command_service.execute_from_payload(
-        cmd,
-        context=InteractionContext(
-            sender_id="dashboard",
-            source="dashboard",
-            permissions={"admin", "moderator"},
-        ),
+    context = InteractionContext(
+        sender_id="dashboard",
+        source="dashboard",
+        permissions={"admin", "moderator"},
     )
+    command = command_from_payload(cmd, context=context)
+    result = await simulation.command_dispatcher.dispatch(command, context=context)
     return {
         "status": result.status,
         "message": result.user_message,

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -24,13 +24,14 @@ from src.infra import config, event_log
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
 from src.interfaces import metrics
-from src.interfaces.interaction_commands import InteractionEnvelope
+from src.interfaces.domain_command_adapters import command_from_discord_message
 from src.interfaces.interaction_policy import (
     check_command_rate_limit,
     has_admin_permission,
     has_control_command_permission,
     set_max_rate,
 )
+from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
 from src.interfaces.transport_adapters import parse_discord_message_routing
 from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
@@ -687,19 +688,20 @@ class SimulationDiscordBot:
                     bus = get_command_bus(self.context)
                     if bus is None:
                         return
-                    intent = "broadcast" if is_broadcast else ("direct_message" if recipient else "human_message")
+                    command = command_from_discord_message(
+                        content=parsed_content,
+                        recipient_id=recipient,
+                        is_broadcast=is_broadcast,
+                        target_agent_id=target_agent_id,
+                        raw_payload={"channel_id": channel_id, "user_id": user_id},
+                    )
                     result = await bus.dispatch(
-                        InteractionEnvelope(
-                            intent=intent,
-                            content=parsed_content,
-                            routing={
-                                "sender_id": str(user_id) if user_id is not None else "human",
-                                "channel_id": str(channel_id) if channel_id is not None else None,
-                                "source": "discord",
-                                "recipient_id": recipient,
-                                "target_agent_id": target_agent_id,
-                            },
-                        )
+                        command,
+                        context=InteractionContext(
+                            sender_id=str(user_id) if user_id is not None else "human",
+                            channel_id=str(channel_id) if channel_id is not None else None,
+                            source="discord",
+                        ),
                     )
                     if result.status != "ok":
                         await send_channel_message(channel, content=result.user_message)

--- a/src/interfaces/domain_command_adapters.py
+++ b/src/interfaces/domain_command_adapters.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+from src.sim.commands.domain_commands import (
+    BroadcastCommand,
+    ControlCommand,
+    DirectMessageCommand,
+    DomainCommandT,
+    HumanMessageCommand,
+    InjectEventCommand,
+    KnowledgeBoardCommand,
+    ModerationCommand,
+    SpawnAgentCommand,
+)
+
+
+def command_from_payload(
+    payload: Mapping[str, Any],
+    *,
+    context: InteractionContext | None = None,
+) -> DomainCommandT:
+    data = dict(payload)
+    ctx = context or InteractionContext()
+    command = str(data.get("command_type") or data.get("command") or "").strip()
+    if command == "dm":
+        command = "direct_message"
+    elif command == "kb":
+        command = "knowledge_board"
+    elif command in {"pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"}:
+        command = "control"
+    elif command == "inject_event":
+        command = "inject_event"
+
+    metadata = {**data, "adapter_context": ctx.model_dump()}
+    if command == "direct_message":
+        return DirectMessageCommand(
+            content=str(data.get("content") or data.get("text") or ""),
+            recipient_id=_string_or_none(data.get("recipient_id")),
+            target_agent_id=_string_or_none(data.get("target_agent_id")),
+            budget_agent_id=_string_or_none(data.get("budget_agent_id")),
+            metadata=metadata,
+        )
+    if command == "broadcast":
+        return BroadcastCommand(
+            content=str(data.get("content") or data.get("text") or ""),
+            budget_agent_id=_string_or_none(data.get("budget_agent_id")),
+            metadata=metadata,
+        )
+    if command == "knowledge_board":
+        return KnowledgeBoardCommand(content=str(data.get("content") or ""), metadata=metadata)
+    if command == "spawn":
+        return SpawnAgentCommand(
+            agent_id=_string_or_none(data.get("agent_id") or data.get("author")),
+            role=data.get("role"),
+            persona=_string_or_none(data.get("persona")),
+            backstory=_string_or_none(data.get("backstory")),
+            traits=data.get("traits") if isinstance(data.get("traits"), dict) else None,
+            metadata=metadata,
+        )
+    if command == "inject_event":
+        return InjectEventCommand(
+            text=str(data.get("text") or data.get("content") or ""),
+            scope=str(data.get("prompt") or data.get("scope") or "global"),
+            agent_id=_string_or_none(data.get("agent_id") or data.get("author")),
+            metadata=metadata,
+        )
+    if command in {"moderation", "reset_memory", "penalty", "mute", "unmute"}:
+        return ModerationCommand(
+            action=str(data.get("action") or command or data.get("command") or "moderation"),
+            agent_id=_string_or_none(data.get("agent_id")),
+            value=_float_or_none(data.get("value")),
+            metadata=metadata,
+        )
+    if command == "control" or command in {
+        "pause",
+        "resume",
+        "pause_all",
+        "start",
+        "stop",
+        "set_speed",
+        "kill_agent",
+        "set_breakpoints",
+    }:
+        return ControlCommand(
+            action=str(data.get("action") or data.get("command") or "control"),
+            value=_float_or_none(data.get("value")),
+            tags=_coerce_tags(data.get("tags")),
+            agent_id=_string_or_none(data.get("agent_id")),
+            metadata=metadata,
+        )
+    return HumanMessageCommand(
+        content=str(data.get("content") or data.get("text") or ""),
+        recipient_id=_string_or_none(data.get("recipient_id")),
+        target_agent_id=_string_or_none(data.get("target_agent_id")),
+        metadata=metadata,
+    )
+
+
+def command_from_discord_message(
+    *,
+    content: str,
+    recipient_id: str | None,
+    is_broadcast: bool,
+    target_agent_id: str | None,
+    budget_agent_id: str | None = None,
+    raw_payload: Mapping[str, Any] | None = None,
+) -> DomainCommandT:
+    metadata = dict(raw_payload or {})
+    if is_broadcast:
+        return BroadcastCommand(content=content, budget_agent_id=budget_agent_id, metadata=metadata)
+    if recipient_id is not None:
+        return DirectMessageCommand(
+            content=content,
+            recipient_id=recipient_id,
+            target_agent_id=target_agent_id,
+            budget_agent_id=budget_agent_id,
+            metadata=metadata,
+        )
+    return HumanMessageCommand(
+        content=content,
+        recipient_id=recipient_id,
+        target_agent_id=target_agent_id,
+        metadata=metadata,
+    )
+
+
+def command_from_envelope(envelope: InteractionEnvelope) -> DomainCommandT:
+    payload = envelope.model_dump()
+    payload["command_type"] = envelope.intent
+    if envelope.action is not None:
+        payload["command"] = envelope.action
+    return command_from_payload(payload)
+
+
+def _string_or_none(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_tags(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    return [str(item) for item in value]

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_schema import (
     ENVELOPE_INTENTS,
     InteractionAuthScope,
     InteractionBudgetAttribution,
     InteractionContext,
-    InteractionEnvelope,
     InteractionResult,
     InteractionRouting,
 )
 
 if TYPE_CHECKING:
+    from src.sim.commands.domain_commands import DomainCommandT
     from src.sim.simulation import Simulation
 
 
@@ -25,19 +25,20 @@ class InteractionService:
 
     async def execute(
         self,
-        command: InteractionEnvelope,
+        command: DomainCommandT,
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        return await self.simulation.command_service.execute(command, context=context)
+        return await self.simulation.command_dispatcher.dispatch(command, context=context)
 
     async def execute_from_payload(
         self,
-        payload: Mapping[str, Any],
+        payload: dict[str, object],
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        return await self.simulation.command_service.execute_from_payload(payload, context=context)
+        command = command_from_payload(payload, context=context)
+        return await self.execute(command, context=context)
 
 
 __all__ = [
@@ -45,7 +46,6 @@ __all__ = [
     "InteractionAuthScope",
     "InteractionBudgetAttribution",
     "InteractionContext",
-    "InteractionEnvelope",
     "InteractionResult",
     "InteractionRouting",
     "InteractionService",

--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -11,14 +11,15 @@ from src.governance.decision_kernel import DecisionProvenance, PolicyDecisionSer
 from src.infra import config
 from src.infra import ledger as infra_ledger
 from src.infra.event_log import log_event
-from src.interfaces.command_bus import parse_bus_command
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
+from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_schema import (
     InteractionContext,
     InteractionEnvelope,
     InteractionResult,
 )
 from src.shared.typing import SimulationMessage
+from src.sim.commands.domain_commands import DomainCommandT
 
 if TYPE_CHECKING:
     from src.sim.simulation import Simulation
@@ -39,32 +40,22 @@ class SimulationCommandService:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        try:
-            envelope = parse_bus_command(payload, context=context)
-        except Exception as exc:
-            return InteractionResult(
-                status="rejected",
-                user_message=f"Invalid command payload: {exc}",
-                reason_code="invalid_payload",
-                decision_provenance=DecisionProvenance(
-                    policy_id="interaction-policy-v1",
-                    rule_id="policy.validation.payload",
-                ),
-            )
-        return await self.execute(envelope, context=context)
+        command = command_from_payload(payload, context=context)
+        return await self.execute(command, context=context)
 
     async def execute(
         self,
-        command: InteractionEnvelope,
+        command: DomainCommandT,
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
         ctx = context or InteractionContext()
+        envelope = command.to_envelope(context=ctx)
         await emit_event(
             SimulationEvent(
                 type="human_command",
                 data={
-                    "command_type": command.intent,
+                    "command_type": envelope.intent,
                     "sender_id": ctx.sender_id,
                     "source": ctx.source,
                     "step": self.simulation.current_step,
@@ -73,15 +64,15 @@ class SimulationCommandService:
         )
 
         entry_decision = self.decision_service.decide(
-            envelope=command,
+            envelope=envelope,
             context=ctx,
             simulation=self.simulation,
             stage="entry",
         )
         envelope = (
-            command.model_copy(update=entry_decision.transformed_updates)
+            envelope.model_copy(update=entry_decision.transformed_updates)
             if entry_decision.decision == "transform"
-            else command
+            else envelope
         )
 
         if entry_decision.decision == "deny":
@@ -425,7 +416,7 @@ class SimulationCommandService:
         except Exception:
             logger.debug("Ledger spend failed", exc_info=True)
 
-        world_time = self.simulation._world_time_snapshot()
+        world_time = self.simulation.environment_system.world_time_snapshot()
         turn_index = self.simulation.current_step
         recipients = self.simulation.agents if broadcast else [target]
         msgs = [

--- a/src/sim/commands/__init__.py
+++ b/src/sim/commands/__init__.py
@@ -1,0 +1,27 @@
+from src.sim.commands.dispatcher import SimulationCommandDispatcher
+from src.sim.commands.domain_commands import (
+    BroadcastCommand,
+    ControlCommand,
+    DirectMessageCommand,
+    DomainCommand,
+    DomainCommandT,
+    HumanMessageCommand,
+    InjectEventCommand,
+    KnowledgeBoardCommand,
+    ModerationCommand,
+    SpawnAgentCommand,
+)
+
+__all__ = [
+    "BroadcastCommand",
+    "ControlCommand",
+    "DirectMessageCommand",
+    "DomainCommand",
+    "DomainCommandT",
+    "HumanMessageCommand",
+    "InjectEventCommand",
+    "KnowledgeBoardCommand",
+    "ModerationCommand",
+    "SimulationCommandDispatcher",
+    "SpawnAgentCommand",
+]

--- a/src/sim/commands/dispatcher.py
+++ b/src/sim/commands/dispatcher.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.interfaces.interaction_schema import InteractionContext, InteractionResult
+from src.sim.commands.domain_commands import DomainCommandT
+
+if TYPE_CHECKING:
+    from src.sim.command_service import SimulationCommandService
+
+
+class SimulationCommandDispatcher:
+    """Single command dispatcher for typed domain commands."""
+
+    def __init__(self, command_service: SimulationCommandService) -> None:
+        self.command_service = command_service
+
+    async def dispatch(
+        self,
+        command: DomainCommandT,
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        return await self.command_service.execute(command, context=context)

--- a/src/sim/commands/domain_commands.py
+++ b/src/sim/commands/domain_commands.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+
+
+class DomainCommand(BaseModel):
+    kind: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        raise NotImplementedError
+
+
+class HumanMessageCommand(DomainCommand):
+    kind: Literal["human_message"] = "human_message"
+    content: str
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="human_message",
+            content=self.content,
+            routing={
+                "sender_id": context.sender_id,
+                "source": context.source,
+                "channel_id": context.channel_id,
+                "recipient_id": self.recipient_id,
+                "target_agent_id": self.target_agent_id,
+            },
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+class DirectMessageCommand(DomainCommand):
+    kind: Literal["direct_message"] = "direct_message"
+    content: str
+    recipient_id: str | None = None
+    target_agent_id: str | None = None
+    budget_agent_id: str | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="direct_message",
+            content=self.content,
+            routing={
+                "sender_id": context.sender_id,
+                "source": context.source,
+                "channel_id": context.channel_id,
+                "recipient_id": self.recipient_id,
+                "target_agent_id": self.target_agent_id,
+            },
+            auth={"permissions": set(context.permissions)},
+            budget={"budget_agent_id": self.budget_agent_id},
+            metadata=self.metadata,
+        )
+
+
+class BroadcastCommand(DomainCommand):
+    kind: Literal["broadcast"] = "broadcast"
+    content: str
+    budget_agent_id: str | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="broadcast",
+            content=self.content,
+            routing={
+                "sender_id": context.sender_id,
+                "source": context.source,
+                "channel_id": context.channel_id,
+            },
+            auth={"permissions": set(context.permissions)},
+            budget={"budget_agent_id": self.budget_agent_id},
+            metadata=self.metadata,
+        )
+
+
+class KnowledgeBoardCommand(DomainCommand):
+    kind: Literal["knowledge_board"] = "knowledge_board"
+    content: str
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="knowledge_board",
+            content=self.content,
+            routing={"sender_id": context.sender_id, "source": context.source},
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+class SpawnAgentCommand(DomainCommand):
+    kind: Literal["spawn"] = "spawn"
+    agent_id: str | None = None
+    role: str | dict[str, Any] | None = None
+    persona: str | None = None
+    backstory: str | None = None
+    traits: dict[str, float] | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="spawn",
+            action="spawn",
+            agent_id=self.agent_id,
+            role=self.role,
+            persona=self.persona,
+            backstory=self.backstory,
+            traits=self.traits,
+            routing={"sender_id": context.sender_id, "source": context.source},
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+class ControlCommand(DomainCommand):
+    kind: Literal["control"] = "control"
+    action: str
+    value: float | None = None
+    tags: list[str] | None = None
+    agent_id: str | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="control",
+            action=self.action,
+            value=self.value,
+            tags=self.tags,
+            agent_id=self.agent_id,
+            routing={"sender_id": context.sender_id, "source": context.source},
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+class ModerationCommand(DomainCommand):
+    kind: Literal["moderation"] = "moderation"
+    action: str
+    agent_id: str | None = None
+    value: float | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="moderation",
+            action=self.action,
+            agent_id=self.agent_id,
+            value=self.value,
+            routing={"sender_id": context.sender_id, "source": context.source},
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+class InjectEventCommand(DomainCommand):
+    kind: Literal["inject_event"] = "inject_event"
+    text: str
+    scope: str = "global"
+    agent_id: str | None = None
+
+    def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
+        return InteractionEnvelope(
+            intent="inject_event",
+            text=self.text,
+            prompt=self.scope,
+            agent_id=self.agent_id,
+            routing={"sender_id": context.sender_id, "source": context.source},
+            auth={"permissions": set(context.permissions)},
+            metadata=self.metadata,
+        )
+
+
+DomainCommandT = (
+    HumanMessageCommand
+    | DirectMessageCommand
+    | BroadcastCommand
+    | KnowledgeBoardCommand
+    | SpawnAgentCommand
+    | ControlCommand
+    | ModerationCommand
+    | InjectEventCommand
+)

--- a/src/sim/control_service.py
+++ b/src/sim/control_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_schema import InteractionContext
 
 
@@ -13,12 +14,11 @@ class SimulationControlService:
         self.simulation = simulation
 
     async def handle_control_command(self, cmd: Mapping[str, Any]) -> dict[str, Any] | None:
-        result = await self.simulation.command_service.execute_from_payload(
-            dict(cmd),
-            context=InteractionContext(
-                sender_id="simulation",
-                source="simulation",
-                permissions={"admin", "moderator"},
-            ),
+        context = InteractionContext(
+            sender_id="simulation",
+            source="simulation",
+            permissions={"admin", "moderator"},
         )
+        command = command_from_payload(dict(cmd), context=context)
+        result = await self.simulation.command_dispatcher.dispatch(command, context=context)
         return result.data if isinstance(result.data, dict) else None

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -36,12 +36,13 @@ from src.infra.event_log import log_event
 from src.infra.ledger import ledger
 from src.infra.llm_client import get_llm_client
 from src.infra.logging_config import setup_logging
-from src.interfaces.command_bus import CommandBus, parse_bus_command
+from src.interfaces.command_bus import CommandBus
 from src.interfaces.dashboard_backend import (
     SimulationEvent,
     emit_event,
 )
 from src.interfaces.discord_event_listener import DiscordSimulationEventListener
+from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_commands import InteractionContext, InteractionService
 from src.interfaces.metrics import (
     ACTIVE_AGENT_COUNT,
@@ -51,6 +52,7 @@ from src.interfaces.metrics import (
 from src.shared.telemetry import trace_agent_action
 from src.shared.typing import SimulationMessage
 from src.sim.command_service import SimulationCommandService
+from src.sim.commands.dispatcher import SimulationCommandDispatcher
 from src.sim.control_service import SimulationControlService
 from src.sim.engine import SimulationEngine
 from src.sim.environment import EnvironmentState, EnvironmentSystem
@@ -383,6 +385,7 @@ class Simulation:
         self._event_loop = None
         self._event_loop_thread = None
         self.command_service = SimulationCommandService(self)
+        self.command_dispatcher = SimulationCommandDispatcher(self.command_service)
         self.interaction_service = InteractionService(self)
         self.command_bus = CommandBus(self.interaction_service)
         self.decision_service = PolicyDecisionService()
@@ -474,14 +477,11 @@ class Simulation:
         command_type = payload.get("command_type")
         if not command_type and bool(payload.get("broadcast")):
             command_type = "broadcast"
-        result = await self.command_service.execute_from_payload(
-            {
-                "command_type": command_type or "human_message",
-                "content": text,
-                **payload,
-            },
+        command = command_from_payload(
+            {"command_type": command_type or "human_message", "content": text, **payload},
             context=context,
         )
+        result = await self.command_dispatcher.dispatch(command, context=context)
         if result.status != "ok" and self.discord_bot:
             channel_id = context.channel_id
             target_channel_id = (
@@ -531,7 +531,7 @@ class Simulation:
 
     async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process moderation actions like muting or penalties."""
-        from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+        from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
 
         envelope = InteractionEnvelope.model_validate(
             {
@@ -1480,7 +1480,7 @@ class Simulation:
                 ),
                 metadata={k: v for k, v in evt.data.items()},
             )
-            await self.command_bus.dispatch(parse_bus_command(evt.data), context=context)
+            await self.command_bus.dispatch_payload(evt.data, context=context)
             return
         if evt.type == "moderation":
             context = InteractionContext(
@@ -1489,7 +1489,7 @@ class Simulation:
                 permissions={"admin", "moderator"},
                 metadata={k: v for k, v in evt.data.items()},
             )
-            await self.command_bus.dispatch(parse_bus_command(evt.data), context=context)
+            await self.command_bus.dispatch_payload(evt.data, context=context)
             return
         sender = str(evt.data.get("author", "external"))
         if sender in self.muted_agents:

--- a/tests/unit/interfaces/test_interaction_contract.py
+++ b/tests/unit/interfaces/test_interaction_contract.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 import pytest
 
-from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+from src.interfaces.interaction_commands import InteractionContext
+from src.sim.commands.domain_commands import HumanMessageCommand
 
 pytestmark = pytest.mark.unit
 
@@ -46,11 +47,7 @@ def _snapshot(sim) -> tuple[list[tuple[str, str]], float, float]:
 async def _run_path(path: str, sim, content: str):
     if path == "discord":
         result = await sim.command_bus.dispatch(
-            InteractionEnvelope(
-                intent="human_message",
-                content=content,
-                routing={"sender_id": "user-1", "source": "discord"},
-            ),
+            HumanMessageCommand(content=content),
             context=InteractionContext(sender_id="user-1", source="discord"),
         )
     elif path == "dashboard":

--- a/tests/unit/interfaces/test_simulation_command_service_contract.py
+++ b/tests/unit/interfaces/test_simulation_command_service_contract.py
@@ -3,8 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+from src.interfaces.domain_command_adapters import (
+    command_from_discord_message,
+    command_from_payload,
+)
+from src.interfaces.interaction_schema import InteractionContext
 from src.interfaces.transport_adapters import parse_discord_message_routing
+from src.sim.commands.domain_commands import ControlCommand, DirectMessageCommand
 
 pytestmark = pytest.mark.unit
 
@@ -53,7 +58,7 @@ async def test_equivalent_direct_message_paths_produce_identical_outcomes(
     from src.sim.simulation import Simulation
 
     outcomes = []
-    for path in ("discord", "dashboard", "internal"):
+    for path in ("discord", "event_bus", "dashboard", "internal"):
         ledger = Ledger(tmp_path / f"cmd-{path}.sqlite")
         monkeypatch.setattr("src.infra.ledger.ledger", ledger)
         monkeypatch.setattr("src.sim.simulation.ledger", ledger)
@@ -62,41 +67,52 @@ async def test_equivalent_direct_message_paths_produce_identical_outcomes(
             if path == "discord":
                 recipient, is_broadcast, content, err = parse_discord_message_routing("/dm beta hello")
                 assert err is None and not is_broadcast
-                result = await sim.command_service.execute_from_payload(
-                    {
-                        "command_type": "direct_message",
-                        "content": content,
-                        "recipient_id": recipient,
-                        "target_agent_id": recipient,
-                    },
+                command = command_from_discord_message(
+                    content=content,
+                    recipient_id=recipient,
+                    is_broadcast=is_broadcast,
+                    target_agent_id=recipient,
+                )
+                result = await sim.command_dispatcher.dispatch(
+                    command,
                     context=InteractionContext(sender_id="user-1", source="discord"),
                 )
-            elif path == "dashboard":
-                result = await sim.command_service.execute_from_payload(
+            elif path == "event_bus":
+                command = command_from_payload(
                     {
                         "command_type": "direct_message",
                         "content": "hello",
                         "recipient_id": "beta",
                         "target_agent_id": "beta",
-                        "sender_id": "user-1",
-                        "source": "dashboard",
-                    },
+                    }
+                )
+                result = await sim.command_dispatcher.dispatch(
+                    command,
+                    context=InteractionContext(sender_id="user-1", source="event_bus"),
+                )
+            elif path == "dashboard":
+                command = command_from_payload(
+                    {
+                        "command_type": "direct_message",
+                        "content": "hello",
+                        "recipient_id": "beta",
+                        "target_agent_id": "beta",
+                    }
+                )
+                result = await sim.command_dispatcher.dispatch(
+                    command,
                     context=InteractionContext(sender_id="user-1", source="dashboard"),
                 )
             else:
-                result = await sim.command_service.execute(
-                    InteractionEnvelope(
-                        intent="direct_message",
-                        content="hello",
-                        routing={"sender_id": "user-1", "source": "internal", "recipient_id": "beta", "target_agent_id": "beta"},
-                    ),
+                result = await sim.command_dispatcher.dispatch(
+                    DirectMessageCommand(content="hello", recipient_id="beta", target_agent_id="beta"),
                     context=InteractionContext(sender_id="user-1", source="internal"),
                 )
             outcomes.append((result.model_dump(), _snapshot_messages(sim)))
         finally:
             sim.close()
 
-    assert outcomes[0] == outcomes[1] == outcomes[2]
+    assert outcomes[0] == outcomes[1] == outcomes[2] == outcomes[3]
 
 
 @pytest.mark.asyncio
@@ -116,18 +132,20 @@ async def test_equivalent_control_paths_mutate_state_identically(
         sim = Simulation([DummyAgent("alpha"), DummyAgent("beta")])
         try:
             if path == "discord":
-                result = await sim.command_service.execute_from_payload(
-                    {"command": "set_speed", "value": 2.5},
+                command = command_from_payload({"command": "set_speed", "value": 2.5})
+                result = await sim.command_dispatcher.dispatch(
+                    command,
                     context=InteractionContext(sender_id="user-1", source="discord", permissions={"admin"}),
                 )
             elif path == "dashboard":
-                result = await sim.command_service.execute_from_payload(
-                    {"command": "set_speed", "value": 2.5},
+                command = command_from_payload({"command": "set_speed", "value": 2.5})
+                result = await sim.command_dispatcher.dispatch(
+                    command,
                     context=InteractionContext(sender_id="dashboard", source="dashboard", permissions={"admin"}),
                 )
             else:
-                result = await sim.command_service.execute(
-                    InteractionEnvelope(intent="control", action="set_speed", value=2.5),
+                result = await sim.command_dispatcher.dispatch(
+                    ControlCommand(action="set_speed", value=2.5),
                     context=InteractionContext(sender_id="internal", source="internal", permissions={"admin"}),
                 )
             states.append((result.status, sim.speed, result.reason_code))


### PR DESCRIPTION
### Motivation
- Provide a typed domain command layer so transports only map external input to explicit command objects rather than building canonical envelopes inline.  
- Centralize command dispatch so the simulation and all transports reuse a single pathway for governance and rate-limit evaluation.  
- Ensure semantic equivalence across transports (Discord, event bus, dashboard, internal) by moving payload parsing/coercion into adapters and adding regression tests.

### Description
- Add typed domain commands under `src/sim/commands/domain_commands.py` (e.g., `BroadcastCommand`, `DirectMessageCommand`, `SpawnAgentCommand`, `InjectEventCommand`) that can produce canonical `InteractionEnvelope` instances.  
- Introduce `src/interfaces/domain_command_adapters.py` to normalize external payloads and Discord text into domain commands, and update `src/interfaces/command_bus.py` and `src/interfaces/interaction_commands.py` to map payloads -> domain commands.  
- Add a single dispatcher `SimulationCommandDispatcher` and wire `Simulation` to expose `command_dispatcher`, updating `SimulationCommandService` to accept domain command types and convert them to envelopes before calling `PolicyDecisionService`.  
- Update control flow in `src/interfaces/discord_bot.py`, `src/interfaces/dashboard_backend.py`, and `src/sim/control_service.py` to use the new adapters/dispatcher, and add package exports `src/sim/commands/__init__.py`; update tests to exercise transport-equivalence via the new domain-command paths.

### Testing
- Ran static checks with `ruff` over the touched modules which returned no failures.  
- Ran unit tests `pytest -q tests/unit/interfaces/test_interaction_contract.py tests/unit/interfaces/test_simulation_command_service_contract.py` and confirmed they passed (tests validate transport-equivalence across Discord/event-bus/dashboard/internal paths).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a488ead88326807cda2c3e36740f)