### PR TITLE
Unify simulation runtime flow through a single command and step path

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -713,4 +713,63 @@ The Culture.ai architecture provides a flexible, modular foundation for multi-ag
 
 The memory-centric approach, with its sophisticated hierarchical organization and intelligent pruning, enables agents to develop persistent personalities and knowledge bases that evolve throughout the simulation. The LangGraph-based decision process provides a structured yet flexible framework for agent reasoning and action selection.
 
-This architecture documentation will evolve as the system grows and new capabilities are added. 
+This architecture documentation will evolve as the system grows and new capabilities are added.
+
+
+## Runtime Command Flow (Authoritative)
+
+All runtime interactions now follow one authoritative lifecycle:
+
+**ingest → decide → execute → persist → publish**
+
+Canonical implementation path:
+
+- `src/sim/simulation.py::Simulation.run_step` → `Simulation._progress_step`
+- `src/sim/engine.py::SimulationEngine.run_step`
+- `src/sim/kernel/simulation_kernel.py::SimulationKernel.run_tick`
+
+```mermaid
+sequenceDiagram
+    participant Discord as Discord / Human UI
+    participant Dashboard as Dashboard Control API
+    participant Bus as Event Bus
+    participant Adapter as Transport Adapter
+    participant Dispatcher as SimulationCommandDispatcher
+    participant Service as SimulationCommandService
+    participant Engine as SimulationEngine
+    participant Kernel as SimulationKernel
+    participant Persist as Persistence/Event Log
+    participant Publish as WS/SSE/Discord Publisher
+
+    Discord->>Adapter: message payload
+    Dashboard->>Adapter: control payload
+    Bus->>Adapter: control/moderation payload
+    Adapter->>Dispatcher: dispatch_payload(...)
+    Dispatcher->>Service: execute(command)
+    Service->>Service: policy decision (decide)
+    Service->>Engine: runtime action / run step (execute)
+    Engine->>Kernel: run_tick(...)
+    Kernel->>Persist: capture + log batch (persist)
+    Persist-->>Publish: persisted event batch
+    Publish-->>Discord: updates
+    Publish-->>Dashboard: ws/sse events
+```
+
+### Deprecated Path Policy
+
+The following legacy entrypoints are compatibility adapters only and must normalize
+into the same command dispatcher before state mutation:
+
+- `Simulation._handle_human_command(...)` (deprecated)
+- `Simulation._handle_human_command_from_bus(...)` (deprecated)
+- Direct external queue broadcast handlers (deprecated)
+- `Simulation.run_turns_concurrent(...)` for runtime progression (deprecated adapter)
+
+Policy requirements:
+
+1. New transport interfaces must call `Simulation.command_bus.dispatch_payload(...)` or
+   `Simulation.command_dispatcher.dispatch_*`.
+2. Adapters may parse/normalize payload shape, but may not mutate simulation state
+   before dispatcher routing.
+3. Any new step progression path must route through `Simulation._progress_step(...)`.
+

--- a/src/sim/runtime/external_event_ingestion_service.py
+++ b/src/sim/runtime/external_event_ingestion_service.py
@@ -24,7 +24,7 @@ class ExternalEventIngestionService:
             sim._event_listener_task = asyncio.create_task(self._event_listener_loop())
         if sim._event_task is None or sim._event_task.done():
             sim._event_task = asyncio.create_task(
-                sim.event_kernel.forward_external_events(sim._handle_human_command_from_bus)
+                sim.event_kernel.forward_external_events(sim._ingest_legacy_event_queue_payload)
             )
 
     async def stop(self) -> None:
@@ -67,7 +67,7 @@ class ExternalEventIngestionService:
         sim = self.simulation
         payload = normalize_human_command_payload(text, metadata)
         context = build_interaction_context(payload, default_source="simulation")
-        result = await sim.interaction_service.execute_from_payload(payload, context=context)
+        result = await sim.command_bus.dispatch_payload(payload, context=context)
         if result.status == "ok" or not sim.discord_bot:
             return
         channel_id = context.channel_id

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -7,6 +7,7 @@ import random
 import statistics
 import threading
 import time
+import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from itertools import pairwise
 from pathlib import Path
@@ -42,6 +43,10 @@ from src.interfaces.dashboard_backend import (
     emit_event,
 )
 from src.interfaces.discord_event_listener import DiscordSimulationEventListener
+from src.interfaces.external_event_routing import (
+    build_interaction_context,
+    normalize_human_command_payload,
+)
 from src.interfaces.interaction_commands import InteractionService
 from src.interfaces.metrics import (
     ACTIVE_AGENT_COUNT,
@@ -400,7 +405,7 @@ class Simulation:
                 self.external_event_ingestion._event_listener_loop()
             )
             self._event_task = loop.create_task(
-                self.event_kernel.forward_external_events(self._handle_human_command_from_bus)
+                self.event_kernel.forward_external_events(self._ingest_legacy_event_queue_payload)
             )
         else:
             asyncio.set_event_loop(asyncio.new_event_loop())
