### PR TITLE
Refactor simulation runtime phases and external event ingestion

### DIFF
--- a/src/sim/engine.py
+++ b/src/sim/engine.py
@@ -7,9 +7,8 @@ from opentelemetry import trace
 
 from src.infra.event_log import log_event
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
-from src.interfaces.metrics import STEP_PHASE_QUEUE_DEPTH
-from src.shared.telemetry import trace_agent_action
 from src.sim.persistence.trace_hash_service import TraceHashService
+from src.sim.runtime import ActionPhase, DecisionPhase, PerceptionPhase, PostStepPhase, StepContext
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -20,6 +19,11 @@ class SimulationEngine:
 
     def __init__(self, simulation: Any) -> None:
         self.simulation = simulation
+        self.perception_phase = PerceptionPhase()
+        self.decision_phase = DecisionPhase()
+        self.action_phase = ActionPhase()
+        self.post_step_phase = PostStepPhase()
+        self.last_step_context: StepContext | None = None
 
     async def run_step(self, max_turns: int = 1) -> int:
         sim = self.simulation
@@ -27,31 +31,18 @@ class SimulationEngine:
             logger.warning("No agents in simulation to run.")
             return 0
 
-        await sim.start_event_listener()
+        context = StepContext(max_turns=max_turns)
+        await self.perception_phase.execute(sim, context)
+        await self.decision_phase.execute(sim, context)
+        await self.action_phase.execute(sim, context)
+        await self.post_step_phase.execute(sim, context)
+        self.last_step_context = context
 
-        queue_depth = sim.event_kernel.queue_depth()
-        sim._set_labeled_gauge(STEP_PHASE_QUEUE_DEPTH, phase="queue_pre_step", value=queue_depth)
+        if context.planned_outputs:
+            return len(context.planned_outputs)
+        return len(context.events)
 
-        if max_turns > 1:
-            planned = await sim._run_step_pipeline(max_turns=max_turns)
-            if planned:
-                return len(planned)
-
-        if sim.event_kernel.empty():
-            sim.vector.increment(sim.agents[sim.current_agent_index].get_id())
-            sim.event_kernel.schedule_immediate_nowait(
-                sim._create_agent_event(sim.current_agent_index),
-                agent_id=sim.agents[sim.current_agent_index].get_id(),
-                vector=sim.vector,
-            )
-
-        agent_id = sim.agents[sim.current_agent_index].get_id()
-        with trace_agent_action("tick", agent_id=agent_id, step=sim.current_step):
-            events = await sim.event_kernel.step(max_turns)
-            await self._run_evaluation_hooks(events)
-            return len(events)
-
-    async def _run_evaluation_hooks(self, events: list[dict[str, Any]]) -> None:
+    async def emit_evaluation_events(self, events: list[dict[str, Any]]) -> None:
         sim = self.simulation
         metrics: dict[str, Any] = {}
         for hook in sim.evaluation_hooks:
@@ -59,7 +50,10 @@ class SimulationEngine:
                 with tracer.start_as_current_span("simulation.evaluation_hook") as span:
                     span.set_attribute("hook.name", getattr(hook, "__name__", repr(hook)))
                     span.set_attribute("simulation.step", sim.current_step)
-                    result = hook(sim, events) or {}
+                    try:
+                        result = hook(sim, events) or {}
+                    except TypeError:
+                        result = hook(events) or {}
                     for key, value in result.items():
                         span.set_attribute(f"metric.{key}", value)
                     metrics.update(result)

--- a/src/sim/runtime/__init__.py
+++ b/src/sim/runtime/__init__.py
@@ -1,0 +1,12 @@
+from src.sim.runtime.external_event_ingestion_service import ExternalEventIngestionService
+from src.sim.runtime.phases import ActionPhase, DecisionPhase, PerceptionPhase, PostStepPhase
+from src.sim.runtime.step_context import StepContext
+
+__all__ = [
+    "ActionPhase",
+    "DecisionPhase",
+    "ExternalEventIngestionService",
+    "PerceptionPhase",
+    "PostStepPhase",
+    "StepContext",
+]

