### PR TITLE
Refactor interaction transports around canonical InteractionIntent

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -19,7 +19,6 @@ from src.infra import event_log
 from src.infra import metrics as infra_metrics
 from src.infra.ledger import ledger
 from src.interfaces import metrics
-from src.interfaces.domain_command_adapters import command_from_payload
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
 from src.sim.persistence.snapshot_service import SnapshotPersistenceService
@@ -1026,8 +1025,7 @@ async def handle_control_command(
         source="dashboard",
         permissions={"admin", "moderator"},
     )
-    command = command_from_payload(cmd, context=context)
-    result = await simulation.command_dispatcher.dispatch(command, context=context)
+    result = await simulation.interaction_service.execute_from_payload(cmd, context=context)
     return {
         "status": result.status,
         "message": result.user_message,

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -24,9 +24,10 @@ from src.infra import config, event_log
 from src.infra.ledger import ledger
 from src.interfaces import dashboard_backend as db
 from src.interfaces import metrics
-from src.interfaces.domain_command_adapters import command_from_discord_message
 from src.interfaces.interaction_policy import (
     check_command_rate_limit,
+    discord_interaction_context,
+    discord_message_to_intent_payload,
     has_admin_permission,
     has_control_command_permission,
     set_max_rate,
@@ -34,11 +35,9 @@ from src.interfaces.interaction_policy import (
 from src.interfaces.interaction_schema import (
     ControlEnvelope,
     InjectEventEnvelope,
-    InteractionContext,
     KnowledgeBoardEnvelope,
     SpawnEnvelope,
 )
-from src.interfaces.transport_adapters import parse_discord_message_routing
 from src.sim.context import SimulationContext
 from src.utils.policy import allow_message, evaluate_with_opa
 
@@ -671,42 +670,33 @@ class SimulationDiscordBot:
                     if user_id and channel_id:
                         self.user_channels[str(user_id)] = channel_id
                         self.last_user_id = str(user_id)
-                    recipient, is_broadcast, parsed_content, validation_error = parse_discord_message_routing(content)
+                    sender = self.user_agents.get(str(user_id)) if user_id else None
+                    fallback_agent = _default_agent_for_channel(self, channel_id)
+                    payload, validation_error = discord_message_to_intent_payload(
+                        content=content,
+                        sender_agent_id=sender,
+                        fallback_agent_id=fallback_agent,
+                        raw_metadata={"channel_id": channel_id, "user_id": user_id},
+                    )
                     if validation_error is not None:
                         await send_channel_message(channel, content=validation_error)
                         return
-                    if not parsed_content:
+                    if payload is None:
                         return
-                    sender = self.user_agents.get(str(user_id)) if user_id else None
-                    fallback_agent = _default_agent_for_channel(self, channel_id)
-                    target_agent_id = recipient or sender or fallback_agent
+                    target_agent_id = payload.get("target_agent_id")
                     span.set_attribute("discord.agent.id", target_agent_id or "")
-                    if target_agent_id is None:
-                        await send_channel_message(
-                            channel,
-                            content="No agents available to route this message",
-                        )
-                        return
-                    if user_id and sender is None:
-                        self.user_agents[str(user_id)] = target_agent_id
+                    if user_id and sender is None and target_agent_id is not None:
+                        self.user_agents[str(user_id)] = str(target_agent_id)
                     self.last_agent_id = target_agent_id
                     self.last_channel_id = channel_id
                     bus = get_command_bus(self.context)
                     if bus is None:
                         return
-                    command = command_from_discord_message(
-                        content=parsed_content,
-                        recipient_id=recipient,
-                        is_broadcast=is_broadcast,
-                        target_agent_id=target_agent_id,
-                        raw_payload={"channel_id": channel_id, "user_id": user_id},
-                    )
-                    result = await bus.dispatch(
-                        command,
-                        context=InteractionContext(
-                            sender_id=str(user_id) if user_id is not None else "human",
-                            channel_id=str(channel_id) if channel_id is not None else None,
-                            source="discord",
+                    result = await bus.dispatch_payload(
+                        payload,
+                        context=discord_interaction_context(
+                            user=user,
+                            channel=channel,
                         ),
                     )
                     if result.status != "ok":

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -8,6 +8,7 @@ from src.interfaces.interaction_schema import (
     InteractionAuthScope,
     InteractionBudgetAttribution,
     InteractionContext,
+    InteractionIntent,
     InteractionResult,
     InteractionRouting,
 )
@@ -46,6 +47,7 @@ __all__ = [
     "InteractionAuthScope",
     "InteractionBudgetAttribution",
     "InteractionContext",
+    "InteractionIntent",
     "InteractionResult",
     "InteractionRouting",
     "InteractionService",

--- a/src/interfaces/interaction_policy/__init__.py
+++ b/src/interfaces/interaction_policy/__init__.py
@@ -1,0 +1,24 @@
+from .identity_adapters import discord_interaction_context
+from .parsing import discord_message_to_intent_payload, parse_discord_message_routing
+from .permissions import (
+    check_command_rate_limit,
+    check_cooldown,
+    context_is_authorized,
+    has_admin_permission,
+    has_control_command_permission,
+    reset_command_counts,
+    set_max_rate,
+)
+
+__all__ = [
+    "check_command_rate_limit",
+    "check_cooldown",
+    "context_is_authorized",
+    "discord_interaction_context",
+    "discord_message_to_intent_payload",
+    "has_admin_permission",
+    "has_control_command_permission",
+    "parse_discord_message_routing",
+    "reset_command_counts",
+    "set_max_rate",
+]

--- a/src/interfaces/interaction_policy/identity_adapters.py
+++ b/src/interfaces/interaction_policy/identity_adapters.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.interfaces.interaction_schema import InteractionContext
+
+
+def discord_interaction_context(*, user: Any, channel: Any) -> InteractionContext:
+    user_id = getattr(user, "id", None)
+    channel_id = getattr(channel, "id", None)
+    return InteractionContext(
+        sender_id=str(user_id) if user_id is not None else "human",
+        channel_id=str(channel_id) if channel_id is not None else None,
+        source="discord",
+    )

--- a/src/interfaces/interaction_policy/parsing.py
+++ b/src/interfaces/interaction_policy/parsing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+_MENTION_TARGET_RE = re.compile(r"^@(?P<agent>[\w.-]+)\s*:\s*(?P<content>.+)$", re.DOTALL)
+_DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.DOTALL)
+
+
+def parse_discord_message_routing(content: str) -> tuple[str | None, bool, str, str | None]:
+    """Parse optional routing directives from plain Discord messages."""
+    cleaned = content.strip()
+    if not cleaned:
+        return None, False, "", None
+
+    if cleaned == "/broadcast":
+        return None, True, "", "Broadcast message cannot be empty. Use /broadcast <message>."
+
+    if cleaned.startswith("/broadcast "):
+        payload = cleaned[len("/broadcast ") :].strip()
+        if not payload:
+            return (
+                None,
+                True,
+                "",
+                "Broadcast message cannot be empty. Use /broadcast <message>.",
+            )
+        return None, True, payload, None
+
+    mention_match = _MENTION_TARGET_RE.match(cleaned)
+    if mention_match:
+        return mention_match.group("agent"), False, mention_match.group("content").strip(), None
+
+    dm_match = _DM_TARGET_RE.match(cleaned)
+    if dm_match:
+        return dm_match.group("agent"), False, dm_match.group("content").strip(), None
+
+    return None, False, cleaned, None
+
+
+def discord_message_to_intent_payload(
+    *,
+    content: str,
+    sender_agent_id: str | None,
+    fallback_agent_id: str | None,
+    raw_metadata: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Convert Discord content into canonical interaction payload."""
+    recipient, is_broadcast, parsed_content, validation_error = parse_discord_message_routing(content)
+    if validation_error is not None:
+        return None, validation_error
+    if not parsed_content:
+        return None, None
+
+    target_agent_id = recipient or sender_agent_id or fallback_agent_id
+
+    payload: dict[str, Any] = {
+        "intent": "broadcast" if is_broadcast else ("direct_message" if recipient else "human_message"),
+        "text": parsed_content,
+        "target_agent_id": target_agent_id,
+        "recipient_id": recipient,
+        "metadata": dict(raw_metadata or {}),
+    }
+    return payload, None

--- a/src/interfaces/interaction_policy/permissions.py
+++ b/src/interfaces/interaction_policy/permissions.py
@@ -8,10 +8,10 @@ from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from src.infra import config
+from src.utils.policy import evaluate_with_opa
 
 if TYPE_CHECKING:
-    from src.interfaces.interaction_commands import InteractionContext
-from src.utils.policy import evaluate_with_opa
+    from src.interfaces.interaction_schema import InteractionContext
 
 logger = logging.getLogger(__name__)
 

--- a/src/interfaces/interaction_schema.py
+++ b/src/interfaces/interaction_schema.py
@@ -57,7 +57,7 @@ class InteractionBudgetAttribution(BaseModel):
     attribution_scope: str = "default"
 
 
-class BaseInteractionEnvelope(BaseModel):
+class BaseInteractionIntent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     intent: str
@@ -67,27 +67,27 @@ class BaseInteractionEnvelope(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-class HumanMessageEnvelope(BaseInteractionEnvelope):
+class HumanMessageIntent(BaseInteractionIntent):
     intent: Literal["human_message"] = "human_message"
     text: str
 
 
-class DirectMessageEnvelope(BaseInteractionEnvelope):
+class DirectMessageIntent(BaseInteractionIntent):
     intent: Literal["direct_message"] = "direct_message"
     text: str
 
 
-class BroadcastEnvelope(BaseInteractionEnvelope):
+class BroadcastIntent(BaseInteractionIntent):
     intent: Literal["broadcast"] = "broadcast"
     text: str
 
 
-class KnowledgeBoardEnvelope(BaseInteractionEnvelope):
+class KnowledgeBoardIntent(BaseInteractionIntent):
     intent: Literal["knowledge_board"] = "knowledge_board"
     text: str
 
 
-class SpawnEnvelope(BaseInteractionEnvelope):
+class SpawnIntent(BaseInteractionIntent):
     intent: Literal["spawn"] = "spawn"
     agent_id: str | None = None
     role: str | dict[str, Any] | None = None
@@ -96,7 +96,7 @@ class SpawnEnvelope(BaseInteractionEnvelope):
     traits: dict[str, float] | None = None
 
 
-class ControlEnvelope(BaseInteractionEnvelope):
+class ControlIntent(BaseInteractionIntent):
     intent: Literal["control"] = "control"
     action: str
     value: float | None = None
@@ -104,34 +104,48 @@ class ControlEnvelope(BaseInteractionEnvelope):
     agent_id: str | None = None
 
 
-class ModerationEnvelope(BaseInteractionEnvelope):
+class ModerationIntent(BaseInteractionIntent):
     intent: Literal["moderation"] = "moderation"
     action: str
     agent_id: str | None = None
     value: float | None = None
 
 
-class InjectEventEnvelope(BaseInteractionEnvelope):
+class InjectEventIntent(BaseInteractionIntent):
     intent: Literal["inject_event"] = "inject_event"
     text: str
     scope: str = "global"
     agent_id: str | None = None
 
 
-InteractionEnvelope = Annotated[
-    HumanMessageEnvelope
-    | DirectMessageEnvelope
-    | BroadcastEnvelope
-    | KnowledgeBoardEnvelope
-    | SpawnEnvelope
-    | ControlEnvelope
-    | ModerationEnvelope
-    | InjectEventEnvelope,
+InteractionIntent = Annotated[
+    HumanMessageIntent
+    | DirectMessageIntent
+    | BroadcastIntent
+    | KnowledgeBoardIntent
+    | SpawnIntent
+    | ControlIntent
+    | ModerationIntent
+    | InjectEventIntent,
     Field(discriminator="intent"),
 ]
 
-_INTERACTION_ENVELOPE_ADAPTER = TypeAdapter(InteractionEnvelope)
+_INTERACTION_INTENT_ADAPTER = TypeAdapter(InteractionIntent)
 
 
-def parse_interaction_envelope(payload: dict[str, Any]) -> InteractionEnvelope:
-    return _INTERACTION_ENVELOPE_ADAPTER.validate_python(payload)
+def parse_interaction_intent(payload: dict[str, Any]) -> InteractionIntent:
+    return _INTERACTION_INTENT_ADAPTER.validate_python(payload)
+
+
+# Backward-compatible aliases during transport migration.
+BaseInteractionEnvelope = BaseInteractionIntent
+HumanMessageEnvelope = HumanMessageIntent
+DirectMessageEnvelope = DirectMessageIntent
+BroadcastEnvelope = BroadcastIntent
+KnowledgeBoardEnvelope = KnowledgeBoardIntent
+SpawnEnvelope = SpawnIntent
+ControlEnvelope = ControlIntent
+ModerationEnvelope = ModerationIntent
+InjectEventEnvelope = InjectEventIntent
+InteractionEnvelope = InteractionIntent
+parse_interaction_envelope = parse_interaction_intent

--- a/src/interfaces/transport_adapters.py
+++ b/src/interfaces/transport_adapters.py
@@ -1,37 +1,5 @@
 from __future__ import annotations
 
-import re
+from src.interfaces.interaction_policy import parse_discord_message_routing
 
-_MENTION_TARGET_RE = re.compile(r"^@(?P<agent>[\w.-]+)\s*:\s*(?P<content>.+)$", re.DOTALL)
-_DM_TARGET_RE = re.compile(r"^/dm\s+(?P<agent>[\w.-]+)\s+(?P<content>.+)$", re.DOTALL)
-
-
-def parse_discord_message_routing(content: str) -> tuple[str | None, bool, str, str | None]:
-    """Parse optional routing directives from plain Discord messages."""
-    cleaned = content.strip()
-    if not cleaned:
-        return None, False, "", None
-
-    if cleaned == "/broadcast":
-        return None, True, "", "Broadcast message cannot be empty. Use /broadcast <message>."
-
-    if cleaned.startswith("/broadcast "):
-        payload = cleaned[len("/broadcast ") :].strip()
-        if not payload:
-            return (
-                None,
-                True,
-                "",
-                "Broadcast message cannot be empty. Use /broadcast <message>.",
-            )
-        return None, True, payload, None
-
-    mention_match = _MENTION_TARGET_RE.match(cleaned)
-    if mention_match:
-        return mention_match.group("agent"), False, mention_match.group("content").strip(), None
-
-    dm_match = _DM_TARGET_RE.match(cleaned)
-    if dm_match:
-        return dm_match.group("agent"), False, dm_match.group("content").strip(), None
-
-    return None, False, cleaned, None
+__all__ = ["parse_discord_message_routing"]

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -43,7 +43,6 @@ from src.interfaces.dashboard_backend import (
     emit_event,
 )
 from src.interfaces.discord_event_listener import DiscordSimulationEventListener
-from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_commands import InteractionContext, InteractionService
 from src.interfaces.metrics import (
     ACTIVE_AGENT_COUNT,
@@ -491,11 +490,10 @@ class Simulation:
         command_type = payload.get("command_type")
         if not command_type and bool(payload.get("broadcast")):
             command_type = "broadcast"
-        command = command_from_payload(
+        result = await self.interaction_service.execute_from_payload(
             {"command_type": command_type or "human_message", "content": text, **payload},
             context=context,
         )
-        result = await self.command_dispatcher.dispatch(command, context=context)
         if result.status != "ok" and self.discord_bot:
             channel_id = context.channel_id
             target_channel_id = (

--- a/tests/integration/interfaces/test_interaction_transport_conformance.py
+++ b/tests/integration/interfaces/test_interaction_transport_conformance.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.interfaces.interaction_policy import (
+    discord_interaction_context,
+    discord_message_to_intent_payload,
+)
+from src.interfaces.interaction_schema import InteractionContext
+
+
+class DummyDiscordClient:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.event = lambda f: f
+        self.user = "dummy"
+
+
+class DummyState:
+    def __init__(self) -> None:
+        self.ip = 2.0
+        self.du = 2.0
+        self.short_term_memory: list[object] = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:
+        return self._state
+
+    def update_state(self, state: DummyState) -> None:
+        self._state = state
+
+    async def run_turn(self, *args: object, **kwargs: object) -> dict[str, object]:
+        return {}
+
+
+async def _pending_message_shape(sim) -> tuple[str, str | None, str | None]:
+    async with sim._msg_lock:
+        msg = sim.pending_messages_for_next_round[-1]
+        return (
+            str(msg.get("content", "")),
+            msg.get("recipient_id"),
+            msg.get("target_agent_id"),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.anyio("asyncio")
+async def test_intent_conformance_across_transports(tmp_path: Path) -> None:
+    from src.infra.ledger import Ledger
+    from src.sim.simulation import Simulation
+
+    ledger = Ledger(tmp_path / "ledger.sqlite")
+    with (
+        patch("src.infra.ledger.ledger", ledger),
+        patch("src.sim.simulation.ledger", ledger),
+        patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient),
+    ):
+        # Discord transport adapter -> canonical intent
+        discord_sim = Simulation([DummyAgent("A")])
+        discord_payload, err = discord_message_to_intent_payload(
+            content="hello world",
+            sender_agent_id=None,
+            fallback_agent_id="A",
+            raw_metadata={"channel_id": 10, "user_id": 20},
+        )
+        assert err is None
+        assert discord_payload is not None
+        discord_result = await discord_sim.interaction_service.execute_from_payload(
+            discord_payload,
+            context=discord_interaction_context(
+                user=SimpleNamespace(id=20),
+                channel=SimpleNamespace(id=10),
+            ),
+        )
+        discord_outcome = await _pending_message_shape(discord_sim)
+
+        # Dashboard transport -> same canonical intent and same domain outcome
+        dashboard_sim = Simulation([DummyAgent("A")])
+        dashboard_result = await dashboard_sim.interaction_service.execute_from_payload(
+            {
+                "intent": "human_message",
+                "text": "hello world",
+                "target_agent_id": "A",
+            },
+            context=InteractionContext(sender_id="dashboard", source="dashboard"),
+        )
+        dashboard_outcome = await _pending_message_shape(dashboard_sim)
+
+        # Future websocket/API transport -> same canonical intent through same service
+        ws_sim = Simulation([DummyAgent("A")])
+        ws_result = await ws_sim.interaction_service.execute_from_payload(
+            {
+                "intent": "human_message",
+                "text": "hello world",
+                "target_agent_id": "A",
+            },
+            context=InteractionContext(sender_id="api-user", source="websocket"),
+        )
+        ws_outcome = await _pending_message_shape(ws_sim)
+
+        assert discord_result.status == dashboard_result.status == ws_result.status == "ok"
+        assert discord_outcome == dashboard_outcome == ws_outcome
+
+        discord_sim.close()
+        dashboard_sim.close()
+        ws_sim.close()


### PR DESCRIPTION
### Motivation
- Create a source-neutral canonical intent model so all transports (Discord, dashboard, future websocket/API) can submit the same domain intents through a single execution path.
- Separate transport parsing and identity mapping from permissions/rate-limit policy so domain intent handling is transport-agnostic.
- Reduce Discord adapter responsibilities to message extraction, identity mapping, intent submission, and response rendering to simplify transport code and improve reuse.

### Description
- Introduced `InteractionIntent` and `parse_interaction_intent` in `src/interfaces/interaction_schema.py` and retained backward-compatible aliases (`InteractionEnvelope`, `parse_interaction_envelope`, etc.) for a smooth migration.
- Extracted interaction policy into `src/interfaces/interaction_policy/` with `permissions.py` (auth/rate-limits), `parsing.py` (Discord content -> canonical intent payload), and `identity_adapters.py` (source-specific identity -> `InteractionContext`), and re-exported them via `__init__.py`.
- Simplified Discord inbound handling in `src/interfaces/discord_bot.py` to use `discord_message_to_intent_payload(...)` and `discord_interaction_context(...)` and submit via `CommandBus.dispatch_payload(...)` (payload path), removing transport-specific command construction.
- Unified transport execution by switching dashboard and simulation ingress to `InteractionService.execute_from_payload(...)` so every transport uses the same `InteractionService.execute()` execution path.
- Added `tests/integration/interfaces/test_interaction_transport_conformance.py` which feeds identical canonical intents from Discord/dashboard/websocket-style contexts and asserts identical domain outcomes.

### Testing
- Ran linting with `ruff check ...` on modified modules and all checks passed.
- Ran integration tests with `pytest -q -m integration tests/integration/interfaces/test_interaction_transport_conformance.py tests/integration/interfaces/test_discord_message_flow.py::test_user_channel_reply` and confirmed the modified flows passed (2 tests passed, warnings only).
- Verified the new conformance test `tests/integration/interfaces/test_interaction_transport_conformance.py` succeeds when run under the integration marker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a834a9ac548326b526b7eef7fa671f)