### PR TITLE
Refactor interaction envelopes into strict discriminated schemas

### DIFF
--- a/src/governance/decision_kernel.py
+++ b/src/governance/decision_kernel.py
@@ -52,29 +52,29 @@ class PolicyDecisionService:
         if envelope.intent in {"moderation", "control", "inject_event"}:
             return self._control_decision(envelope=envelope, context=context)
         if envelope.intent == "human_message":
-            content = str(envelope.content or "").strip()
+            content = str(envelope.text or "").strip()
             if content == "/broadcast":
                 return self._transform(
                     "policy.normalize.human_message",
                     "normalized_human_command",
-                    {"intent": "broadcast", "content": ""},
+                    {"intent": "broadcast", "text": ""},
                 )
             if content.startswith("/broadcast "):
                 return self._transform(
                     "policy.normalize.human_message",
                     "normalized_human_command",
-                    {"intent": "broadcast", "content": content[len("/broadcast ") :]},
+                    {"intent": "broadcast", "text": content[len("/broadcast ") :]},
                 )
             if content.startswith("/kb "):
                 return self._transform(
                     "policy.normalize.human_message",
                     "normalized_human_command",
-                    {"intent": "knowledge_board", "content": content[4:]},
+                    {"intent": "knowledge_board", "text": content[4:]},
                 )
             return self._transform(
                 "policy.normalize.human_message",
                 "normalized_human_command",
-                {"intent": "direct_message", "content": content},
+                {"intent": "direct_message", "text": content},
             )
         return self._allow("policy.entry", "policy_allowed")
 

