### PR TITLE
Add replayable PersonalityTransition events and normalized trait projection

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -309,6 +309,7 @@ class AgentStateData(BaseModel):
     current_role: RoleProfile = Field(default_factory=_get_default_role_profile)
     traits: PersonalityTraits = Field(default_factory=PersonalityTraits)
     trait_change_audit: list[dict[str, Any]] = Field(default_factory=list)
+    personality_transition_events: list[dict[str, Any]] = Field(default_factory=list)
     steps_in_current_role: int = 0
     reputation: dict[str, float] = Field(default_factory=dict)
     role_reputation: dict[str, float] = Field(default_factory=dict)

--- a/src/agents/core/personality_engine.py
+++ b/src/agents/core/personality_engine.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import cast
 from warnings import warn
 
 from pydantic import BaseModel
 
 from .agent_state import AgentState
+from .personality_transition import PersonalityTransition, TraitDelta
 from .trait_policy import (
     action_intent_biasing,
     merge_trait_policy_coefficients,
     mood_update_multiplier,
+    normalize_trait_projection,
     relationship_update_sensitivity,
     trait_drift_from_experience,
 )
@@ -29,17 +31,26 @@ class ExperienceSignal(BaseModel):
 class PersonalityEngine:
     """Sole owner of personality-dependent strategy and trait drift updates."""
 
-    def _apply_trait_adjustments(
+    def _coefficients(self, state: AgentState) -> dict[str, float]:
+        coefficients = merge_trait_policy_coefficients(state.trait_policy_coefficients)
+        return cast(dict[str, float], coefficients)
+
+    def trait_projection(self, state: AgentState) -> dict[str, dict[str, float]]:
+        """Return normalized trait projection consumed by influence policy points."""
+
+        return normalize_trait_projection(state.traits)
+
+    def _build_transition(
         self,
         state: AgentState,
-        deltas: dict[str, float],
+        deltas: Mapping[str, float],
         *,
         max_step: float,
         cause: str,
         source: str,
-        context: dict[str, float | str] | None = None,
-    ) -> list[dict[str, float | str | int]]:
-        records: list[dict[str, float | str | int]] = []
+        input_signals: Mapping[str, float] | None = None,
+    ) -> PersonalityTransition:
+        transition_deltas: list[TraitDelta] = []
         for trait, proposed_delta in deltas.items():
             if not hasattr(state.traits, trait):
                 continue
@@ -49,45 +60,94 @@ class PersonalityEngine:
             applied_delta = after - before
             if abs(applied_delta) < 1e-12:
                 continue
-            setattr(state.traits, trait, after)
+            transition_deltas.append(
+                TraitDelta(
+                    trait=trait,
+                    before=before,
+                    proposed_delta=float(proposed_delta),
+                    bounded_delta=applied_delta,
+                    after=after,
+                )
+            )
+
+        return PersonalityTransition(
+            step=int(state.step_counter),
+            cause=cause,
+            source=source,
+            max_step=float(max_step),
+            input_signals={str(k): float(v) for k, v in (input_signals or {}).items()},
+            deltas=transition_deltas,
+        )
+
+    def _reduce_transition(
+        self,
+        state: AgentState,
+        transition: PersonalityTransition,
+    ) -> list[dict[str, float | str | int]]:
+        """Apply transition event through a single reducer and persist event history."""
+
+        records: list[dict[str, float | str | int]] = []
+        for delta in transition.deltas:
+            setattr(state.traits, delta.trait, delta.after)
             record: dict[str, float | str | int] = {
-                "step": int(state.step_counter),
-                "trait": trait,
-                "before": before,
-                "delta": applied_delta,
-                "after": after,
-                "cause": cause,
-                "source": source,
+                "step": transition.step,
+                "trait": delta.trait,
+                "before": delta.before,
+                "delta": delta.bounded_delta,
+                "after": delta.after,
+                "cause": transition.cause,
+                "source": transition.source,
             }
-            if context:
-                record.update(context)
+            if transition.input_signals:
+                record.update(transition.input_signals)
             records.append(record)
 
