### PR TITLE
Refactor world evolution to canonical pure reducers

### DIFF
--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -488,7 +488,7 @@ class SimulationCommandService:
         except Exception:
             logger.debug("Ledger spend failed", exc_info=True)
 
-        world_time = self.simulation.environment_system.world_time_snapshot()
+        world_time = self.simulation.environment_system.world_time_snapshot(self.simulation.world_state)
         turn_index = self.simulation.current_step
         recipients = self.simulation.agents if broadcast else [target]
         msgs = [

--- a/src/sim/engines/world_engine.py
+++ b/src/sim/engines/world_engine.py
@@ -13,17 +13,17 @@ class WorldEngine:
         world_time = TickContext.freeze_mapping(simulation._world_time_from_projection(world_projection))
         governance_state = TickContext.freeze_mapping(
             {
-                "council_window_active": simulation.environment_state.council_window_active,
-                "world_day": simulation.environment_state.world_day,
+                "council_window_active": simulation.world_state.environment.council_window_active,
+                "world_day": simulation.world_state.temporal.world_day,
             }
         )
         return TickContext(
             step=int(simulation.current_step),
             world_time=world_time,
-            weather=str(simulation.environment_state.weather),
+            weather=str(simulation.world_state.environment.weather),
             governance_state=governance_state,
             world_modifiers=TickContext.freeze_mapping(
-                simulation.environment_state.active_global_modifiers
+                simulation.world_state.environment.active_global_modifiers
             ),
             replay_metadata=TickContext.freeze_mapping(
                 {

--- a/src/sim/environment.py
+++ b/src/sim/environment.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from src.sim.world.state import EnvironmentTickDelta, WorldState
 
 
-@dataclass
-class EnvironmentState:
-    world_tick: int = 0
-    world_hour: int = 0
-    world_day: int = 0
-    world_season: int | None = None
-    weather: str = "clear"
-    season_effects: dict[str, Any] = field(default_factory=dict)
-    active_global_modifiers: list[str] = field(default_factory=list)
-    council_window_active: bool = False
+@dataclass(frozen=True)
+class EnvironmentReducerEvent:
+    turn_index: int
+
+
+@dataclass(frozen=True)
+class EnvironmentConfig:
+    world_ticks_per_day: int
+    turns_per_world_tick: int
+    world_season_length_days: int | None
+    weather_shift_interval_ticks: int
+    council_window_days: int
+    council_window_start_hour: int
+    council_window_duration_hours: int
+    world_time_broadcast_cadence_ticks: int
 
 
 class EnvironmentSystem:
-    """Owns temporal progression and environment context generation."""
+    """Pure world-environment reducers and read projections."""
 
     _WEATHER_CYCLE = ("clear", "rain", "windy", "storm")
     _SEASON_NAMES = ("spring", "summer", "autumn", "winter")
@@ -27,7 +32,6 @@ class EnvironmentSystem:
     def __init__(
         self,
         *,
-        state: EnvironmentState,
         world_ticks_per_day: int,
         turns_per_world_tick: int,
         world_season_length_days: int | None,
@@ -36,63 +40,40 @@ class EnvironmentSystem:
         council_window_start_hour: int = 9,
         council_window_duration_hours: int = 3,
         world_time_broadcast_cadence_ticks: int = 24,
-        world_state: WorldState | None = None,
     ) -> None:
-        self.state = state
-        self.world_state = world_state
-        if world_state is not None:
-            self._sync_state_to_world()
-        self.world_ticks_per_day = max(1, int(world_ticks_per_day))
-        self.turns_per_world_tick = max(1, int(turns_per_world_tick))
-        self.world_season_length_days = (
-            int(world_season_length_days) if world_season_length_days is not None else None
+        self.config = EnvironmentConfig(
+            world_ticks_per_day=max(1, int(world_ticks_per_day)),
+            turns_per_world_tick=max(1, int(turns_per_world_tick)),
+            world_season_length_days=(
+                int(world_season_length_days) if world_season_length_days is not None else None
+            ),
+            weather_shift_interval_ticks=max(1, int(weather_shift_interval_ticks)),
+            council_window_days=max(1, int(council_window_days)),
+            council_window_start_hour=max(0, int(council_window_start_hour)),
+            council_window_duration_hours=max(1, int(council_window_duration_hours)),
+            world_time_broadcast_cadence_ticks=max(1, int(world_time_broadcast_cadence_ticks)),
         )
-        self.weather_shift_interval_ticks = max(1, int(weather_shift_interval_ticks))
-        self.council_window_days = max(1, int(council_window_days))
-        self.council_window_start_hour = max(0, int(council_window_start_hour))
-        self.council_window_duration_hours = max(1, int(council_window_duration_hours))
-        self.world_time_broadcast_cadence_ticks = max(1, int(world_time_broadcast_cadence_ticks))
 
-    def _sync_state_to_world(self) -> None:
-        if self.world_state is None:
-            return
-        self.world_state.temporal.world_tick = self.state.world_tick
-        self.world_state.temporal.world_hour = self.state.world_hour
-        self.world_state.temporal.world_day = self.state.world_day
-        self.world_state.temporal.world_season = self.state.world_season
-        self.world_state.environment.weather = self.state.weather
-        self.world_state.environment.season_effects = dict(self.state.season_effects)
-        self.world_state.environment.active_global_modifiers = list(
-            self.state.active_global_modifiers
+    def set_turns_per_world_tick(self, value: int) -> None:
+        self.config = EnvironmentConfig(
+            **{**self.config.__dict__, "turns_per_world_tick": max(1, int(value))}
         )
-        self.world_state.environment.council_window_active = self.state.council_window_active
 
-    def _sync_world_to_state(self) -> None:
-        if self.world_state is None:
-            return
-        self.state.world_tick = self.world_state.temporal.world_tick
-        self.state.world_hour = self.world_state.temporal.world_hour
-        self.state.world_day = self.world_state.temporal.world_day
-        self.state.world_season = self.world_state.temporal.world_season
-        self.state.weather = self.world_state.environment.weather
-        self.state.season_effects = dict(self.world_state.environment.season_effects)
-        self.state.active_global_modifiers = list(
-            self.world_state.environment.active_global_modifiers
+    def _format_world_time(self, world_state: WorldState) -> str:
+        time_str = (
+            f"Day {world_state.temporal.world_day}, "
+            f"{world_state.temporal.world_hour:02d}:00"
         )
-        self.state.council_window_active = self.world_state.environment.council_window_active
-
-    def _format_world_time(self) -> str:
-        time_str = f"Day {self.state.world_day}, {self.state.world_hour:02d}:00"
-        if self.state.world_season is not None:
-            time_str += f" (Season {self.state.world_season})"
+        if world_state.temporal.world_season is not None:
+            time_str += f" (Season {world_state.temporal.world_season})"
         return time_str
 
-    def _season_name(self) -> str | None:
-        if self.state.world_season is None:
+    def season_name(self, world_state: WorldState) -> str | None:
+        if world_state.temporal.world_season is None:
             return None
-        return self._SEASON_NAMES[self.state.world_season % len(self._SEASON_NAMES)]
+        return self._SEASON_NAMES[world_state.temporal.world_season % len(self._SEASON_NAMES)]
 
-    def _condition_hooks(self) -> dict[str, Any]:
+    def condition_hooks(self, world_state: WorldState) -> dict[str, Any]:
         # unchanged semantics
         weather_hooks: dict[str, dict[str, Any]] = {
             "clear": {
@@ -134,8 +115,8 @@ class EnvironmentSystem:
                 "mood_modifiers": {"baseline": -0.06},
             },
         }
-        weather = weather_hooks.get(self.state.weather, weather_hooks["clear"])
-        season = season_hooks.get(self._season_name() or "spring", {})
+        weather = weather_hooks.get(world_state.environment.weather, weather_hooks["clear"])
+        season = season_hooks.get(self.season_name(world_state) or "spring", {})
         return {
             "resource_multipliers": {
                 **weather.get("resource_multipliers", {}),
@@ -148,67 +129,72 @@ class EnvironmentSystem:
             },
         }
 
-    def world_time_snapshot(self) -> dict[str, Any]:
-        self._sync_world_to_state()
+    def world_time_snapshot(self, world_state: WorldState) -> dict[str, Any]:
         return {
-            "world_tick": self.state.world_tick,
-            "world_hour": self.state.world_hour,
-            "world_day": self.state.world_day,
-            "world_season": self.state.world_season,
-            "formatted": self._format_world_time(),
+            "world_tick": world_state.temporal.world_tick,
+            "world_hour": world_state.temporal.world_hour,
+            "world_day": world_state.temporal.world_day,
+            "world_season": world_state.temporal.world_season,
+            "formatted": self._format_world_time(world_state),
         }
 
-    def tick(self, turn_index: int) -> tuple[EnvironmentTickDelta, ...]:
-        self._sync_world_to_state()
-        if turn_index <= 0:
-            return ()
-        target_tick = (turn_index - 1) // self.turns_per_world_tick
+    def tick(
+        self, world_state: WorldState, turn_index: int
+    ) -> tuple[WorldState, tuple[EnvironmentTickDelta, ...]]:
+        return self.reduce(world_state, EnvironmentReducerEvent(turn_index=turn_index))
+
+    def reduce(
+        self, world_state: WorldState, event: EnvironmentReducerEvent
+    ) -> tuple[WorldState, tuple[EnvironmentTickDelta, ...]]:
+        if event.turn_index <= 0:
+            return world_state, ()
+        state = WorldState.from_snapshot(world_state.snapshot())
+        target_tick = (event.turn_index - 1) // self.config.turns_per_world_tick
         events: list[EnvironmentTickDelta] = []
-        while self.state.world_tick < target_tick:
-            self.state.world_tick += 1
-            self.state.world_hour += 1
-            if self.state.world_hour >= self.world_ticks_per_day:
-                self.state.world_hour = 0
-                self.state.world_day += 1
-                events.append(self._event("daily_reset", turn_index))
-            if self.state.world_tick % self.weather_shift_interval_ticks == 0:
-                idx = (self.state.world_tick // self.weather_shift_interval_ticks) % len(
+        while state.temporal.world_tick < target_tick:
+            state.temporal.world_tick += 1
+            state.temporal.world_hour += 1
+            if state.temporal.world_hour >= self.config.world_ticks_per_day:
+                state.temporal.world_hour = 0
+                state.temporal.world_day += 1
+                events.append(self._event(state, "daily_reset", event.turn_index))
+            if state.temporal.world_tick % self.config.weather_shift_interval_ticks == 0:
+                idx = (state.temporal.world_tick // self.config.weather_shift_interval_ticks) % len(
                     self._WEATHER_CYCLE
                 )
-                self.state.weather = self._WEATHER_CYCLE[idx]
-                events.append(self._event("weather_shift", turn_index))
-            if self.world_season_length_days and self.state.world_day > 0:
-                new_season = self.state.world_day // self.world_season_length_days
-                if new_season != self.state.world_season:
-                    self.state.world_season = new_season
-                    self.state.season_effects = {
-                        "season": self._season_name(),
-                        "hooks": self._condition_hooks(),
+                state.environment.weather = self._WEATHER_CYCLE[idx]
+                events.append(self._event(state, "weather_shift", event.turn_index))
+            if self.config.world_season_length_days and state.temporal.world_day > 0:
+                new_season = state.temporal.world_day // self.config.world_season_length_days
+                if new_season != state.temporal.world_season:
+                    state.temporal.world_season = new_season
+                    state.environment.season_effects = {
+                        "season": self.season_name(state),
+                        "hooks": self.condition_hooks(state),
                     }
-                    events.append(self._event("season_transition", turn_index))
-            is_council_day = (self.state.world_day % self.council_window_days) == 0
+                    events.append(self._event(state, "season_transition", event.turn_index))
+            is_council_day = (state.temporal.world_day % self.config.council_window_days) == 0
             in_hour_window = (
-                self.council_window_start_hour
-                <= self.state.world_hour
-                < self.council_window_start_hour + self.council_window_duration_hours
+                self.config.council_window_start_hour
+                <= state.temporal.world_hour
+                < self.config.council_window_start_hour + self.config.council_window_duration_hours
             )
             council_active = is_council_day and in_hour_window
-            if council_active != self.state.council_window_active:
-                self.state.council_window_active = council_active
-                events.append(self._event("council_meeting_window", turn_index))
-            if self.state.world_tick % self.world_time_broadcast_cadence_ticks == 0:
-                events.append(self._event("world_time", turn_index))
-        self._sync_state_to_world()
-        return tuple(events)
+            if council_active != state.environment.council_window_active:
+                state.environment.council_window_active = council_active
+                events.append(self._event(state, "council_meeting_window", event.turn_index))
+            if state.temporal.world_tick % self.config.world_time_broadcast_cadence_ticks == 0:
+                events.append(self._event(state, "world_time", event.turn_index))
+        return state, tuple(events)
 
-    def _event(self, event_name: str, turn_index: int) -> EnvironmentTickDelta:
+    def _event(self, world_state: WorldState, event_name: str, turn_index: int) -> EnvironmentTickDelta:
         return EnvironmentTickDelta(
             event_name=event_name,
             turn_index=turn_index,
-            world_time=self.world_time_snapshot(),
-            weather=self.state.weather,
-            season=self._season_name(),
-            council_window_active=self.state.council_window_active,
-            active_global_modifiers=tuple(self.state.active_global_modifiers),
-            effect_hooks=self._condition_hooks(),
+            world_time=self.world_time_snapshot(world_state),
+            weather=world_state.environment.weather,
+            season=self.season_name(world_state),
+            council_window_active=world_state.environment.council_window_active,
+            active_global_modifiers=tuple(world_state.environment.active_global_modifiers),
+            effect_hooks=self.condition_hooks(world_state),
         )

--- a/src/sim/runtime/external_event_ingestion_service.py
+++ b/src/sim/runtime/external_event_ingestion_service.py
@@ -104,7 +104,7 @@ class ExternalEventIngestionService:
         msg: SimulationMessage = {
             "step": sim.current_step,
             "turn_index": sim.current_step,
-            "world_time": sim.environment_system.world_time_snapshot(),
+            "world_time": sim.environment_system.world_time_snapshot(sim.world_state),
             "sender_id": sender,
             "recipient_id": recipient,
             "content": str(evt.data.get("content", "")),

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -57,7 +57,7 @@ from src.sim.contracts.lifecycle import EVENT_STEP_LIFECYCLE_CONTRACTS
 from src.sim.control_service import SimulationControlService
 from src.sim.engine import SimulationEngine
 from src.sim.engines.persistence_engine import PersistenceEngine
-from src.sim.environment import EnvironmentState, EnvironmentSystem
+from src.sim.environment import EnvironmentSystem
 from src.sim.event_kernel import EventKernel
 from src.sim.knowledge_board_protocol import (
     GraphKnowledgeBoardAdapter,
@@ -172,14 +172,9 @@ class Simulation:
         )
         season_len = int(config.get_config("WORLD_SEASON_LENGTH_DAYS") or 0)
         self.world_season_length_days: int | None = season_len if season_len > 0 else None
-        self.environment_state = EnvironmentState(
-            world_season=0 if self.world_season_length_days else None
-        )
         self.world_state = WorldState()
-        self.world_state.temporal.world_season = self.environment_state.world_season
+        self.world_state.temporal.world_season = 0 if self.world_season_length_days else None
         self.environment_system = EnvironmentSystem(
-            state=self.environment_state,
-            world_state=self.world_state,
             world_ticks_per_day=self.world_ticks_per_day,
             turns_per_world_tick=self.turns_per_world_tick,
             world_season_length_days=self.world_season_length_days,
@@ -685,41 +680,42 @@ class Simulation:
 
     @property
     def world_tick_index(self: Self) -> int:
-        return self.environment_state.world_tick
+        return self.world_state.temporal.world_tick
 
     @world_tick_index.setter
     def world_tick_index(self: Self, value: int) -> None:
-        self.environment_state.world_tick = int(value)
+        self.world_state.temporal.world_tick = int(value)
 
     @property
     def world_hour(self: Self) -> int:
-        return self.environment_state.world_hour
+        return self.world_state.temporal.world_hour
 
     @world_hour.setter
     def world_hour(self: Self, value: int) -> None:
-        self.environment_state.world_hour = int(value)
+        self.world_state.temporal.world_hour = int(value)
 
     @property
     def world_day(self: Self) -> int:
-        return self.environment_state.world_day
+        return self.world_state.temporal.world_day
 
     @world_day.setter
     def world_day(self: Self, value: int) -> None:
-        self.environment_state.world_day = int(value)
+        self.world_state.temporal.world_day = int(value)
 
     @property
     def world_season(self: Self) -> int | None:
-        return self.environment_state.world_season
+        return self.world_state.temporal.world_season
 
     @world_season.setter
     def world_season(self: Self, value: int | None) -> None:
-        self.environment_state.world_season = int(value) if value is not None else None
+        self.world_state.temporal.world_season = int(value) if value is not None else None
 
     def _build_world_context_projection(self: Self, *, actor_id: str) -> WorldContextProjection:
         return WorldContextProjection.build(
             turn_index=self.current_step,
             actor_id=actor_id,
             environment_system=self.environment_system,
+            world_state=self.world_state,
             world_map=self.world_map,
         )
 
@@ -750,7 +746,7 @@ class Simulation:
     ) -> None:
         environment_context = self._environment_context_from_projection(
             world_projection,
-            effect_hooks=self.environment_system._condition_hooks(),
+            effect_hooks=self.environment_system.condition_hooks(self.world_state),
         )
         world_time = self._world_time_from_projection(world_projection)
         for raw_event in events:
@@ -844,7 +840,9 @@ class Simulation:
 
         # Increment turn index, then sync world time to the configured tick boundary.
         self.current_step += 1
-        environment_deltas = self.environment_system.tick(self.current_step)
+        self.world_state, environment_deltas = self.environment_system.tick(
+            self.world_state, self.current_step
+        )
         environment_events = [delta.as_event() for delta in environment_deltas]
         agent = self.agents[agent_index]
         agent_id = agent.agent_id
@@ -909,11 +907,10 @@ class Simulation:
         knowledge_board_content = (
             self.knowledge_board.get_recent_entries_for_prompt() if self.knowledge_board else []
         )
-        effect_hooks = self.environment_system._condition_hooks()
+        effect_hooks = self.environment_system.condition_hooks(self.world_state)
         perception_data = self.world_perception_builder.build(
             world_state=self.world_state,
-            actor_id=agent_id,
-            turn_index=self.current_step,
+            world_projection=world_projection,
             effect_hooks=effect_hooks,
             perceived_messages=perceived_messages,
             knowledge_board_content=knowledge_board_content,
@@ -1206,14 +1203,14 @@ class Simulation:
                 "world_tick": self.world_tick_index,
                 "turns_per_world_tick": self.turns_per_world_tick,
                 "environment_state": {
-                    "world_tick": self.environment_state.world_tick,
-                    "world_hour": self.environment_state.world_hour,
-                    "world_day": self.environment_state.world_day,
-                    "world_season": self.environment_state.world_season,
-                    "weather": self.environment_state.weather,
-                    "season_effects": self.environment_state.season_effects,
-                    "active_global_modifiers": self.environment_state.active_global_modifiers,
-                    "council_window_active": self.environment_state.council_window_active,
+                    "world_tick": self.world_state.temporal.world_tick,
+                    "world_hour": self.world_state.temporal.world_hour,
+                    "world_day": self.world_state.temporal.world_day,
+                    "world_season": self.world_state.temporal.world_season,
+                    "weather": self.world_state.environment.weather,
+                    "season_effects": self.world_state.environment.season_effects,
+                    "active_global_modifiers": self.world_state.environment.active_global_modifiers,
+                    "council_window_active": self.world_state.environment.council_window_active,
                 },
                 "metadata": {"world_context_projection": world_projection.to_dict()},
                 "trace_hash": self._last_trace_hash,
@@ -1672,7 +1669,7 @@ class Simulation:
         )
         environment_context = self._environment_context_from_projection(
             projection,
-            effect_hooks=self.environment_system._condition_hooks(),
+            effect_hooks=self.environment_system.condition_hooks(self.world_state),
         )
         snapshot: dict[str, Any] = {
             "perceived_messages": copy.deepcopy(self.messages_to_perceive_this_round),
@@ -2169,15 +2166,15 @@ class Simulation:
         sim.world_tick_index = int(env_snapshot["world_tick"])
         world_season_value = env_snapshot.get("world_season")
         sim.world_season = int(world_season_value) if world_season_value is not None else None
-        sim.environment_state.weather = str(env_snapshot["weather"])
-        sim.environment_state.season_effects = dict(env_snapshot["season_effects"])
-        sim.environment_state.active_global_modifiers = list(
+        sim.world_state.environment.weather = str(env_snapshot["weather"])
+        sim.world_state.environment.season_effects = dict(env_snapshot["season_effects"])
+        sim.world_state.environment.active_global_modifiers = list(
             env_snapshot["active_global_modifiers"]
         )
-        sim.environment_state.council_window_active = bool(env_snapshot["council_window_active"])
+        sim.world_state.environment.council_window_active = bool(env_snapshot["council_window_active"])
         snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
         sim.turns_per_world_tick = max(1, snapshot_turn_quantum)
-        sim.environment_system.turns_per_world_tick = sim.turns_per_world_tick
+        sim.environment_system.set_turns_per_world_tick(sim.turns_per_world_tick)
         if sim.world_tick_index < 0 and sim.current_step > 0:
             sim.world_tick_index = (sim.current_step - 1) // sim.turns_per_world_tick
         sim.collective_ip = float(snapshot.get("collective_ip", 0.0))

--- a/src/sim/world/perception.py
+++ b/src/sim/world/perception.py
@@ -10,62 +10,36 @@ class WorldPerceptionBuilder:
         self,
         *,
         world_state: WorldState,
-        actor_id: str,
-        turn_index: int,
+        world_projection: Any,
         effect_hooks: dict[str, Any],
         perceived_messages: list[Any],
         knowledge_board_content: list[str] | None,
     ) -> dict[str, Any]:
-        location = world_state.spatial.agent_positions.get(actor_id, (0, 0))
-        nearby_agents = sorted(
-            other_id
-            for other_id, other_location in world_state.spatial.agent_positions.items()
-            if other_id != actor_id and other_location == location
-        )
-
-        neighboring_cells: list[list[int]] = []
-        x, y = location
-        for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
-            nx, ny = x + dx, y + dy
-            if 0 <= nx < world_state.spatial.width and 0 <= ny < world_state.spatial.height:
-                if (nx, ny) not in world_state.spatial.obstacles:
-                    neighboring_cells.append([nx, ny])
-
-        season_name = None
-        if world_state.temporal.world_season is not None:
-            names = ("spring", "summer", "autumn", "winter")
-            season_name = names[world_state.temporal.world_season % len(names)]
-
         return {
             "perceived_messages": list(perceived_messages),
             "knowledge_board_content": list(knowledge_board_content or []),
             "environment_context": {
-                "turn_index": turn_index,
+                "turn_index": world_projection.turn_index,
                 "time": {
-                    "world_tick": world_state.temporal.world_tick,
-                    "world_hour": world_state.temporal.world_hour,
-                    "world_day": world_state.temporal.world_day,
-                    "world_season": world_state.temporal.world_season,
-                    "formatted": (
-                        f"Day {world_state.temporal.world_day}, "
-                        f"{world_state.temporal.world_hour:02d}:00"
-                    ),
+                    "world_tick": world_projection.time.world_tick,
+                    "world_hour": world_projection.time.world_hour,
+                    "world_day": world_projection.time.world_day,
+                    "world_season": world_projection.time.world_season,
+                    "formatted": world_projection.time.formatted,
                 },
-                "weather": world_state.environment.weather,
-                "season": season_name,
+                "weather": world_projection.weather,
+                "season": world_projection.season,
                 "season_effects": dict(world_state.environment.season_effects),
                 "active_global_modifiers": list(world_state.environment.active_global_modifiers),
-                "council_window_active": world_state.environment.council_window_active,
-                "governance_phase": (
-                    "council_window"
-                    if world_state.environment.council_window_active
-                    else "standard"
-                ),
+                "council_window_active": world_projection.council.council_window_active,
+                "governance_phase": world_projection.council.phase,
                 "map_neighborhood": {
-                    "actor_id": actor_id,
-                    "location": [x, y],
-                    "neighboring_cells": neighboring_cells,
-                    "nearby_agents": nearby_agents,
+                    "actor_id": world_projection.map_neighborhood.actor_id,
+                    "location": list(world_projection.map_neighborhood.location),
+                    "neighboring_cells": [
+                        list(cell) for cell in world_projection.map_neighborhood.neighboring_cells
+                    ],
+                    "nearby_agents": list(world_projection.map_neighborhood.nearby_agents),
                 },
                 "effect_hooks": effect_hooks,
             },

--- a/src/sim/world_context.py
+++ b/src/sim/world_context.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from src.sim.environment import EnvironmentSystem
+from src.sim.world.state import WorldState
 from src.sim.world_map import WorldMap
 
 WORLD_CONTEXT_PROJECTION_VERSION = 1
@@ -49,9 +50,10 @@ class WorldContextProjection:
         turn_index: int,
         actor_id: str,
         environment_system: EnvironmentSystem,
+        world_state: WorldState,
         world_map: WorldMap,
     ) -> WorldContextProjection:
-        world_time = environment_system.world_time_snapshot()
+        world_time = environment_system.world_time_snapshot(world_state)
         location = world_map.agent_positions.get(actor_id, (0, 0))
         nearby_agents = sorted(
             other_id
@@ -59,7 +61,7 @@ class WorldContextProjection:
             if other_id != actor_id and other_location == location
         )
         governance_phase = (
-            "council_window" if environment_system.state.council_window_active else "standard"
+            "council_window" if world_state.environment.council_window_active else "standard"
         )
         return cls(
             projection_version=WORLD_CONTEXT_PROJECTION_VERSION,
@@ -75,10 +77,10 @@ class WorldContextProjection:
                 ),
                 formatted=str(world_time["formatted"]),
             ),
-            weather=str(environment_system.state.weather),
-            season=environment_system._season_name(),
+            weather=str(world_state.environment.weather),
+            season=environment_system.season_name(world_state),
             council=GovernanceContext(
-                council_window_active=bool(environment_system.state.council_window_active),
+                council_window_active=bool(world_state.environment.council_window_active),
                 phase=governance_phase,
             ),
             map_neighborhood=MapNeighborhoodContext(

--- a/tests/unit/sim/test_world_state_replay.py
+++ b/tests/unit/sim/test_world_state_replay.py
@@ -1,15 +1,14 @@
 import asyncio
 import json
 
-from src.sim.environment import EnvironmentState, EnvironmentSystem
+from src.sim.environment import EnvironmentReducerEvent, EnvironmentSystem
+from src.sim.persistence.trace_hash_service import TraceHashService
 from src.sim.world import WorldState
 from src.sim.world_map import ResourceToken, WorldMap
 
 
 def _build_environment(world_state: WorldState) -> EnvironmentSystem:
     return EnvironmentSystem(
-        state=EnvironmentState(world_season=0),
-        world_state=world_state,
         world_ticks_per_day=24,
         turns_per_world_tick=1,
         world_season_length_days=3,
@@ -20,13 +19,15 @@ def _build_environment(world_state: WorldState) -> EnvironmentSystem:
 def test_world_state_replay_is_deterministic_and_serializable() -> None:
     initial = WorldState()
     world_map = WorldMap(width=8, height=8, world_state=initial)
+    initial.temporal.world_season = 0
     env = _build_environment(initial)
 
     asyncio.run(world_map.add_agent("a", x=0, y=0))
     asyncio.run(world_map.add_resource(1, 0, ResourceToken.WOOD, 3))
     events_run_1: list[list[dict[str, object]]] = []
     for turn in range(1, 7):
-        events_run_1.append(env.tick(turn))
+        initial, events = env.reduce(initial, EnvironmentReducerEvent(turn_index=turn))
+        events_run_1.append([event.as_event() for event in events])
         asyncio.run(world_map.move_to("a", 1, 0))
         asyncio.run(world_map.gather("a", ResourceToken.WOOD))
 
@@ -38,8 +39,10 @@ def test_world_state_replay_is_deterministic_and_serializable() -> None:
     replay_env = _build_environment(restored)
     events_run_2: list[list[dict[str, object]]] = []
     for turn in range(1, 7):
-        events_run_2.append(replay_env.tick(turn))
+        restored, events = replay_env.reduce(restored, EnvironmentReducerEvent(turn_index=turn))
+        events_run_2.append([event.as_event() for event in events])
 
     assert snapshot == restored.snapshot()
     assert events_run_1 == events_run_2
     assert replay_map.agent_positions["a"] == (1, 0)
+    assert TraceHashService.compute(snapshot) == TraceHashService.compute(restored.snapshot())


### PR DESCRIPTION
### Motivation
- Consolidate world temporal/environment/spatial/resource state into a single canonical `WorldState` and remove duplicated mutable timing fields previously held on `Simulation` and `EnvironmentSystem`.
- Make environment evolution deterministic and side-effect free by converting tick logic into pure reducers that accept a `WorldState` + event and return a new `WorldState` and emitted environment events.
- Ensure all agent perception and context projections read from the canonical state so snapshotting and replay are reliable.

### Description
- Introduced reducer-oriented API in `src/sim/environment.py` with `EnvironmentReducerEvent`, `EnvironmentConfig`, `EnvironmentSystem.reduce()` and `tick(world_state, turn_index)` returning `(WorldState, emitted_events)` and replaced in-place mutation logic with pure state transformations.
- Replaced duplicated mutable world-time fields on `Simulation` with projection properties that read from `self.world_state.temporal.*` and apply environment reducer output to `self.world_state` during each step (`src/sim/simulation.py`).
- Updated world-context and perception flow so `WorldContextProjection.build()` receives the canonical `WorldState` and `WorldPerceptionBuilder` consumes a projection rather than reading timing fields directly (`src/sim/world_context.py`, `src/sim/world/perception.py`).
- Updated downstream consumers to read from canonical projections/state (world engine, command service, external event ingestion) and added `EnvironmentSystem` helpers (`world_time_snapshot`, `season_name`, `condition_hooks`) that operate on `WorldState` (`src/sim/engines/world_engine.py`, `src/sim/command_service.py`, `src/sim/runtime/external_event_ingestion_service.py`).
- Added deterministic snapshot replay assertions to `tests/unit/sim/test_world_state_replay.py` that replay reducer events and assert emitted event equality and trace-hash equality via `TraceHashService.compute()`.

### Testing
- Ran linter checks with `ruff check` against modified modules, which completed with no reported issues.
- Ran focused unit tests with `pytest -q tests/unit/sim/test_world_state_replay.py tests/unit/sim/test_simulation_world_time.py` and both tests passed (`4 passed, 1 deselected` in the run reported).
- Verified the new reducer-based `EnvironmentSystem.reduce()` behaviour by updating and running `tests/unit/sim/test_world_state_replay.py`, which now also asserts deterministic `TraceHashService.compute()` equality for snapshots after replay.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab046fdad08326b3b6a670e3b0ca37)