--- a/src/interfaces/command_bus.py
+++ b/src/interfaces/command_bus.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from src.governance.decision_kernel import DecisionProvenance
 from src.interfaces.domain_command_adapters import command_from_envelope, command_from_payload
 from src.interfaces.interaction_schema import (
+    BaseInteractionEnvelope,
     InteractionContext,
     InteractionEnvelope,
     InteractionResult,
@@ -30,7 +31,7 @@ class CommandBus:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        normalized = command_from_envelope(command) if isinstance(command, InteractionEnvelope) else command
+        normalized = command_from_envelope(command) if isinstance(command, BaseInteractionEnvelope) else command
         return await self.interaction_service.execute(normalized, context=context)
 
     async def dispatch_payload(

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -31,7 +31,13 @@ from src.interfaces.interaction_policy import (
     has_control_command_permission,
     set_max_rate,
 )
-from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+from src.interfaces.interaction_schema import (
+    ControlEnvelope,
+    InjectEventEnvelope,
+    InteractionContext,
+    KnowledgeBoardEnvelope,
+    SpawnEnvelope,
+)
 from src.interfaces.transport_adapters import parse_discord_message_routing
 from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
@@ -1315,8 +1321,7 @@ async def slash_pause(interaction: Any) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="pause",
                     routing={
                         "sender_id": str(getattr(interaction, "user", "discord")),
@@ -1336,8 +1341,7 @@ async def slash_resume(interaction: Any) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="resume",
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
                     auth={"permissions": {"admin", "moderator"}},
@@ -1357,8 +1361,7 @@ async def slash_pause_all(interaction: Any) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="pause_all",
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
                     auth={"permissions": {"admin", "moderator"}},
@@ -1378,8 +1381,7 @@ async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="kill_agent",
                     agent_id=agent_id,
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
@@ -1421,8 +1423,7 @@ async def slash_start(interaction: Any) -> None:
             if bus is None:
                 raise RuntimeError("command bus unavailable")
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="start",
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
                     auth={"permissions": {"admin", "moderator"}},
@@ -1478,8 +1479,7 @@ async def slash_stop(interaction: Any) -> None:
             if bus is None:
                 raise RuntimeError("command bus unavailable")
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="stop",
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
                     auth={"permissions": {"admin", "moderator"}},
@@ -1561,8 +1561,7 @@ async def slash_spawn(
             if bus is None:
                 raise RuntimeError("command bus unavailable")
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="spawn",
+                SpawnEnvelope(
                     agent_id=agent_id,
                     role=spawn_kwargs.get("role"),
                     persona=spawn_kwargs.get("persona"),
@@ -1623,8 +1622,7 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="control",
+                ControlEnvelope(
                     action="set_speed",
                     value=value,
                     routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
@@ -1657,9 +1655,8 @@ async def slash_kb(interaction: Any, text: str) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="knowledge_board",
-                    content=text,
+                KnowledgeBoardEnvelope(
+                    text=text,
                     routing={"sender_id": str(getattr(interaction, "user", "human")), "source": "discord"},
                 )
             )
@@ -1681,11 +1678,9 @@ async def slash_event(interaction: Any, text: str) -> None:
         bus = get_command_bus(ctx)
         if bus is not None:
             await bus.dispatch(
-                InteractionEnvelope(
-                    intent="inject_event",
-                    action="inject_event",
+                InjectEventEnvelope(
                     text=text,
-                    prompt="global",
+                    scope="global",
                     agent_id=str(getattr(interaction, "user", "human")),
                     routing={"sender_id": str(getattr(interaction, "user", "human")), "source": "discord"},
                     auth={"permissions": {"admin", "moderator"}},

--- a/src/interfaces/domain_command_adapters.py
+++ b/src/interfaces/domain_command_adapters.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
-from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+from src.interfaces.interaction_schema import (
+    BroadcastEnvelope,
+    DirectMessageEnvelope,
+    HumanMessageEnvelope,
+    InjectEventEnvelope,
+    InteractionContext,
+    InteractionEnvelope,
+    KnowledgeBoardEnvelope,
+    ModerationEnvelope,
+    SpawnEnvelope,
+    parse_interaction_envelope,
+)
 from src.sim.commands.domain_commands import (
     BroadcastCommand,
     ControlCommand,
@@ -17,86 +29,79 @@ from src.sim.commands.domain_commands import (
 )
 
 
+def parse_bus_command(
+    payload: Mapping[str, Any],
+    *,
+    context: InteractionContext | None = None,
+) -> InteractionEnvelope:
+    data = _normalize_legacy_payload(payload)
+    ctx = context or InteractionContext()
+    intent = _canonical_intent(data)
+
+    routing = data.get("routing") if isinstance(data.get("routing"), Mapping) else {}
+    auth = data.get("auth") if isinstance(data.get("auth"), Mapping) else {}
+    budget = data.get("budget") if isinstance(data.get("budget"), Mapping) else {}
+
+    envelope_payload: dict[str, Any] = {
+        "intent": intent,
+        "routing": {
+            "sender_id": routing.get("sender_id") or data.get("sender_id") or ctx.sender_id,
+            "source": routing.get("source") or data.get("source") or ctx.source,
+            "channel_id": routing.get("channel_id") or data.get("channel_id") or ctx.channel_id,
+            "recipient_id": routing.get("recipient_id") or data.get("recipient_id"),
+            "target_agent_id": routing.get("target_agent_id") or data.get("target_agent_id"),
+        },
+        "auth": {
+            "permissions": auth.get("permissions")
+            if auth.get("permissions") is not None
+            else set(ctx.permissions),
+        },
+        "budget": {
+            "budget_agent_id": budget.get("budget_agent_id") or data.get("budget_agent_id"),
+            "attribution_scope": budget.get("attribution_scope") or "default",
+        },
+        "metadata": _metadata_with_context(data, ctx),
+    }
+
+    if intent in {"human_message", "direct_message", "broadcast", "knowledge_board"}:
+        envelope_payload["text"] = str(data.get("text") or "")
+    elif intent == "spawn":
+        envelope_payload.update(
+            {
+                "agent_id": _string_or_none(data.get("agent_id") or data.get("author")),
+                "role": data.get("role"),
+                "persona": _string_or_none(data.get("persona")),
+                "backstory": _string_or_none(data.get("backstory")),
+                "traits": data.get("traits") if isinstance(data.get("traits"), dict) else None,
+            }
+        )
+    elif intent == "inject_event":
+        envelope_payload.update(
+            {
+                "text": str(data.get("text") or ""),
+                "scope": str(data.get("scope") or "global"),
+                "agent_id": _string_or_none(data.get("agent_id") or data.get("author")),
+            }
+        )
+    elif intent in {"moderation", "control"}:
+        envelope_payload.update(
+            {
+                "action": str(data.get("action") or data.get("command") or intent),
+                "value": _float_or_none(data.get("value")),
+                "tags": _coerce_tags(data.get("tags")),
+                "agent_id": _string_or_none(data.get("agent_id")),
+            }
+        )
+
+    return parse_interaction_envelope(envelope_payload)
+
+
 def command_from_payload(
     payload: Mapping[str, Any],
     *,
     context: InteractionContext | None = None,
 ) -> DomainCommandT:
-    data = dict(payload)
-    ctx = context or InteractionContext()
-    command = str(data.get("command_type") or data.get("command") or "").strip()
-    if command == "dm":
-        command = "direct_message"
-    elif command == "kb":
-        command = "knowledge_board"
-    elif command in {"pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"}:
-        command = "control"
-    elif command == "inject_event":
-        command = "inject_event"
-
-    metadata = {**data, "adapter_context": ctx.model_dump()}
-    if command == "direct_message":
-        return DirectMessageCommand(
-            content=str(data.get("content") or data.get("text") or ""),
-            recipient_id=_string_or_none(data.get("recipient_id")),
-            target_agent_id=_string_or_none(data.get("target_agent_id")),
-            budget_agent_id=_string_or_none(data.get("budget_agent_id")),
-            metadata=metadata,
-        )
-    if command == "broadcast":
-        return BroadcastCommand(
-            content=str(data.get("content") or data.get("text") or ""),
-            budget_agent_id=_string_or_none(data.get("budget_agent_id")),
-            metadata=metadata,
-        )
-    if command == "knowledge_board":
-        return KnowledgeBoardCommand(content=str(data.get("content") or ""), metadata=metadata)
-    if command == "spawn":
-        return SpawnAgentCommand(
-            agent_id=_string_or_none(data.get("agent_id") or data.get("author")),
-            role=data.get("role"),
-            persona=_string_or_none(data.get("persona")),
-            backstory=_string_or_none(data.get("backstory")),
-            traits=data.get("traits") if isinstance(data.get("traits"), dict) else None,
-            metadata=metadata,
-        )
-    if command == "inject_event":
-        return InjectEventCommand(
-            text=str(data.get("text") or data.get("content") or ""),
-            scope=str(data.get("prompt") or data.get("scope") or "global"),
-            agent_id=_string_or_none(data.get("agent_id") or data.get("author")),
-            metadata=metadata,
-        )
-    if command in {"moderation", "reset_memory", "penalty", "mute", "unmute"}:
-        return ModerationCommand(
-            action=str(data.get("action") or command or data.get("command") or "moderation"),
-            agent_id=_string_or_none(data.get("agent_id")),
-            value=_float_or_none(data.get("value")),
-            metadata=metadata,
-        )
-    if command == "control" or command in {
-        "pause",
-        "resume",
-        "pause_all",
-        "start",
-        "stop",
-        "set_speed",
-        "kill_agent",
-        "set_breakpoints",
-    }:
-        return ControlCommand(
-            action=str(data.get("action") or data.get("command") or "control"),
-            value=_float_or_none(data.get("value")),
-            tags=_coerce_tags(data.get("tags")),
-            agent_id=_string_or_none(data.get("agent_id")),
-            metadata=metadata,
-        )
-    return HumanMessageCommand(
-        content=str(data.get("content") or data.get("text") or ""),
-        recipient_id=_string_or_none(data.get("recipient_id")),
-        target_agent_id=_string_or_none(data.get("target_agent_id")),
-        metadata=metadata,
-    )
+    return command_from_envelope(parse_bus_command(payload, context=context))
 
 
 def command_from_discord_message(
@@ -128,11 +133,98 @@ def command_from_discord_message(
 
 
 def command_from_envelope(envelope: InteractionEnvelope) -> DomainCommandT:
-    payload = envelope.model_dump()
-    payload["command_type"] = envelope.intent
-    if envelope.action is not None:
-        payload["command"] = envelope.action
-    return command_from_payload(payload)
+    if isinstance(envelope, HumanMessageEnvelope):
+        return HumanMessageCommand(
+            content=envelope.text,
+            recipient_id=envelope.routing.recipient_id,
+            target_agent_id=envelope.routing.target_agent_id,
+            metadata=envelope.metadata,
+        )
+    if isinstance(envelope, DirectMessageEnvelope):
+        return DirectMessageCommand(
+            content=envelope.text,
+            recipient_id=envelope.routing.recipient_id,
+            target_agent_id=envelope.routing.target_agent_id,
+            budget_agent_id=envelope.budget.budget_agent_id,
+            metadata=envelope.metadata,
+        )
+    if isinstance(envelope, BroadcastEnvelope):
+        return BroadcastCommand(
+            content=envelope.text,
+            budget_agent_id=envelope.budget.budget_agent_id,
+            metadata=envelope.metadata,
+        )
+    if isinstance(envelope, KnowledgeBoardEnvelope):
+        return KnowledgeBoardCommand(content=envelope.text, metadata=envelope.metadata)
+    if isinstance(envelope, SpawnEnvelope):
+        return SpawnAgentCommand(
+            agent_id=envelope.agent_id,
+            role=envelope.role,
+            persona=envelope.persona,
+            backstory=envelope.backstory,
+            traits=envelope.traits,
+            metadata=envelope.metadata,
+        )
+    if isinstance(envelope, InjectEventEnvelope):
+        return InjectEventCommand(
+            text=envelope.text,
+            scope=envelope.scope,
+            agent_id=envelope.agent_id,
+            metadata=envelope.metadata,
+        )
+    if isinstance(envelope, ModerationEnvelope):
+        return ModerationCommand(
+            action=envelope.action,
+            agent_id=envelope.agent_id,
+            value=envelope.value,
+            metadata=envelope.metadata,
+        )
+    return ControlCommand(
+        action=envelope.action,
+        value=envelope.value,
+        tags=envelope.tags,
+        agent_id=envelope.agent_id,
+        metadata=envelope.metadata,
+    )
+
+
+def _canonical_intent(data: Mapping[str, Any]) -> str:
+    command = str(
+        data.get("intent") or data.get("type") or data.get("command_type") or data.get("command") or ""
+    ).strip()
+    if command == "dm":
+        return "direct_message"
+    if command == "kb":
+        return "knowledge_board"
+    if command in {"pause", "resume", "pause_all", "start", "stop", "set_speed", "kill_agent"}:
+        return "control"
+    if command in {"moderation", "reset_memory", "penalty", "mute", "unmute"}:
+        return "moderation"
+    if command == "inject_event":
+        return "inject_event"
+    if command in {"human_message", "direct_message", "broadcast", "knowledge_board", "spawn", "control"}:
+        return command
+    return "human_message"
+
+
+def _normalize_legacy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(payload)
+    if "content" in data and "text" not in data:
+        data["text"] = data["content"]
+        warnings.warn("'content' is deprecated; use 'text'.", DeprecationWarning, stacklevel=3)
+    if "prompt" in data and "scope" not in data:
+        data["scope"] = data["prompt"]
+        warnings.warn("'prompt' is deprecated; use 'scope'.", DeprecationWarning, stacklevel=3)
+    if "command_type" in data and "intent" not in data and "type" not in data:
+        warnings.warn("'command_type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3)
+    if "type" in data and "intent" not in data:
+        data["intent"] = data["type"]
+        warnings.warn("'type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3)
+    return data
+
+
+def _metadata_with_context(data: Mapping[str, Any], context: InteractionContext) -> dict[str, Any]:
+    return {**dict(data), "adapter_context": context.model_dump()}
 
 
 def _string_or_none(value: Any) -> str | None:

--- a/src/interfaces/interaction_schema.py
+++ b/src/interfaces/interaction_schema.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from src.governance.decision_kernel import DecisionProvenance
 
@@ -35,6 +35,8 @@ class InteractionContext(BaseModel):
 
 
 class InteractionRouting(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     sender_id: str = "human"
     source: str = "unknown"
     channel_id: str | None = None
@@ -43,37 +45,93 @@ class InteractionRouting(BaseModel):
 
 
 class InteractionAuthScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     permissions: set[str] = Field(default_factory=set)
 
 
 class InteractionBudgetAttribution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     budget_agent_id: str | None = None
     attribution_scope: str = "default"
 
 
-class InteractionEnvelope(BaseModel):
-    intent: Literal[
-        "human_message",
-        "direct_message",
-        "broadcast",
-        "knowledge_board",
-        "spawn",
-        "moderation",
-        "control",
-        "inject_event",
-    ]
-    content: str | None = None
-    action: str | None = None
-    value: float | None = None
-    tags: list[str] | None = None
-    prompt: str | None = None
-    text: str | None = None
+class BaseInteractionEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    intent: str
+    routing: InteractionRouting = Field(default_factory=InteractionRouting)
+    auth: InteractionAuthScope = Field(default_factory=InteractionAuthScope)
+    budget: InteractionBudgetAttribution = Field(default_factory=InteractionBudgetAttribution)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class HumanMessageEnvelope(BaseInteractionEnvelope):
+    intent: Literal["human_message"] = "human_message"
+    text: str
+
+
+class DirectMessageEnvelope(BaseInteractionEnvelope):
+    intent: Literal["direct_message"] = "direct_message"
+    text: str
+
+
+class BroadcastEnvelope(BaseInteractionEnvelope):
+    intent: Literal["broadcast"] = "broadcast"
+    text: str
+
+
+class KnowledgeBoardEnvelope(BaseInteractionEnvelope):
+    intent: Literal["knowledge_board"] = "knowledge_board"
+    text: str
+
+
+class SpawnEnvelope(BaseInteractionEnvelope):
+    intent: Literal["spawn"] = "spawn"
     agent_id: str | None = None
     role: str | dict[str, Any] | None = None
     persona: str | None = None
     backstory: str | None = None
     traits: dict[str, float] | None = None
-    routing: InteractionRouting = Field(default_factory=InteractionRouting)
-    auth: InteractionAuthScope = Field(default_factory=InteractionAuthScope)
-    budget: InteractionBudgetAttribution = Field(default_factory=InteractionBudgetAttribution)
-    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ControlEnvelope(BaseInteractionEnvelope):
+    intent: Literal["control"] = "control"
+    action: str
+    value: float | None = None
+    tags: list[str] | None = None
+    agent_id: str | None = None
+
+
+class ModerationEnvelope(BaseInteractionEnvelope):
+    intent: Literal["moderation"] = "moderation"
+    action: str
+    agent_id: str | None = None
+    value: float | None = None
+
+
+class InjectEventEnvelope(BaseInteractionEnvelope):
+    intent: Literal["inject_event"] = "inject_event"
+    text: str
+    scope: str = "global"
+    agent_id: str | None = None
+
+
+InteractionEnvelope = Annotated[
+    HumanMessageEnvelope
+    | DirectMessageEnvelope
+    | BroadcastEnvelope
+    | KnowledgeBoardEnvelope
+    | SpawnEnvelope
+    | ControlEnvelope
+    | ModerationEnvelope
+    | InjectEventEnvelope,
+    Field(discriminator="intent"),
+]
+
+_INTERACTION_ENVELOPE_ADAPTER = TypeAdapter(InteractionEnvelope)
+
+
+def parse_interaction_envelope(payload: dict[str, Any]) -> InteractionEnvelope:
+    return _INTERACTION_ENVELOPE_ADAPTER.validate_python(payload)

--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -14,9 +14,17 @@ from src.infra.event_log import log_event
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
 from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_schema import (
+    BroadcastEnvelope,
+    ControlEnvelope,
+    DirectMessageEnvelope,
+    HumanMessageEnvelope,
+    InjectEventEnvelope,
     InteractionContext,
-    InteractionEnvelope,
     InteractionResult,
+    KnowledgeBoardEnvelope,
+    ModerationEnvelope,
+    SpawnEnvelope,
+    parse_interaction_envelope,
 )
 from src.shared.typing import SimulationMessage
 from src.sim.commands.domain_commands import DomainCommandT
@@ -69,11 +77,10 @@ class SimulationCommandService:
             simulation=self.simulation,
             stage="entry",
         )
-        envelope = (
-            envelope.model_copy(update=entry_decision.transformed_updates)
-            if entry_decision.decision == "transform"
-            else envelope
-        )
+        if entry_decision.decision == "transform":
+            transformed = envelope.model_dump()
+            transformed.update(entry_decision.transformed_updates)
+            envelope = parse_interaction_envelope(transformed)
 
         if entry_decision.decision == "deny":
             return InteractionResult(
@@ -91,11 +98,11 @@ class SimulationCommandService:
                 decision_provenance=entry_decision.provenance,
             )
 
-        if envelope.intent == "knowledge_board":
+        if isinstance(envelope, KnowledgeBoardEnvelope):
             return await self._dispatch_knowledge_board(envelope, context=ctx)
-        if envelope.intent in {"human_message", "broadcast", "direct_message"}:
+        if isinstance(envelope, (HumanMessageEnvelope, BroadcastEnvelope, DirectMessageEnvelope)):
             return await self._dispatch_message(envelope, context=ctx)
-        if envelope.intent in {"spawn", "moderation", "control", "inject_event"}:
+        if isinstance(envelope, (SpawnEnvelope, ModerationEnvelope, ControlEnvelope, InjectEventEnvelope)):
             return await self._dispatch_control(envelope, provenance=entry_decision.provenance)
 
         return InteractionResult(
@@ -107,7 +114,7 @@ class SimulationCommandService:
 
     async def _dispatch_control(
         self,
-        envelope: InteractionEnvelope,
+        envelope: SpawnEnvelope | ModerationEnvelope | ControlEnvelope | InjectEventEnvelope,
         *,
         provenance: DecisionProvenance,
     ) -> InteractionResult:
@@ -120,11 +127,16 @@ class SimulationCommandService:
             decision_provenance=provenance,
         )
 
-    async def _apply_control_action(self, envelope: InteractionEnvelope) -> dict[str, Any] | None:
+    async def _apply_control_action(
+        self, envelope: SpawnEnvelope | ModerationEnvelope | ControlEnvelope | InjectEventEnvelope
+    ) -> dict[str, Any] | None:
         sim = self.simulation
-        action = str(envelope.action or "").strip()
-        if envelope.intent == "spawn" and action != "spawn":
+        if isinstance(envelope, SpawnEnvelope):
             action = "spawn"
+        elif isinstance(envelope, InjectEventEnvelope):
+            action = "inject_event"
+        else:
+            action = str(envelope.action).strip()
 
         if action == "pause":
             sim.paused = True
@@ -143,7 +155,7 @@ class SimulationCommandService:
         elif action == "stop":
             sim.simulation_complete = True
             await sim.stop_event_listener()
-        elif action == "spawn":
+        elif action == "spawn" and isinstance(envelope, SpawnEnvelope):
             await self._spawn_agent(envelope)
         elif action == "kill_agent":
             if envelope.agent_id:
@@ -160,9 +172,9 @@ class SimulationCommandService:
                 sim.speed = float(envelope.value or 1)
             except (TypeError, ValueError):
                 pass
-        elif action == "post_kb":
+        elif action == "post_kb" and isinstance(envelope, (ModerationEnvelope, ControlEnvelope)):
             await self._post_knowledge_board(envelope)
-        elif action == "inject_event":
+        elif action == "inject_event" and isinstance(envelope, InjectEventEnvelope):
             await self._inject_world_event(envelope)
 
         return {
@@ -171,7 +183,7 @@ class SimulationCommandService:
             "simulation_complete": sim.simulation_complete,
         }
 
-    async def _spawn_agent(self, envelope: InteractionEnvelope) -> None:
+    async def _spawn_agent(self, envelope: SpawnEnvelope) -> None:
         sim = self.simulation
         if not envelope.agent_id:
             return
@@ -206,9 +218,9 @@ class SimulationCommandService:
         new_agent = Agent(agent_id=agent_id, name=agent_id, initial_state=initial_state or None)
         await sim.spawn_agent(new_agent)
 
-    async def _post_knowledge_board(self, envelope: InteractionEnvelope) -> None:
+    async def _post_knowledge_board(self, envelope: ModerationEnvelope | ControlEnvelope) -> None:
         sim = self.simulation
-        text = envelope.text
+        text = str(envelope.metadata.get("text") or envelope.metadata.get("content") or "").strip()
         author = envelope.agent_id or "human"
         if text and sim.knowledge_board:
             await sim.knowledge_board_service.post_human_message(
@@ -224,13 +236,13 @@ class SimulationCommandService:
                 )
             )
 
-    async def _inject_world_event(self, envelope: InteractionEnvelope) -> None:
+    async def _inject_world_event(self, envelope: InjectEventEnvelope) -> None:
         sim = self.simulation
         text = str(envelope.text or "").strip()
         if not text:
             return
         author = str(envelope.agent_id or "human")
-        scope = str(envelope.prompt or "global")
+        scope = str(envelope.scope or "global")
         event_payload = {
             "type": "world_event",
             "author": author,
@@ -261,9 +273,9 @@ class SimulationCommandService:
             )
 
     async def _dispatch_knowledge_board(
-        self, command: InteractionEnvelope, *, context: InteractionContext
+        self, command: KnowledgeBoardEnvelope, *, context: InteractionContext
     ) -> InteractionResult:
-        content = str(command.content or "").strip()
+        content = str(command.text or "").strip()
         if not content:
             return InteractionResult(
                 status="rejected",
@@ -313,9 +325,12 @@ class SimulationCommandService:
         )
 
     async def _dispatch_message(
-        self, command: InteractionEnvelope, *, context: InteractionContext
+        self,
+        command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope,
+        *,
+        context: InteractionContext,
     ) -> InteractionResult:
-        text = str(command.content or "").strip()
+        text = str(command.text or "").strip()
         if not text:
             return InteractionResult(
                 status="rejected",
@@ -469,7 +484,7 @@ class SimulationCommandService:
             decision_provenance=decision.provenance,
         )
 
-    def _resolve_target(self, command: InteractionEnvelope) -> Any:
+    def _resolve_target(self, command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope) -> Any:
         target = None
         if command.routing.target_agent_id:
             target = next(
@@ -500,7 +515,9 @@ class SimulationCommandService:
             )
         return target or self.simulation.agents[self.simulation.current_agent_index]
 
-    def _resolve_budget_agent_id(self, command: InteractionEnvelope, fallback: str) -> str:
+    def _resolve_budget_agent_id(
+        self, command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope, fallback: str
+    ) -> str:
         configured_budget_id = config.get_config("HUMAN_COMMAND_BUDGET_AGENT_ID")
         if command.budget.budget_agent_id:
             return command.budget.budget_agent_id

--- a/src/sim/commands/domain_commands.py
+++ b/src/sim/commands/domain_commands.py
@@ -4,7 +4,18 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+from src.interfaces.interaction_schema import (
+    BroadcastEnvelope,
+    ControlEnvelope,
+    DirectMessageEnvelope,
+    HumanMessageEnvelope,
+    InjectEventEnvelope,
+    InteractionContext,
+    InteractionEnvelope,
+    KnowledgeBoardEnvelope,
+    ModerationEnvelope,
+    SpawnEnvelope,
+)
 
 
 class DomainCommand(BaseModel):
@@ -22,9 +33,8 @@ class HumanMessageCommand(DomainCommand):
     target_agent_id: str | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="human_message",
-            content=self.content,
+        return HumanMessageEnvelope(
+            text=self.content,
             routing={
                 "sender_id": context.sender_id,
                 "source": context.source,
@@ -45,9 +55,8 @@ class DirectMessageCommand(DomainCommand):
     budget_agent_id: str | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="direct_message",
-            content=self.content,
+        return DirectMessageEnvelope(
+            text=self.content,
             routing={
                 "sender_id": context.sender_id,
                 "source": context.source,
@@ -67,9 +76,8 @@ class BroadcastCommand(DomainCommand):
     budget_agent_id: str | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="broadcast",
-            content=self.content,
+        return BroadcastEnvelope(
+            text=self.content,
             routing={
                 "sender_id": context.sender_id,
                 "source": context.source,
@@ -86,9 +94,8 @@ class KnowledgeBoardCommand(DomainCommand):
     content: str
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="knowledge_board",
-            content=self.content,
+        return KnowledgeBoardEnvelope(
+            text=self.content,
             routing={"sender_id": context.sender_id, "source": context.source},
             auth={"permissions": set(context.permissions)},
             metadata=self.metadata,
@@ -104,9 +111,7 @@ class SpawnAgentCommand(DomainCommand):
     traits: dict[str, float] | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="spawn",
-            action="spawn",
+        return SpawnEnvelope(
             agent_id=self.agent_id,
             role=self.role,
             persona=self.persona,
@@ -126,8 +131,7 @@ class ControlCommand(DomainCommand):
     agent_id: str | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="control",
+        return ControlEnvelope(
             action=self.action,
             value=self.value,
             tags=self.tags,
@@ -145,8 +149,7 @@ class ModerationCommand(DomainCommand):
     value: float | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="moderation",
+        return ModerationEnvelope(
             action=self.action,
             agent_id=self.agent_id,
             value=self.value,
@@ -163,10 +166,9 @@ class InjectEventCommand(DomainCommand):
     agent_id: str | None = None
 
     def to_envelope(self, *, context: InteractionContext) -> InteractionEnvelope:
-        return InteractionEnvelope(
-            intent="inject_event",
+        return InjectEventEnvelope(
             text=self.text,
-            prompt=self.scope,
+            scope=self.scope,
             agent_id=self.agent_id,
             routing={"sender_id": context.sender_id, "source": context.source},
             auth={"permissions": set(context.permissions)},

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -531,9 +531,12 @@ class Simulation:
 
     async def handle_moderation_command(self: Self, cmd: dict[str, Any]) -> None:
         """Process moderation actions like muting or penalties."""
-        from src.interfaces.interaction_schema import InteractionContext, InteractionEnvelope
+        from src.interfaces.interaction_schema import (
+            InteractionContext,
+            parse_interaction_envelope,
+        )
 
-        envelope = InteractionEnvelope.model_validate(
+        envelope = parse_interaction_envelope(
             {
                 "intent": "moderation",
                 "action": cmd.get("command"),

--- a/tests/integration/interfaces/test_policy_decision_kernel_integration.py
+++ b/tests/integration/interfaces/test_policy_decision_kernel_integration.py
@@ -1,7 +1,8 @@
 import pytest
 
 from src.interfaces import dashboard_backend as db
-from src.interfaces.interaction_commands import InteractionContext, InteractionEnvelope
+from src.interfaces.interaction_commands import InteractionContext
+from src.interfaces.interaction_schema import HumanMessageEnvelope
 from src.sim.simulation import Simulation
 
 
@@ -36,9 +37,8 @@ class DummyAgent:
 async def test_equivalent_human_message_has_identical_policy_outcome() -> None:
     sim = Simulation([DummyAgent("alpha"), DummyAgent("beta")])
     try:
-        envelope = InteractionEnvelope(
-            intent="human_message",
-            content="hello kernel",
+        envelope = HumanMessageEnvelope(
+            text="hello kernel",
             routing={"sender_id": "user-1", "source": "discord"},
             metadata={"request_id": "equiv-1"},
         )
@@ -50,7 +50,7 @@ async def test_equivalent_human_message_has_identical_policy_outcome() -> None:
         dashboard_result = await sim.command_bus.dispatch_payload(
             {
                 "command_type": "human_message",
-                "content": "hello kernel",
+                "text": "hello kernel",
                 "sender_id": "user-1",
                 "source": "dashboard",
                 "request_id": "equiv-1",

--- a/tests/unit/interfaces/test_interaction_schema_compat.py
+++ b/tests/unit/interfaces/test_interaction_schema_compat.py
@@ -1,0 +1,43 @@
+import pytest
+from pydantic import ValidationError
+
+from src.interfaces.domain_command_adapters import parse_bus_command
+from src.interfaces.interaction_commands import InteractionContext
+from src.interfaces.interaction_schema import (
+    InjectEventEnvelope,
+    KnowledgeBoardEnvelope,
+    parse_interaction_envelope,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_parse_bus_command_accepts_modern_text_payload() -> None:
+    envelope = parse_bus_command(
+        {"intent": "knowledge_board", "text": "hello", "sender_id": "u-1", "source": "dashboard"}
+    )
+
+    assert isinstance(envelope, KnowledgeBoardEnvelope)
+    assert envelope.text == "hello"
+
+
+def test_parse_bus_command_supports_legacy_fields_with_deprecation_warning() -> None:
+    with pytest.deprecated_call(match="deprecated"):
+        envelope = parse_bus_command(
+            {
+                "command_type": "inject_event",
+                "content": "storm incoming",
+                "prompt": "global",
+                "agent_id": "mod-1",
+            },
+            context=InteractionContext(sender_id="mod-1", source="discord", permissions={"admin"}),
+        )
+
+    assert isinstance(envelope, InjectEventEnvelope)
+    assert envelope.text == "storm incoming"
+    assert envelope.scope == "global"
+
+
+def test_parse_bus_command_rejects_forbidden_fields_for_intent() -> None:
+    with pytest.raises(ValidationError):
+        parse_interaction_envelope({"intent": "knowledge_board", "text": "hi", "action": "pause"})


### PR DESCRIPTION
### Motivation
- Enforce strict per-intent validation for incoming transport payloads so command handlers receive well-formed, intent-specific data. 
- Keep parsing ergonomic for callers while preventing accidental/ambiguous fields by switching to concrete Pydantic models and a discriminated union. 
- Preserve backward compatibility by migrating legacy payload shapes (`content`/`prompt`/`command_type`/`type`) with deprecation warnings to guide consumers to the new `text`/`scope`/`intent` naming.

### Description
- Split the flat `InteractionEnvelope` into intent-specific Pydantic models (`HumanMessageEnvelope`, `DirectMessageEnvelope`, `BroadcastEnvelope`, `KnowledgeBoardEnvelope`, `SpawnEnvelope`, `ControlEnvelope`, `ModerationEnvelope`, `InjectEventEnvelope`) and a `BaseInteractionEnvelope` with `extra="forbid"` to reject forbidden fields. 
- Introduced a discriminated union `InteractionEnvelope` and a helper `parse_interaction_envelope` (TypeAdapter-based) to validate and dispatch by concrete schema. 
- Replaced ad-hoc payload parsing with `parse_bus_command` which normalizes legacy fields (`content`→`text`, `prompt`→`scope`, `command_type`/`type`→`intent`) with `DeprecationWarning` and returns a typed envelope; adapters and `command_from_envelope` now pattern-match on concrete envelope classes. 
- Updated domain command constructors, command dispatching and service handlers to accept and pattern-match concrete envelope classes (e.g. `HumanMessageEnvelope`, `KnowledgeBoardEnvelope`, `InjectEventEnvelope`) and standardized all payload text to `text` (policy transforms were updated accordingly). 

### Testing
- Ran `ruff check` on modified files which completed with all checks passed. 
- Executed `pytest -q` for the updated interface/unit/integration slices (`tests/unit/interfaces/test_interaction_schema_compat.py`, `tests/unit/interfaces/test_interaction_contract.py`, `tests/unit/interfaces/test_simulation_command_service_contract.py`, `tests/integration/interfaces/test_policy_decision_kernel_integration.py`) and all tests passed. 
- New compatibility unit tests (`tests/unit/interfaces/test_interaction_schema_compat.py`) exercise modern parsing, legacy-shim deprecation warnings, and forbidden-field rejection and passed. 
- Tests observed expected `DeprecationWarning`s from the legacy migration shim while exercising equivalence across transport paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a766bf5c8326badc6767c1e26fe2)