+        transition.resulting_traits = self.trait_projection(state)["raw"]
+        dumped = transition.model_dump(mode="python") if hasattr(transition, "model_dump") else transition.dict()
+        state.personality_transition_events.append(dumped)
         if records:
             state.trait_change_audit.extend(records)
         return records
 
-    def _coefficients(self, state: AgentState) -> dict[str, float]:
-        coefficients = merge_trait_policy_coefficients(state.trait_policy_coefficients)
-        return cast(dict[str, float], coefficients)
+    def replay_transitions(
+        self,
+        initial_traits: Mapping[str, float],
+        transitions: Sequence[Mapping[str, object] | PersonalityTransition],
+    ) -> dict[str, float]:
+        """Replay transitions deterministically from a seed trait state."""
+
+        replayed = {str(k): float(v) for k, v in initial_traits.items()}
+        for entry in transitions:
+            transition = (
+                entry
+                if isinstance(entry, PersonalityTransition)
+                else (
+                    PersonalityTransition.model_validate(entry)
+                    if hasattr(PersonalityTransition, "model_validate")
+                    else PersonalityTransition.parse_obj(entry)
+                )
+            )
+            for delta in transition.deltas:
+                replayed[delta.trait] = float(delta.after)
+        return replayed
 
     def action_biases(self, state: AgentState, available_actions: Sequence[str]) -> dict[str, float]:
         return cast(
             dict[str, float],
             action_intent_biasing(
-                state.traits,
+                self.trait_projection(state),
                 available_actions,
                 self._coefficients(state),
             ),
         )
 
     def mood_multiplier(self, state: AgentState) -> float:
-        return float(mood_update_multiplier(state.traits, self._coefficients(state)))
+        return float(mood_update_multiplier(self.trait_projection(state), self._coefficients(state)))
 
     def relationship_sensitivity(self, state: AgentState, *, is_targeted: bool) -> float:
         return float(
             relationship_update_sensitivity(
-                state.traits,
+                self.trait_projection(state),
                 is_targeted=is_targeted,
                 coefficients=self._coefficients(state),
             )
@@ -103,11 +163,12 @@ class PersonalityEngine:
     ) -> list[dict[str, float | str | int]]:
         """Apply bounded per-turn drift updates and persist an audit trail on ``state``."""
 
+        projection = self.trait_projection(state)
         drift = trait_drift_from_experience(
             {
                 "social_outcome": signals.social_outcome,
                 "mood_level": signals.mood_trajectory,
-                "adaptability": state.traits.adaptability,
+                "adaptability": projection["raw"]["adaptability"],
             },
             self._coefficients(state),
         )
@@ -115,20 +176,15 @@ class PersonalityEngine:
         drift["adaptability"] += 0.003 * signals.governance_participation
         drift["assertiveness"] += 0.002 * signals.conflict_outcome
 
