### PR TITLE
Add public_persistent deployment profile, health/readiness endpoints, startup script and smoke tests

### DIFF
--- a/docs/configuration_system.md
+++ b/docs/configuration_system.md
@@ -128,6 +128,25 @@ L2 MUS-based pruning:
 
 - `MAX_PROJECT_MEMBERS` - Maximum number of members in a project
 
+
+### Deployment Profiles
+
+- `PROFILE` - Optional named preset. Set `PROFILE=public_persistent` to enable a cohesive deployment tuned for persistent public worlds.
+
+`public_persistent` applies defaults for:
+- vLLM-backed LLM endpoint/model (`LLM_API_BASE`, `VLLM_API_BASE`, `DEFAULT_LLM_MODEL`)
+- Faster snapshot cadence (`SNAPSHOT_INTERVAL_STEPS=25`)
+- Memory pruning policy (`MEMORY_PRUNING_*` toggles + MUS thresholds)
+- Moderation defaults (`DISCORD_DEFAULT_BROADCAST=1`, `DISCORD_ALLOW_OPA_CONTROL_COMMANDS=1`)
+- Governance toggles (`USE_COUNCIL_MODE=1`, `USE_COUNCIL_FOR_DECISIONS=1`)
+- Graph knowledge backend (`KNOWLEDGE_BOARD_BACKEND=graph`)
+
+Use the startup helper to validate dependencies and start with this profile:
+
+```bash
+scripts/start_public_persistent.sh --steps 25
+```
+
 ### Observability Settings
 
 - `ENABLE_OTEL` - Set to `1` to enable OpenTelemetry log export

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -153,3 +153,54 @@ Follow these steps to manually export a dataset using `scripts/export_traces.py`
    ```bash
    python scripts/export_traces.py --snapshots snapshots/ --output data/traces.jsonl
    ```
+
+## Public Persistent World Profile
+Use the `public_persistent` profile for long-lived public deployments:
+
+```bash
+PROFILE=public_persistent scripts/start_public_persistent.sh --steps 100
+```
+
+This launcher validates Python/runtime dependencies and checks LLM connectivity before booting.
+
+## Incident Recovery
+When production traffic degrades or halts:
+1. Check subsystem status and readiness:
+   ```bash
+   curl -s http://localhost:8000/health | jq
+   curl -s -o /tmp/ready.json -w "%{http_code}\n" http://localhost:8000/ready
+   cat /tmp/ready.json | jq
+   ```
+2. If `llm` is degraded, restore backend first (`scripts/start_vllm.sh` or Ollama fallback) and retest `/ready`.
+3. If `event_bus` is degraded, restart the app process to reinitialize subscribers.
+4. If `graph_store`/`vector_store` is degraded, switch to safe mode by temporarily setting `KNOWLEDGE_BOARD_BACKEND=memory` and restarting.
+5. Confirm recovery by replaying one smoke event through dashboard/event ingestion test.
+
+## Snapshot Restore
+To restore from latest snapshot:
+
+```bash
+python -m src.app --replay snapshots/snapshot_<step>.json --replay-start <step>
+```
+
+To inspect available snapshots and latest candidate:
+
+```bash
+ls snapshots/snapshot_*.json snapshots/snapshot_*.json.zst 2>/dev/null | tail -n 5
+```
+
+After restore, verify `/health` and compare expected current step in dashboard.
+
+## Schema Migration
+Snapshots are schema-versioned and validated on load. For migrations:
+1. Back up snapshots:
+   ```bash
+   cp -r snapshots snapshots.backup.$(date +%Y%m%d%H%M%S)
+   ```
+2. Apply migration tooling/process for the new release.
+3. Run targeted tests:
+   ```bash
+   python -m pytest tests/integration/test_snapshot_replay.py
+   ```
+4. Load a migrated snapshot in staging and verify `/ready` plus event ingestion.
+5. Promote only after successful replay and health checks.

