### PR TITLE
Unify interface ingress through CommandBus envelopes

### DIFF
--- a/src/interfaces/command_bus.py
+++ b/src/interfaces/command_bus.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from pydantic import ValidationError
-
-from src.governance.decision_kernel import DecisionProvenance
-from src.interfaces.domain_command_adapters import command_from_envelope, command_from_payload
 from src.interfaces.interaction_schema import (
     BaseInteractionEnvelope,
     InteractionContext,
@@ -31,8 +27,10 @@ class CommandBus:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        normalized = command_from_envelope(command) if isinstance(command, BaseInteractionEnvelope) else command
-        return await self.interaction_service.execute(normalized, context=context)
+        dispatcher = self.interaction_service.simulation.command_dispatcher
+        if isinstance(command, BaseInteractionEnvelope):
+            return await dispatcher.dispatch_envelope(command, context=context)
+        return await dispatcher.dispatch(command, context=context)
 
     async def dispatch_payload(
         self,
@@ -40,16 +38,5 @@ class CommandBus:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        try:
-            command = command_from_payload(payload, context=context)
-        except ValidationError as exc:
-            return InteractionResult(
-                status="rejected",
-                user_message=f"Invalid command payload: {exc}",
-                reason_code="invalid_payload",
-                decision_provenance=DecisionProvenance(
-                    policy_id="interaction-policy-v1",
-                    rule_id="policy.validation.payload",
-                ),
-            )
-        return await self.dispatch(command, context=context)
+        dispatcher = self.interaction_service.simulation.command_dispatcher
+        return await dispatcher.dispatch_payload(payload, context=context)

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
-import httpx
 from opentelemetry import trace
 from typing_extensions import Self
 
@@ -39,6 +38,7 @@ from src.interfaces.interaction_schema import (
     ControlEnvelope,
     InjectEventEnvelope,
     KnowledgeBoardEnvelope,
+    ModerationEnvelope,
     SpawnEnvelope,
 )
 from src.sim.context import SimulationContext
@@ -79,7 +79,6 @@ if dashboard_message_queue is None or not hasattr(dashboard_message_queue, "put_
 message_sse_queue = dashboard_message_queue
 
 
-_DEFAULT_DASHBOARD_API_BASE_URL = "http://localhost:8000"
 _MAX_RATE = 5
 has_admin_permission = interaction_permissions.has_admin_permission
 reset_command_counts = interaction_permissions.reset_command_counts
@@ -90,20 +89,6 @@ async def check_command_rate_limit(user: Any) -> bool:
     set_max_rate(_MAX_RATE)
     interaction_permissions.time = time
     return await policy_check_command_rate_limit(user)
-
-
-def _dashboard_api_base_url() -> str:
-    configured = str(config.get("DASHBOARD_API_BASE_URL", _DEFAULT_DASHBOARD_API_BASE_URL)).strip()
-    return configured.rstrip("/") or _DEFAULT_DASHBOARD_API_BASE_URL
-
-
-def _classify_api_error(exc: Exception) -> str:
-    if isinstance(exc, httpx.HTTPStatusError):
-        if exc.response.status_code in (400, 422):
-            return "invalid_payload"
-    if isinstance(exc, (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError)):
-        return "network_unavailable"
-    return "network_unavailable"
 
 
 def _governance_message_from_outcome(
@@ -118,19 +103,6 @@ def _governance_message_from_outcome(
     if approved:
         return "Approved"
     return "Rejected by vote"
-
-
-def _governance_simulation_from_interaction(interaction: Any) -> Any | None:
-    bot_instance = get_active_bot()
-    if bot_instance is not None:
-        return bot_instance.context.sim_state.get("simulation")
-    return DEFAULT_CONTEXT.sim_state.get("simulation")
-
-
-def _governance_agent_for_sim(sim: Any, agent_id: str) -> Any | None:
-    return next(
-        (agent for agent in getattr(sim, "agents", []) if agent.agent_id == agent_id), None
-    )
 
 
 @contextmanager
@@ -277,6 +249,8 @@ def create_onboarding_embed(channel_id: int) -> Any:
 
 
 MAX_EMBED_DESCRIPTION_LENGTH = 4096
+
+
 def _parse_json_object_argument(raw: str | None, field_name: str) -> dict[str, Any] | None:
     """Parse a JSON object argument from a slash-command string option."""
     if raw is None:
@@ -696,7 +670,9 @@ class SimulationDiscordBot:
                         return
                     if payload is None:
                         return
-                    routing = payload.get("routing") if isinstance(payload.get("routing"), dict) else {}
+                    routing = (
+                        payload.get("routing") if isinstance(payload.get("routing"), dict) else {}
+                    )
                     target_agent_id = routing.get("target_agent_id")
                     span.set_attribute("discord.agent.id", target_agent_id or "")
                     if user_id and sender is None and target_agent_id is not None:
@@ -1222,7 +1198,9 @@ async def _has_control_command_permission(
 
 async def _rate_limit_check(interaction: Any) -> bool:
     """Global slash-command check enforcing per-user rate limits."""
-    identity = discord_identity(user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None))
+    identity = discord_identity(
+        user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)
+    )
     if await check_command_rate_limit(identity):
         return True
     try:
@@ -1353,7 +1331,10 @@ async def slash_resume(interaction: Any) -> None:
             await bus.dispatch(
                 ControlEnvelope(
                     action="resume",
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1363,7 +1344,9 @@ async def slash_resume(interaction: Any) -> None:
 async def slash_pause_all(interaction: Any) -> None:
     """Pause all activity in the simulation. Administrator only."""
     with command_span("pause_all", interaction) as span:
-        if not discord_identity(user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)).is_admin:
+        if not discord_identity(
+            user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)
+        ).is_admin:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         bot_instance = get_active_bot()
@@ -1373,7 +1356,10 @@ async def slash_pause_all(interaction: Any) -> None:
             await bus.dispatch(
                 ControlEnvelope(
                     action="pause_all",
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1383,7 +1369,9 @@ async def slash_pause_all(interaction: Any) -> None:
 async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
     """Remove an agent from the simulation. Administrator only."""
     with command_span("kill_agent", interaction, agent_id=agent_id) as span:
-        if not discord_identity(user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)).is_admin:
+        if not discord_identity(
+            user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)
+        ).is_admin:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         bot_instance = get_active_bot()
@@ -1394,7 +1382,10 @@ async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
                 ControlEnvelope(
                     action="kill_agent",
                     agent_id=agent_id,
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1402,13 +1393,32 @@ async def slash_kill_agent(interaction: Any, agent_id: str) -> None:
 
 
 async def slash_nudge(interaction: Any, prompt: str) -> None:
-    """Send a custom prompt to the simulation."""
+    """Send a custom prompt through the command bus."""
     with command_span("nudge", interaction) as span:
         span.set_attribute("discord.message.length", len(prompt))
         bot_instance = get_active_bot()
         ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
-        await ctx.get_event_queue().put(SimulationEvent(type="nudge", data={"prompt": prompt}))
-        await send_interaction_response(interaction, "nudge sent", ephemeral=True)
+        bus = get_command_bus(ctx)
+        if bus is None:
+            await send_interaction_response(interaction, "command bus unavailable", ephemeral=True)
+            return
+        result = await bus.dispatch(
+            ModerationEnvelope(
+                action="nudge",
+                agent_id=str(getattr(interaction, "user", "human")),
+                routing={
+                    "sender_id": str(getattr(interaction, "user", "human")),
+                    "source": "discord",
+                },
+                auth={"permissions": {"admin", "moderator"}},
+                metadata={
+                    "prompt": prompt,
+                    "correlation_id": str(getattr(interaction, "id", "")) or None,
+                },
+                correlation_id=str(getattr(interaction, "id", "")) or None,
+            )
+        )
+        await send_interaction_response(interaction, result.user_message, ephemeral=True)
 
 
 async def slash_start(interaction: Any) -> None:
@@ -1436,7 +1446,10 @@ async def slash_start(interaction: Any) -> None:
             await bus.dispatch(
                 ControlEnvelope(
                     action="start",
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1493,7 +1506,10 @@ async def slash_stop(interaction: Any) -> None:
             await bus.dispatch(
                 ControlEnvelope(
                     action="stop",
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1580,7 +1596,10 @@ async def slash_spawn(
                     persona=spawn_kwargs.get("persona"),
                     backstory=spawn_kwargs.get("backstory"),
                     traits=spawn_kwargs.get("traits"),
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1609,7 +1628,9 @@ async def slash_spawn(
 async def slash_kill(interaction: Any) -> None:
     """Shutdown the bot. Administrator only."""
     with command_span("kill", interaction) as span:
-        if not discord_identity(user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)).is_admin:
+        if not discord_identity(
+            user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)
+        ).is_admin:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         await send_interaction_response(interaction, "shutting down", ephemeral=True)
@@ -1619,7 +1640,9 @@ async def slash_kill(interaction: Any) -> None:
 async def slash_set_max_rate(interaction: Any, value: int) -> None:
     """Adjust the per-user command rate limit."""
     with command_span("set_max_rate", interaction) as span:
-        if not discord_identity(user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)).is_admin:
+        if not discord_identity(
+            user=getattr(interaction, "user", None), channel=getattr(interaction, "channel", None)
+        ).is_admin:
             await send_interaction_response(interaction, "unauthorized", ephemeral=True)
             return
         set_max_rate(value)
@@ -1638,7 +1661,10 @@ async def slash_set_speed(interaction: Any, value: float) -> None:
                 ControlEnvelope(
                     action="set_speed",
                     value=value,
-                    routing={"sender_id": str(getattr(interaction, "user", "discord")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "discord")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1670,7 +1696,10 @@ async def slash_kb(interaction: Any, text: str) -> None:
             await bus.dispatch(
                 KnowledgeBoardEnvelope(
                     text=text,
-                    routing={"sender_id": str(getattr(interaction, "user", "human")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "human")),
+                        "source": "discord",
+                    },
                 )
             )
         await send_interaction_response(interaction, "KB entry created", ephemeral=True)
@@ -1696,7 +1725,10 @@ async def slash_event(interaction: Any, text: str) -> None:
                     text=text,
                     scope="global",
                     agent_id=str(getattr(interaction, "user", "human")),
-                    routing={"sender_id": str(getattr(interaction, "user", "human")), "source": "discord"},
+                    routing={
+                        "sender_id": str(getattr(interaction, "user", "human")),
+                        "source": "discord",
+                    },
                     auth={"permissions": {"admin", "moderator"}},
                 )
             )
@@ -1704,7 +1736,7 @@ async def slash_event(interaction: Any, text: str) -> None:
 
 
 async def slash_propose(interaction: Any, text: str) -> None:
-    """Propose a law via the dashboard API."""
+    """Propose a law through the command bus."""
     with command_span("propose", interaction) as span:
         span.set_attribute("discord.message.length", len(text))
         agent_id = None
@@ -1721,37 +1753,30 @@ async def slash_propose(interaction: Any, text: str) -> None:
         if ip <= 0 or du <= 0:
             await send_interaction_response(interaction, "Insufficient IP/DU", ephemeral=True)
             return
-        payload: dict[str, object] = {"proposer_id": agent_id, "text": text}
-        approved = False
-        error_kind: str | None = None
-        sim = _governance_simulation_from_interaction(interaction)
-        if sim is not None and hasattr(sim, "propose_law"):
-            try:
-                approved = bool(await sim.propose_law(agent_id, text))
-            except Exception:
-                error_kind = "network_unavailable"
-        else:
-            endpoint = f"{_dashboard_api_base_url()}/api/governance/propose"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.post(endpoint, json=payload)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    approved = bool(data.get("approved", False))
-            except Exception as exc:
-                error_kind = _classify_api_error(exc)
-        try:
-            await send_interaction_response(
-                interaction,
-                _governance_message_from_outcome(approved=approved, error_kind=error_kind),
-                ephemeral=True,
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        bus = get_command_bus(ctx)
+        if bus is None:
+            await send_interaction_response(interaction, "command bus unavailable", ephemeral=True)
+            return
+        result = await bus.dispatch(
+            ModerationEnvelope(
+                action="propose",
+                agent_id=agent_id,
+                routing={"sender_id": agent_id, "source": "discord", "target_agent_id": agent_id},
+                metadata={"text": text},
+                correlation_id=str(getattr(interaction, "id", "")) or None,
             )
-        except Exception:  # pragma: no cover - defensive
-            await send_interaction_response(interaction, "Rejected by vote", ephemeral=True)
+        )
+        approved = bool((result.data or {}).get("approved", False))
+        await send_interaction_response(
+            interaction,
+            _governance_message_from_outcome(approved=approved),
+            ephemeral=True,
+        )
 
 
 async def slash_propose_law(interaction: Any, text: str, weights: str | None = None) -> None:
-    """Propose a law via the dashboard API."""
+    """Propose a law through the command bus."""
     with command_span("propose_law", interaction) as span:
         span.set_attribute("discord.message.length", len(text))
         agent_id = None
@@ -1768,46 +1793,30 @@ async def slash_propose_law(interaction: Any, text: str, weights: str | None = N
         if ip <= 0 or du <= 0:
             await send_interaction_response(interaction, "Insufficient IP/DU", ephemeral=True)
             return
-        payload: dict[str, object] = {"proposer_id": agent_id, "text": text}
-        if weights:
-            try:
-                payload["vote_weights"] = json.loads(weights)
-            except Exception:
-                await send_interaction_response(
-                    interaction,
-                    _governance_message_from_outcome(error_kind="invalid_payload"),
-                    ephemeral=True,
-                )
-                return
-
-        approved = False
-        error_kind: str | None = None
-        sim = _governance_simulation_from_interaction(interaction)
-        if sim is not None and hasattr(sim, "propose_law"):
-            try:
-                vote_weights = cast(dict[str, int] | None, payload.get("vote_weights"))
-                approved = bool(await sim.propose_law(agent_id, text, vote_weights))
-            except Exception:
-                error_kind = "network_unavailable"
-        else:
-            endpoint = f"{_dashboard_api_base_url()}/api/propose_law"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.post(endpoint, json=payload)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    approved = bool(data.get("approved", False))
-            except Exception as exc:
-                error_kind = _classify_api_error(exc)
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        bus = get_command_bus(ctx)
+        if bus is None:
+            await send_interaction_response(interaction, "command bus unavailable", ephemeral=True)
+            return
+        result = await bus.dispatch(
+            ModerationEnvelope(
+                action="propose_law",
+                agent_id=agent_id,
+                routing={"sender_id": agent_id, "source": "discord", "target_agent_id": agent_id},
+                metadata={"text": text, "vote_weights": weights},
+                correlation_id=str(getattr(interaction, "id", "")) or None,
+            )
+        )
+        approved = bool((result.data or {}).get("approved", False))
         await send_interaction_response(
             interaction,
-            _governance_message_from_outcome(approved=approved, error_kind=error_kind),
+            _governance_message_from_outcome(approved=approved),
             ephemeral=True,
         )
 
 
 async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
-    """Cast a manual vote on a proposal via the governance service."""
+    """Cast a governance vote through the command bus."""
     with command_span("vote", interaction) as span:
         span.set_attribute("discord.message.length", len(text))
         agent_id = None
@@ -1824,34 +1833,24 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
         if ip <= 0 or du <= 0:
             await send_interaction_response(interaction, "Insufficient IP/DU", ephemeral=True)
             return
-        payload = {"agent_id": agent_id, "text": text, "approve": approve}
-        vote_cast = False
-        error_kind: str | None = None
-        sim = _governance_simulation_from_interaction(interaction)
-        if sim is not None:
-            agent = _governance_agent_for_sim(sim, agent_id)
-            if agent is not None:
-                try:
-                    from src.governance.service import governance
-
-                    vote_cast = bool(await governance.vote_weighted(agent, text, 1, approve))
-                except Exception:
-                    error_kind = "network_unavailable"
-            else:
-                error_kind = "invalid_payload"
-        else:
-            endpoint = f"{_dashboard_api_base_url()}/api/vote"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.post(endpoint, json=payload)
-                    resp.raise_for_status()
-                    data = resp.json()
-                    vote_cast = bool(data.get("vote", False))
-            except Exception as exc:
-                error_kind = _classify_api_error(exc)
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        bus = get_command_bus(ctx)
+        if bus is None:
+            await send_interaction_response(interaction, "command bus unavailable", ephemeral=True)
+            return
+        result = await bus.dispatch(
+            ModerationEnvelope(
+                action="vote",
+                agent_id=agent_id,
+                routing={"sender_id": agent_id, "source": "discord", "target_agent_id": agent_id},
+                metadata={"text": text, "approve": approve},
+                correlation_id=str(getattr(interaction, "id", "")) or None,
+            )
+        )
+        vote_cast = bool((result.data or {}).get("vote", False))
         await send_interaction_response(
             interaction,
-            _governance_message_from_outcome(vote_cast=vote_cast, error_kind=error_kind),
+            _governance_message_from_outcome(vote_cast=vote_cast),
             ephemeral=True,
         )
 
@@ -1859,34 +1858,30 @@ async def slash_vote(interaction: Any, text: str, approve: bool = True) -> None:
 async def slash_gov(interaction: Any) -> None:
     """Show active governance rules and enforcement stats."""
     with command_span("gov", interaction):
-        sim = _governance_simulation_from_interaction(interaction)
-        rules: list[dict[str, Any]] = []
-        if sim is not None and hasattr(sim, "get_governance_read_model"):
-            try:
-                model = cast(dict[str, Any], sim.get_governance_read_model())
-                rules = cast(list[dict[str, Any]], model.get("rules", []))
-            except Exception:
-                rules = []
-        if not rules:
-            endpoint = f"{_dashboard_api_base_url()}/api/gov"
-            try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.get(endpoint)
-                    resp.raise_for_status()
-                    payload = cast(dict[str, Any], resp.json())
-                    rules = cast(list[dict[str, Any]], payload.get("rules", []))
-            except Exception:
-                await send_interaction_response(
-                    interaction, "No active governance rules.", ephemeral=True
-                )
-                return
-
+        bot_instance = get_active_bot()
+        ctx = bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        bus = get_command_bus(ctx)
+        if bus is None:
+            await send_interaction_response(
+                interaction, "No active governance rules.", ephemeral=True
+            )
+            return
+        result = await bus.dispatch(
+            ModerationEnvelope(
+                action="gov",
+                routing={
+                    "sender_id": str(getattr(interaction, "user", "human")),
+                    "source": "discord",
+                },
+                correlation_id=str(getattr(interaction, "id", "")) or None,
+            )
+        )
+        rules = cast(list[dict[str, Any]], (result.data or {}).get("rules", []))
         if not rules:
             await send_interaction_response(
                 interaction, "No active governance rules.", ephemeral=True
             )
             return
-
         lines = []
         for rule in rules[:8]:
             stats = cast(dict[str, Any], rule.get("enforcement_stats", {}))

--- a/src/interfaces/domain_command_adapters.py
+++ b/src/interfaces/domain_command_adapters.py
@@ -42,8 +42,14 @@ def parse_bus_command(
     auth = data.get("auth") if isinstance(data.get("auth"), Mapping) else {}
     budget = data.get("budget") if isinstance(data.get("budget"), Mapping) else {}
 
+    metadata = _metadata_with_context(data, ctx)
+    correlation_id = (
+        data.get("correlation_id") or metadata.get("correlation_id") or metadata.get("request_id")
+    )
+
     envelope_payload: dict[str, Any] = {
         "intent": intent,
+        "correlation_id": str(correlation_id) if correlation_id is not None else None,
         "routing": {
             "sender_id": routing.get("sender_id") or data.get("sender_id") or ctx.sender_id,
             "source": routing.get("source") or data.get("source") or ctx.source,
@@ -60,7 +66,7 @@ def parse_bus_command(
             "budget_agent_id": budget.get("budget_agent_id") or data.get("budget_agent_id"),
             "attribution_scope": budget.get("attribution_scope") or "default",
         },
-        "metadata": _metadata_with_context(data, ctx),
+        "metadata": metadata,
     }
 
     if intent in {"human_message", "direct_message", "broadcast", "knowledge_board"}:
@@ -115,7 +121,9 @@ def command_from_discord_message(
 ) -> DomainCommandT:
     metadata = dict(raw_payload or {})
     if is_broadcast:
-        return BroadcastCommand(content=content, budget_agent_id=budget_agent_id, metadata=metadata)
+        return BroadcastCommand(
+            content=content, budget_agent_id=budget_agent_id, metadata=metadata
+        )
     if recipient_id is not None:
         return DirectMessageCommand(
             content=content,
@@ -190,7 +198,11 @@ def command_from_envelope(envelope: InteractionEnvelope) -> DomainCommandT:
 
 def _canonical_intent(data: Mapping[str, Any]) -> str:
     command = str(
-        data.get("intent") or data.get("type") or data.get("command_type") or data.get("command") or ""
+        data.get("intent")
+        or data.get("type")
+        or data.get("command_type")
+        or data.get("command")
+        or ""
     ).strip()
     if command == "dm":
         return "direct_message"
@@ -202,7 +214,14 @@ def _canonical_intent(data: Mapping[str, Any]) -> str:
         return "moderation"
     if command == "inject_event":
         return "inject_event"
-    if command in {"human_message", "direct_message", "broadcast", "knowledge_board", "spawn", "control"}:
+    if command in {
+        "human_message",
+        "direct_message",
+        "broadcast",
+        "knowledge_board",
+        "spawn",
+        "control",
+    }:
         return command
     return "human_message"
 
@@ -216,7 +235,9 @@ def _normalize_legacy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
         data["scope"] = data["prompt"]
         warnings.warn("'prompt' is deprecated; use 'scope'.", DeprecationWarning, stacklevel=3)
     if "command_type" in data and "intent" not in data and "type" not in data:
-        warnings.warn("'command_type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3)
+        warnings.warn(
+            "'command_type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3
+        )
     if "type" in data and "intent" not in data:
         data["intent"] = data["type"]
         warnings.warn("'type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3)

--- a/src/interfaces/interaction_commands.py
+++ b/src/interfaces/interaction_commands.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from src.interfaces.domain_command_adapters import command_from_envelope
 from src.interfaces.interaction_schema import (
     ENVELOPE_INTENTS,
     InteractionAuthScope,
@@ -11,7 +10,6 @@ from src.interfaces.interaction_schema import (
     InteractionIntent,
     InteractionResult,
     InteractionRouting,
-    parse_interaction_intent,
 )
 
 if TYPE_CHECKING:
@@ -33,14 +31,13 @@ class InteractionService:
     ) -> InteractionResult:
         return await self.simulation.command_dispatcher.dispatch(command, context=context)
 
-
     async def execute_intent(
         self,
         intent: InteractionIntent,
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        return await self.execute(command_from_envelope(intent), context=context)
+        return await self.simulation.command_dispatcher.dispatch_envelope(intent, context=context)
 
     async def execute_from_payload(
         self,
@@ -48,8 +45,7 @@ class InteractionService:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        intent = parse_interaction_intent(payload)
-        return await self.execute_intent(intent, context=context)
+        return await self.simulation.command_dispatcher.dispatch_payload(payload, context=context)
 
 
 __all__ = [

--- a/src/interfaces/interaction_schema.py
+++ b/src/interfaces/interaction_schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
@@ -17,11 +17,17 @@ ENVELOPE_INTENTS = {
     "inject_event",
 }
 
+INTERACTION_SCHEMA_NAME = "interaction-envelope"
+INTERACTION_SCHEMA_VERSION = "2.0"
+
 
 class InteractionResult(BaseModel):
+    schema_name: Literal["interaction-envelope"] = "interaction-envelope"
+    schema_version: Literal["2.0"] = "2.0"
     status: Literal["ok", "rejected", "error"]
     user_message: str
     reason_code: str
+    correlation_id: str | None = None
     data: dict[str, Any] | None = None
     decision_provenance: DecisionProvenance
 
@@ -70,6 +76,9 @@ class InteractionBudgetAttribution(BaseModel):
 class BaseInteractionIntent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    schema_name: Literal["interaction-envelope"] = "interaction-envelope"
+    schema_version: Literal["2.0"] = "2.0"
+    correlation_id: str | None = None
     intent: str
     routing: InteractionRouting = Field(default_factory=InteractionRouting)
     auth: InteractionAuthScope = Field(default_factory=InteractionAuthScope)
@@ -140,18 +149,22 @@ InteractionIntent = Annotated[
     Field(discriminator="intent"),
 ]
 
-_INTERACTION_INTENT_ADAPTER = TypeAdapter(InteractionIntent)
+_INTERACTION_INTENT_ADAPTER: TypeAdapter[InteractionIntent] = TypeAdapter(InteractionIntent)
 
 
 def parse_interaction_intent(payload: dict[str, Any]) -> InteractionIntent:
     normalized = dict(payload)
-    routing = dict(normalized.get("routing") or {}) if isinstance(normalized.get("routing"), dict) else {}
+    routing = (
+        dict(normalized.get("routing") or {})
+        if isinstance(normalized.get("routing"), dict)
+        else {}
+    )
     for key in ("sender_id", "source", "channel_id", "recipient_id", "target_agent_id"):
         if key in normalized and key not in routing:
             routing[key] = normalized[key]
     if routing:
         normalized["routing"] = routing
-    return _INTERACTION_INTENT_ADAPTER.validate_python(normalized)
+    return cast(InteractionIntent, _INTERACTION_INTENT_ADAPTER.validate_python(normalized))
 
 
 # Backward-compatible aliases during transport migration.

--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from src.agents.core.agent_state import AgentActionIntent, AgentLifecycleState
 from src.agents.core.personality_profile_factory import PersonalityProfileFactory
@@ -13,7 +14,6 @@ from src.infra import config
 from src.infra import ledger as infra_ledger
 from src.infra.event_log import log_event
 from src.interfaces.dashboard_backend import SimulationEvent, emit_event
-from src.interfaces.domain_command_adapters import command_from_payload
 from src.interfaces.interaction_schema import (
     BroadcastEnvelope,
     ControlEnvelope,
@@ -49,8 +49,7 @@ class SimulationCommandService:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        command = command_from_payload(payload, context=context)
-        return await self.execute(command, context=context)
+        return await self.simulation.command_dispatcher.dispatch_payload(payload, context=context)
 
     async def execute(
         self,
@@ -103,7 +102,9 @@ class SimulationCommandService:
             return await self._dispatch_knowledge_board(envelope, context=ctx)
         if isinstance(envelope, (HumanMessageEnvelope, BroadcastEnvelope, DirectMessageEnvelope)):
             return await self._dispatch_message(envelope, context=ctx)
-        if isinstance(envelope, (SpawnEnvelope, ModerationEnvelope, ControlEnvelope, InjectEventEnvelope)):
+        if isinstance(
+            envelope, (SpawnEnvelope, ModerationEnvelope, ControlEnvelope, InjectEventEnvelope)
+        ):
             return await self._dispatch_control(envelope, provenance=entry_decision.provenance)
 
         return InteractionResult(
@@ -177,12 +178,61 @@ class SimulationCommandService:
             await self._post_knowledge_board(envelope)
         elif action == "inject_event" and isinstance(envelope, InjectEventEnvelope):
             await self._inject_world_event(envelope)
+        elif action in {"nudge", "propose", "propose_law", "vote", "gov"}:
+            return await self._handle_governance_or_nudge(action, envelope)
 
         return {
             "paused": sim.paused,
             "speed": sim.speed,
             "simulation_complete": sim.simulation_complete,
         }
+
+    async def _handle_governance_or_nudge(
+        self,
+        action: str,
+        envelope: SpawnEnvelope | ModerationEnvelope | ControlEnvelope | InjectEventEnvelope,
+    ) -> dict[str, Any]:
+        sim = self.simulation
+        if action == "nudge":
+            prompt = str(
+                envelope.metadata.get("prompt") or envelope.metadata.get("text") or ""
+            ).strip()
+            if prompt:
+                await emit_event(SimulationEvent(type="nudge", data={"prompt": prompt}))
+            return {"ack": "nudge_sent"}
+
+        if action in {"propose", "propose_law"}:
+            proposer_id = str(envelope.agent_id or envelope.routing.target_agent_id or "")
+            text = str(envelope.metadata.get("text") or "").strip()
+            vote_weights = envelope.metadata.get("vote_weights")
+            if isinstance(vote_weights, str):
+                vote_weights = json.loads(vote_weights)
+            approved = False
+            if proposer_id and text and hasattr(sim, "propose_law"):
+                approved = bool(await sim.propose_law(proposer_id, text, vote_weights))
+            return {"approved": approved}
+
+        if action == "vote":
+            text = str(envelope.metadata.get("text") or "").strip()
+            approve = bool(envelope.metadata.get("approve", True))
+            voter_id = str(envelope.agent_id or envelope.routing.target_agent_id or "")
+            agent = next((a for a in sim.agents if a.agent_id == voter_id), None)
+            if agent is None:
+                return {"vote": False}
+            from src.governance.service import governance
+
+            vote_cast = bool(await governance.vote_weighted(agent, text, 1, approve))
+            return {"vote": vote_cast}
+
+        if action == "gov":
+            model = (
+                sim.get_governance_read_model()
+                if hasattr(sim, "get_governance_read_model")
+                else {}
+            )
+            return {"rules": cast(dict[str, Any], model).get("rules", [])}
+
+        return {"ack": "noop"}
 
     async def _spawn_agent(self, envelope: SpawnEnvelope) -> None:
         sim = self.simulation
@@ -491,7 +541,9 @@ class SimulationCommandService:
             decision_provenance=decision.provenance,
         )
 
-    def _resolve_target(self, command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope) -> Any:
+    def _resolve_target(
+        self, command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope
+    ) -> Any:
         target = None
         if command.routing.target_agent_id:
             target = next(
@@ -523,7 +575,9 @@ class SimulationCommandService:
         return target or self.simulation.agents[self.simulation.current_agent_index]
 
     def _resolve_budget_agent_id(
-        self, command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope, fallback: str
+        self,
+        command: HumanMessageEnvelope | BroadcastEnvelope | DirectMessageEnvelope,
+        fallback: str,
     ) -> str:
         configured_budget_id = config.get_config("HUMAN_COMMAND_BUDGET_AGENT_ID")
         if command.budget.budget_agent_id:

--- a/src/sim/commands/dispatcher.py
+++ b/src/sim/commands/dispatcher.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Literal
 
+from pydantic import ValidationError
+
+from src.governance.decision_kernel import DecisionProvenance
 from src.interfaces.interaction_schema import InteractionContext, InteractionResult
 from src.sim.commands.domain_commands import DomainCommandT
 
@@ -10,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class SimulationCommandDispatcher:
-    """Single command dispatcher for typed domain commands."""
+    """Single ingress dispatcher for payloads, envelopes, and typed domain commands."""
 
     def __init__(self, command_service: SimulationCommandService) -> None:
         self.command_service = command_service
@@ -21,4 +25,64 @@ class SimulationCommandDispatcher:
         *,
         context: InteractionContext | None = None,
     ) -> InteractionResult:
-        return await self.command_service.execute(command, context=context)
+        try:
+            return await self.command_service.execute(command, context=context)
+        except Exception as exc:  # pragma: no cover - defensive normalization path
+            return self._error_result(str(exc), reason_code="command_dispatch_failed")
+
+    async def dispatch_envelope(
+        self,
+        envelope: Any,
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        try:
+            from src.interfaces.domain_command_adapters import command_from_envelope
+
+            result = await self.dispatch(command_from_envelope(envelope), context=context)
+        except ValidationError as exc:
+            return self._error_result(
+                f"Invalid interaction envelope: {exc}",
+                reason_code="invalid_payload",
+                status="rejected",
+            )
+
+        correlation_id = getattr(envelope, "correlation_id", None)
+        if result.correlation_id is None and isinstance(correlation_id, str):
+            return result.model_copy(update={"correlation_id": correlation_id})
+        return result
+
+    async def dispatch_payload(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        context: InteractionContext | None = None,
+    ) -> InteractionResult:
+        try:
+            from src.interfaces.domain_command_adapters import parse_bus_command
+
+            envelope = parse_bus_command(payload, context=context)
+        except ValidationError as exc:
+            return self._error_result(
+                f"Invalid command payload: {exc}",
+                reason_code="invalid_payload",
+                status="rejected",
+            )
+        return await self.dispatch_envelope(envelope, context=context)
+
+    def _error_result(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        status: Literal["ok", "rejected", "error"] = "error",
+    ) -> InteractionResult:
+        return InteractionResult(
+            status=status,
+            user_message=message,
+            reason_code=reason_code,
+            decision_provenance=DecisionProvenance(
+                policy_id="interaction-policy-v1",
+                rule_id=f"dispatcher.{reason_code}",
+            ),
+        )

--- a/tests/integration/interfaces/test_transport_agnostic_envelopes.py
+++ b/tests/integration/interfaces/test_transport_agnostic_envelopes.py
@@ -1,0 +1,91 @@
+import pytest
+
+from src.interfaces.interaction_commands import InteractionContext
+from src.interfaces.interaction_schema import ControlEnvelope, HumanMessageEnvelope
+from src.sim.simulation import Simulation
+
+
+class DummyAgentState:
+    def __init__(self) -> None:
+        self.ip = 10.0
+        self.du = 10.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = DummyAgentState()
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    def update_state(self, state: DummyAgentState) -> None:
+        self.state = state
+
+    async def run_turn(self, *args: object, **kwargs: object) -> dict:
+        return {}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["discord", "web", "api"])
+async def test_human_message_envelope_has_same_result_across_transports(source: str) -> None:
+    sim = Simulation([DummyAgent("alpha"), DummyAgent("beta")])
+    envelope = HumanMessageEnvelope(
+        text="transport invariance",
+        routing={"sender_id": "user-1", "source": source},
+        correlation_id="corr-transport-1",
+    )
+    context = InteractionContext(sender_id="user-1", source=source)
+
+    try:
+        if source == "discord":
+            result = await sim.command_bus.dispatch(envelope, context=context)
+        elif source == "web":
+            result = await sim.command_bus.dispatch_payload(envelope.model_dump(), context=context)
+        else:
+            result = await sim.interaction_service.execute_from_payload(
+                envelope.model_dump(),
+                context=context,
+            )
+
+        assert result.status == "ok"
+        assert result.reason_code == "message_dispatched"
+        assert result.correlation_id == "corr-transport-1"
+    finally:
+        await sim.stop_event_listener()
+        sim.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_envelope_dispatches_consistently_for_web_and_api() -> None:
+    sim = Simulation([DummyAgent("alpha")])
+    envelope = ControlEnvelope(
+        action="set_speed",
+        value=2.5,
+        routing={"sender_id": "moderator-1", "source": "web"},
+        auth={"permissions": {"admin"}},
+        correlation_id="corr-control-1",
+    )
+    context = InteractionContext(sender_id="moderator-1", source="web", permissions={"admin"})
+
+    try:
+        web_result = await sim.command_bus.dispatch_payload(envelope.model_dump(), context=context)
+        api_result = await sim.interaction_service.execute_from_payload(
+            envelope.model_dump(),
+            context=context,
+        )
+
+        assert web_result.status == api_result.status == "ok"
+        assert web_result.reason_code == api_result.reason_code == "moderation_applied"
+        assert web_result.correlation_id == "corr-control-1"
+        assert api_result.correlation_id == "corr-control-1"
+    finally:
+        await sim.stop_event_listener()
+        sim.close()


### PR DESCRIPTION
### Motivation

- Enforce a single ingress path for all human/system interactions so interface adapters never call simulation internals directly and every incoming message is normalized, audited, and policy-evaluated in one place.

### Description

- Centralized ingress in `SimulationCommandDispatcher` by adding `dispatch_envelope` and `dispatch_payload` paths that validate/normalize inputs, propagate `correlation_id`, and return normalized `InteractionResult`/error shapes (see `src/sim/commands/dispatcher.py`).
- Made `CommandBus` and `InteractionService` delegate to the dispatcher rather than performing payload-to-command translation themselves (see `src/interfaces/command_bus.py` and `src/interfaces/interaction_commands.py`).
- Tightened the interaction contract by adding explicit `schema_name`/`schema_version` and `correlation_id` fields to envelopes and `InteractionResult` (see `src/interfaces/interaction_schema.py`) and propagated `correlation_id` from payloads in adapters (`src/interfaces/domain_command_adapters.py`).
- Removed direct governance/nudge calls from the Discord adapter and routed `/nudge`, `/propose`, `/propose_law`, `/vote`, `/gov` through the command bus using `ModerationEnvelope`, and centralized handling in the command service `_handle_governance_or_nudge` (see `src/interfaces/discord_bot.py` and `src/sim/command_service.py`).
- Added transport-agnostic integration tests that exercise the same envelopes via Discord/web/API style paths (`tests/integration/interfaces/test_transport_agnostic_envelopes.py`).

### Testing

- Ran linter/formatter: `ruff check` and `ruff format` on touched files — checks passed.
- Ran targeted pytest: `pytest -q tests/unit/interfaces/test_interaction_schema_compat.py tests/unit/interfaces/test_interaction_contract.py tests/integration/interfaces/test_policy_decision_kernel_integration.py tests/integration/interfaces/test_transport_agnostic_envelopes.py` — tests passed (5 passed, 6 deselected in the run executed for this change set).
- Ran `mypy` on the touched files; `mypy` was executed but reported broad, pre-existing repository type errors outside this change-set that did not block the change (type issues are unrelated to the new ingress wiring).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bf6c4cb08326b61c72a8aa50a64d)