### PR TITLE
Move step side-effects into kernel reducer; make _run_step_pipeline a compatibility shim; add golden-trace parity tests

### DIFF
--- a/src/sim/engines/reducers.py
+++ b/src/sim/engines/reducers.py
@@ -23,8 +23,16 @@ class DomainEventReducer:
                 context.planned_outputs = list(event.payload.get("planned_outputs", []))
             elif event.name == "planned_turns_committed":
                 context.planned_outputs = list(event.payload.get("committed_outputs", []))
+                turn_count = int(event.payload.get("turn_count", len(context.planned_outputs)))
+                if simulation.agents:
+                    simulation.current_step += turn_count
+                    simulation.current_agent_index = (
+                        simulation.current_agent_index + turn_count
+                    ) % len(simulation.agents)
+                simulation.total_turns_executed += int(event.payload.get("accepted_turn_count", 0))
             elif event.name == "scheduler_events_ready":
                 context.events = list(event.payload.get("events", []))
+                simulation.total_turns_executed += len(context.events)
             elif event.name == "bootstrap_agent_event_requested":
                 agent_index = int(event.payload["agent_index"])
                 agent_id = str(event.payload["agent_id"])

--- a/src/sim/engines/turn_engine.py
+++ b/src/sim/engines/turn_engine.py
@@ -124,15 +124,12 @@ class TurnEngine:
             intents = [dict(intent) for intent in context.planned_outputs]
             accepted, rejected = simulation._resolve_tick_conflicts(intents)
             committed = [*accepted, *rejected]
+            accepted_turns = 0
             for commit_index, intent in enumerate(committed):
                 intent["commit_index"] = commit_index
                 if intent.get("merge_outcome") == "accepted":
-                    simulation.total_turns_executed += 1
+                    accepted_turns += 1
 
-            simulation.current_step += len(intents)
-            simulation.current_agent_index = (simulation.current_agent_index + len(intents)) % len(
-                simulation.agents
-            )
             simulation._set_labeled_gauge(
                 STEP_PHASE_LATENCY_MS,
                 phase="deterministic_commit_apply",
@@ -147,7 +144,12 @@ class TurnEngine:
                 DomainEvent(
                     domain="turn",
                     name="planned_turns_committed",
-                    payload={"committed_outputs": committed, "tick_step": tick.step},
+                    payload={
+                        "committed_outputs": committed,
+                        "tick_step": tick.step,
+                        "turn_count": len(intents),
+                        "accepted_turn_count": accepted_turns,
+                    },
                 )
             ]
         agent_id = simulation.agents[simulation.current_agent_index].get_id()

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -54,8 +54,6 @@ from src.interfaces.external_event_routing import (
 from src.interfaces.interaction_commands import InteractionService
 from src.interfaces.metrics import (
     ACTIVE_AGENT_COUNT,
-    STEP_PHASE_LATENCY_MS,
-    STEP_PHASE_QUEUE_DEPTH,
 )
 from src.shared.telemetry import trace_agent_action
 from src.shared.typing import SimulationMessage
@@ -1869,123 +1867,21 @@ class Simulation:
         *,
         parallel_decision: bool = True,
     ) -> list[dict[str, Any]]:
-        """Run a phased step pipeline: perception, parallel planning, deterministic commit."""
+        """Deprecated compatibility adapter around the canonical kernel step path."""
 
         warnings.warn(
-            "Simulation._run_step_pipeline is an internal kernel path and will be removed as "
-            "a public entrypoint; use Simulation.run_step instead.",
+            "Simulation._run_step_pipeline is a compatibility adapter; use "
+            "Simulation.run_step for canonical runtime progression.",
             DeprecationWarning,
             stacklevel=2,
         )
-
-        if not self.agents:
+        _ = parallel_decision
+        await self._progress_step(max_turns=max_turns)
+        context = self.engine.last_step_context
+        if context is None:
             return []
+        return context.planned_outputs if context.planned_outputs else context.events
 
