### PR TITLE
Knowledge Board: add query DTOs, ranking, digests, dashboard & Discord views

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -21,6 +21,15 @@ from src.infra.ledger import ledger
 from src.interfaces import metrics
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
+from src.sim.knowledge_board_queries import (
+    AgentContributionQueryDTO,
+    CausalChainQueryDTO,
+    ProposalStatusQueryDTO,
+    QueryFilters,
+    QueryPagination,
+    ThreadQueryDTO,
+    TimelineQueryDTO,
+)
 from src.sim.persistence.snapshot_service import SnapshotPersistenceService
 
 from .widget_registry import WidgetRegistry
@@ -255,6 +264,17 @@ class StakeRequest(BaseModel):
 
 
 app = FastAPI()
+
+
+def _csv_param(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _sim_kb_service() -> Any | None:
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    return getattr(sim, "knowledge_board_service", None) if sim is not None else None
 
 
 async def _require_token(
@@ -582,6 +602,115 @@ async def api_memory(agent_id: str, limit: int = 5) -> Response:
     return JSONResponse({"semantic": semantic, "episodic": episodic})
 
 
+@app.get("/api/knowledge/timeline")
+async def api_knowledge_timeline(
+    page: int = 1,
+    page_size: int = 20,
+    agent_id: str | None = None,
+    entry_types: str | None = None,
+    tags: str | None = None,
+    search: str | None = None,
+    start_step: int | None = None,
+    end_step: int | None = None,
+    anchor_entry_id: str | None = None,
+) -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse({"total": 0, "page": page, "page_size": page_size, "items": []})
+    query = TimelineQueryDTO(
+        filters=QueryFilters(
+            agent_id=agent_id,
+            entry_types=_csv_param(entry_types),
+            tags=_csv_param(tags),
+            search=search,
+            start_step=start_step,
+            end_step=end_step,
+        ),
+        pagination=QueryPagination(page=page, page_size=page_size),
+        anchor_entry_id=anchor_entry_id,
+    )
+    return JSONResponse(service.query_timeline(query).to_dict())
+
+
+@app.get("/api/knowledge/thread/{root_entry_id}")
+async def api_knowledge_thread(root_entry_id: str, page: int = 1, page_size: int = 20) -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse({"total": 0, "page": page, "page_size": page_size, "items": []})
+    query = ThreadQueryDTO(
+        root_entry_id=root_entry_id,
+        pagination=QueryPagination(page=page, page_size=page_size),
+    )
+    return JSONResponse(service.query_thread(query).to_dict())
+
+
+@app.get("/api/knowledge/proposal/{proposal_id}")
+async def api_knowledge_proposal_status(
+    proposal_id: str, page: int = 1, page_size: int = 20
+) -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse(
+            {
+                "proposal_id": proposal_id,
+                "proposal": None,
+                "consensus": {"approvals": 0, "rejections": 0, "consensus": False},
+                "votes": {"total": 0, "page": page, "page_size": page_size, "items": []},
+            }
+        )
+    query = ProposalStatusQueryDTO(
+        proposal_id=proposal_id,
+        pagination=QueryPagination(page=page, page_size=page_size),
+    )
+    return JSONResponse(service.query_proposal_status(query))
+
+
+@app.get("/api/knowledge/agent/{agent_id}")
+async def api_knowledge_agent_contribution(
+    agent_id: str,
+    page: int = 1,
+    page_size: int = 20,
+    entry_types: str | None = None,
+    tags: str | None = None,
+    search: str | None = None,
+    start_step: int | None = None,
+    end_step: int | None = None,
+) -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse({"total": 0, "page": page, "page_size": page_size, "items": []})
+    query = AgentContributionQueryDTO(
+        agent_id=agent_id,
+        filters=QueryFilters(
+            entry_types=_csv_param(entry_types),
+            tags=_csv_param(tags),
+            search=search,
+            start_step=start_step,
+            end_step=end_step,
+        ),
+        pagination=QueryPagination(page=page, page_size=page_size),
+    )
+    return JSONResponse(service.query_agent_contribution(query).to_dict())
+
+
+@app.get("/api/knowledge/causal/{entry_id}")
+async def api_knowledge_causal_chain(entry_id: str, depth: int = 3) -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse({"entry_id": entry_id, "chain": []})
+    chain = service.query_causal_chain(CausalChainQueryDTO(entry_id=entry_id, depth=depth))
+    return JSONResponse({"entry_id": entry_id, "chain": [item.to_dict() for item in chain]})
+
+
+@app.get("/api/knowledge/digests")
+async def api_knowledge_digests() -> Response:
+    service = _sim_kb_service()
+    if service is None:
+        return JSONResponse({"daily": None, "weekly": None})
+    digests = service.generate_story_digests()
+    return JSONResponse({key: value.to_dict() for key, value in digests.items()})
+
+
 @app.post("/api/propose_law")
 async def api_propose_law(proposal: LawProposal) -> Response:
     """Submit a (weighted) law proposal to the active simulation."""
@@ -798,8 +927,6 @@ async def api_observability_metrics() -> Response:
     return JSONResponse(_cost_metrics_data())
 
 
-
-
 @app.get("/api/character_arcs")
 async def api_character_arcs() -> Response:
     """Return user-facing character-arc event streams per agent."""
@@ -815,6 +942,7 @@ async def api_character_arcs() -> Response:
             "identity": list(getattr(agent.state, "identity_events", [])),
         }
     return JSONResponse({"arcs": arcs})
+
 
 @app.get("/api/auctions")
 async def api_auctions() -> Response:

--- a/src/interfaces/discord_bot.py
+++ b/src/interfaces/discord_bot.py
@@ -42,6 +42,14 @@ from src.interfaces.interaction_schema import (
     SpawnEnvelope,
 )
 from src.sim.context import SimulationContext
+from src.sim.knowledge_board_queries import (
+    AgentContributionQueryDTO,
+    CausalChainQueryDTO,
+    ProposalStatusQueryDTO,
+    QueryPagination,
+    ThreadQueryDTO,
+    TimelineQueryDTO,
+)
 from src.utils.policy import allow_message, evaluate_with_opa
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -197,6 +205,7 @@ def build_help_text() -> str:
             "- `/dm <agent_id> <message>` — send a direct message to one agent.",
             "- `/broadcast <message>` — send a message to all agents.",
             "- `/kb <text>` — add a note to the Knowledge Board.",
+            "- `/kb_timeline`, `/kb_thread`, `/kb_proposal_status`, `/kb_agent`, `/kb_causal_chain`, `/kb_digest` — query KB views.",
             "- `/status`, `/stats` — view current state/metrics.",
             "- `/start_here` — show onboarding, modes, and scenario cards.",
             "- `/propose`, `/propose_law`, `/vote` — governance interactions.",
@@ -1732,18 +1741,20 @@ async def slash_help(interaction: Any) -> None:
         await send_interaction_response(interaction, help_text, ephemeral=True)
 
 
-
-
 async def slash_start_here(interaction: Any) -> None:
     """Show onboarding flow with modes and scenario cards."""
     with command_span("start_here", interaction):
         cards = scenario_intro_cards()
-        lines = ["## 🚀 Start Here", "Modes: observer · participant · world-shaper · moderator", "", "Scenario cards:"]
+        lines = [
+            "## 🚀 Start Here",
+            "Modes: observer · participant · world-shaper · moderator",
+            "",
+            "Scenario cards:",
+        ]
         for card in cards:
-            lines.append(
-                f"- **{card['title']}** ({card['recommended_mode']}): {card['prompt']}"
-            )
+            lines.append(f"- **{card['title']}** ({card['recommended_mode']}): {card['prompt']}")
         await send_interaction_response(interaction, "\n".join(lines), ephemeral=True)
+
 
 async def slash_kb(interaction: Any, text: str) -> None:
     """Post an entry to the Knowledge Board."""
@@ -1763,6 +1774,167 @@ async def slash_kb(interaction: Any, text: str) -> None:
                 )
             )
         await send_interaction_response(interaction, "KB entry created", ephemeral=True)