--- a/scripts/start_public_persistent.sh
+++ b/scripts/start_public_persistent.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${PROFILE:-public_persistent}"
+if [[ "$profile" != "public_persistent" ]]; then
+  echo "[warn] PROFILE='$profile' overridden to public_persistent for this launcher."
+  profile="public_persistent"
+fi
+
+errors=()
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    errors+=("Missing '$cmd'. $hint")
+  fi
+}
+
+require_cmd python "Install Python 3.11+ and ensure it is on PATH."
+
+python - <<'PY' || errors+=("Python package validation failed. Install project deps with: pip install -r requirements.txt -r requirements-dev.txt")
+import importlib
+import sys
+required = ["fastapi", "uvicorn", "httpx", "pydantic"]
+missing = [pkg for pkg in required if importlib.util.find_spec(pkg) is None]
+if missing:
+    print("Missing python packages:", ", ".join(missing))
+    sys.exit(1)
+print("Python dependencies look good.")
+PY
+
+: "${LLM_API_BASE:=http://localhost:8001/v1}"
+: "${REDPANDA_BROKER:=localhost:9092}"
+: "${GRAPH_DB_URI:=bolt://localhost:7687}"
+
+if ! curl -fsS "${LLM_API_BASE%/}/models" >/dev/null 2>&1; then
+  errors+=("LLM endpoint not reachable at $LLM_API_BASE/models. Start vLLM/Ollama and export LLM_API_BASE.")
+fi
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "Public persistent profile preflight failed:" >&2
+  for err in "${errors[@]}"; do
+    echo " - $err" >&2
+  done
+  exit 1
+fi
+
+echo "Preflight passed. Starting Culture with PROFILE=$profile"
+exec env PROFILE="$profile" python -m src.app "$@"

