### PR TITLE
Unify long-horizon identity evolution with domain event streams

### DIFF
--- a/src/agents/core/agent_state.py
+++ b/src/agents/core/agent_state.py
@@ -299,6 +299,7 @@ class AgentStateData(BaseModel):
     traits: PersonalityTraits = Field(default_factory=PersonalityTraits)
     trait_change_audit: list[dict[str, Any]] = Field(default_factory=list)
     personality_transition_events: list[dict[str, Any]] = Field(default_factory=list)
+    identity_events: list[dict[str, Any]] = Field(default_factory=list)
     trait_transition_log: TraitTransitionLog = Field(default_factory=TraitTransitionLog)
     steps_in_current_role: int = 0
     reputation: dict[str, float] = Field(default_factory=dict)

--- a/src/agents/core/personality_engine.py
+++ b/src/agents/core/personality_engine.py
@@ -5,6 +5,8 @@ from typing import cast
 
 from pydantic import BaseModel
 
+from src.sim.engines.domain_events import TraitDriftApplied
+
 from .agent_state import AgentState
 from .personality_transition import PersonalityTransition, TraitDelta, TraitTransitionLog
 from .trait_policy import (
@@ -163,16 +165,31 @@ class PersonalityEngine:
             )
         )
 
-    def apply_experience_drift(
+    def reduce_trait_drift_event(
+        self,
+        state: AgentState,
+        event: TraitDriftApplied,
+    ) -> list[dict[str, float | str | int]]:
+        """Apply trait drift exclusively from a domain event payload."""
+
+        transition = self._build_transition(
+            state,
+            event.deltas,
+            max_step=event.max_step,
+            cause=event.cause,
+            source=event.source,
+            input_signals=event.input_signals,
+        )
+        return self._reduce_transition(state, transition)
+
+    def build_experience_drift_event(
         self,
         state: AgentState,
         signals: ExperienceSignal,
         *,
         max_step: float = 0.01,
         source: str = "simulation.turn",
-    ) -> list[dict[str, float | str | int]]:
-        """Apply bounded per-turn drift updates and persist an audit trail on ``state``."""
-
+    ) -> TraitDriftApplied:
         projection = self.trait_projection(state)
         drift = trait_drift_from_experience(
             {
@@ -185,16 +202,33 @@ class PersonalityEngine:
         drift["resilience"] += 0.003 * signals.task_outcome
         drift["adaptability"] += 0.003 * signals.governance_participation
         drift["assertiveness"] += 0.002 * signals.conflict_outcome
-
-        transition = self._build_transition(
-            state,
-            drift,
-            max_step=max_step,
-            cause="experience_drift",
+        return TraitDriftApplied(
+            agent_id=str(getattr(state, "agent_id", "")),
+            step=int(state.step_counter),
             source=source,
+            cause="experience_drift",
+            deltas={str(k): float(v) for k, v in drift.items()},
+            max_step=float(max_step),
             input_signals=signals.model_dump(),
         )
-        return self._reduce_transition(state, transition)
+
+    def apply_experience_drift(
+        self,
+        state: AgentState,
+        signals: ExperienceSignal,
+        *,
+        max_step: float = 0.01,
+        source: str = "simulation.turn",
+    ) -> list[dict[str, float | str | int]]:
+        """Apply bounded per-turn drift updates and persist an audit trail on ``state``."""
+
+        drift_event = self.build_experience_drift_event(
+            state,
+            signals,
+            max_step=max_step,
+            source=source,
+        )
+        return self.reduce_trait_drift_event(state, drift_event)
 
     def apply_role_transition_blend(
         self,
@@ -212,15 +246,16 @@ class PersonalityEngine:
             for trait, target in target_traits.items()
             if hasattr(state.traits, trait)
         }
-        transition = self._build_transition(
-            state,
-            deltas,
-            max_step=max_step,
-            cause="role_transition_blend",
+        event = TraitDriftApplied(
+            agent_id=str(getattr(state, "agent_id", "")),
+            step=int(state.step_counter),
             source=source,
-            input_signals={"blend_ratio": blend_ratio},
+            cause="role_transition_blend",
+            deltas={str(k): float(v) for k, v in deltas.items()},
+            max_step=float(max_step),
+            input_signals={"blend_ratio": float(blend_ratio)},
         )
-        return self._reduce_transition(state, transition)
+        return self.reduce_trait_drift_event(state, event)
 
     def apply_exogenous_trait_intervention(
         self,
@@ -233,11 +268,13 @@ class PersonalityEngine:
     ) -> list[dict[str, float | str | int]]:
         """Apply external/admin trait edits through the same bounded/audited engine path."""
 
-        transition = self._build_transition(
-            state,
-            trait_updates,
-            max_step=max_step,
-            cause=cause,
+        event = TraitDriftApplied(
+            agent_id=str(getattr(state, "agent_id", "")),
+            step=int(state.step_counter),
             source=source,
+            cause=cause,
+            deltas={str(k): float(v) for k, v in trait_updates.items()},
+            max_step=float(max_step),
+            input_signals={},
         )
-        return self._reduce_transition(state, transition)
+        return self.reduce_trait_drift_event(state, event)

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -798,6 +798,24 @@ async def api_observability_metrics() -> Response:
     return JSONResponse(_cost_metrics_data())
 
 
+
+
+@app.get("/api/character_arcs")
+async def api_character_arcs() -> Response:
+    """Return user-facing character-arc event streams per agent."""
+
+    simulation = DEFAULT_CONTEXT.sim_state.get("simulation")
+    if simulation is None:
+        return JSONResponse({"arcs": {}})
+
+    arcs: dict[str, dict[str, Any]] = {}
+    for agent in getattr(simulation, "agents", []):
+        arcs[str(agent.agent_id)] = {
+            "personality": list(getattr(agent.state, "personality_transition_events", [])),
+            "identity": list(getattr(agent.state, "identity_events", [])),
+        }
+    return JSONResponse({"arcs": arcs})
+
 @app.get("/api/auctions")
 async def api_auctions() -> Response:
     """Return auctions and their current bids."""

--- a/src/sim/engines/domain_events.py
+++ b/src/sim/engines/domain_events.py
@@ -9,3 +9,107 @@ class DomainEvent:
     domain: str
     name: str
     payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class TraitDriftApplied:
+    agent_id: str
+    step: int
+    source: str
+    cause: str
+    deltas: dict[str, float]
+    max_step: float
+    input_signals: dict[str, float] = field(default_factory=dict)
+
+    def to_domain_event(self) -> DomainEvent:
+        return DomainEvent(
+            domain="identity",
+            name="TraitDriftApplied",
+            payload={
+                "agent_id": self.agent_id,
+                "step": self.step,
+                "source": self.source,
+                "cause": self.cause,
+                "deltas": dict(self.deltas),
+                "max_step": float(self.max_step),
+                "input_signals": dict(self.input_signals),
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleTransitioned:
+    agent_id: str
+    step: int
+    from_state: str
+    to_state: str
+    reason: str
+    legacy_artifacts: dict[str, Any] = field(default_factory=dict)
+    memory_archival_policy: dict[str, Any] = field(default_factory=dict)
+
+    def to_domain_event(self) -> DomainEvent:
+        return DomainEvent(
+            domain="population",
+            name="LifecycleTransitioned",
+            payload={
+                "agent_id": self.agent_id,
+                "step": int(self.step),
+                "from_state": self.from_state,
+                "to_state": self.to_state,
+                "reason": self.reason,
+                "legacy_artifacts": dict(self.legacy_artifacts),
+                "memory_archival_policy": dict(self.memory_archival_policy),
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SuccessorRegistered:
+    predecessor_id: str
+    successor_id: str
+    step: int
+    inherited: dict[str, Any] = field(default_factory=dict)
+
+    def to_domain_event(self) -> DomainEvent:
+        return DomainEvent(
+            domain="population",
+            name="SuccessorRegistered",
+            payload={
+                "predecessor_id": self.predecessor_id,
+                "successor_id": self.successor_id,
+                "step": int(self.step),
+                "relationship": "successor_of",
+                "inherited": dict(self.inherited),
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SocialImpactApplied:
+    departed_agent_id: str
+    survivor_id: str
+    step: int
+    reason: str
+    relationship_delta: float
+
+    def to_domain_event(self) -> DomainEvent:
+        return DomainEvent(
+            domain="identity",
+            name="SocialImpactApplied",
+            payload={
+                "departed_agent_id": self.departed_agent_id,
+                "survivor_id": self.survivor_id,
+                "step": int(self.step),
+                "reason": self.reason,
+                "relationship_delta": float(self.relationship_delta),
+            },
+        )
+
+
+__all__ = [
+    "DomainEvent",
+    "LifecycleTransitioned",
+    "SocialImpactApplied",
+    "SuccessorRegistered",
+    "TraitDriftApplied",
+]

--- a/src/sim/persistence/snapshot_migrations.py
+++ b/src/sim/persistence/snapshot_migrations.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
 
-CURRENT_SNAPSHOT_SCHEMA_VERSION = 3
+CURRENT_SNAPSHOT_SCHEMA_VERSION = 4
 
 
 def _migrate_v1_to_v2(snapshot: dict[str, Any]) -> dict[str, Any]:
@@ -55,13 +55,35 @@ def _migrate_v2_to_v3(snapshot: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(migrated.get("world_map"), dict):
         migrated["world_map"] = {"width": 10, "height": 10, "agents": {}, "vector": {}}
 
-    migrated["snapshot_schema_version"] = CURRENT_SNAPSHOT_SCHEMA_VERSION
+    migrated["snapshot_schema_version"] = 3
     return migrated
 
 
+
+
+def _migrate_v3_to_v4(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Backfill identity/personality arc event payloads for snapshots."""
+
+    migrated = deepcopy(snapshot)
+    agents = migrated.get("agents")
+    if isinstance(agents, list):
+        for agent_data in agents:
+            if not isinstance(agent_data, dict):
+                continue
+            agent_data.setdefault("personality_transition_events", [])
+            agent_data.setdefault("identity_events", [])
+
+    metadata = migrated.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    metadata.setdefault("character_arcs", {})
+    migrated["metadata"] = metadata
+    migrated["snapshot_schema_version"] = CURRENT_SNAPSHOT_SCHEMA_VERSION
+    return migrated
 SNAPSHOT_MIGRATIONS: dict[int, Callable[[dict[str, Any]], dict[str, Any]]] = {
     1: _migrate_v1_to_v2,
     2: _migrate_v2_to_v3,
+    3: _migrate_v3_to_v4,
 }
 
 

--- a/src/sim/population_service.py
+++ b/src/sim/population_service.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from src.agents.core.agent_state import AgentLifecycleState
+from src.sim.engines.domain_events import (
+    LifecycleTransitioned,
+    SocialImpactApplied,
+    SuccessorRegistered,
+)
 
 
 @dataclass(slots=True)
@@ -97,21 +102,17 @@ class PopulationService:
             )
 
         archival_policy = self._memory_archival_policy(to_state)
-        history = list(getattr(state, "lifecycle_history", []) or [])
-        history.append(
-            {
-                "step": simulation.current_step,
-                "from": from_state.value,
-                "to": to_state.value,
-                "reason": reason,
-            }
-        )
 
-        state.lifecycle_state = to_state
-        state.lifecycle_history = history
-        state.legacy_artifacts = artifacts
-        state.memory_archival_policy = archival_policy
-        state.is_alive = to_state != AgentLifecycleState.DECEASED
+        lifecycle_event = LifecycleTransitioned(
+            agent_id=agent.agent_id,
+            step=int(simulation.current_step),
+            from_state=from_state.value,
+            to_state=to_state.value,
+            reason=reason,
+            legacy_artifacts=artifacts,
+            memory_archival_policy=archival_policy,
+        )
+        self._apply_lifecycle_transition(state=state, event=lifecycle_event)
 
         if from_state == AgentLifecycleState.ACTIVE and to_state != AgentLifecycleState.ACTIVE:
             state.inheritance = float(getattr(state, "ip", 0.0)) + float(getattr(state, "du", 0.0))
@@ -165,9 +166,6 @@ class PopulationService:
             autonomous=autonomous,
         )
 
-        predecessor.state.successor_id = successor.agent_id
-        successor.state.predecessor_id = predecessor.agent_id
-
         inherited: dict[str, Any] = {}
         if inherit_role:
             successor.state.current_role = predecessor.state.current_role
@@ -191,12 +189,12 @@ class PopulationService:
             predecessor.state.inheritance = 0.0
             inherited["inheritance"] = transferred
 
-        payload = {
-            "relationship": "successor_of",
-            "predecessor_id": predecessor.agent_id,
-            "successor_id": successor.agent_id,
-            "inherited": inherited,
-        }
+        payload = self._apply_successor_registration(
+            predecessor=predecessor,
+            successor=successor,
+            inherited=inherited,
+            step=int(simulation.current_step),
+        )
         await self._emit_lifecycle_event(
             simulation=simulation,
             actor_id=predecessor.agent_id,
@@ -209,20 +207,66 @@ class PopulationService:
 
     def apply_lifecycle_transition_event(self, *, agent: Any, event: dict[str, Any]) -> None:
         """Project a persisted lifecycle transition event onto an agent state."""
-        to_state = AgentLifecycleState(str(event.get("to_state", AgentLifecycleState.ACTIVE.value)))
-        history = list(getattr(agent.state, "lifecycle_history", []) or [])
+        transition = LifecycleTransitioned(
+            agent_id=agent.agent_id,
+            step=int(event.get("step", 0)),
+            from_state=str(event.get("from_state", AgentLifecycleState.ACTIVE.value)),
+            to_state=str(event.get("to_state", AgentLifecycleState.ACTIVE.value)),
+            reason=str(event.get("reason", "")),
+            legacy_artifacts=dict(event.get("legacy_artifacts") or {}),
+            memory_archival_policy=dict(event.get("memory_archival_policy") or {}),
+        )
+        self._apply_lifecycle_transition(state=agent.state, event=transition)
+
+
+    def _append_identity_event(self, state: Any, event_payload: dict[str, Any]) -> None:
+        events = list(getattr(state, "identity_events", []) or [])
+        events.append(event_payload)
+        state.identity_events = events
+
+    def _apply_successor_registration(
+        self,
+        *,
+        predecessor: Any,
+        successor: Any,
+        inherited: dict[str, Any],
+        step: int,
+    ) -> dict[str, Any]:
+        predecessor.state.successor_id = successor.agent_id
+        successor.state.predecessor_id = predecessor.agent_id
+        event = SuccessorRegistered(
+            predecessor_id=predecessor.agent_id,
+            successor_id=successor.agent_id,
+            step=step,
+            inherited=inherited,
+        )
+        event_payload = event.to_domain_event().payload
+        self._append_identity_event(predecessor.state, event_payload)
+        self._append_identity_event(successor.state, event_payload)
+        return event_payload
+
+    def _apply_lifecycle_transition(
+        self,
+        *,
+        state: Any,
+        event: LifecycleTransitioned,
+    ) -> None:
+        to_state = AgentLifecycleState(event.to_state)
+        history = list(getattr(state, "lifecycle_history", []) or [])
         history.append(
             {
-                "step": int(event.get("step", 0)),
-                "from": str(event.get("from_state", "active")),
-                "to": to_state.value,
-                "reason": str(event.get("reason", "")),
+                "step": int(event.step),
+                "from": str(event.from_state),
+                "to": str(event.to_state),
+                "reason": str(event.reason),
             }
         )
-        agent.state.lifecycle_state = to_state
-        agent.state.lifecycle_history = history
-        agent.state.legacy_artifacts = dict(event.get("legacy_artifacts") or {})
-        agent.state.memory_archival_policy = dict(event.get("memory_archival_policy") or {})
+        state.lifecycle_state = to_state
+        state.lifecycle_history = history
+        state.legacy_artifacts = dict(event.legacy_artifacts)
+        state.memory_archival_policy = dict(event.memory_archival_policy)
+        state.is_alive = to_state != AgentLifecycleState.DECEASED
+        self._append_identity_event(state, event.to_domain_event().payload)
 
     def _enforce_policy(
         self,
@@ -313,6 +357,14 @@ class PopulationService:
                         "reason": reason,
                     }
                 )
+            social_event = SocialImpactApplied(
+                departed_agent_id=departed_agent.agent_id,
+                survivor_id=survivor.agent_id,
+                step=int(simulation.current_step),
+                reason=reason,
+                relationship_delta=-1.0,
+            )
+            self._append_identity_event(survivor.state, social_event.to_domain_event().payload)
 
     async def _emit_lifecycle_event(
         self,

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -1192,6 +1192,10 @@ class Simulation:
                         ),
                         "predecessor_id": getattr(ag.state, "predecessor_id", None),
                         "successor_id": getattr(ag.state, "successor_id", None),
+                        "personality_transition_events": list(
+                            getattr(ag.state, "personality_transition_events", [])
+                        ),
+                        "identity_events": list(getattr(ag.state, "identity_events", [])),
                     }
                     for ag in self.agents
                 ],
@@ -1212,7 +1216,18 @@ class Simulation:
                     "active_global_modifiers": self.world_state.environment.active_global_modifiers,
                     "council_window_active": self.world_state.environment.council_window_active,
                 },
-                "metadata": {"world_context_projection": world_projection.to_dict()},
+                "metadata": {
+                    "world_context_projection": world_projection.to_dict(),
+                    "character_arcs": {
+                        ag.agent_id: {
+                            "personality_events": list(
+                                getattr(ag.state, "personality_transition_events", [])
+                            ),
+                            "identity_events": list(getattr(ag.state, "identity_events", [])),
+                        }
+                        for ag in self.agents
+                    },
+                },
                 "trace_hash": self._last_trace_hash,
             }
             snapshot["trace_hash"] = SnapshotPersistenceService.compute_hash(snapshot)
@@ -2188,16 +2203,32 @@ class Simulation:
                     ag.state.ip = float(a_data.get("ip", 0.0))
                     ag.state.du = float(a_data.get("du", 0.0))
                     ag.state.mood_level = float(a_data.get("mood", 0.0))
-                    ag.state.lifecycle_state = AgentLifecycleState(
+                    target_state = AgentLifecycleState(
                         str(a_data.get("lifecycle_state", AgentLifecycleState.ACTIVE.value))
                     )
+                    if target_state != AgentLifecycleState.ACTIVE:
+                        self_event = {
+                            "step": int(sim.current_step),
+                            "from_state": AgentLifecycleState.ACTIVE.value,
+                            "to_state": target_state.value,
+                            "reason": "snapshot_restore",
+                            "legacy_artifacts": dict(a_data.get("legacy_artifacts", {})),
+                            "memory_archival_policy": dict(a_data.get("memory_archival_policy", {})),
+                        }
+                        sim.population_service.apply_lifecycle_transition_event(
+                            agent=ag,
+                            event=self_event,
+                        )
                     ag.state.lifecycle_history = list(a_data.get("lifecycle_history", []))
                     ag.state.legacy_artifacts = dict(a_data.get("legacy_artifacts", {}))
-                    ag.state.memory_archival_policy = dict(
-                        a_data.get("memory_archival_policy", {})
-                    )
+                    ag.state.memory_archival_policy = dict(a_data.get("memory_archival_policy", {}))
+                    ag.state.is_alive = target_state != AgentLifecycleState.DECEASED
                     ag.state.predecessor_id = a_data.get("predecessor_id")
                     ag.state.successor_id = a_data.get("successor_id")
+                    ag.state.personality_transition_events = list(
+                        a_data.get("personality_transition_events", [])
+                    )
+                    ag.state.identity_events = list(a_data.get("identity_events", []))
                     break
 
         kb = snapshot.get("knowledge_board", {})

--- a/tests/integration/sim/fixtures/normalized_from_v1_snapshot_v3.json
+++ b/tests/integration/sim/fixtures/normalized_from_v1_snapshot_v3.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_schema_version": 3,
+  "snapshot_schema_version": 4,
   "step": 5,
   "collective_ip": 3.5,
   "collective_du": 1.25,
@@ -14,7 +14,9 @@
       "legacy_artifacts": {},
       "memory_archival_policy": {},
       "predecessor_id": null,
-      "successor_id": null
+      "successor_id": null,
+      "personality_transition_events": [],
+      "identity_events": []
     }
   ],
   "seed": 17,
@@ -42,5 +44,8 @@
     "height": 10,
     "agents": {},
     "vector": {}
+  },
+  "metadata": {
+    "character_arcs": {}
   }
 }

--- a/tests/integration/sim/fixtures/normalized_from_v2_snapshot_v3.json
+++ b/tests/integration/sim/fixtures/normalized_from_v2_snapshot_v3.json
@@ -1,5 +1,5 @@
 {
-  "snapshot_schema_version": 3,
+  "snapshot_schema_version": 4,
   "step": 8,
   "collective_ip": 7.0,
   "collective_du": 2.0,
@@ -14,7 +14,9 @@
       "legacy_artifacts": {},
       "memory_archival_policy": {},
       "predecessor_id": null,
-      "successor_id": null
+      "successor_id": null,
+      "personality_transition_events": [],
+      "identity_events": []
     }
   ],
   "seed": 23,
@@ -36,7 +38,13 @@
     "width": 12,
     "height": 8,
     "agents": {
-      "agent-2": [1, 1]
+      "agent-2": [
+        1,
+        1
+      ]
     }
+  },
+  "metadata": {
+    "character_arcs": {}
   }
 }

--- a/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
+++ b/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
@@ -78,3 +78,25 @@ async def test_api_observability_metrics_serializes_extended_payload(
     assert expected_keys.issubset(payload.keys())
     assert payload["memory_retrieval_errors_total"] == 20
     assert payload["llm_errors_total"] == 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_character_arcs_returns_identity_and_personality_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_dashboard_backend(monkeypatch)
+    db = load_dashboard_backend()
+
+    state = types.SimpleNamespace(
+        personality_transition_events=[{"cause": "experience_drift"}],
+        identity_events=[{"to_state": "retired"}],
+    )
+    sim = types.SimpleNamespace(agents=[types.SimpleNamespace(agent_id="agent-1", state=state)])
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "simulation", sim)
+
+    resp = await db.api_character_arcs()
+    payload = json.loads(resp.body)
+
+    assert payload["arcs"]["agent-1"]["personality"][0]["cause"] == "experience_drift"
+    assert payload["arcs"]["agent-1"]["identity"][0]["to_state"] == "retired"

--- a/tests/unit/sim/test_identity_event_replay_invariants.py
+++ b/tests/unit/sim/test_identity_event_replay_invariants.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.agents.core.agent_state import AgentLifecycleState, AgentState, PersonalityTraits
+from src.agents.core.personality_engine import ExperienceSignal, PersonalityEngine
+from src.sim.population_service import PopulationService
+
+pytestmark = pytest.mark.unit
+
+
+class _Agent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.state = AgentState(agent_id=agent_id, name=agent_id, traits=PersonalityTraits())
+
+
+class _Sim:
+    def __init__(self, agents: list[_Agent]) -> None:
+        self.current_step = 4
+        self.projects = {}
+        self.agents = agents
+        self.event_kernel = type("Kernel", (), {"emit_environment_event": _noop_async})()
+        self.knowledge_board = None
+        self.knowledge_board_service = None
+
+
+async def _noop_async(*args, **kwargs):
+    return None
+
+
+def _clone_state(state: AgentState) -> AgentState:
+    dumped = state.model_dump(mode="python") if hasattr(state, "model_dump") else state.dict()
+    if hasattr(AgentState, "model_validate"):
+        return AgentState.model_validate(dumped)
+    return AgentState.parse_obj(dumped)
+
+
+def test_trait_event_replay_reaches_equal_agent_state() -> None:
+    engine = PersonalityEngine()
+    baseline = AgentState(agent_id="a", name="A", traits=PersonalityTraits())
+    direct = _clone_state(baseline)
+    replayed = _clone_state(baseline)
+    signal = ExperienceSignal(social_outcome=0.7, conflict_outcome=-0.2, mood_trajectory=0.3)
+
+    engine.apply_experience_drift(direct, signal, max_step=0.01, source="test")
+    event = engine.build_experience_drift_event(replayed, signal, max_step=0.01, source="test")
+    engine.reduce_trait_drift_event(replayed, event)
+
+    assert replayed.traits.model_dump(mode="python") == direct.traits.model_dump(mode="python")
+    assert replayed.personality_transition_events == direct.personality_transition_events
+    assert replayed.trait_change_audit == direct.trait_change_audit
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_event_replay_reaches_equal_agent_state() -> None:
+    svc = PopulationService()
+    a = _Agent("A")
+    b = _Agent("B")
+    sim = _Sim([a, b])
+
+    await svc.transition_lifecycle(
+        simulation=sim,
+        agent=a,
+        to_state=AgentLifecycleState.RETIRED,
+        reason="test_transition",
+    )
+    transition_event = a.state.identity_events[-1]
+
+    replay_agent = _Agent("A")
+    svc.apply_lifecycle_transition_event(agent=replay_agent, event=transition_event)
+
+    assert replay_agent.state.lifecycle_state == a.state.lifecycle_state
+    assert replay_agent.state.legacy_artifacts == a.state.legacy_artifacts
+    assert replay_agent.state.memory_archival_policy == a.state.memory_archival_policy


### PR DESCRIPTION
### Motivation
- Provide a single, auditable event path for long-horizon identity changes (traits & lifecycle) so updates are bounded, replayable, and observable.
- Ensure lifecycle state is only projected by the population domain service to avoid scattered direct state mutation.
- Surface character-arc event streams in snapshots and observability APIs for user-facing retrospection.
- Add invariants that replay events and validate final AgentState equality.

### Description
- Added domain event dataclasses in `src/sim/engines/domain_events.py`: `TraitDriftApplied`, `LifecycleTransitioned`, `SuccessorRegistered`, and `SocialImpactApplied` with `to_domain_event()` helpers. 
- Refactored `PersonalityEngine` (`src/agents/core/personality_engine.py`) to build and consume `TraitDriftApplied` events via `build_experience_drift_event` and `reduce_trait_drift_event`, and to route experience drift, role-transition blends, and exogenous trait interventions through that event reducer path so deltas remain bounded and auditable.
- Centralized lifecycle projection in `PopulationService` (`src/sim/population_service.py`) by emitting/creating `LifecycleTransitioned` and `SuccessorRegistered` events, applying them via `_apply_lifecycle_transition` and `_apply_successor_registration`, and appending identity events rather than permitting ad-hoc lifecycle mutation elsewhere; `_fan_out_social_impact` now creates `SocialImpactApplied` identity events for survivors.
- Persisted personality and identity event streams into snapshots and snapshot metadata in `src/sim/simulation.py`, and added snapshot migration logic in `src/sim/persistence/snapshot_migrations.py` (bumped schema to v4 and backfilled `personality_transition_events`/`identity_events` and `metadata.character_arcs`).
- Extended `AgentState` (`src/agents/core/agent_state.py`) with `identity_events` and ensured snapshot load restores arc streams via `PopulationService` replay path.
- Exposed a new observability endpoint `GET /api/character_arcs` in `src/interfaces/dashboard_backend.py` to return per-agent personality and identity event streams.
- Added invariant tests `tests/unit/sim/test_identity_event_replay_invariants.py` to validate that (a) trait deltas applied directly vs via event replay reach the same final trait state and event logs, and (b) lifecycle transition events can be replayed to reach an equal lifecycle projection; also added a small API test for the new arcs endpoint.
- Updated integration fixtures to reflect snapshot schema v4 and include empty arc arrays where appropriate.

### Testing
- Ran targeted linter checks: `ruff check` against the modified files (`src/sim/engines/domain_events.py`, `src/agents/core/personality_engine.py`, `src/sim/population_service.py`, `src/agents/core/agent_state.py`, `src/sim/simulation.py`, `src/sim/persistence/snapshot_migrations.py`, `src/interfaces/dashboard_backend.py`, and new/updated tests) and they passed.
- Executed focused unit/integration test suite: `pytest -q tests/unit/core/test_personality_transition_replay.py tests/unit/sim/test_lifecycle_service.py tests/unit/sim/test_identity_event_replay_invariants.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py tests/integration/sim/test_snapshot_schema_migrations.py`, which completed successfully (all selected tests passed: 11 passed, 4 deselected).
- Updated snapshot migration fixtures and validated `migrate_snapshot` behavior via the integration migration test, which passed after the migration and fixture updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0bf2ce7c8326a0fb0a0b652c8185)