-        batch_size = min(max_turns, len(self.agents))
-        base_step = self.current_step + 1
-
-        tick_snapshot = self._build_tick_read_snapshot(turn_index=base_step)
-
-        phase_start = time.perf_counter()
-        plans: list[dict[str, Any]] = []
-        for idx in range(batch_size):
-            agent_index = (self.current_agent_index + idx) % len(self.agents)
-            agent = self.agents[agent_index]
-            plans.append(
-                {
-                    "batch_index": idx,
-                    "agent_index": agent_index,
-                    "agent_id": agent.agent_id,
-                    "simulation_step": base_step + idx,
-                    "resource": "agent_turn",
-                    "target": agent.agent_id,
-                    "tick_snapshot": tick_snapshot,
-                    "snapshot": self._build_step_perception_snapshot(base_step + idx),
-                }
-            )
-        self._set_labeled_gauge(
-            STEP_PHASE_LATENCY_MS,
-            phase="perception_snapshot",
-            value=(time.perf_counter() - phase_start) * 1000,
-        )
-        self._set_labeled_gauge(
-            STEP_PHASE_QUEUE_DEPTH, phase="planning_batch_size", value=len(plans)
-        )
-
-        phase_start = time.perf_counter()
-
-        async def _run_plan(plan: Mapping[str, Any]) -> Mapping[str, Any]:
-            return await self.agents[int(plan["agent_index"])].run_turn(
-                simulation_step=int(plan["simulation_step"]),
-                environment_perception=dict(cast(Mapping[str, Any], plan["snapshot"])),
-                memory_service=self.memory_service,
-                vector_store_manager=self.vector_store_manager,
-                knowledge_board=self.knowledge_board,
-            )
-
-        if parallel_decision:
-            planning_results = await asyncio.gather(*[_run_plan(plan) for plan in plans])
-        else:
-            planning_results = []
-            for plan in plans:
-                planning_results.append(await _run_plan(plan))
-        self._set_labeled_gauge(
-            STEP_PHASE_LATENCY_MS,
-            phase="concurrent_planning",
-            value=(time.perf_counter() - phase_start) * 1000,
-        )
-
-        phase_start = time.perf_counter()
-        intents: list[dict[str, Any]] = []
-        for plan, output in zip(plans, planning_results, strict=False):
-            plan["output"] = output
-            if isinstance(output, Mapping):
-                action_intent = str(output.get("action_intent", AgentActionIntent.IDLE.value))
-                intent = {
-                    "batch_index": int(plan["batch_index"]),
-                    "agent_index": int(plan["agent_index"]),
-                    "agent_id": str(plan["agent_id"]),
-                    "simulation_step": int(plan["simulation_step"]),
-                    "action_intent": action_intent,
-                    "requested_action_intent": action_intent,
-                    "message_content": output.get("message_content"),
-                    "message_recipient_id": output.get("message_recipient_id"),
-                    "map_action": output.get("map_action"),
-                    "resource": self._action_resource_key(
-                        {
-                            "agent_id": plan["agent_id"],
-                            "action_intent": action_intent,
-                            "map_action": output.get("map_action"),
-                            "message_recipient_id": output.get("message_recipient_id"),
-                        }
-                    ),
-                    "target": str(output.get("target", plan["target"])),
-                    "metadata": {
-                        "governance_sensitive": self._is_governance_sensitive(
-                            {"action_intent": action_intent}
-                        ),
-                        "tick_snapshot_turn": tick_snapshot["turn_index"],
-                    },
-                }
-                intents.append(intent)
-
-        ordered, rejected = self._resolve_tick_conflicts(intents)
-        committed: list[dict[str, Any]] = []
-        for intent in ordered:
-            committed.append(intent)
-            self.total_turns_executed += 1
-        committed.extend(rejected)
-        self.current_step += len(intents)
-        self.current_agent_index = (self.current_agent_index + len(intents)) % len(self.agents)
-        self._set_labeled_gauge(
-            STEP_PHASE_LATENCY_MS,
-            phase="deterministic_commit_apply",
-            value=(time.perf_counter() - phase_start) * 1000,
-        )
-        self._set_labeled_gauge(
-            STEP_PHASE_QUEUE_DEPTH, phase="commit_batch_size", value=len(committed)
-        )
-        return committed
 
     async def async_run(self: Self, num_steps: int) -> None:
         """

--- a/tests/unit/sim/test_kernel_golden_trace_parity.py
+++ b/tests/unit/sim/test_kernel_golden_trace_parity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from src.sim.simulation import Simulation
+
+
+@dataclass
+class DummyState:
+    ip: float = 0.0
+    du: float = 0.0
+    mood_level: float = 0.0
+    short_term_memory: list[dict[str, Any]] = field(default_factory=list)
+    messages_sent_count: int = 0
+    last_message_step: int | None = None
+    collective_ip: float = 0.0
+    collective_du: float = 0.0
+
+
+class ScriptedAgent:
+    def __init__(self, agent_id: str, recipient: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState()
+        self._recipient = recipient
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:
+        return self._state
+
+    async def run_turn(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "action_intent": "send_direct_message",
+            "message_content": f"golden:{self.agent_id}",
+            "message_recipient_id": self._recipient,
+            "map_action": {"action": "gather", "x": 2, "y": 2},
+        }
+
+
+def _normalize_trace(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ignored = {"simulation_step", "commit_index", "ordering_key"}
+    normalized: list[dict[str, Any]] = []
+    for event in events:
+        normalized.append({k: v for k, v in event.items() if k not in ignored})
+    return normalized
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_golden_trace_compat_pipeline_matches_kernel_run_step() -> None:
+    compat_sim = Simulation([ScriptedAgent("A", "R"), ScriptedAgent("B", "R")], seed=123)
+    kernel_sim = Simulation([ScriptedAgent("A", "R"), ScriptedAgent("B", "R")], seed=123)
+
+    try:
+        compat_events = await compat_sim._run_step_pipeline(max_turns=2)
+
+        _ = await kernel_sim.run_step(max_turns=2)
+        kernel_context = kernel_sim.engine.last_step_context
+        assert kernel_context is not None
+        kernel_events = (
+            kernel_context.planned_outputs if kernel_context.planned_outputs else kernel_context.events
+        )
+
+        assert _normalize_trace(compat_events) == _normalize_trace(kernel_events)
+    finally:
+        await compat_sim.stop_event_listener()
+        compat_sim.close()
+        await kernel_sim.stop_event_listener()
+        kernel_sim.close()

--- a/tests/unit/sim/test_reducer_kernel_side_effects.py
+++ b/tests/unit/sim/test_reducer_kernel_side_effects.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.sim.engines.domain_events import DomainEvent
+from src.sim.engines.reducers import DomainEventReducer
+from src.sim.runtime.step_context import StepContext
+
+
+@pytest.mark.unit
+def test_reducer_applies_committed_turn_side_effects() -> None:
+    simulation = SimpleNamespace(
+        agents=[SimpleNamespace(), SimpleNamespace()],
+        current_step=4,
+        current_agent_index=1,
+        total_turns_executed=10,
+        vector=SimpleNamespace(increment=lambda _agent_id: None),
+        event_kernel=SimpleNamespace(schedule_immediate_nowait=lambda *_args, **_kwargs: None),
+        _create_agent_event=lambda _index: None,
+        _set_labeled_gauge=lambda *_args, **_kwargs: None,
+    )
+    reducer = DomainEventReducer()
+    context = StepContext(max_turns=2)
+
+    reducer.apply(
+        simulation,
+        context,
+        [
+            DomainEvent(
+                domain="turn",
+                name="planned_turns_committed",
+                payload={
+                    "committed_outputs": [{"merge_outcome": "accepted"}, {"merge_outcome": "rejected"}],
+                    "turn_count": 2,
+                    "accepted_turn_count": 1,
+                },
+            )
+        ],
+    )
+
+    assert simulation.current_step == 6
+    assert simulation.current_agent_index == 1
+    assert simulation.total_turns_executed == 11
+
+
+@pytest.mark.unit
+def test_reducer_counts_scheduler_events_as_executed_turns() -> None:
+    simulation = SimpleNamespace(
+        agents=[SimpleNamespace()],
+        current_step=2,
+        current_agent_index=0,
+        total_turns_executed=3,
+        vector=SimpleNamespace(increment=lambda _agent_id: None),
+        event_kernel=SimpleNamespace(schedule_immediate_nowait=lambda *_args, **_kwargs: None),
+        _create_agent_event=lambda _index: None,
+        _set_labeled_gauge=lambda *_args, **_kwargs: None,
+    )
+    reducer = DomainEventReducer()
+    context = StepContext(max_turns=2)
+
+    reducer.apply(
+        simulation,
+        context,
+        [
+            DomainEvent(
+                domain="turn",
+                name="scheduler_events_ready",
+                payload={"events": [{"type": "agent_action"}, {"type": "agent_action"}]},
+            )
+        ],
+    )
+
+    assert simulation.total_turns_executed == 5

--- a/tests/unit/sim/test_simulation_kernel.py
+++ b/tests/unit/sim/test_simulation_kernel.py
@@ -60,6 +60,7 @@ class DummySimulation:
             temporal=SimpleNamespace(world_day=0),
         )
         self.engine = SimpleNamespace(emit_evaluation_events=self._emit_eval)
+        self.total_turns_executed = 0
         self._evaluated = False
 
     async def _emit_eval(self, _events: list[dict[str, Any]]) -> None:


### PR DESCRIPTION
### Motivation
- Consolidate step progression through the deterministic kernel path so all ingest→decide→execute→persist→publish side-effects are deterministic and replayable.
- Isolate legacy orchestration behind a compatibility adapter and emit explicit domain events for reducers to apply, enabling easier parity verification and future removal of deprecated entry points.

### Description
- `TurnEngine.commit` no longer mutates simulation counters; it emits a `planned_turns_committed` `DomainEvent` that includes `turn_count` and `accepted_turn_count` metadata. (`src/sim/engines/turn_engine.py`)
- `DomainEventReducer` now applies committed-turn side effects (advancing `current_step`, rotating `current_agent_index`, incrementing `total_turns_executed`) and counts scheduler events, centralizing state mutations into deterministic reducers. (`src/sim/engines/reducers.py`)
- `Simulation._run_step_pipeline` was converted into a thin, deprecated compatibility adapter that delegates to the canonical kernel execution path (`_progress_step` / `SimulationEngine.run_step`) so only the kernel path is authoritative. (`src/sim/simulation.py`)
- Added golden-trace regression test to compare normalized event streams between the legacy compatibility adapter and the kernel path, and added reducer-focused unit tests to validate deterministic application of side effects; updated test scaffolding where needed. (`tests/unit/sim/test_kernel_golden_trace_parity.py`, `tests/unit/sim/test_reducer_kernel_side_effects.py`, modified `tests/unit/sim/test_simulation_kernel.py`)

### Testing
- Ran linters with `ruff check <files>` and the linter run passed for the modified files. (`ruff check src/sim/engines/turn_engine.py src/sim/engines/reducers.py src/sim/simulation.py tests/unit/sim/test_kernel_golden_trace_parity.py tests/unit/sim/test_reducer_kernel_side_effects.py tests/unit/sim/test_simulation_kernel.py`)
- Executed unit tests with `pytest -q` for the affected simulation tests and they passed (the run used `pytest -q tests/unit/sim/test_simulation_kernel.py tests/unit/sim/test_tick_pipeline_determinism.py tests/unit/sim/test_kernel_golden_trace_parity.py tests/unit/sim/test_reducer_kernel_side_effects.py` and reported all tests green).
- Ran `mypy` for validation but it reported pre-existing unrelated type errors in other modules (`src/governance/rules_engine.py` and `src/infra/settings.py`), so type checks for this change are blocked by unrelated project issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80e6f4c448326813394b74b37d3b9)