--- a/src/sim/runtime/external_event_ingestion_service.py
+++ b/src/sim/runtime/external_event_ingestion_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from src.interfaces.dashboard_backend import SimulationEvent
+from src.interfaces.interaction_commands import InteractionContext
+from src.shared.typing import SimulationMessage
+from src.sim.event_bus import get_event_bus
+
+
+class ExternalEventIngestionService:
+    """Owns event-listener lifecycle and external event routing."""
+
+    def __init__(self, simulation: Any) -> None:
+        self.simulation = simulation
+
+    async def start(self) -> None:
+        sim = self.simulation
+        if sim._event_listener_task is None or sim._event_listener_task.done():
+            sim._event_listener_task = asyncio.create_task(self._event_listener_loop())
+        if sim._event_task is None or sim._event_task.done():
+            sim._event_task = asyncio.create_task(
+                sim.event_kernel.forward_external_events(sim._handle_human_command_from_bus)
+            )
+
+    async def stop(self) -> None:
+        sim = self.simulation
+        if sim._event_listener_task:
+            sim._event_listener_task.cancel()
+            try:
+                await sim._event_listener_task
+            except asyncio.CancelledError:  # pragma: no cover - expected
+                pass
+            sim._event_listener_task = None
+        if sim._event_task:
+            sim._event_task.cancel()
+            try:
+                await sim._event_task
+            except asyncio.CancelledError:  # pragma: no cover - expected
+                pass
+            sim._event_task = None
+        if sim._discord_listener is not None:
+            await sim._discord_listener.stop()
+            sim._discord_listener = None
+
+    async def _event_listener_loop(self) -> None:
+        bus = get_event_bus()
+        queue = bus.subscribe()
+        try:
+            while True:
+                evt: SimulationEvent | None = await queue.get()
+                if evt is None:
+                    break
+                await self.route_event(evt)
+        except asyncio.CancelledError:  # pragma: no cover - task cancelled
+            pass
+        finally:
+            bus.unsubscribe(queue)
+
+    async def route_event(self, evt: SimulationEvent) -> None:
+        sim = self.simulation
+        if not evt.data:
+            return
+        if evt.type == "control":
+            context = InteractionContext(
+                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
+                channel_id=str(evt.data.get("channel_id")) if evt.data.get("channel_id") else None,
+                source=str(evt.data.get("source", "event_bus")),
+                permissions=(
+                    set(evt.data.get("permissions", []))
+                    if isinstance(evt.data.get("permissions"), list)
+                    else set()
+                ),
+                metadata={k: v for k, v in evt.data.items()},
+            )
+            await sim.command_bus.dispatch_payload(evt.data, context=context)
+            return
+        if evt.type == "moderation":
+            context = InteractionContext(
+                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
+                source=str(evt.data.get("source", "event_bus")),
+                permissions={"admin", "moderator"},
+                metadata={k: v for k, v in evt.data.items()},
+            )
+            await sim.command_bus.dispatch_payload(evt.data, context=context)
+            return
+
+        sender = str(evt.data.get("author", "external"))
+        if sender in sim.muted_agents:
+            return
+
+        recipient = evt.data.get("recipient_id") if evt.type == "direct_message" else None
+        msg: SimulationMessage = {
+            "step": sim.current_step,
+            "turn_index": sim.current_step,
+            "world_time": sim.environment_system.world_time_snapshot(),
+            "sender_id": sender,
+            "recipient_id": recipient,
+            "content": str(evt.data.get("content", "")),
+            "action_intent": None,
+            "sentiment_score": None,
+        }
+        async with sim._msg_lock:
+            sim.pending_messages_for_next_round.append(msg)
+            sim.messages_to_perceive_this_round.append(msg)