--- a/src/infra/config.py
+++ b/src/infra/config.py
@@ -25,6 +25,7 @@ CONFIG_OVERRIDES: dict[str, Any] = {}
 
 # Default values
 DEFAULT_CONFIG: dict[str, object] = {
+    "PROFILE": "",
     "LLM_API_BASE": "http://localhost:11434",
     "OLLAMA_API_BASE": "http://localhost:11434",
     "VLLM_API_BASE": "",
@@ -347,6 +348,38 @@ BOOL_CONFIG_KEYS = [
     "DISCORD_CHARACTER_ARC_SUMMARIES",
 ]
 
+PUBLIC_PERSISTENT_PROFILE: dict[str, Any] = {
+    "LLM_API_BASE": "http://localhost:8001/v1",
+    "VLLM_API_BASE": "http://localhost:8001/v1",
+    "DEFAULT_LLM_MODEL": "mistralai/Mistral-7B-Instruct-v0.2",
+    "MODEL_NAME": "mistralai/Mistral-7B-Instruct-v0.2",
+    "SNAPSHOT_INTERVAL_STEPS": 25,
+    "MEMORY_PRUNING_ENABLED": True,
+    "MEMORY_PRUNING_L2_ENABLED": True,
+    "MEMORY_PRUNING_L1_MUS_ENABLED": True,
+    "MEMORY_PRUNING_L2_MUS_ENABLED": True,
+    "MEMORY_PRUNING_L1_MUS_THRESHOLD": 0.2,
+    "MEMORY_PRUNING_L2_MUS_THRESHOLD": 0.2,
+    "MEMORY_PRUNING_USAGE_COUNT_THRESHOLD": 2,
+    "DISCORD_DEFAULT_BROADCAST": True,
+    "DISCORD_ALLOW_OPA_CONTROL_COMMANDS": True,
+    "USE_COUNCIL_MODE": True,
+    "USE_COUNCIL_FOR_DECISIONS": True,
+    "KNOWLEDGE_BOARD_BACKEND": "graph",
+}
+
+
+def _apply_profile_overrides(data: dict[str, Any]) -> dict[str, Any]:
+    """Apply optional named configuration profile defaults."""
+    profile = str(data.get("PROFILE") or os.getenv("PROFILE") or "").strip().lower()
+    if profile == "public_persistent":
+        for key, value in PUBLIC_PERSISTENT_PROFILE.items():
+            if key not in os.environ:
+                data[key] = value
+        data["PROFILE"] = "public_persistent"
+    return data
+
+
 # Keys that must be defined for a complete runtime configuration.
 # ``REDPANDA_BROKER`` enables event logging through Redpanda, while
 # ``OPA_URL`` points to the Open Policy Agent service used to filter
@@ -386,7 +419,7 @@ def load_config(*, validate_required: bool = True) -> dict[str, Any]:
         if missing:
             raise RuntimeError("Missing mandatory configuration keys: " + ", ".join(missing))
 
-    data: dict[str, Any] = new_settings.model_dump()
+    data: dict[str, Any] = _apply_profile_overrides(new_settings.model_dump())
     for key, value in data.items():
         setattr(settings, key, value)
     _CONFIG.update(data)
@@ -396,7 +429,7 @@ def load_config(*, validate_required: bool = True) -> dict[str, Any]:
 def get_config(key: str | None = None) -> Any:
     """Return a configuration value from :class:`ConfigSettings`."""
     if key is None:
-        return settings.model_dump()
+        return _apply_profile_overrides(settings.model_dump())
     if key in _CONFIG and str(_CONFIG.get(key, "")).strip() != "":
         return _CONFIG[key]
     if hasattr(settings, key):

--- a/src/infra/settings.py
+++ b/src/infra/settings.py
@@ -28,6 +28,7 @@ class ConfigSettings(BaseSettings):
         super().__init__(**data)
 
     # Deprecated individual base URLs - still loaded for backward compatibility
+    PROFILE: str = ""
     OLLAMA_API_BASE: str = "http://localhost:11434"
     VLLM_API_BASE: str = ""
 
@@ -114,6 +115,7 @@ class ConfigSettings(BaseSettings):
     DISCORD_BOT_TOKEN: str = ""
     DISCORD_CHANNEL_ID: int | None = None
     DISCORD_TOKENS_DB_URL: str = ""
+    DISCORD_DEFAULT_BROADCAST: bool = False
     DASHBOARD_API_BASE_URL: str = "http://localhost:8000"
     DISCORD_ALLOW_OPA_CONTROL_COMMANDS: bool = False
     OPENAI_API_KEY: str = ""

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -177,6 +177,60 @@ MISSIONS_PATH = (
 )
 
 
+def _subsystem_status() -> dict[str, dict[str, str | bool]]:
+    """Return readiness details for core runtime subsystems."""
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    statuses: dict[str, dict[str, str | bool]] = {
+        "llm": {"ok": False, "detail": "simulation not initialized"},
+        "vector_store": {"ok": False, "detail": "simulation not initialized"},
+        "graph_store": {"ok": False, "detail": "simulation not initialized"},
+        "event_bus": {"ok": False, "detail": "event bus unavailable"},
+        "snapshot_service": {"ok": False, "detail": "snapshot service unavailable"},
+    }
+
+    llm_base = str(get_config("LLM_API_BASE") or "").strip()
+    if llm_base:
+        statuses["llm"] = {"ok": True, "detail": f"configured at {llm_base}"}
+    else:
+        statuses["llm"] = {"ok": False, "detail": "LLM_API_BASE is not configured"}
+
+    if sim is not None:
+        vector_store = getattr(sim, "vector_store_manager", None)
+        if vector_store is not None:
+            statuses["vector_store"] = {"ok": True, "detail": type(vector_store).__name__}
+        else:
+            statuses["vector_store"] = {"ok": False, "detail": "vector store manager missing"}
+
+        board = getattr(sim, "knowledge_board", None)
+        board_name = type(board).__name__ if board is not None else "None"
+        if board is not None and "graph" in board_name.lower():
+            statuses["graph_store"] = {"ok": True, "detail": board_name}
+        else:
+            statuses["graph_store"] = {
+                "ok": False,
+                "detail": f"graph backend not active (current: {board_name})",
+            }
+
+    try:
+        bus = get_event_bus()
+    except Exception as exc:  # pragma: no cover - defensive
+        statuses["event_bus"] = {"ok": False, "detail": f"event bus error: {exc}"}
+    else:
+        subscribers = len(getattr(bus, "_queues", []))
+        statuses["event_bus"] = {"ok": True, "detail": f"active with {subscribers} subscribers"}
+
+    latest = SnapshotPersistenceService.latest_snapshot_path(directory=SNAPSHOT_DIR)
+    if latest is not None:
+        statuses["snapshot_service"] = {"ok": True, "detail": f"latest snapshot: {latest.name}"}
+    else:
+        statuses["snapshot_service"] = {
+            "ok": True,
+            "detail": f"snapshot directory ready at {SNAPSHOT_DIR}",
+        }
+
+    return statuses
+
+
 class AgentMessage(BaseModel):
     agent_id: str
     content: str
@@ -519,7 +573,18 @@ async def api_agent_stats() -> Response:
 
 @app.get("/health")
 async def health() -> Response:
-    return JSONResponse({"status": "ok"})
+    statuses = _subsystem_status()
+    overall = "ok" if all(bool(item.get("ok")) for item in statuses.values()) else "degraded"
+    return JSONResponse({"status": overall, "subsystems": statuses})
+
+
+@app.get("/ready")
+async def readiness() -> Response:
+    statuses = _subsystem_status()
+    required = ("llm", "event_bus", "snapshot_service")
+    missing = [name for name in required if not bool(statuses[name].get("ok"))]
+    payload = {"ready": not missing, "required": required, "subsystems": statuses}
+    return JSONResponse(payload, status_code=200 if not missing else 503)
 
 
 @app.get("/api/missions")

--- a/tests/integration/test_public_persistent_profile_smoke.py
+++ b/tests/integration/test_public_persistent_profile_smoke.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.infra import config
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.integration
+def test_public_persistent_profile_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROFILE", "public_persistent")
+    monkeypatch.setenv("REDPANDA_BROKER", "localhost:9092")
+    monkeypatch.setenv("OPA_URL", "http://localhost:8181")
+    monkeypatch.setenv("MODEL_NAME", "mistralai/Mistral-7B-Instruct-v0.2")
+
+    cfg = config.load_config(validate_required=False)
+
+    assert cfg["PROFILE"] == "public_persistent"
+    assert cfg["SNAPSHOT_INTERVAL_STEPS"] == 25
+    assert cfg["MEMORY_PRUNING_ENABLED"] is True
+    assert cfg["USE_COUNCIL_MODE"] is True
+    assert cfg["KNOWLEDGE_BOARD_BACKEND"] == "graph"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_public_persistent_dashboard_and_event_ingestion() -> None:
+    health = await db.health()
+    ready = await db.readiness()
+
+    health_status = getattr(health, "status_code", 200)
+    ready_status = getattr(ready, "status_code", 200)
+    health_body = getattr(health, "body", b"")
+    ready_body = getattr(ready, "body", b"")
+
+    assert health_status == 200
+    assert ready_status in {200, 503}
+    assert b"subsystems" in health_body
+    assert b"subsystems" in ready_body
+
+    embed = db.board_payload_to_embed({"agent_id": "agent_1", "content": "hello", "step": 1})
+    assert "Knowledge Board Entry" in embed["title"]
+
+    bus = db.get_event_bus()
+    queue = bus.subscribe()
+    try:
+        await db.emit_event(db.SimulationEvent(type="discord_message", data={"step": 1}))
+        event = await asyncio.wait_for(queue.get(), timeout=1)
+    finally:
+        bus.unsubscribe(queue)
+
+    assert event is not None
+    assert event.type == "discord_message"
+
+
+@pytest.mark.integration
+def test_public_persistent_startup_script_reports_actionable_failures() -> None:
+    script_path = (
+        Path(__file__).resolve().parents[1] / ".." / "scripts" / "start_public_persistent.sh"
+    ).resolve()
+    env = dict(os.environ)
+    env["LLM_API_BASE"] = "http://127.0.0.1:9"
+    result = subprocess.run(
+        ["bash", str(script_path), "--steps", "1"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Public persistent profile preflight failed" in result.stderr
+    assert "LLM endpoint not reachable" in result.stderr


### PR DESCRIPTION
### Motivation

- Provide an opinionated deployment preset tuned for long-lived public worlds that centralizes LLM backend, snapshot cadence, pruning, moderation and governance defaults. 
- Give operators a single startup entrypoint that validates runtime dependencies and emits actionable failures before booting. 
- Improve observability and operational playbooks by exposing subsystem health/readiness and documenting incident recovery, snapshot restore, and schema migration flows.

### Description

- Added a `PROFILE` setting and a `public_persistent` preset applied during config load via `_apply_profile_overrides`, which sets LLM endpoints/models, faster `SNAPSHOT_INTERVAL_STEPS`, memory-pruning toggles/thresholds, moderation and governance toggles, and `KNOWLEDGE_BOARD_BACKEND=graph` (changes in `src/infra/config.py` and `src/infra/settings.py`).
- Added a single launcher script `scripts/start_public_persistent.sh` that validates CLI/runtime dependencies, checks Python package availability, probes the configured `LLM_API_BASE`, prints actionable error messages, and launches the app with `PROFILE=public_persistent` when checks pass.
- Implemented subsystem-aware health/readiness endpoints in the dashboard backend: `GET /health` returns overall status and subsystem details, and `GET /ready` returns readiness with required subsystem checks for `llm`, `event_bus`, and `snapshot_service` (changes in `src/interfaces/dashboard_backend.py`).
- Added documentation and runbook sections describing the `public_persistent` profile, incident recovery steps, snapshot restore, and schema migration guidance, and added an integration smoke test that covers profile defaults, startup preflight failure behavior, and dashboard/event ingestion wiring (`docs/configuration_system.md`, `docs/runbook.md`, `tests/integration/test_public_persistent_profile_smoke.py`).

### Testing

- Ran `ruff check` against modified files with success on the changed files: `ruff check src/infra/settings.py src/infra/config.py src/interfaces/dashboard_backend.py tests/integration/test_public_persistent_profile_smoke.py` (passed for those targets).
- Ran the integration smoke suite with `python -m pytest -m integration tests/integration/test_public_persistent_profile_smoke.py -q` which exercised config load overrides, the health/readiness endpoints and event ingestion, and completed successfully (tests passed).
- Ran the project lint helper `scripts/lint.sh` which surfaced pre-existing repository-wide lint findings unrelated to these changes (the script run failed due to existing issues outside the modified files).
- Ran `mypy` on the primary modified modules which reported typing errors caused by existing untyped FastAPI decorators / typing debt in the codebase; these are pre-existing and unrelated to the new profile logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ebab18d08326aacae5c9daf8e56a)