### PR TITLE
Refine SimulationKernel phase orchestration with explicit reducer events

### DIFF
--- a/src/sim/engines/persistence_engine.py
+++ b/src/sim/engines/persistence_engine.py
@@ -7,7 +7,9 @@ from typing import Any
 class PersistenceEngine:
     """Encapsulates snapshot/replay/checkpointing entrypoints."""
 
-    def from_snapshot(self, simulation_cls: type[Any], snapshot: dict[str, Any], seed: int | None = None) -> Any:
+    def from_snapshot(
+        self, simulation_cls: type[Any], snapshot: dict[str, Any], seed: int | None = None
+    ) -> Any:
         return simulation_cls._from_snapshot_impl(snapshot, seed=seed)
 
     def replay_from_snapshot(
@@ -23,3 +25,10 @@ class PersistenceEngine:
             seed=seed,
             stop_step=stop_step,
         )
+
+    def capture_tick(self, simulation: Any, tick: Any) -> dict[str, Any]:
+        return {
+            "step": tick.step,
+            "trace_hash": getattr(simulation, "_last_trace_hash", ""),
+            "replay_metadata": dict(tick.replay_metadata),
+        }

--- a/src/sim/engines/reducers.py
+++ b/src/sim/engines/reducers.py
@@ -23,3 +23,12 @@ class DomainEventReducer:
                 context.planned_outputs = list(event.payload.get("planned_outputs", []))
             elif event.name == "scheduler_events_ready":
                 context.events = list(event.payload.get("events", []))
+            elif event.name == "bootstrap_agent_event_requested":
+                agent_index = int(event.payload["agent_index"])
+                agent_id = str(event.payload["agent_id"])
+                simulation.vector.increment(agent_id)
+                simulation.event_kernel.schedule_immediate_nowait(
+                    simulation._create_agent_event(agent_index),
+                    agent_id=agent_id,
+                    vector=simulation.vector,
+                )

--- a/src/sim/engines/turn_engine.py
+++ b/src/sim/engines/turn_engine.py
@@ -11,7 +11,9 @@ from src.sim.runtime.step_context import StepContext
 class TurnEngine:
     """Coordinates agent planning and deterministic commit boundaries."""
 
-    async def plan(self, simulation: Any, context: StepContext, tick: TickContext) -> list[DomainEvent]:
+    async def plan(
+        self, simulation: Any, context: StepContext, tick: TickContext
+    ) -> list[DomainEvent]:
         if context.max_turns <= 1:
             return []
         planned = await simulation._run_step_pipeline(max_turns=context.max_turns)
@@ -28,14 +30,6 @@ class TurnEngine:
     ) -> list[DomainEvent]:
         if context.planned_outputs:
             return []
-        if simulation.event_kernel.empty():
-            simulation.vector.increment(simulation.agents[simulation.current_agent_index].get_id())
-            simulation.event_kernel.schedule_immediate_nowait(
-                simulation._create_agent_event(simulation.current_agent_index),
-                agent_id=simulation.agents[simulation.current_agent_index].get_id(),
-                vector=simulation.vector,
-            )
-
         agent_id = simulation.agents[simulation.current_agent_index].get_id()
         with trace_agent_action("tick", agent_id=agent_id, step=tick.step):
             events = await simulation.event_kernel.step(context.max_turns)
@@ -44,5 +38,24 @@ class TurnEngine:
                 domain="turn",
                 name="scheduler_events_ready",
                 payload={"events": events},
+            )
+        ]
+
+    async def prepare_commit(
+        self, simulation: Any, context: StepContext, tick: TickContext
+    ) -> list[DomainEvent]:
+        if context.planned_outputs or not simulation.event_kernel.empty():
+            return []
+
+        agent_id = simulation.agents[simulation.current_agent_index].get_id()
+        return [
+            DomainEvent(
+                domain="turn",
+                name="bootstrap_agent_event_requested",
+                payload={
+                    "agent_index": simulation.current_agent_index,
+                    "agent_id": agent_id,
+                    "tick_step": tick.step,
+                },
             )
         ]

--- a/src/sim/simulation_kernel.py
+++ b/src/sim/simulation_kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.sim.contracts.lifecycle import LIFECYCLE_PHASES
 from src.sim.engines.interaction_engine import InteractionEngine
 from src.sim.engines.persistence_engine import PersistenceEngine
 from src.sim.engines.reducers import DomainEventReducer
@@ -26,17 +27,27 @@ class SimulationKernel:
         tick = self.world_engine.build_tick_context(simulation)
         context.tick_context = tick
 
-        context.phase_order.append("perception")
-        self.reducer.apply(simulation, context, await self.interaction_engine.ingress(simulation, tick))
+        context.phase_order.append(LIFECYCLE_PHASES[0])
+        self.reducer.apply(
+            simulation, context, await self.interaction_engine.ingress(simulation, tick)
+        )
 
-        context.phase_order.append("decision")
-        self.reducer.apply(simulation, context, await self.turn_engine.plan(simulation, context, tick))
+        context.phase_order.append(LIFECYCLE_PHASES[1])
+        self.reducer.apply(
+            simulation, context, await self.turn_engine.plan(simulation, context, tick)
+        )
 