-        return self._apply_trait_adjustments(
+        transition = self._build_transition(
             state,
             drift,
             max_step=max_step,
             cause="experience_drift",
             source=source,
-            context={
-                "social_outcome": signals.social_outcome,
-                "conflict_outcome": signals.conflict_outcome,
-                "task_outcome": signals.task_outcome,
-                "mood_trajectory": signals.mood_trajectory,
-                "governance_participation": signals.governance_participation,
-            },
+            input_signals=signals.model_dump(),
         )
+        return self._reduce_transition(state, transition)
 
     def apply_role_transition_blend(
         self,
@@ -146,14 +202,15 @@ class PersonalityEngine:
             for trait, target in target_traits.items()
             if hasattr(state.traits, trait)
         }
-        return self._apply_trait_adjustments(
+        transition = self._build_transition(
             state,
             deltas,
             max_step=max_step,
             cause="role_transition_blend",
             source=source,
-            context={"blend_ratio": blend_ratio},
+            input_signals={"blend_ratio": blend_ratio},
         )
+        return self._reduce_transition(state, transition)
 
     def apply_exogenous_trait_intervention(
         self,
@@ -166,13 +223,14 @@ class PersonalityEngine:
     ) -> list[dict[str, float | str | int]]:
         """Apply external/admin trait edits through the same bounded/audited engine path."""
 
-        return self._apply_trait_adjustments(
+        transition = self._build_transition(
             state,
             trait_updates,
             max_step=max_step,
             cause=cause,
             source=source,
         )
+        return self._reduce_transition(state, transition)
 
     def update_traits(
         self,

--- a/src/agents/core/personality_transition.py
+++ b/src/agents/core/personality_transition.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class TraitDelta(BaseModel):
+    """A bounded update applied to a single trait."""
+
+    trait: str
+    before: float
+    proposed_delta: float
+    bounded_delta: float
+    after: float
+
+
+class PersonalityTransition(BaseModel):
+    """Event emitted whenever personality traits transition through the reducer."""
+
+    step: int
+    cause: str
+    source: str
+    max_step: float
+    input_signals: dict[str, float] = Field(default_factory=dict)
+    deltas: list[TraitDelta] = Field(default_factory=list)
+    resulting_traits: dict[str, float] = Field(default_factory=dict)

--- a/src/agents/core/trait_policy.py
+++ b/src/agents/core/trait_policy.py
@@ -25,6 +25,26 @@ DEFAULT_TRAIT_POLICY_COEFFICIENTS: dict[str, float] = {
 }
 
 
+TRAIT_KEYS: tuple[str, ...] = (
+    "openness",
+    "analytical_focus",
+    "empathy",
+    "assertiveness",
+    "emotional_sensitivity",
+    "resilience",
+    "trust_baseline",
+    "adaptability",
+)
+
+
+def normalize_trait_projection(traits: PersonalityTraits) -> dict[str, dict[str, float]]:
+    """Return normalized trait projection used by all trait influence computations."""
+
+    raw = {key: float(getattr(traits, key)) for key in TRAIT_KEYS}
+    centered = {key: value - 0.5 for key, value in raw.items()}
+    return {"raw": raw, "centered": centered}
+
+
 def _coefficient(
     coefficients: Mapping[str, float] | None,
     key: str,
@@ -35,7 +55,7 @@ def _coefficient(
 
 
 def action_intent_biasing(
-    traits: PersonalityTraits,
+    trait_projection: Mapping[str, Mapping[str, float]],
     available_actions: Sequence[str],
     coefficients: Mapping[str, float] | None = None,
 ) -> dict[str, float]:
@@ -47,13 +67,7 @@ def action_intent_biasing(
     assertive_w = _coefficient(coefficients, "action_bias.assertiveness")
     adaptability_w = _coefficient(coefficients, "action_bias.adaptability")
 
-    centered = {
-        "openness": traits.openness - 0.5,
-        "analytical_focus": traits.analytical_focus - 0.5,
-        "empathy": traits.empathy - 0.5,
-        "assertiveness": traits.assertiveness - 0.5,
-        "adaptability": traits.adaptability - 0.5,
-    }
+    centered = trait_projection["centered"]
 
     templates = {
         "propose_idea": (1.0, 0.2, 0.2, 0.8, 0.4),
@@ -80,21 +94,22 @@ def action_intent_biasing(
 
 
 def mood_update_multiplier(
-    traits: PersonalityTraits,
+    trait_projection: Mapping[str, Mapping[str, float]],
     coefficients: Mapping[str, float] | None = None,
 ) -> float:
     """Return multiplier applied to sentiment before mood update rates."""
 
     sensitivity_weight = _coefficient(coefficients, "mood.sensitivity_weight")
     resilience_weight = _coefficient(coefficients, "mood.resilience_weight")
+    centered = trait_projection["centered"]
     multiplier = 1.0 + (
-        sensitivity_weight * (traits.emotional_sensitivity - 0.5)
-    ) - (resilience_weight * (traits.resilience - 0.5))
+        sensitivity_weight * centered["emotional_sensitivity"]
+    ) - (resilience_weight * centered["resilience"])
     return max(0.1, multiplier)
 
 
 def relationship_update_sensitivity(
-    traits: PersonalityTraits,
+    trait_projection: Mapping[str, Mapping[str, float]],
     *,
     is_targeted: bool,
     coefficients: Mapping[str, float] | None = None,
@@ -105,7 +120,7 @@ def relationship_update_sensitivity(
     trust_weight = _coefficient(coefficients, "relationship.trust_weight")
     targeted_weight = _coefficient(coefficients, "relationship.targeted_weight")
     targeted_factor = targeted_weight if is_targeted else 1.0
-    return targeted_factor * (base + trust_weight * traits.trust_baseline)
+    return targeted_factor * (base + trust_weight * trait_projection["raw"]["trust_baseline"])
 
 
 def trait_drift_from_experience(

--- a/tests/unit/core/test_personality_transition_replay.py
+++ b/tests/unit/core/test_personality_transition_replay.py
@@ -1,0 +1,78 @@
+import random
+
+import pytest
+
+from src.agents.core.agent_state import AgentState, PersonalityTraits
+from src.agents.core.personality_engine import ExperienceSignal, PersonalityEngine
+
+
+@pytest.mark.unit
+def test_experience_drift_persists_transition_events() -> None:
+    state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits())
+    engine = PersonalityEngine()
+
+    engine.apply_experience_drift(
+        state,
+        ExperienceSignal(social_outcome=0.8, conflict_outcome=0.1, mood_trajectory=0.2),
+        max_step=0.01,
+        source="test.turn",
+    )
+
+    assert state.personality_transition_events
+    event = state.personality_transition_events[-1]
+    assert event["cause"] == "experience_drift"
+    assert event["source"] == "test.turn"
+    assert event["resulting_traits"]["openness"] == pytest.approx(state.traits.openness)
+
+
+@pytest.mark.unit
+def test_replay_transitions_is_deterministic_for_identical_stream() -> None:
+    rng = random.Random(17)
+    signals = [
+        ExperienceSignal(
+            social_outcome=rng.uniform(-1.0, 1.0),
+            conflict_outcome=rng.uniform(-1.0, 1.0),
+            task_outcome=rng.uniform(-1.0, 1.0),
+            mood_trajectory=rng.uniform(-1.0, 1.0),
+            governance_participation=rng.uniform(-1.0, 1.0),
+        )
+        for _ in range(25)
+    ]
+
+    engine = PersonalityEngine()
+    state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits())
+    initial_projection = engine.trait_projection(state)["raw"]
+
+    for signal in signals:
+        engine.apply_experience_drift(state, signal)
+
+    replayed = engine.replay_transitions(initial_projection, state.personality_transition_events)
+    final_projection = engine.trait_projection(state)["raw"]
+
+    assert replayed == pytest.approx(final_projection)
+
+
+@pytest.mark.unit
+def test_drift_deltas_are_bounded_by_max_step_property() -> None:
+    rng = random.Random(23)
+    engine = PersonalityEngine()
+    state = AgentState(agent_id="agent", name="Agent", traits=PersonalityTraits())
+
+    for _ in range(50):
+        max_step = rng.uniform(0.001, 0.03)
+        engine.apply_experience_drift(
+            state,
+            ExperienceSignal(
+                social_outcome=rng.uniform(-1.0, 1.0),
+                conflict_outcome=rng.uniform(-1.0, 1.0),
+                task_outcome=rng.uniform(-1.0, 1.0),
+                mood_trajectory=rng.uniform(-1.0, 1.0),
+                governance_participation=rng.uniform(-1.0, 1.0),
+            ),
+            max_step=max_step,
+            source="property.test",
+        )
+
+        event = state.personality_transition_events[-1]
+        for delta in event["deltas"]:
+            assert abs(float(delta["bounded_delta"])) <= max_step + 1e-12

--- a/tests/unit/core/test_trait_policy.py
+++ b/tests/unit/core/test_trait_policy.py
@@ -4,6 +4,7 @@ from src.agents.core.agent_state import PersonalityTraits
 from src.agents.core.trait_policy import (
     action_intent_biasing,
     mood_update_multiplier,
+    normalize_trait_projection,
     relationship_update_sensitivity,
     trait_drift_from_experience,
 )
@@ -19,7 +20,7 @@ def test_action_intent_biasing_returns_known_action_biases() -> None:
         adaptability=0.9,
     )
     biases = action_intent_biasing(
-        traits,
+        normalize_trait_projection(traits),
         ["propose_idea", "perform_deep_analysis", "idle"],
     )
 
@@ -33,7 +34,7 @@ def test_mood_update_multiplier_reacts_to_traits() -> None:
     calm = PersonalityTraits(emotional_sensitivity=0.2, resilience=0.9)
     reactive = PersonalityTraits(emotional_sensitivity=0.9, resilience=0.2)
 
-    assert mood_update_multiplier(reactive) > mood_update_multiplier(calm)
+    assert mood_update_multiplier(normalize_trait_projection(reactive)) > mood_update_multiplier(normalize_trait_projection(calm))
 
 
 @pytest.mark.unit
@@ -41,12 +42,12 @@ def test_relationship_update_sensitivity_scales_targeted_and_trust() -> None:
     low_trust = PersonalityTraits(trust_baseline=0.2)
     high_trust = PersonalityTraits(trust_baseline=0.9)
 
-    assert relationship_update_sensitivity(high_trust, is_targeted=False) > relationship_update_sensitivity(
-        low_trust,
+    assert relationship_update_sensitivity(normalize_trait_projection(high_trust), is_targeted=False) > relationship_update_sensitivity(
+        normalize_trait_projection(low_trust),
         is_targeted=False,
     )
-    assert relationship_update_sensitivity(high_trust, is_targeted=True) >= relationship_update_sensitivity(
-        high_trust,
+    assert relationship_update_sensitivity(normalize_trait_projection(high_trust), is_targeted=True) >= relationship_update_sensitivity(
+        normalize_trait_projection(high_trust),
         is_targeted=False,
     )
 


### PR DESCRIPTION
### Motivation
- Make personality updates deterministic, inspectable, and replayable by emitting structured transition events instead of applying ad-hoc trait edits. 
- Consolidate trait update semantics behind a single reducer to ensure consistent bounding and auditing of per-trait deltas. 
- Standardize all trait-influence entry points to use a single normalized trait projection API for clearer, reusable computations. 
- Add invariant/property tests to ensure bounded drift and deterministic replay from identical event streams.

### Description
- Add a typed `PersonalityTransition` schema with `TraitDelta` in `src/agents/core/personality_transition.py` capturing `cause`, `source`, `input_signals`, bounded per-trait deltas, and `resulting_traits` snapshots. 
- Refactor `PersonalityEngine` (`src/agents/core/personality_engine.py`) to build a `PersonalityTransition`, apply changes through `_reduce_transition` (single reducer), persist events to state, and expose `replay_transitions` for deterministic replay. 
- Persist transition events on `AgentState` via the new `personality_transition_events` field in `src/agents/core/agent_state.py`. 
- Introduce `normalize_trait_projection` (and `trait_projection` accessor) in `src/agents/core/trait_policy.py` and update `action_intent_biasing`, `mood_update_multiplier`, and `relationship_update_sensitivity` to consume the normalized projection. 
- Add unit tests in `tests/unit/core/test_personality_transition_replay.py` and update `tests/unit/core/test_trait_policy.py` to validate normalized projection usage, bounded deltas, and deterministic replay.

### Testing
- Ran `ruff check` on modified files (`src/agents/core/personality_transition.py`, `src/agents/core/personality_engine.py`, `src/agents/core/trait_policy.py`, `src/agents/core/agent_state.py`, and new/updated tests) and the checks passed for the change-set. 
- Ran `pytest -q` for the relevant unit suites with the modified code (`tests/unit/core/test_trait_policy.py`, `tests/unit/core/test_personality_engine.py`, `tests/unit/core/test_personality_transition_replay.py`, `tests/unit/core/test_agent_controller_updates.py`, and `tests/unit/sim/test_trait_invariants.py`) and all tests passed (`17 passed`). 
- Noted that running the repository-wide linter script `bash scripts/lint.sh` surfaces pre-existing Ruff issues outside this change-set and therefore failed; those issues are unrelated to this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b056bc448326a4d156e5700a6557)