@@ -454,18 +459,43 @@ class Simulation:
     async def _handle_human_command_from_bus(
         self: Self, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
-        """Compatibility adapter for external event forwarding callbacks."""
+        """Deprecated compatibility adapter for external event forwarding callbacks."""
 
-        try:
-            await self._handle_human_command(text, metadata)
-        except TypeError:
-            await self._handle_human_command(text)  # type: ignore[misc]
+        warnings.warn(
+            "Simulation._handle_human_command_from_bus is deprecated; "
+            "use Simulation._ingest_legacy_event_queue_payload instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        await self._ingest_legacy_event_queue_payload(text, metadata)
+
+    async def _ingest_legacy_event_queue_payload(
+        self: Self, text: str, metadata: dict[str, Any] | None = None
+    ) -> None:
+        """Normalize legacy queue injections into the canonical command pipeline."""
+
+        payload = normalize_human_command_payload(text, metadata)
+        if (
+            payload.get("command_type") == "human_message"
+            and payload.get("recipient_id")
+            and not bool(payload.get("broadcast"))
+        ):
+            payload["command_type"] = "direct_message"
+        context = build_interaction_context(payload, default_source="simulation")
+        await self.command_bus.dispatch_payload(payload, context=context)
 
     async def _handle_human_command(
         self: Self, text: str, metadata: dict[str, Any] | None = None
     ) -> None:
-        """Delegate inbound command parsing/routing to the ingestion service."""
-        await self.external_event_ingestion.handle_human_command(text, metadata)
+        """Legacy adapter for human commands; routes through the unified command dispatcher."""
+
+        warnings.warn(
+            "Simulation._handle_human_command is deprecated; send payloads via command_bus or "
+            "interaction_service instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        await self._ingest_legacy_event_queue_payload(text, metadata)
 
     async def handle_control_command(self: Self, cmd: Mapping[str, Any]) -> dict[str, Any] | None:
         """Process a control command sent via the event queue."""
@@ -1598,6 +1628,14 @@ class Simulation:
 
     async def run_step(self: Self, max_turns: int = 1) -> int:
         """Dispatch up to ``max_turns`` events via the deterministic simulation engine."""
+        return await self._progress_step(max_turns=max_turns)
+
+    async def _progress_step(self: Self, *, max_turns: int = 1) -> int:
+        """Authoritative runtime step progression entrypoint.
+
+        Flow: ingest → decide → execute → persist → publish.
+        """
+
         return await self.engine.run_step(max_turns=max_turns)
 
     def _build_snapshot_payload(self: Self) -> dict[str, Any]:
@@ -1793,6 +1831,13 @@ class Simulation:
         parallel_decision: bool = True,
     ) -> list[dict[str, Any]]:
         """Run a phased step pipeline: perception, parallel planning, deterministic commit."""
+
+        warnings.warn(
+            "Simulation._run_step_pipeline is an internal kernel path and will be removed as "
+            "a public entrypoint; use Simulation.run_step instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if not self.agents:
             return []
@@ -2348,21 +2393,24 @@ class Simulation:
         )
 
     async def run_turns_concurrent(self: Self, agents: list["Agent"]) -> list[dict[str, Any]]:
-        """Run a batch of agent turns concurrently.
+        """Deprecated compatibility adapter for concurrent turn progression.
 
-        Each agent executes ``run_turn`` simultaneously using :func:`asyncio.gather`.
-        This helper is useful for stress testing large simulations where sequential
-        execution would be too slow.
-
-        Args:
-            agents: The agents whose turns should be executed.
-
-        Returns:
-            A list of dictionaries returned by each agent's ``run_turn``.
+        Runtime state progression now routes through :meth:`_progress_step` so every
+        ingest→decide→execute→persist→publish lifecycle uses the same kernel path.
         """
 
+        warnings.warn(
+            "Simulation.run_turns_concurrent is deprecated; use Simulation.run_step "
+            "for canonical runtime progression.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         _ = agents
-        return await self._run_step_pipeline(max_turns=len(agents))
+        await self._progress_step(max_turns=len(agents))
+        context = self.engine.last_step_context
+        if context is None:
+            return []
+        return context.planned_outputs if context.planned_outputs else context.events
 
     def close(self: Self) -> None:
         """Release resources held by the simulation."""

--- a/tests/unit/sim/test_runtime_flow_architecture.py
+++ b/tests/unit/sim/test_runtime_flow_architecture.py
@@ -1,0 +1,128 @@
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.governance.decision_kernel import DecisionProvenance
+from src.interfaces import dashboard_backend as db
+from src.interfaces.dashboard_backend import SimulationEvent
+from src.interfaces.interaction_schema import InteractionResult
+
+pytestmark = pytest.mark.unit
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyState:
+    def __init__(self, ip: float = 2.0, du: float = 2.0) -> None:
+        self.ip = ip
+        self.du = du
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str, ip: float = 2.0, du: float = 2.0) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState(ip, du)
+        from src.infra.ledger import ledger as _ledger
+
+        _ledger.log_change(agent_id, ip, du, "init")
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:
+        return self._state
+
+    async def run_turn(
+        self,
+        simulation_step: int,
+        environment_perception: dict | None = None,
+        vector_store_manager=None,
+        knowledge_board=None,
+    ) -> dict:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_legacy_human_command_routes_through_command_bus() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    sim.command_bus.dispatch_payload = AsyncMock()
+
+    await sim._handle_human_command("hello", {"sender_id": "user-1"})
+
+    sim.command_bus.dispatch_payload.assert_awaited_once()
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.asyncio
+async def test_event_bus_control_routes_through_command_bus() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    sim.command_bus.dispatch_payload = AsyncMock()
+
+    evt = SimulationEvent(type="control", data={"command": "pause"})
+    await sim.external_event_ingestion.route_event(evt)
+
+    sim.command_bus.dispatch_payload.assert_awaited_once()
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_control_routes_through_dispatcher() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    dispatched = AsyncMock(
+        return_value=InteractionResult(
+            status="ok",
+            user_message="Command accepted.",
+            reason_code="ok",
+            data={"paused": True},
+            decision_provenance=DecisionProvenance(policy_id="p", rule_id="r"),
+        )
+    )
+    sim.command_dispatcher.dispatch_payload = dispatched
+
+    state = dict(db.DEFAULT_CONTEXT.sim_state)
+    state["simulation"] = sim
+    ctx = db.SimulationContext(sim_state=state)
+
+    result = await db.handle_control_command({"command": "pause"}, ctx=ctx)
+
+    dispatched.assert_awaited_once()
+    assert result["status"] == "ok"
+    await sim.stop_event_listener()
+    sim.close()
+
+
+@pytest.mark.asyncio
+async def test_run_step_routes_through_progress_method() -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("A")])
+    sim._progress_step = AsyncMock(return_value=7)
+
+    out = await sim.run_step(max_turns=3)
+
+    assert out == 7
+    sim._progress_step.assert_awaited_once_with(max_turns=3)
+    await sim.stop_event_listener()
+    sim.close()


### PR DESCRIPTION
### Motivation

- Ensure a single authoritative runtime lifecycle (ingest → decide → execute → persist → publish) so all transports and adapters route through one deterministic command/step path. 
- Remove duplicate direct mutation entrypoints and treat legacy handlers as adapters that normalize into the canonical dispatcher.

### Description

- Introduced `Simulation._progress_step(...)` as the canonical step progression and routed `Simulation.run_step(...)` to call it so all step progression funnels through `src/sim/engine.py` → `src/sim/kernel/simulation_kernel.py`.
- Added `_ingest_legacy_event_queue_payload(...)` to normalize legacy human/event queue payloads and changed `_handle_human_command(...)` and `_handle_human_command_from_bus(...)` to warn and forward into that normalization path which dispatches via `command_bus.dispatch_payload(...)`.
- Rewired external-event forwarding to use the normalized ingress (updated `ExternalEventIngestionService` and the event-kernel forwarder wiring) and added safe coercion for legacy human→direct-message payloads.
- Marked legacy entrypoints as deprecated with warnings (`_run_step_pipeline` public use, `_handle_human_command*`, and `run_turns_concurrent` now a compatibility adapter) and added `docs/architecture.md` documentation describing the single flow and a “deprecated path” policy.
- Added a unit test `tests/unit/sim/test_runtime_flow_architecture.py` asserting that external interfaces (event bus, dashboard control, legacy human command) route through the dispatcher and that `run_step` calls `_progress_step`.

### Testing

- Ran linter checks (`ruff`) for the modified code files and the new test file; initial mis-targeting of a Markdown file was corrected and subsequent `ruff` checks passed for the changed Python files.
- Executed the focused pytest suite: `tests/unit/sim/test_runtime_flow_architecture.py`, `tests/unit/sim/test_human_command.py`, and `tests/unit/interfaces/test_dashboard_backend_control.py`, and verified they pass in the final run (all tests in that run passed). 
- Observed only existing runtime/deprecation warnings (asyncio pending-task warnings and DeprecationWarnings) but no new test failures from the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b033b406608326a7e8628a40d6ceb0)