-        context.phase_order.append("action")
-        self.reducer.apply(simulation, context, await self.turn_engine.commit(simulation, context, tick))
+        context.phase_order.append(LIFECYCLE_PHASES[2])
+        self.reducer.apply(
+            simulation, context, await self.turn_engine.prepare_commit(simulation, context, tick)
+        )
+        self.reducer.apply(
+            simulation, context, await self.turn_engine.commit(simulation, context, tick)
+        )
 
-        context.phase_order.append("post_step")
+        context.phase_order.append(LIFECYCLE_PHASES[3])
         _ = self.society_engine.snapshot(simulation, tick)
+        _ = self.persistence_engine.capture_tick(simulation, tick)
         if not context.planned_outputs:
             await simulation.engine.emit_evaluation_events(context.events)
 

--- a/tests/integration/sim/test_simulation_kernel_migration.py
+++ b/tests/integration/sim/test_simulation_kernel_migration.py
@@ -60,9 +60,15 @@ def test_replay_from_snapshot_preserves_event_reducer_behavior(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("src.agents.core.base_agent.Agent", DummySnapshotAgent)
-    snapshot = json.loads((FIXTURES / "normalized_from_v1_snapshot_v3.json").read_text(encoding="utf-8"))
+    snapshot = json.loads(
+        (FIXTURES / "normalized_from_v1_snapshot_v3.json").read_text(encoding="utf-8")
+    )
     events = [
-        {"type": "tick", "step": snapshot["step"] + 1, "agent_id": snapshot["agents"][0]["agent_id"]}
+        {
+            "type": "tick",
+            "step": snapshot["step"] + 1,
+            "agent_id": snapshot["agents"][0]["agent_id"],
+        }
     ]
 
     monkeypatch.setattr(
@@ -73,3 +79,45 @@ def test_replay_from_snapshot_preserves_event_reducer_behavior(
     replay = Simulation.replay_from_snapshot("ignored.json")
 
     assert replay.current_step >= snapshot["step"]
+
+
+@pytest.mark.integration
+def test_simulation_facade_delegates_persistence_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.agents.core.base_agent.Agent", DummySnapshotAgent)
+    historical = json.loads((FIXTURES / "historical_snapshot_v1.json").read_text(encoding="utf-8"))
+
+    calls: list[tuple[str, object]] = []
+
+    def _from_snapshot(
+        _self: object,
+        simulation_cls: type[Simulation],
+        snapshot: dict[str, object],
+        seed: int | None = None,
+    ) -> Simulation:
+        calls.append(("from_snapshot", seed))
+        return simulation_cls._from_snapshot_impl(snapshot, seed=seed)
+
+    def _replay(
+        _self: object,
+        simulation_cls: type[Simulation],
+        _snapshot_path: str | Path,
+        *,
+        seed: int | None = None,
+        stop_step: int | None = None,
+    ) -> Simulation:
+        calls.append(("replay_from_snapshot", stop_step))
+        return simulation_cls._from_snapshot_impl(historical, seed=seed)
+
+    monkeypatch.setattr(
+        "src.sim.engines.persistence_engine.PersistenceEngine.from_snapshot", _from_snapshot
+    )
+    monkeypatch.setattr(
+        "src.sim.engines.persistence_engine.PersistenceEngine.replay_from_snapshot", _replay
+    )
+
+    from_snapshot = Simulation.from_snapshot(historical, seed=7)
+    replayed = Simulation.replay_from_snapshot("ignored.json", end_step=42)
+
+    assert from_snapshot.current_step == historical["step"]
+    assert replayed.current_step == historical["step"]
+    assert calls == [("from_snapshot", 7), ("replay_from_snapshot", 42)]


### PR DESCRIPTION
### Motivation
- Make the simulation kernel a thin coordinator that drives ordered lifecycle phases and delegates domain work to isolated engines and reducers.
- Remove direct cross-domain mutable writes from engines and replace them with explicit domain events handled by a reducer.
- Keep `Simulation` as a backward-compatible façade for persistence (snapshot/replay) while enabling clearer migration/testing boundaries.

### Description
- Use `LIFECYCLE_PHASES` from the lifecycle contracts to populate phase ordering and keep the kernel orchestration thin in `src/sim/simulation_kernel.py`.
- Split turn commit into two steps in `src/sim/engines/turn_engine.py`: `plan()` (planning), `prepare_commit()` (emit `bootstrap_agent_event_requested` domain event) and `commit()` (scheduler step only) to avoid direct pre-step mutations.
- Extend `DomainEventReducer` in `src/sim/engines/reducers.py` to handle `bootstrap_agent_event_requested` by performing vector increment and immediate scheduling so state changes are applied via reducer events.
- Add `capture_tick()` to `src/sim/engines/persistence_engine.py` and call it from the kernel post-step to centralize tick/persistence metadata concerns.
- Add an integration test in `tests/integration/sim/test_simulation_kernel_migration.py` to assert the `Simulation` façade delegates `from_snapshot` / `replay_from_snapshot` to `PersistenceEngine` and preserves historical snapshot shapes.

### Testing
- Ran linting checks with `ruff check` for modified files and formatting with `ruff format`, both completed successfully.
- Ran unit tests with `pytest -q -m unit tests/unit/sim/test_simulation_kernel.py` and the test passed.
- Ran integration migration tests with `pytest -q -m integration tests/integration/sim/test_simulation_kernel_migration.py` and all tests passed.
- All automated checks mentioned above completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90c87d2a08326ada8e0d1e7103076)