### PR TITLE
Add simulator user-value KPI analytics, dashboard endpoints, and A/B harness

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -26,6 +26,7 @@ from src.infra import metrics as infra_metrics
 from src.infra.config import get_config
 from src.infra.ledger import ledger
 from src.interfaces import metrics
+from src.sim.analytics import compute_user_value_kpis
 from src.sim.context import SimulationContext
 from src.sim.event_bus import get_event_bus
 from src.sim.knowledge_board_queries import (
@@ -1019,6 +1020,46 @@ async def api_token_balances() -> Response:
     return JSONResponse({"agents": agents})
 
 
+
+
+def _knowledge_entries_for_analytics(sim: Any) -> list[dict[str, Any]]:
+    board = getattr(sim, "knowledge_board", None)
+    if board is None:
+        return []
+    if hasattr(board, "to_snapshot"):
+        try:
+            snapshot = board.to_snapshot()
+            entries = snapshot.get("entries", []) if isinstance(snapshot, dict) else []
+            if isinstance(entries, list):
+                return [dict(item) for item in entries if isinstance(item, dict)]
+        except Exception:
+            logger.exception("Failed to snapshot knowledge board for analytics")
+    entries = getattr(board, "entries", [])
+    return [
+        item.model_dump() if hasattr(item, "model_dump") else dict(item)
+        for item in entries
+        if hasattr(item, "model_dump") or isinstance(item, dict)
+    ]
+
+
+def _user_value_metrics_data() -> dict[str, Any]:
+    sim = SIM_STATE.get("simulation")
+    if sim is None:
+        return {}
+    events = event_log.fetch_events(after_step=0)
+    knowledge_entries = _knowledge_entries_for_analytics(sim)
+    report = compute_user_value_kpis(events=events, knowledge_entries=knowledge_entries)
+    latest_eval = sim.metrics[-1] if getattr(sim, "metrics", None) else {}
+    target_summary = latest_eval.get("_target_summary") if isinstance(latest_eval, dict) else None
+    target_alerts = latest_eval.get("_target_alerts") if isinstance(latest_eval, dict) else []
+    payload = report.as_dict()
+    payload["periodic_summary"] = {
+        "step": getattr(sim, "current_step", 0),
+        "target_summary": target_summary if isinstance(target_summary, dict) else {},
+        "target_alerts": target_alerts if isinstance(target_alerts, list) else [],
+    }
+    return payload
+
 def _cost_metrics_data() -> dict[str, float | int]:
     """Collect DU cost, sentiment, and reliability metrics for dashboards."""
 
@@ -1055,14 +1096,25 @@ def _cost_metrics_data() -> dict[str, float | int]:
 async def api_cost_metrics() -> Response:
     """Return DU cost and latency metrics for dashboards."""
 
-    return JSONResponse(_cost_metrics_data())
+    payload = _cost_metrics_data()
+    payload["user_value_kpis"] = _user_value_metrics_data()
+    return JSONResponse(payload)
 
 
 @app.get("/api/observability_metrics")
 async def api_observability_metrics() -> Response:
     """Return DU cost and latency metrics for dashboards."""
 
-    return JSONResponse(_cost_metrics_data())
+    payload = _cost_metrics_data()
+    payload["user_value_kpis"] = _user_value_metrics_data()
+    return JSONResponse(payload)
+
+
+@app.get("/api/user_value_metrics")
+async def api_user_value_metrics() -> Response:
+    """Return simulator user-value KPIs, stagnation alerts, and periodic summary metadata."""
+
+    return JSONResponse(_user_value_metrics_data())
 
 
 @app.get("/api/character_arcs")

--- a/src/sim/analytics.py
+++ b/src/sim/analytics.py
@@ -1,0 +1,192 @@
+"""User-value analytics for simulation event streams and knowledge board data."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationStagnationThresholds:
+    """Alert limits for detecting simulation stagnation signals."""
+
+    min_cross_agent_interaction_diversity: float = 0.2
+    max_repetitive_intents_ratio: float = 0.75
+    min_social_graph_change_count: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class UserValueKPIReport:
+    """Canonical user-value KPI payload consumed by dashboards and summaries."""
+
+    narrative_continuity_score: float
+    unresolved_conflict_count: int
+    cross_agent_interaction_diversity: float
+    user_intervention_rate: float
+    return_session_continuity: float
+    novelty_score: float
+    repetitive_intents_ratio: float
+    social_graph_change_count: int
+    stagnation_alerts: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "narrative_continuity_score": self.narrative_continuity_score,
+            "unresolved_conflict_count": self.unresolved_conflict_count,
+            "cross_agent_interaction_diversity": self.cross_agent_interaction_diversity,
+            "user_intervention_rate": self.user_intervention_rate,
+            "return_session_continuity": self.return_session_continuity,
+            "novelty_score": self.novelty_score,
+            "repetitive_intents_ratio": self.repetitive_intents_ratio,
+            "social_graph_change_count": self.social_graph_change_count,
+            "stagnation_alerts": list(self.stagnation_alerts),
+        }
+
+
+def _as_step(entry: Mapping[str, Any]) -> int:
+    try:
+        return int(entry.get("step", 0))
+    except Exception:
+        return 0
+
+
+def compute_user_value_kpis(
+    *,
+    events: Iterable[Mapping[str, Any]],
+    knowledge_entries: Iterable[Mapping[str, Any]],
+    thresholds: SimulationStagnationThresholds | None = None,
+) -> UserValueKPIReport:
+    """Compute user-value KPIs from event logs and board entries."""
+
+    cfg = thresholds or SimulationStagnationThresholds()
+    event_rows = [dict(event) for event in events]
+    entries = [dict(entry) for entry in knowledge_entries]
+
+    entry_ids = {str(entry.get("entry_id", "")) for entry in entries if entry.get("entry_id")}
+    parent_refs = [
+        str(entry.get("parent_entry_id", ""))
+        for entry in entries
+        if isinstance(entry.get("parent_entry_id"), str)
+    ]
+    continuation_ratio = (
+        sum(1 for parent in parent_refs if parent in entry_ids) / len(entries) if entries else 0.0
+    )
+    event_steps = sorted({_as_step(event) for event in event_rows if _as_step(event) > 0})
+    if len(event_steps) > 1:
+        contiguous = sum(1 for prev, curr in pairwise(event_steps) if curr - prev <= 1)
+        event_continuity = contiguous / (len(event_steps) - 1)
+    elif event_steps:
+        event_continuity = 1.0
+    else:
+        event_continuity = 0.0
+    narrative_continuity_score = (continuation_ratio + event_continuity) / 2.0
+
+    conflict_entries: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        entry_id = str(entry.get("entry_id", ""))
+        if not entry_id:
+            continue
+        tags = {str(tag).lower() for tag in entry.get("tags", [])}
+        entry_type = str(entry.get("entry_type", "")).lower()
+        summary = str(entry.get("content_summary", "")).lower()
+        if "conflict" in tags or "conflict" in entry_type or "conflict" in summary:
+            conflict_entries[entry_id] = entry
+
+    resolved_conflicts: set[str] = set()
+    for entry in entries:
+        parent_id = str(entry.get("parent_entry_id", "") or "")
+        if not parent_id or parent_id not in conflict_entries:
+            continue
+        tags = {str(tag).lower() for tag in entry.get("tags", [])}
+        entry_type = str(entry.get("entry_type", "")).lower()
+        summary = str(entry.get("content_summary", "")).lower()
+        if (
+            "resolution" in tags
+            or "resolved" in tags
+            or "resolve" in entry_type
+            or "resolved" in summary
+            or "resolution" in summary
+        ):
+            resolved_conflicts.add(parent_id)
+    unresolved_conflict_count = max(0, len(conflict_entries) - len(resolved_conflicts))
+
+    agents = {
+        str(event.get("agent_id"))
+        for event in event_rows
+        if isinstance(event.get("agent_id"), str) and str(event.get("agent_id"))
+    }
+    interaction_pairs: set[tuple[str, str]] = set()
+    for event in event_rows:
+        origin = event.get("agent_id")
+        if not isinstance(origin, str) or not origin:
+            continue
+        for field in ("recipient_id", "target_agent_id"):
+            target = event.get(field)
+            if isinstance(target, str) and target and target != origin:
+                interaction_pairs.add((origin, target))
+    possible_pairs = max(len(agents) * max(len(agents) - 1, 0), 1)
+    cross_agent_interaction_diversity = min(1.0, len(interaction_pairs) / possible_pairs)
+
+    user_interventions = sum(1 for event in event_rows if event.get("type") == "human_command")
+    user_intervention_rate = user_interventions / len(event_rows) if event_rows else 0.0
+
+    snapshot_steps = sorted(
+        {_as_step(event) for event in event_rows if str(event.get("type")) == "snapshot"}
+    )
+    if len(snapshot_steps) >= 2:
+        resumed_pairs = sum(1 for prev, curr in pairwise(snapshot_steps) if curr > prev)
+        return_session_continuity = resumed_pairs / (len(snapshot_steps) - 1)
+    elif len(snapshot_steps) == 1:
+        return_session_continuity = 1.0
+    else:
+        return_session_continuity = 0.0
+
+    intent_values = [
+        str(event.get("action_intent", "")).strip()
+        for event in event_rows
+        if isinstance(event.get("action_intent"), str) and str(event.get("action_intent", "")).strip()
+    ]
+    if intent_values:
+        counts = Counter(intent_values)
+        most_common = counts.most_common(1)[0][1]
+        repetitive_intents_ratio = most_common / len(intent_values)
+        novelty_score = len(counts) / len(intent_values)
+    else:
+        repetitive_intents_ratio = 0.0
+        novelty_score = 0.0
+
+    social_graph_change_count = 0
+    for event in event_rows:
+        payload_blob = " ".join(
+            [
+                str(event.get("type", "")).lower(),
+                str(event.get("action_intent", "")).lower(),
+                str(event.get("content", "")).lower(),
+            ]
+        )
+        if any(token in payload_blob for token in ("relationship", "coalition", "ally", "rival")):
+            social_graph_change_count += 1
+
+    stagnation_alerts: list[str] = []
+    if novelty_score < cfg.min_cross_agent_interaction_diversity:
+        stagnation_alerts.append("low_novelty")
+    if repetitive_intents_ratio > cfg.max_repetitive_intents_ratio:
+        stagnation_alerts.append("repetitive_intents")
+    if social_graph_change_count < cfg.min_social_graph_change_count:
+        stagnation_alerts.append("no_social_graph_change")
+
+    return UserValueKPIReport(
+        narrative_continuity_score=round(narrative_continuity_score, 4),
+        unresolved_conflict_count=unresolved_conflict_count,
+        cross_agent_interaction_diversity=round(cross_agent_interaction_diversity, 4),
+        user_intervention_rate=round(user_intervention_rate, 4),
+        return_session_continuity=round(return_session_continuity, 4),
+        novelty_score=round(novelty_score, 4),
+        repetitive_intents_ratio=round(repetitive_intents_ratio, 4),
+        social_graph_change_count=social_graph_change_count,
+        stagnation_alerts=tuple(stagnation_alerts),
+    )
+

--- a/src/sim/runtime/load_test_harness.py
+++ b/src/sim/runtime/load_test_harness.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import statistics
 import time
 import tracemalloc
 from dataclasses import dataclass
+from typing import Any
 
+from src.sim.analytics import compute_user_value_kpis
 from src.sim.runtime.actor_runtime import RuntimeOrchestrator, replay_event_log
 
 
@@ -78,3 +81,75 @@ def observability_payload(results: list[LoadScenarioResult]) -> list[dict[str, f
         }
         for result in results
     ]
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioABResult:
+    scenario_name: str
+    variant_a: str
+    variant_b: str
+    engagement_metrics_a: dict[str, float | int]
+    engagement_metrics_b: dict[str, float | int]
+    deltas: dict[str, float]
+
+
+def _to_sim_events(runtime: RuntimeOrchestrator, *, include_interactions: bool) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for envelope in runtime.event_log:
+        payload = dict(envelope.payload)
+        record: dict[str, Any] = {
+            "type": envelope.event_type,
+            "step": envelope.step + 1,
+            "agent_id": payload.get("agent_id", envelope.from_actor),
+        }
+        if envelope.event_type == "agent_step":
+            record["action_intent"] = "collaborate" if include_interactions else "idle"
+            if include_interactions and runtime.agent_ids:
+                idx = runtime.agent_ids.index(str(payload.get("agent_id", runtime.agent_ids[0])))
+                record["target_agent_id"] = runtime.agent_ids[(idx + 1) % len(runtime.agent_ids)]
+        events.append(record)
+    return events
+
+
+def run_scenario_ab_harness(
+    *, scenario_name: str, agent_count: int, steps: int = 10
+) -> ScenarioABResult:
+    """Run an A/B scenario harness and compare engagement-oriented KPI impact."""
+
+    runtime_a = RuntimeOrchestrator(agent_count=agent_count)
+    runtime_b = RuntimeOrchestrator(agent_count=agent_count)
+    for step in range(steps):
+        for agent_id in runtime_a.agent_ids:
+            runtime_a.submit_agent_step(agent_id=agent_id, step=step)
+        for agent_id in runtime_b.agent_ids:
+            runtime_b.submit_agent_step(agent_id=agent_id, step=step)
+        asyncio.run(runtime_a.drain())
+        asyncio.run(runtime_b.drain())
+
+    report_a = compute_user_value_kpis(events=_to_sim_events(runtime_a, include_interactions=False), knowledge_entries=[])
+    report_b = compute_user_value_kpis(events=_to_sim_events(runtime_b, include_interactions=True), knowledge_entries=[])
+
+    metrics_a: dict[str, float | int] = {
+        "narrative_continuity_score": report_a.narrative_continuity_score,
+        "cross_agent_interaction_diversity": report_a.cross_agent_interaction_diversity,
+        "user_intervention_rate": report_a.user_intervention_rate,
+        "novelty_score": report_a.novelty_score,
+    }
+    metrics_b: dict[str, float | int] = {
+        "narrative_continuity_score": report_b.narrative_continuity_score,
+        "cross_agent_interaction_diversity": report_b.cross_agent_interaction_diversity,
+        "user_intervention_rate": report_b.user_intervention_rate,
+        "novelty_score": report_b.novelty_score,
+    }
+    deltas = {
+        key: float(metrics_b[key]) - float(metrics_a[key])
+        for key in metrics_a
+    }
+    return ScenarioABResult(
+        scenario_name=scenario_name,
+        variant_a="baseline",
+        variant_b="interaction_enhanced",
+        engagement_metrics_a=metrics_a,
+        engagement_metrics_b=metrics_b,
+        deltas=deltas,
+    )

--- a/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
+++ b/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
@@ -180,3 +180,48 @@ async def test_agent_state_and_timeline_include_trait_artifacts(
         "personality_transition",
         "lifecycle_transition",
     }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_user_value_metrics_includes_kpis_and_periodic_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_dashboard_backend(monkeypatch)
+    db = load_dashboard_backend()
+
+    sim = types.SimpleNamespace(
+        current_step=12,
+        metrics=[{"_target_summary": {"novelty": {"status": "pass"}}, "_target_alerts": ["none"]}],
+        knowledge_board=types.SimpleNamespace(
+            to_snapshot=lambda: {
+                "entries": [
+                    {
+                        "entry_id": "e1",
+                        "step": 1,
+                        "entry_type": "conflict",
+                        "content_summary": "conflict",
+                        "tags": ["conflict"],
+                    }
+                ]
+            }
+        ),
+    )
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "simulation", sim)
+    monkeypatch.setattr(
+        db.event_log,
+        "fetch_events",
+        lambda after_step=0: [
+            {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "idle"},
+            {"type": "human_command", "step": 2},
+            {"type": "snapshot", "step": 3},
+        ],
+    )
+
+    resp = await db.api_user_value_metrics()
+    payload = json.loads(resp.body)
+
+    assert "narrative_continuity_score" in payload
+    assert "unresolved_conflict_count" in payload
+    assert "stagnation_alerts" in payload
+    assert payload["periodic_summary"]["step"] == 12

--- a/tests/unit/sim/runtime/test_actor_runtime_load_harness.py
+++ b/tests/unit/sim/runtime/test_actor_runtime_load_harness.py
@@ -5,7 +5,11 @@ import asyncio
 import pytest
 
 from src.sim.runtime.actor_runtime import EventEnvelope, Mailbox
-from src.sim.runtime.load_test_harness import observability_payload, run_default_load_suite
+from src.sim.runtime.load_test_harness import (
+    observability_payload,
+    run_default_load_suite,
+    run_scenario_ab_harness,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -53,3 +57,14 @@ def test_observability_payload_includes_latency_and_memory_growth() -> None:
         assert "tick_latency_p50_ms" in row
         assert "tick_latency_p95_ms" in row
         assert "memory_growth_bytes" in row
+
+
+def test_run_scenario_ab_harness_reports_metric_deltas() -> None:
+    result = run_scenario_ab_harness(scenario_name="engagement", agent_count=6, steps=3)
+
+    assert result.scenario_name == "engagement"
+    assert result.variant_a == "baseline"
+    assert result.variant_b == "interaction_enhanced"
+    assert "cross_agent_interaction_diversity" in result.engagement_metrics_a
+    assert "cross_agent_interaction_diversity" in result.engagement_metrics_b
+    assert "cross_agent_interaction_diversity" in result.deltas

--- a/tests/unit/sim/test_analytics.py
+++ b/tests/unit/sim/test_analytics.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from src.sim.analytics import compute_user_value_kpis
+
+pytestmark = pytest.mark.unit
+
+
+def test_compute_user_value_kpis_from_events_and_board_entries() -> None:
+    events = [
+        {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "propose", "target_agent_id": "b"},
+        {"type": "agent_action", "step": 2, "agent_id": "b", "action_intent": "respond", "target_agent_id": "a"},
+        {"type": "human_command", "step": 3},
+        {"type": "snapshot", "step": 4},
+        {"type": "snapshot", "step": 8},
+    ]
+    entries = [
+        {"entry_id": "c1", "step": 1, "entry_type": "conflict", "content_summary": "Conflict started", "tags": ["conflict"], "parent_entry_id": None},
+        {"entry_id": "r1", "step": 2, "entry_type": "resolution", "content_summary": "resolved", "tags": ["resolution"], "parent_entry_id": "c1"},
+    ]
+
+    report = compute_user_value_kpis(events=events, knowledge_entries=entries)
+
+    assert report.narrative_continuity_score >= 0
+    assert report.unresolved_conflict_count == 0
+    assert report.cross_agent_interaction_diversity > 0
+    assert report.user_intervention_rate > 0
+    assert report.return_session_continuity == 1.0
+
+
+def test_compute_user_value_kpis_emits_stagnation_alerts() -> None:
+    events = [
+        {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "idle"},
+        {"type": "agent_action", "step": 2, "agent_id": "a", "action_intent": "idle"},
+        {"type": "agent_action", "step": 3, "agent_id": "a", "action_intent": "idle"},
+    ]
+
+    report = compute_user_value_kpis(events=events, knowledge_entries=[])
+
+    assert "repetitive_intents" in report.stagnation_alerts
+    assert "no_social_graph_change" in report.stagnation_alerts


### PR DESCRIPTION
### Motivation
- Provide explicit user-value KPIs aligned to the simulator vision so dashboards and periodic summaries can surface narrative and engagement signals. 
- Detect simulation stagnation (low novelty, repetitive intents, no social-graph change) and enable A/B comparisons to measure feature impact on engagement metrics.

### Description
- Added a dedicated analytics module `src/sim/analytics.py` implementing `compute_user_value_kpis` and the `UserValueKPIReport` model to compute narrative continuity, unresolved-conflict count, cross-agent interaction diversity, user intervention rate, return-session continuity, novelty/repetitive-intent metrics, social-graph change count, and stagnation alerts.
- Integrated KPIs into the dashboard by adding `_knowledge_entries_for_analytics`, `_user_value_metrics_data`, wiring `user_value_kpis` into the payloads returned by `/api/cost_metrics` and `/api/observability_metrics`, and adding a new endpoint `/api/user_value_metrics` in `src/interfaces/dashboard_backend.py`.
- Added A/B scenario harness support in `src/sim/runtime/load_test_harness.py` with `run_scenario_ab_harness` and `ScenarioABResult` to run two variants and return engagement metric deltas.
- Added unit tests covering KPI computation, stagnation alerting, dashboard KPI endpoint payload, and A/B harness deltas (`tests/unit/sim/test_analytics.py`, updated `tests/unit/sim/runtime/test_actor_runtime_load_harness.py`, and updated dashboard backend observability tests).

### Testing
- Ran `pytest -q tests/unit/sim/test_analytics.py tests/unit/sim/runtime/test_actor_runtime_load_harness.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py` and all tests passed (11 passed, 0 failed).
- Ran static checks with `ruff check src/sim/analytics.py src/interfaces/dashboard_backend.py src/sim/runtime/load_test_harness.py tests/unit/sim/test_analytics.py tests/unit/sim/runtime/test_actor_runtime_load_harness.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py` which reported no issues.
- Attempted `npm run -s lint` in this environment which failed due to missing `pre-commit` tooling (environment limitation), not code issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80852ea9083269515317ffa80e90e)