--- a/src/sim/runtime/phases.py
+++ b/src/sim/runtime/phases.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.interfaces.metrics import STEP_PHASE_QUEUE_DEPTH
+from src.shared.telemetry import trace_agent_action
+from src.sim.runtime.step_context import StepContext
+
+logger = logging.getLogger(__name__)
+
+
+class PerceptionPhase:
+    """Prepare runtime listener and pre-step metrics."""
+
+    async def execute(self, simulation: Any, context: StepContext) -> None:
+        context.phase_order.append("perception")
+        await simulation.start_event_listener()
+        context.queue_depth = simulation.event_kernel.queue_depth()
+        simulation._set_labeled_gauge(
+            STEP_PHASE_QUEUE_DEPTH,
+            phase="queue_pre_step",
+            value=context.queue_depth,
+        )
+
+
+class DecisionPhase:
+    """Run optional parallel planning pipeline."""
+
+    async def execute(self, simulation: Any, context: StepContext) -> None:
+        context.phase_order.append("decision")
+        if context.max_turns <= 1:
+            return
+        context.planned_outputs = await simulation._run_step_pipeline(max_turns=context.max_turns)
+
+
+class ActionPhase:
+    """Execute scheduler step or bootstrap immediate event when needed."""
+
+    async def execute(self, simulation: Any, context: StepContext) -> None:
+        context.phase_order.append("action")
+        if context.planned_outputs:
+            return
+
+        if simulation.event_kernel.empty():
+            simulation.vector.increment(simulation.agents[simulation.current_agent_index].get_id())
+            simulation.event_kernel.schedule_immediate_nowait(
+                simulation._create_agent_event(simulation.current_agent_index),
+                agent_id=simulation.agents[simulation.current_agent_index].get_id(),
+                vector=simulation.vector,
+            )
+
+        agent_id = simulation.agents[simulation.current_agent_index].get_id()
+        with trace_agent_action("tick", agent_id=agent_id, step=simulation.current_step):
+            context.events = await simulation.event_kernel.step(context.max_turns)
+
+
+class PostStepPhase:
+    """Run evaluation hooks after events are produced for the step."""
+
+    async def execute(self, simulation: Any, context: StepContext) -> None:
+        context.phase_order.append("post_step")
+        if context.planned_outputs:
+            return
+        await simulation.engine.emit_evaluation_events(context.events)

--- a/src/sim/runtime/step_context.py
+++ b/src/sim/runtime/step_context.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class StepContext:
+    """Per-step runtime state shared across phase components."""
+
+    max_turns: int
+    queue_depth: int = 0
+    phase_order: list[str] = field(default_factory=list)
+    planned_outputs: list[dict[str, Any]] = field(default_factory=list)
+    events: list[dict[str, Any]] = field(default_factory=list)

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -75,6 +75,7 @@ from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 from src.sim.persistence.trace_hash_service import TraceHashService
 from src.sim.quests import generate_quest
 from src.sim.resource_manager import get_resource_manager
+from src.sim.runtime import ExternalEventIngestionService
 from src.sim.scheduler_protocol import SchedulerProtocol
 from src.sim.version_vector import VersionVector
 from src.sim.world_context import WorldContextProjection
@@ -391,6 +392,7 @@ class Simulation:
         self.decision_service = PolicyDecisionService()
         self.control_service = SimulationControlService(self)
         self.engine = SimulationEngine(self)
+        self.external_event_ingestion = ExternalEventIngestionService(self)
 
         # Automatically start listening for external events when an event loop
         # is already running. This allows tests to enqueue events before calling
@@ -400,9 +402,11 @@ class Simulation:
         except RuntimeError:
             loop = None
         if loop is not None:
-            self._event_listener_task = loop.create_task(self._event_listener_loop())
+            self._event_listener_task = loop.create_task(
+                self.external_event_ingestion._event_listener_loop()
+            )
             self._event_task = loop.create_task(
-                self.event_kernel.forward_external_events(self._handle_human_command)
+                self.event_kernel.forward_external_events(self._handle_human_command_from_bus)
             )
         else:
             asyncio.set_event_loop(asyncio.new_event_loop())
@@ -452,6 +456,16 @@ class Simulation:
                 raise AssertionError(f"Trait drift exceeded per-step max: {record}")
             if not record.get("cause") or not record.get("source"):
                 raise AssertionError(f"Trait audit record missing cause/source: {record}")