+
+
+async def slash_kb_timeline(interaction: Any, page: int = 1, page_size: int = 10) -> None:
+    """Show ranked Knowledge Board timeline entries."""
+    with command_span("kb_timeline", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        result = service.query_timeline(
+            TimelineQueryDTO(pagination=QueryPagination(page=page, page_size=page_size))
+        )
+        lines = [
+            f"{item.step} · {item.entry_type} · {item.agent_id}: {item.content_summary}"
+            for item in result.items
+        ]
+        await send_interaction_response(
+            interaction,
+            "\n".join(lines) if lines else "No timeline entries.",
+            ephemeral=True,
+        )
+
+
+async def slash_kb_thread(
+    interaction: Any, root_entry_id: str, page: int = 1, page_size: int = 10
+) -> None:
+    """Show thread replies rooted at an entry."""
+    with command_span("kb_thread", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        result = service.query_thread(
+            ThreadQueryDTO(
+                root_entry_id=root_entry_id,
+                pagination=QueryPagination(page=page, page_size=page_size),
+            )
+        )
+        lines = [f"{item.step} · {item.agent_id}: {item.content_summary}" for item in result.items]
+        await send_interaction_response(
+            interaction,
+            "\n".join(lines) if lines else "No thread entries.",
+            ephemeral=True,
+        )
+
+
+async def slash_kb_proposal_status(
+    interaction: Any, proposal_id: str, page: int = 1, page_size: int = 10
+) -> None:
+    """Show proposal status and vote rollup."""
+    with command_span("kb_proposal_status", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        result = service.query_proposal_status(
+            ProposalStatusQueryDTO(
+                proposal_id=proposal_id,
+                pagination=QueryPagination(page=page, page_size=page_size),
+            )
+        )
+        consensus = result["consensus"]
+        await send_interaction_response(
+            interaction,
+            f"approvals={consensus['approvals']} rejections={consensus['rejections']} consensus={consensus['consensus']}",
+            ephemeral=True,
+        )
+
+
+async def slash_kb_agent(
+    interaction: Any, agent_id: str, page: int = 1, page_size: int = 10
+) -> None:
+    """Show ranked contributions for an agent."""
+    with command_span("kb_agent", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        result = service.query_agent_contribution(
+            AgentContributionQueryDTO(
+                agent_id=agent_id,
+                pagination=QueryPagination(page=page, page_size=page_size),
+            )
+        )
+        lines = [
+            f"{item.step} · {item.entry_type}: {item.content_summary}" for item in result.items
+        ]
+        await send_interaction_response(
+            interaction,
+            "\n".join(lines) if lines else "No contributions.",
+            ephemeral=True,
+        )
+
+
+async def slash_kb_causal_chain(interaction: Any, entry_id: str, depth: int = 3) -> None:
+    """Show an entry's causal chain."""
+    with command_span("kb_causal_chain", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        chain = service.query_causal_chain(CausalChainQueryDTO(entry_id=entry_id, depth=depth))
+        lines = [f"{item.step} · {item.entry_id} · {item.content_summary}" for item in chain]
+        await send_interaction_response(
+            interaction,
+            "\n".join(lines) if lines else "No causal chain.",
+            ephemeral=True,
+        )
+
+
+async def slash_kb_digest(interaction: Any) -> None:
+    """Show daily and weekly story digests."""
+    with command_span("kb_digest", interaction) as span:
+        bot_instance = get_active_bot()
+        sim = (
+            bot_instance.context if bot_instance is not None else DEFAULT_CONTEXT
+        ).sim_state.get("simulation")
+        service = getattr(sim, "knowledge_board_service", None) if sim is not None else None
+        if service is None:
+            await send_interaction_response(
+                interaction, "Knowledge Board unavailable", ephemeral=True
+            )
+            return
+        digests = service.generate_story_digests()
+        daily = digests["daily"]
+        weekly = digests["weekly"]
+        await send_interaction_response(
+            interaction,
+            f"Daily: {len(daily.highlights)} highlights | Weekly: {len(weekly.highlights)} highlights",
+            ephemeral=True,
+        )
 
 
 async def slash_event(interaction: Any, text: str) -> None:
@@ -2040,6 +2212,12 @@ def register_slash_commands(tree: Any) -> dict[str, Callable[..., Any]]:
     _register("help", slash_help)
     _register("start_here", slash_start_here)
     _register("kb", slash_kb)
+    _register("kb_timeline", slash_kb_timeline)
+    _register("kb_thread", slash_kb_thread)
+    _register("kb_proposal_status", slash_kb_proposal_status)
+    _register("kb_agent", slash_kb_agent)
+    _register("kb_causal_chain", slash_kb_causal_chain)
+    _register("kb_digest", slash_kb_digest)
     _register("event", slash_event)
     _register("propose", slash_propose)
     _register("propose_law", slash_propose_law)

--- a/src/sim/knowledge_board_queries.py
+++ b/src/sim/knowledge_board_queries.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class RankingWeights:
+    recency: float = 0.45
+    endorsement: float = 0.35
+    proximity: float = 0.20
+
+
+@dataclass(frozen=True)
+class QueryPagination:
+    page: int = 1
+    page_size: int = 20
+
+    @property
+    def offset(self) -> int:
+        return max(0, (self.page - 1) * self.page_size)
+
+
+@dataclass(frozen=True)
+class QueryFilters:
+    agent_id: str | None = None
+    entry_types: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    search: str | None = None
+    start_step: int | None = None
+    end_step: int | None = None
+
+
+@dataclass(frozen=True)
+class TimelineQueryDTO:
+    filters: QueryFilters = field(default_factory=QueryFilters)
+    pagination: QueryPagination = field(default_factory=QueryPagination)
+    anchor_entry_id: str | None = None
+    ranking: RankingWeights = field(default_factory=RankingWeights)
+
+
+@dataclass(frozen=True)
+class ThreadQueryDTO:
+    root_entry_id: str
+    pagination: QueryPagination = field(default_factory=QueryPagination)
+    ranking: RankingWeights = field(default_factory=RankingWeights)
+
+
+@dataclass(frozen=True)
+class ProposalStatusQueryDTO:
+    proposal_id: str
+    pagination: QueryPagination = field(default_factory=QueryPagination)
+
+
+@dataclass(frozen=True)
+class AgentContributionQueryDTO:
+    agent_id: str
+    filters: QueryFilters = field(default_factory=QueryFilters)
+    pagination: QueryPagination = field(default_factory=QueryPagination)
+    ranking: RankingWeights = field(default_factory=RankingWeights)
+
+
+@dataclass(frozen=True)
+class CausalChainQueryDTO:
+    entry_id: str
+    depth: int = 3
+
+
+DigestPeriod = Literal["daily", "weekly"]
+
+
+@dataclass(frozen=True)
+class StoryDigestDTO:
+    period: DigestPeriod
+    start_step: int
+    end_step: int
+    generated_at_step: int
+    highlights: tuple[str, ...]
+    source_entry_ids: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RankedEntryDTO:
+    entry_id: str
+    step: int
+    agent_id: str
+    entry_type: str
+    content_summary: str
+    parent_entry_id: str | None
+    tags: tuple[str, ...]
+    score: float
+    signals: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PagedQueryResultDTO:
+    total: int
+    page: int
+    page_size: int
+    items: tuple[RankedEntryDTO, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "page": self.page,
+            "page_size": self.page_size,
+            "items": [item.to_dict() for item in self.items],
+        }

--- a/src/sim/knowledge_board_service.py
+++ b/src/sim/knowledge_board_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+from collections import defaultdict
 from collections.abc import Callable
 from typing import Any
 
@@ -14,6 +16,18 @@ from src.sim.knowledge_board_protocol import (
     AgentStanceProjection,
     ConsensusStatusProjection,
     KnowledgeBoardProtocol,
+)
+from src.sim.knowledge_board_queries import (
+    AgentContributionQueryDTO,
+    CausalChainQueryDTO,
+    PagedQueryResultDTO,
+    ProposalStatusQueryDTO,
+    QueryFilters,
+    RankedEntryDTO,
+    RankingWeights,
+    StoryDigestDTO,
+    ThreadQueryDTO,
+    TimelineQueryDTO,
 )
 from src.sim.knowledge_entry import KnowledgeEntry, KnowledgeEntryType
 
@@ -44,6 +58,128 @@ class KnowledgeBoardService:
 
     def get_agent_stance_projection(self, agent_id: str) -> list[AgentStanceProjection]:
         return self._board.get_agent_stance_projection(agent_id)
+
+    def query_timeline(self, query: TimelineQueryDTO) -> PagedQueryResultDTO:
+        entries = self._filter_entries(self._all_entries(), query.filters)
+        ranked = self._rank_entries(entries, query.ranking, anchor_entry_id=query.anchor_entry_id)
+        return self._to_page(
+            ranked, page=query.pagination.page, page_size=query.pagination.page_size
+        )
+
+    def query_thread(self, query: ThreadQueryDTO) -> PagedQueryResultDTO:
+        all_entries = self._all_entries()
+        children_by_parent: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for entry in all_entries:
+            parent_id = entry.get("parent_entry_id")
+            if isinstance(parent_id, str) and parent_id:
+                children_by_parent[parent_id].append(entry)
+        queue = [query.root_entry_id]
+        seen: set[str] = set()
+        thread_entries: list[dict[str, Any]] = []
+        while queue:
+            current = queue.pop(0)
+            if current in seen:
+                continue
+            seen.add(current)
+            for child in children_by_parent.get(current, []):
+                child_id = str(child.get("entry_id", ""))
+                if child_id:
+                    queue.append(child_id)
+                thread_entries.append(child)
+        ranked = self._rank_entries(
+            thread_entries,
+            query.ranking,
+            anchor_entry_id=query.root_entry_id,
+        )
+        return self._to_page(
+            ranked, page=query.pagination.page, page_size=query.pagination.page_size
+        )
+
+    def query_proposal_status(self, query: ProposalStatusQueryDTO) -> dict[str, Any]:
+        entries = self._all_entries()
+        proposal = next(
+            (entry for entry in entries if str(entry.get("entry_id", "")) == query.proposal_id),
+            None,
+        )
+        consensus = self.get_consensus_projection(query.proposal_id)
+        votes = [
+            entry
+            for entry in entries
+            if str(entry.get("parent_entry_id") or "") == query.proposal_id
+            and str(entry.get("entry_type", "")).lower() == KnowledgeEntryType.VOTE.value
+        ]
+        ranked_votes = self._rank_entries(votes, RankingWeights())
+        vote_page = self._to_page(
+            ranked_votes,
+            page=query.pagination.page,
+            page_size=query.pagination.page_size,
+        )
+        return {
+            "proposal_id": query.proposal_id,
+            "proposal": self._entry_to_ranked(proposal, score=1.0, signals={}).to_dict()
+            if proposal
+            else None,
+            "consensus": {
+                "approvals": consensus.approvals,
+                "rejections": consensus.rejections,
+                "consensus": consensus.consensus,
+            },
+            "votes": vote_page.to_dict(),
+        }
+
+    def query_agent_contribution(self, query: AgentContributionQueryDTO) -> PagedQueryResultDTO:
+        scoped_filters = QueryFilters(
+            agent_id=query.agent_id,
+            entry_types=query.filters.entry_types,
+            tags=query.filters.tags,
+            search=query.filters.search,
+            start_step=query.filters.start_step,
+            end_step=query.filters.end_step,
+        )
+        entries = self._filter_entries(self._all_entries(), scoped_filters)
+        ranked = self._rank_entries(entries, query.ranking)
+        return self._to_page(
+            ranked, page=query.pagination.page, page_size=query.pagination.page_size
+        )
+
+    def query_causal_chain(self, query: CausalChainQueryDTO) -> list[RankedEntryDTO]:
+        entries = self._all_entries()
+        by_id = {str(entry.get("entry_id", "")): entry for entry in entries}
+        path: list[RankedEntryDTO] = []
+        current = by_id.get(query.entry_id)
+        depth = max(1, query.depth)
+        while current is not None and depth > 0:
+            path.append(self._entry_to_ranked(current, score=1.0, signals={"causal_depth": depth}))
+            parent_id = current.get("parent_entry_id")
+            if not isinstance(parent_id, str) or not parent_id:
+                break
+            current = by_id.get(parent_id)
+            depth -= 1
+        return path
+
+    def generate_story_digest(self, period: str) -> StoryDigestDTO:
+        entries = self._all_entries()
+        now = self._step_provider()
+        window = 24 if period == "daily" else 168
+        start_step = max(0, now - window)
+        scoped = [entry for entry in entries if int(entry.get("step", 0)) >= start_step]
+        ranked = self._rank_entries(scoped, RankingWeights())
+        highlights = tuple(item.content_summary for item in ranked[:5])
+        source_entry_ids = tuple(item.entry_id for item in ranked[:10])
+        return StoryDigestDTO(
+            period="daily" if period == "daily" else "weekly",
+            start_step=start_step,
+            end_step=now,
+            generated_at_step=now,
+            highlights=highlights,
+            source_entry_ids=source_entry_ids,
+        )
+
+    def generate_story_digests(self) -> dict[str, StoryDigestDTO]:
+        return {
+            "daily": self.generate_story_digest("daily"),
+            "weekly": self.generate_story_digest("weekly"),
+        }
 
     async def post_idea(
         self,
@@ -244,6 +380,190 @@ class KnowledgeBoardService:
             async with lock:
                 return self._board.add_entry(entry, actor_id, step, self._vector_provider())
         return self._board.add_entry(entry, actor_id, step, self._vector_provider())
+
+    def _all_entries(self) -> list[dict[str, Any]]:
+        get_full_entries = getattr(self._board, "get_full_entries", None)
+        if callable(get_full_entries):
+            return list(get_full_entries())
+        return []
+
+    def _filter_entries(
+        self, entries: list[dict[str, Any]], filters: QueryFilters
+    ) -> list[dict[str, Any]]:
+        filtered = list(entries)
+        if filters.agent_id:
+            filtered = [
+                entry for entry in filtered if str(entry.get("agent_id", "")) == filters.agent_id
+            ]
+        if filters.entry_types:
+            accepted_types = {entry_type.lower() for entry_type in filters.entry_types}
+            filtered = [
+                entry
+                for entry in filtered
+                if str(entry.get("entry_type", "")).lower() in accepted_types
+            ]
+        if filters.tags:
+            accepted_tags = {tag.lower() for tag in filters.tags}
+            filtered = [
+                entry
+                for entry in filtered
+                if accepted_tags.intersection(
+                    {str(tag).lower() for tag in (entry.get("tags") or []) if isinstance(tag, str)}
+                )
+            ]
+        if filters.search:
+            needle = filters.search.strip().lower()
+            filtered = [
+                entry
+                for entry in filtered
+                if needle in str(entry.get("content_full", "")).lower()
+                or needle in str(entry.get("content_summary", "")).lower()
+            ]
+        if filters.start_step is not None:
+            filtered = [
+                entry for entry in filtered if int(entry.get("step", 0)) >= filters.start_step
+            ]
+        if filters.end_step is not None:
+            filtered = [
+                entry for entry in filtered if int(entry.get("step", 0)) <= filters.end_step
+            ]
+        return filtered
+
+    def _rank_entries(
+        self,
+        entries: list[dict[str, Any]],
+        weights: RankingWeights,
+        *,
+        anchor_entry_id: str | None = None,
+    ) -> list[RankedEntryDTO]:
+        if not entries:
+            return []
+        now = self._step_provider()
+        max_gap = max(1, max(now - int(entry.get("step", 0)) for entry in entries))
+        vote_agg = self._aggregate_votes(entries)
+        total_support = max(1, sum(row.get("support", 0) for row in vote_agg.values()))
+        anchor = next(
+            (
+                entry
+                for entry in entries
+                if str(entry.get("entry_id", "")) == (anchor_entry_id or "")
+            ),
+            None,
+        )
+        anchor_agent = str(anchor.get("agent_id", "")) if anchor is not None else ""
+
+        scored: list[RankedEntryDTO] = []
+        for entry in entries:
+            step = int(entry.get("step", 0))
+            recency = 1.0 - min(1.0, max(0, now - step) / max_gap)
+            support = self._support_for_entry(entry, vote_agg)
+            endorsement = min(1.0, support / total_support)
+            proximity = self._relationship_proximity(entry, anchor_agent)
+            score = (
+                weights.recency * recency
+                + weights.endorsement * endorsement
+                + weights.proximity * proximity
+            )
+            scored.append(
+                self._entry_to_ranked(
+                    entry,
+                    score=score,
+                    signals={
+                        "recency": recency,
+                        "endorsement": endorsement,
+                        "proximity": proximity,
+                    },
+                )
+            )
+        scored.sort(key=lambda item: (item.score, item.step), reverse=True)
+        return scored
+
+    def _aggregate_votes(self, entries: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+        aggregate_votes = getattr(self._board, "aggregate_votes", None)
+        if callable(aggregate_votes):
+            return aggregate_votes(None)
+        result: dict[str, dict[str, int]] = {}
+        for entry in entries:
+            if str(entry.get("entry_type", "")).lower() != KnowledgeEntryType.VOTE.value:
+                continue
+            proposal_id = str(entry.get("parent_entry_id") or "")
+            if not proposal_id:
+                continue
+            row = result.setdefault(proposal_id, {"approvals": 0, "rejections": 0, "support": 0})
+            approve = bool((entry.get("reference_metadata") or {}).get("approve", False))
+            if approve:
+                row["approvals"] += 1
+                row["support"] += 1
+            else:
+                row["rejections"] += 1
+        return result
+
+    def _support_for_entry(
+        self,
+        entry: dict[str, Any],
+        vote_agg: dict[str, dict[str, int]],
+    ) -> int:
+        entry_id = str(entry.get("entry_id", ""))
+        if not entry_id:
+            return 0
+        if str(entry.get("entry_type", "")).lower() == KnowledgeEntryType.VOTE.value:
+            metadata = entry.get("reference_metadata") or {}
+            return 1 if bool(metadata.get("approve", False)) else 0
+        return int(vote_agg.get(entry_id, {}).get("support", 0))
+
+    def _relationship_proximity(self, entry: dict[str, Any], anchor_agent: str) -> float:
+        if not anchor_agent:
+            return 0.5
+        if str(entry.get("agent_id", "")) == anchor_agent:
+            return 1.0
+        parent_id = entry.get("parent_entry_id")
+        return 0.75 if isinstance(parent_id, str) and parent_id else 0.4
+
+    def _entry_to_ranked(
+        self,
+        entry: dict[str, Any] | None,
+        *,
+        score: float,
+        signals: dict[str, float],
+    ) -> RankedEntryDTO:
+        if entry is None:
+            return RankedEntryDTO(
+                entry_id="",
+                step=0,
+                agent_id="",
+                entry_type="",
+                content_summary="",
+                parent_entry_id=None,
+                tags=(),
+                score=score,
+                signals=signals,
+            )
+        summary = str(entry.get("content_summary") or entry.get("content_full") or "")
+        clipped = summary[:240]
+        return RankedEntryDTO(
+            entry_id=str(entry.get("entry_id", "")),
+            step=int(entry.get("step", 0)),
+            agent_id=str(entry.get("agent_id", "")),
+            entry_type=str(entry.get("entry_type", "")),
+            content_summary=clipped,
+            parent_entry_id=entry.get("parent_entry_id"),
+            tags=tuple(str(tag) for tag in (entry.get("tags") or []) if isinstance(tag, str)),
+            score=math.floor(score * 1000) / 1000,
+            signals={k: math.floor(v * 1000) / 1000 for k, v in signals.items()},
+        )
+
+    def _to_page(
+        self, entries: list[RankedEntryDTO], *, page: int, page_size: int
+    ) -> PagedQueryResultDTO:
+        normalized_page = max(1, page)
+        normalized_page_size = max(1, page_size)
+        offset = (normalized_page - 1) * normalized_page_size
+        return PagedQueryResultDTO(
+            total=len(entries),
+            page=normalized_page,
+            page_size=normalized_page_size,
+            items=tuple(entries[offset : offset + normalized_page_size]),
+        )
 
     def _with_required_metadata(
         self,

--- a/tests/integration/interfaces/test_dashboard_backend_api.py
+++ b/tests/integration/interfaces/test_dashboard_backend_api.py
@@ -265,3 +265,49 @@ async def test_message_queue_overflow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert queue.qsize() == 2
     remaining = [queue.get_nowait().content for _ in range(queue.qsize())]
     assert remaining == ["2", "3"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_knowledge_query_endpoints() -> None:
+    from src.interfaces import dashboard_backend as db
+    from src.sim.knowledge_board import KnowledgeBoard
+    from src.sim.knowledge_board_service import KnowledgeBoardService
+
+    board = KnowledgeBoard()
+    service = KnowledgeBoardService(
+        board,
+        step_provider=lambda: 30,
+        vector_provider=lambda: {"sim": 30},
+    )
+    await service.post_proposal(
+        actor_id="agent-1",
+        content="proposal body",
+        causal_source="test.proposal",
+    )
+    proposal_id = board.entries[-1].entry_id
+    await service.post_vote(
+        actor_id="agent-2",
+        proposal_id=proposal_id,
+        approve=True,
+        causal_source="test.vote",
+    )
+
+    class _Sim:
+        knowledge_board_service = service
+
+    db.DEFAULT_CONTEXT.sim_state["simulation"] = _Sim()
+
+    timeline_resp = await db.api_knowledge_timeline(page=1, page_size=5)
+    timeline_payload = json.loads(timeline_resp.body)
+    assert timeline_payload["total"] >= 2
+
+    proposal_resp = await db.api_knowledge_proposal_status(
+        proposal_id=proposal_id, page=1, page_size=5
+    )
+    proposal_payload = json.loads(proposal_resp.body)
+    assert proposal_payload["consensus"]["approvals"] == 1
+
+    digest_resp = await db.api_knowledge_digests()
+    digest_payload = json.loads(digest_resp.body)
+    assert digest_payload["daily"]["period"] == "daily"

--- a/tests/unit/sim/test_knowledge_board_service.py
+++ b/tests/unit/sim/test_knowledge_board_service.py
@@ -1,6 +1,14 @@
 import pytest
 
 from src.sim.knowledge_board import KnowledgeBoard
+from src.sim.knowledge_board_queries import (
+    AgentContributionQueryDTO,
+    CausalChainQueryDTO,
+    ProposalStatusQueryDTO,
+    QueryPagination,
+    ThreadQueryDTO,
+    TimelineQueryDTO,
+)
 from src.sim.knowledge_board_service import KnowledgeBoardService
 from src.sim.knowledge_entry import KnowledgeEntryType
 
@@ -71,3 +79,61 @@ async def test_governance_linkage_is_attached_to_entry_and_metadata() -> None:
     metadata = entry.reference_metadata or {}
     governance = metadata.get("governance") or {}
     assert governance.get("rule_id") == "rule-123"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_query_views_and_digest_generation() -> None:
+    step = 40
+    board = KnowledgeBoard()
+    service = KnowledgeBoardService(
+        board,
+        step_provider=lambda: step,
+        vector_provider=lambda: {"sim": step},
+    )
+
+    await service.post_proposal(
+        actor_id="agent-1",
+        content="proposal alpha",
+        causal_source="test.proposal",
+    )
+    proposal_id = board.entries[-1].entry_id
+    await service.post_vote(
+        actor_id="agent-2",
+        proposal_id=proposal_id,
+        approve=True,
+        causal_source="test.vote",
+    )
+    await service.post_vote(
+        actor_id="agent-3",
+        proposal_id=proposal_id,
+        approve=False,
+        causal_source="test.child",
+    )
+
+    timeline = service.query_timeline(TimelineQueryDTO(pagination=QueryPagination(page_size=10)))
+    assert timeline.total >= 3
+
+    thread = service.query_thread(
+        ThreadQueryDTO(root_entry_id=proposal_id, pagination=QueryPagination(page_size=10))
+    )
+    assert any(item.parent_entry_id == proposal_id for item in thread.items)
+
+    status = service.query_proposal_status(
+        ProposalStatusQueryDTO(proposal_id=proposal_id, pagination=QueryPagination(page_size=10))
+    )
+    assert status["consensus"]["approvals"] == 1
+
+    contributions = service.query_agent_contribution(
+        AgentContributionQueryDTO(agent_id="agent-2", pagination=QueryPagination(page_size=10))
+    )
+    assert contributions.total >= 1
+
+    chain = service.query_causal_chain(
+        CausalChainQueryDTO(entry_id=board.entries[-1].entry_id, depth=4)
+    )
+    assert chain
+
+    digests = service.generate_story_digests()
+    assert set(digests.keys()) == {"daily", "weekly"}
+    assert digests["daily"].period == "daily"


### PR DESCRIPTION
### Motivation
- Make the Knowledge Board a discoverable, consumable memory product with explicit read/query surfaces for timeline, thread, proposal status, agent contributions, and causal chains so UIs and bots can consume stable structures.
- Provide stable DTOs and a server-side ranking model to surface the most relevant board content (recency, endorsement, proximity) and produce periodic story digests for daily/weekly summaries.

### Description
- Added a shared schema module with stable query and result DTOs in `src/sim/knowledge_board_queries.py` (timeline/thread/proposal/agent/causal DTOs, `RankedEntryDTO`, `PagedQueryResultDTO`, `StoryDigestDTO`, and ranking weights/pagination types).
- Extended `KnowledgeBoardService` with explicit read/query service methods: `query_timeline`, `query_thread`, `query_proposal_status`, `query_agent_contribution`, `query_causal_chain`, `generate_story_digest`, and `generate_story_digests`, and helper paging/filtering (`src/sim/knowledge_board_service.py`).
- Implemented relevance ranking that blends recency, endorsement/vote signal, and relationship proximity with backend fallbacks (aggregates votes when backend lacks vote-aggregation capability) and returns `RankedEntryDTO` results.
- Added dashboard HTTP endpoints exposing the new views with pagination and filters under `/api/knowledge/*` in `src/interfaces/dashboard_backend.py` and added corresponding Discord slash commands (`/kb_timeline`, `/kb_thread`, `/kb_proposal_status`, `/kb_agent`, `/kb_causal_chain`, `/kb_digest`) and help text wiring in `src/interfaces/discord_bot.py`.
- Added unit and integration tests that exercise service query views, ranking/digest generation, and the dashboard endpoints (`tests/unit/sim/test_knowledge_board_service.py`, `tests/integration/interfaces/test_dashboard_backend_api.py`).

### Testing
- Ran lint/format checks with `ruff` on modified files; checks passed.
- Ran the targeted tests with `pytest -q tests/unit/sim/test_knowledge_board_service.py tests/integration/interfaces/test_dashboard_backend_api.py`; the test suite for these files passed.
- All modified source and added test files were formatted/linted and the above tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cbc273348326944715f737626346)