+
+    async def _handle_human_command_from_bus(
+        self: Self, text: str, metadata: dict[str, Any] | None = None
+    ) -> None:
+        """Compatibility adapter for external event forwarding callbacks."""
+
+        try:
+            await self._handle_human_command(text, metadata)
+        except TypeError:
+            await self._handle_human_command(text)  # type: ignore[misc]
 
     async def _handle_human_command(
         self: Self, text: str, metadata: dict[str, Any] | None = None
@@ -1454,93 +1468,19 @@ class Simulation:
 
     async def _event_listener_loop(self: Self) -> None:
         """Continuously process events from the shared queue."""
-        bus = get_event_bus()
-        queue = bus.subscribe()
-        try:
-            while True:
-                evt: SimulationEvent | None = await queue.get()
-                if evt is None:
-                    break
-                await self._handle_incoming_event(evt)
-        except asyncio.CancelledError:  # pragma: no cover - task cancelled
-            pass
-        finally:
-            bus.unsubscribe(queue)
+        await self.external_event_ingestion._event_listener_loop()
 
     async def _handle_incoming_event(self: Self, evt: SimulationEvent) -> None:
         """Route a ``SimulationEvent`` to agents as a message."""
-        if not evt.data:
-            return
-        if evt.type == "control":
-            context = InteractionContext(
-                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
-                channel_id=str(evt.data.get("channel_id")) if evt.data.get("channel_id") else None,
-                source=str(evt.data.get("source", "event_bus")),
-                permissions=(
-                    set(evt.data.get("permissions", []))
-                    if isinstance(evt.data.get("permissions"), list)
-                    else set()
-                ),
-                metadata={k: v for k, v in evt.data.items()},
-            )
-            await self.command_bus.dispatch_payload(evt.data, context=context)
-            return
-        if evt.type == "moderation":
-            context = InteractionContext(
-                sender_id=str(evt.data.get("sender_id", evt.data.get("author", "external"))),
-                source=str(evt.data.get("source", "event_bus")),
-                permissions={"admin", "moderator"},
-                metadata={k: v for k, v in evt.data.items()},
-            )
-            await self.command_bus.dispatch_payload(evt.data, context=context)
-            return
-        sender = str(evt.data.get("author", "external"))
-        if sender in self.muted_agents:
-            return
-        content = str(evt.data.get("content", ""))
-        recipient = evt.data.get("recipient_id") if evt.type == "direct_message" else None
-        msg: SimulationMessage = {
-            "step": self.current_step,
-            "turn_index": self.current_step,
-            "world_time": self.environment_system.world_time_snapshot(),
-            "sender_id": sender,
-            "recipient_id": recipient,
-            "content": content,
-            "action_intent": None,
-            "sentiment_score": None,
-        }
-        async with self._msg_lock:
-            self.pending_messages_for_next_round.append(msg)
-            self.messages_to_perceive_this_round.append(msg)
+        await self.external_event_ingestion.route_event(evt)
 
     async def start_event_listener(self: Self) -> None:
         """Start background processing of ``event_queue`` events."""
-        if self._event_listener_task is None or self._event_listener_task.done():
-            self._event_listener_task = asyncio.create_task(self._event_listener_loop())
-        if self._event_task is None or self._event_task.done():
-            self._event_task = asyncio.create_task(
-                self.event_kernel.forward_external_events(self._handle_human_command)
-            )
+        await self.external_event_ingestion.start()
 
     async def stop_event_listener(self: Self) -> None:
         """Stop the background event listener task."""
-        if self._event_listener_task:
-            self._event_listener_task.cancel()
-            try:
-                await self._event_listener_task
-            except asyncio.CancelledError:  # pragma: no cover - expected
-                pass
-            self._event_listener_task = None
-        if self._event_task:
-            self._event_task.cancel()
-            try:
-                await self._event_task
-            except asyncio.CancelledError:  # pragma: no cover - expected
-                pass
-            self._event_task = None
-        if self._discord_listener is not None:
-            await self._discord_listener.stop()
-            self._discord_listener = None
+        await self.external_event_ingestion.stop()
 
     def add_evaluation_hook(
         self: Self, hook: Callable[[Self, list[Any]], dict[str, Any] | None]

--- a/tests/integration/sim/fixtures/event_step_runtime_snapshot.json
+++ b/tests/integration/sim/fixtures/event_step_runtime_snapshot.json
@@ -1,0 +1,11 @@
+{
+  "phase_order": [
+    "perception",
+    "decision",
+    "action",
+    "post_step"
+  ],
+  "emitted_event_types": [
+    "evaluation"
+  ]
+}

--- a/tests/integration/sim/test_event_step_lifecycle_invariants.py
+++ b/tests/integration/sim/test_event_step_lifecycle_invariants.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.sim.simulation import EVENT_STEP_LIFECYCLE_MUST_NOT_CHANGE, Simulation
 
+SNAPSHOT_PATH = Path(__file__).with_name("fixtures") / "event_step_runtime_snapshot.json"
+
+
+def _load_snapshot() -> dict[str, object]:
+    return json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+
 
 class DummyAgentState:
     def __init__(self) -> None:
         self.ip = 0.0
         self.du = 0.0
+        self.mood_level = 0.0
         self.short_term_memory = []
         self.messages_sent_count = 0
         self.last_message_step = None
@@ -94,5 +104,32 @@ async def test_lifecycle_invariant_evaluation_event_emits_step(monkeypatch: pyte
     assert evaluation
     assert "step" in (evaluation[-1].data or {})
     assert EVENT_STEP_LIFECYCLE_MUST_NOT_CHANGE["metrics_event_semantics"]
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_lifecycle_runtime_snapshot_phase_order_and_event_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sim = Simulation([DummyAgent("A")])
+    sim.event_kernel.step = AsyncMock(return_value=[])  # type: ignore[assignment]
+    emitted: list[object] = []
+
+    async def _emit(evt: object) -> None:
+        emitted.append(evt)
+
+    monkeypatch.setattr("src.sim.engine.emit_event", _emit)
+    await sim.run_step()
+
+    context = sim.engine.last_step_context
+    assert context is not None
+
+    actual = {
+        "phase_order": context.phase_order,
+        "emitted_event_types": [getattr(evt, "type", "") for evt in emitted],
+    }
+    assert actual == _load_snapshot()
     await sim.stop_event_listener()
     sim.close()


### PR DESCRIPTION
### Motivation

- Separate the step pipeline into explicit phases to make step semantics clearer and testable while preserving existing lifecycle contracts.  
- Move external event listener lifecycle and routing out of `Simulation` into a dedicated service to keep `Simulation` a thin composition root.  
- Introduce a typed per-step object to avoid relying on mutable class-level fields and to make phase handoff explicit.  
- Add snapshot-based coverage to lock down the must-not-change phase ordering and emitted `SimulationEvent` sequences.

### Description

- Extracted phase components into `src/sim/runtime/` with `PerceptionPhase`, `DecisionPhase`, `ActionPhase`, and `PostStepPhase`, each exposing an `execute` method and responsible for a single phase of a step.  
- Added `StepContext` (`src/sim/runtime/step_context.py`) to carry `max_turns`, `queue_depth`, `phase_order`, `planned_outputs`, and `events` across phases.  
- Implemented `ExternalEventIngestionService` (`src/sim/runtime/external_event_ingestion_service.py`) to own the event-listener lifecycle, bus subscription, control/moderation dispatching, and message routing.  
- Updated `SimulationEngine` to orchestrate the phase objects, persist the `last_step_context` for contract verification, and centralize evaluation-event emission with compatibility for different evaluation-hook signatures.  
- Kept `Simulation` as the wiring root by instantiating the new runtime service and delegating start/stop/route logic to it, and added a small adapter `_handle_human_command_from_bus` for callback compatibility.  
- Added a snapshot-backed integration test and fixture (`tests/integration/sim/test_event_step_lifecycle_invariants.py` + `fixtures/event_step_runtime_snapshot.json`) that asserts the phase order and emitted `SimulationEvent` sequence remain stable.

### Testing

- Ran `ruff` across the changed files with `ruff check ...` and the linter completed successfully.  
- Ran the integration lifecycle checks with `pytest -q -m integration tests/integration/sim/test_event_step_lifecycle_invariants.py` and the tests passed (snapshot assertion verifies phase order and emitted `evaluation` event).  
- Ran the unit event-task test with `pytest -q tests/unit/sim/test_event_task_start.py -m unit` and it passed, confirming the listener start/stop behavior remains compatible.  
- The new snapshot test fixture asserts the preserved must-not-change contract for step-phase ordering and emitted `SimulationEvent` sequences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a9682a1c832681d534a104866df3)