### PR TITLE
Unify command ingestion through CommandBus; add legacy adapter with telemetry and canonicalize moderation flows

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -1020,8 +1020,6 @@ async def api_token_balances() -> Response:
     return JSONResponse({"agents": agents})
 
 
-
-
 def _knowledge_entries_for_analytics(sim: Any) -> list[dict[str, Any]]:
     board = getattr(sim, "knowledge_board", None)
     if board is None:
@@ -1059,6 +1057,7 @@ def _user_value_metrics_data() -> dict[str, Any]:
         "target_alerts": target_alerts if isinstance(target_alerts, list) else [],
     }
     return payload
+
 
 def _cost_metrics_data() -> dict[str, float | int]:
     """Collect DU cost, sentiment, and reliability metrics for dashboards."""
@@ -1425,7 +1424,7 @@ async def handle_control_command(
         source="dashboard",
         permissions={"admin", "moderator"},
     )
-    result = await simulation.interaction_service.execute_from_payload(cmd, context=context)
+    result = await simulation.command_bus.dispatch_payload(cmd, context=context)
     return {
         "status": result.status,
         "message": result.user_message,

--- a/src/interfaces/discord_bot/__init__.py
+++ b/src/interfaces/discord_bot/__init__.py
@@ -1,7 +1,7 @@
 """Discord bot interface for the Culture simulation.
 
 Provides real-time updates about the simulation to a Discord channel and
-forwards user messages to :meth:`Simulation._handle_human_command`. Messages
+forwards user messages through the canonical command bus. Messages
 prefixed with ``/broadcast`` will be delivered to all agents, incurring a single
 IP/DU cost for the currently active agent.
 """
@@ -538,7 +538,7 @@ class SimulationDiscordBot:
     simulation events, including Knowledge Board updates, agent messages, role
     changes, and other significant state changes. Incoming Discord messages are
     placed on the shared event queue and ultimately handled by
-    ``Simulation._handle_human_command``.
+    the canonical command bus.
     """
 
     @classmethod

--- a/src/interfaces/discord_moderation.py
+++ b/src/interfaces/discord_moderation.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.infra.ledger import log_penalty
 from src.interfaces import discord_bot
-from src.interfaces.dashboard_backend import DEFAULT_CONTEXT, SimulationEvent
+from src.interfaces.dashboard_backend import DEFAULT_CONTEXT
 from src.utils.policy import evaluate_with_opa
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -108,16 +108,26 @@ def register_moderation_commands(
     @_context_description(agent_id="ID of the agent to reset")
     @moderation_rate_limit("reset_memory")
     async def slash_reset_memory(interaction: Any, agent_id: str) -> None:
-        _, event_queue = resolve_context()
+        context, _ = resolve_context()
         if not has_admin_permission(getattr(interaction, "user", None)):
             await interaction.response.send_message("unauthorized", ephemeral=True)
             return
-        await event_queue.put(
-            SimulationEvent(
-                type="moderation", data={"command": "reset_memory", "agent_id": agent_id}
-            )
+        bus = discord_bot.get_command_bus(context)
+        if bus is None:
+            await interaction.response.send_message("command bus unavailable", ephemeral=True)
+            return
+        command_context = discord_bot.discord_interaction_context(
+            user=getattr(interaction, "user", None),
+            channel=getattr(interaction, "channel", None),
         )
-        await discord_bot.send_interaction_response(interaction, "memory reset", ephemeral=True)
+        command_context.permissions.update({"admin", "moderator"})
+        result = await bus.dispatch_payload(
+            {"intent": "moderation", "command": "reset_memory", "agent_id": agent_id},
+            context=command_context,
+        )
+        await discord_bot.send_interaction_response(
+            interaction, result.user_message, ephemeral=True
+        )
 
     commands["reset_memory"] = slash_reset_memory
 
@@ -134,21 +144,37 @@ def register_moderation_commands(
         ip: float = 0.0,
         du: float = 0.0,
     ) -> None:
-        _, event_queue = resolve_context()
+        context, _ = resolve_context()
         if not has_admin_permission(getattr(interaction, "user", None)):
             await interaction.response.send_message("unauthorized", ephemeral=True)
             return
-        await event_queue.put(
-            SimulationEvent(
-                type="moderation",
-                data={"command": "penalty", "agent_id": agent_id, "ip": ip, "du": du},
-            )
+        bus = discord_bot.get_command_bus(context)
+        if bus is None:
+            await interaction.response.send_message("command bus unavailable", ephemeral=True)
+            return
+        command_context = discord_bot.discord_interaction_context(
+            user=getattr(interaction, "user", None),
+            channel=getattr(interaction, "channel", None),
+        )
+        command_context.permissions.update({"admin", "moderator"})
+        result = await bus.dispatch_payload(
+            {
+                "intent": "moderation",
+                "command": "penalty",
+                "agent_id": agent_id,
+                "value": ip,
+                "ip": ip,
+                "du": du,
+            },
+            context=command_context,
         )
         try:  # pragma: no cover - best effort
             log_penalty(agent_id, abs(ip), abs(du), "moderation_penalty")
         except Exception:
             pass
-        await discord_bot.send_interaction_response(interaction, "penalty applied", ephemeral=True)
+        await discord_bot.send_interaction_response(
+            interaction, result.user_message, ephemeral=True
+        )
 
     commands["penalty"] = slash_penalty
 
@@ -156,11 +182,23 @@ def register_moderation_commands(
     @_context_description(agent_id="ID of the agent to mute")
     @moderation_rate_limit("mute")
     async def slash_mute(interaction: Any, agent_id: str) -> None:
-        _, event_queue = resolve_context()
-        await event_queue.put(
-            SimulationEvent(type="moderation", data={"command": "mute", "agent_id": agent_id})
+        context, _ = resolve_context()
+        bus = discord_bot.get_command_bus(context)
+        if bus is None:
+            await interaction.response.send_message("command bus unavailable", ephemeral=True)
+            return
+        command_context = discord_bot.discord_interaction_context(
+            user=getattr(interaction, "user", None),
+            channel=getattr(interaction, "channel", None),
         )
-        await discord_bot.send_interaction_response(interaction, "muted", ephemeral=True)
+        command_context.permissions.update({"moderator"})
+        result = await bus.dispatch_payload(
+            {"intent": "moderation", "command": "mute", "agent_id": agent_id},
+            context=command_context,
+        )
+        await discord_bot.send_interaction_response(
+            interaction, result.user_message, ephemeral=True
+        )
 
     commands["mute"] = slash_mute
 
@@ -168,11 +206,23 @@ def register_moderation_commands(
     @_context_description(agent_id="ID of the agent to unmute")
     @moderation_rate_limit("unmute")
     async def slash_unmute(interaction: Any, agent_id: str) -> None:
-        _, event_queue = resolve_context()
-        await event_queue.put(
-            SimulationEvent(type="moderation", data={"command": "unmute", "agent_id": agent_id})
+        context, _ = resolve_context()
+        bus = discord_bot.get_command_bus(context)
+        if bus is None:
+            await interaction.response.send_message("command bus unavailable", ephemeral=True)
+            return
+        command_context = discord_bot.discord_interaction_context(
+            user=getattr(interaction, "user", None),
+            channel=getattr(interaction, "channel", None),
         )
-        await discord_bot.send_interaction_response(interaction, "unmuted", ephemeral=True)
+        command_context.permissions.update({"moderator"})
+        result = await bus.dispatch_payload(
+            {"intent": "moderation", "command": "unmute", "agent_id": agent_id},
+            context=command_context,
+        )
+        await discord_bot.send_interaction_response(
+            interaction, result.user_message, ephemeral=True
+        )
 
     commands["unmute"] = slash_unmute
 

--- a/src/interfaces/domain_command_adapters.py
+++ b/src/interfaces/domain_command_adapters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -17,6 +16,7 @@ from src.interfaces.interaction_schema import (
     SpawnEnvelope,
     parse_interaction_envelope,
 )
+from src.interfaces.legacy_command_adapter import normalize_legacy_command_payload
 from src.sim.commands.domain_commands import (
     BroadcastCommand,
     ControlCommand,
@@ -46,7 +46,12 @@ def parse_bus_command(
     *,
     context: InteractionContext | None = None,
 ) -> InteractionEnvelope:
-    data = _normalize_legacy_payload(payload)
+    data = normalize_legacy_command_payload(
+        payload,
+        adapter="domain_command_adapters.parse_bus_command",
+        context_source=(context.source if context is not None else None),
+        sender_id=((context.sender_id) if context is not None else None),
+    )
     ctx = context or InteractionContext()
     mediation = mediate_user_input(data)
     intent = mediation.intent
@@ -302,7 +307,9 @@ def mediate_user_input(payload: Mapping[str, Any]) -> MediatedIntent:
             rationale="broadcast_prefix",
         )
 
-    if any(token in lowered for token in ("spawn", "inject event", "set speed", "pause", "resume")):
+    if any(
+        token in lowered for token in ("spawn", "inject event", "set speed", "pause", "resume")
+    ):
         if mode in {"world-shaper", "moderator"}:
             return MediatedIntent(
                 intent="control",
@@ -335,24 +342,6 @@ def mediate_user_input(payload: Mapping[str, Any]) -> MediatedIntent:
         mode=mode,
         rationale="default_human_message",
     )
-
-
-def _normalize_legacy_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    data = dict(payload)
-    if "content" in data and "text" not in data:
-        data["text"] = data["content"]
-        warnings.warn("'content' is deprecated; use 'text'.", DeprecationWarning, stacklevel=3)
-    if "prompt" in data and "scope" not in data:
-        data["scope"] = data["prompt"]
-        warnings.warn("'prompt' is deprecated; use 'scope'.", DeprecationWarning, stacklevel=3)
-    if "command_type" in data and "intent" not in data and "type" not in data:
-        warnings.warn(
-            "'command_type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3
-        )
-    if "type" in data and "intent" not in data:
-        data["intent"] = data["type"]
-        warnings.warn("'type' is deprecated; use 'intent'.", DeprecationWarning, stacklevel=3)
-    return data
 
 
 def _metadata_with_context(data: Mapping[str, Any], context: InteractionContext) -> dict[str, Any]:

--- a/src/interfaces/external_event_routing.py
+++ b/src/interfaces/external_event_routing.py
@@ -5,7 +5,9 @@ from typing import Any
 from src.interfaces.interaction_commands import InteractionContext
 
 
-def build_interaction_context(payload: dict[str, Any], *, default_source: str) -> InteractionContext:
+def build_interaction_context(
+    payload: dict[str, Any], *, default_source: str
+) -> InteractionContext:
     permissions = payload.get("permissions", [])
     return InteractionContext(
         sender_id=str(payload.get("sender_id", payload.get("author", "external"))),
@@ -16,9 +18,15 @@ def build_interaction_context(payload: dict[str, Any], *, default_source: str) -
     )
 
 
-def normalize_human_command_payload(text: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+def normalize_human_command_payload(
+    text: str, metadata: dict[str, Any] | None = None
+) -> dict[str, Any]:
     payload = dict(metadata or {})
     command_type = payload.get("command_type")
     if not command_type and bool(payload.get("broadcast")):
         command_type = "broadcast"
+    if not command_type and text.lstrip().startswith("/broadcast"):
+        command_type = "broadcast"
+    if not command_type and payload.get("recipient_id") and not bool(payload.get("broadcast")):
+        command_type = "direct_message"
     return {"command_type": command_type or "human_message", "content": text, **payload}

--- a/src/interfaces/interaction_schema.py
+++ b/src/interfaces/interaction_schema.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from src.governance.decision_kernel import DecisionProvenance
+from src.interfaces.legacy_command_adapter import normalize_legacy_command_payload
 
 ENVELOPE_INTENTS = {
     "human_message",
@@ -153,7 +154,7 @@ _INTERACTION_INTENT_ADAPTER: TypeAdapter[InteractionIntent] = TypeAdapter(Intera
 
 
 def parse_interaction_intent(payload: dict[str, Any]) -> InteractionIntent:
-    normalized = dict(payload)
+    normalized = normalize_legacy_command_payload(payload, adapter="interaction_schema.parse")
     routing = (
         dict(normalized.get("routing") or {})
         if isinstance(normalized.get("routing"), dict)

--- a/src/interfaces/legacy_command_adapter.py
+++ b/src/interfaces/legacy_command_adapter.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_WINDOW_END = date.fromisoformat(
+    os.getenv("LEGACY_COMMAND_MIGRATION_WINDOW_END", "2026-12-31")
+)
+
+
+@dataclass(frozen=True)
+class LegacyAdapterTelemetry:
+    adapter: str
+    fields: tuple[str, ...]
+    context_source: str | None
+    sender_id: str | None
+    correlation_id: str | None
+
+    def asdict(self) -> dict[str, Any]:
+        return {
+            "adapter": self.adapter,
+            "fields": list(self.fields),
+            "context_source": self.context_source,
+            "sender_id": self.sender_id,
+            "correlation_id": self.correlation_id,
+            "migration_window_end": MIGRATION_WINDOW_END.isoformat(),
+        }
+
+
+_LEGACY_ADAPTER_HITS: list[LegacyAdapterTelemetry] = []
+
+
+def reset_legacy_adapter_hits() -> None:
+    _LEGACY_ADAPTER_HITS.clear()
+
+
+def get_legacy_adapter_hits() -> list[LegacyAdapterTelemetry]:
+    return list(_LEGACY_ADAPTER_HITS)
+
+
+def assert_no_expired_legacy_adapter_usage(*, today: date | None = None) -> None:
+    current_day = today or date.today()
+    if current_day <= MIGRATION_WINDOW_END:
+        return
+    if _LEGACY_ADAPTER_HITS:
+        raise AssertionError(
+            "Legacy command adapter usage remains after migration window: "
+            + ", ".join(hit.adapter for hit in _LEGACY_ADAPTER_HITS)
+        )
+
+
+def normalize_legacy_command_payload(
+    payload: Mapping[str, Any],
+    *,
+    adapter: str = "legacy_payload_normalizer",
+    context_source: str | None = None,
+    sender_id: str | None = None,
+) -> dict[str, Any]:
+    data = dict(payload)
+    deprecated_fields: list[str] = []
+    if "content" in data and "text" not in data:
+        data["text"] = data["content"]
+        deprecated_fields.append("content")
+    if "prompt" in data and "scope" not in data:
+        data["scope"] = data["prompt"]
+        deprecated_fields.append("prompt")
+    if "command_type" in data and "intent" not in data and "type" not in data:
+        data["intent"] = data["command_type"]
+        deprecated_fields.append("command_type")
+    if "type" in data and "intent" not in data:
+        data["intent"] = data["type"]
+        deprecated_fields.append("type")
+
+    if deprecated_fields:
+        telemetry = LegacyAdapterTelemetry(
+            adapter=adapter,
+            fields=tuple(sorted(deprecated_fields)),
+            context_source=context_source,
+            sender_id=sender_id,
+            correlation_id=(
+                str(data.get("correlation_id")) if data.get("correlation_id") is not None else None
+            ),
+        )
+        _LEGACY_ADAPTER_HITS.append(telemetry)
+        logger.warning("legacy_command_adapter_hit", extra={"telemetry": telemetry.asdict()})
+    return data

--- a/src/sim/command_service.py
+++ b/src/sim/command_service.py
@@ -29,6 +29,7 @@ from src.interfaces.interaction_schema import (
 )
 from src.shared.typing import SimulationMessage
 from src.sim.commands.domain_commands import DomainCommandT
+from src.sim.resources import apply_penalty
 
 if TYPE_CHECKING:
     from src.sim.simulation import Simulation
@@ -197,6 +198,21 @@ class SimulationCommandService:
                 sim.speed = float(envelope.value or 1)
             except (TypeError, ValueError):
                 pass
+        elif action == "mute" and envelope.agent_id:
+            await sim.mute_agent(str(envelope.agent_id), emit_event=False)
+        elif action == "unmute" and envelope.agent_id:
+            await sim.unmute_agent(str(envelope.agent_id), emit_event=False)
+        elif action == "reset_memory" and envelope.agent_id:
+            await sim.reset_memory(str(envelope.agent_id), emit_event=False)
+        elif action == "penalty" and envelope.agent_id:
+            penalty_ip = envelope.metadata.get("ip", envelope.value or 0.0)
+            penalty_du = envelope.metadata.get("du", 0.0)
+            apply_penalty(
+                sim,
+                str(envelope.agent_id),
+                ip=float(penalty_ip or 0.0),
+                du=float(penalty_du or 0.0),
+            )
         elif action == "post_kb" and isinstance(envelope, (ModerationEnvelope, ControlEnvelope)):
             await self._post_knowledge_board(envelope)
         elif action == "inject_event" and isinstance(envelope, InjectEventEnvelope):
@@ -483,7 +499,9 @@ class SimulationCommandService:
 
         try:
             manager = simulation_module.get_resource_manager()
-            budget_check = getattr(manager, "budget_check", None) or getattr(manager, "ensure_du_budget")
+            budget_check = getattr(manager, "budget_check", None) or getattr(
+                manager, "ensure_du_budget"
+            )
             budget_check(budget_agent_id, du_cost)
         except Exception as exc:
             logger.info("Rejecting interaction for %s: %s", budget_agent_id, exc)
@@ -513,7 +531,9 @@ class SimulationCommandService:
         except Exception:
             logger.debug("Ledger spend failed", exc_info=True)
 
-        world_time = self.simulation.environment_system.world_time_snapshot(self.simulation.world_state)
+        world_time = self.simulation.environment_system.world_time_snapshot(
+            self.simulation.world_state
+        )
         turn_index = self.simulation.current_step
         recipients = self.simulation.agents if broadcast else [target]
         msgs = [

--- a/src/sim/runtime/external_event_ingestion_service.py
+++ b/src/sim/runtime/external_event_ingestion_service.py
@@ -24,7 +24,7 @@ class ExternalEventIngestionService:
             sim._event_listener_task = asyncio.create_task(self._event_listener_loop())
         if sim._event_task is None or sim._event_task.done():
             sim._event_task = asyncio.create_task(
-                sim.event_kernel.forward_external_events(sim._ingest_legacy_event_queue_payload)
+                sim.event_kernel.forward_external_events(self.handle_human_command)
             )
 
     async def stop(self) -> None:

--- a/src/sim/simulation.py
+++ b/src/sim/simulation.py
@@ -47,10 +47,6 @@ from src.interfaces.dashboard_backend import (
     emit_event,
 )
 from src.interfaces.discord_event_listener import DiscordSimulationEventListener
-from src.interfaces.external_event_routing import (
-    build_interaction_context,
-    normalize_human_command_payload,
-)
 from src.interfaces.interaction_commands import InteractionService
 from src.interfaces.metrics import (
     ACTIVE_AGENT_COUNT,
@@ -105,6 +101,7 @@ logger = logging.getLogger(__name__)
 
 # Backward-compatible alias retained for existing callers/tests.
 EVENT_STEP_LIFECYCLE_MUST_NOT_CHANGE = EVENT_STEP_LIFECYCLE_CONTRACTS
+
 
 class Simulation:
     """
@@ -271,9 +268,9 @@ class Simulation:
         self.action_rules_engine = ActionRulesEngine()
 
         # --- NEW: Initialize Project Tracking ---
-        self.projects: dict[str, dict[str, Any]] = (
-            {}
-        )  # Structure: {project_id: {name, creator_id, members}}
+        self.projects: dict[
+            str, dict[str, Any]
+        ] = {}  # Structure: {project_id: {name, creator_id, members}}
 
         logger.info("Simulation initialized with project tracking system.")
 
@@ -348,9 +345,9 @@ class Simulation:
 
         self.pending_messages_for_next_round: list[SimulationMessage] = []
         # Messages available for agents to perceive in the current round.
-        self.messages_to_perceive_this_round: list[SimulationMessage] = (
-            []
-        )  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
+        self.messages_to_perceive_this_round: list[
+            SimulationMessage
+        ] = []  # THIS WILL BE THE ACCUMULATOR FOR THE CURRENT ROUND
 
         self.track_collective_metrics: bool = True
 
@@ -407,7 +404,9 @@ class Simulation:
                 self.external_event_ingestion._event_listener_loop()
             )
             self._event_task = loop.create_task(
-                self.event_kernel.forward_external_events(self._ingest_legacy_event_queue_payload)
+                self.event_kernel.forward_external_events(
+                    self.external_event_ingestion.handle_human_command
+                )
             )
         else:
             asyncio.set_event_loop(asyncio.new_event_loop())
@@ -457,47 +456,6 @@ class Simulation:
                 raise AssertionError(f"Trait drift exceeded per-step max: {record}")
             if not record.get("cause") or not record.get("source"):
                 raise AssertionError(f"Trait audit record missing cause/source: {record}")
-
-    async def _handle_human_command_from_bus(
-        self: Self, text: str, metadata: dict[str, Any] | None = None
-    ) -> None:
-        """Deprecated compatibility adapter for external event forwarding callbacks."""
-
-        warnings.warn(
-            "Simulation._handle_human_command_from_bus is deprecated; "
-            "use Simulation._ingest_legacy_event_queue_payload instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self._ingest_legacy_event_queue_payload(text, metadata)
-
-    async def _ingest_legacy_event_queue_payload(
-        self: Self, text: str, metadata: dict[str, Any] | None = None
-    ) -> None:
-        """Normalize legacy queue injections into the canonical command pipeline."""
-
-        payload = normalize_human_command_payload(text, metadata)
-        if (
-            payload.get("command_type") == "human_message"
-            and payload.get("recipient_id")
-            and not bool(payload.get("broadcast"))
-        ):
-            payload["command_type"] = "direct_message"
-        context = build_interaction_context(payload, default_source="simulation")
-        await self.command_bus.dispatch_payload(payload, context=context)
-
-    async def _handle_human_command(
-        self: Self, text: str, metadata: dict[str, Any] | None = None
-    ) -> None:
-        """Legacy adapter for human commands; routes through the unified command dispatcher."""
-
-        warnings.warn(
-            "Simulation._handle_human_command is deprecated; send payloads via command_bus or "
-            "interaction_service instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self._ingest_legacy_event_queue_payload(text, metadata)
 
     async def handle_control_command(self: Self, cmd: Mapping[str, Any]) -> dict[str, Any] | None:
         """Process a control command sent via the event queue."""
@@ -945,9 +903,7 @@ class Simulation:
             # and populate it from what was pending for the next round.
             if agent_to_run_index == 0:
                 self.messages_to_perceive_this_round = list(self.pending_messages_for_next_round)
-                self.pending_messages_for_next_round = (
-                    []
-                )  # Clear pending for the new round accumulation
+                self.pending_messages_for_next_round = []  # Clear pending for the new round accumulation
 
                 debug_len = len(self.messages_to_perceive_this_round)
                 logger.debug(
@@ -1697,7 +1653,9 @@ class Simulation:
                     ).value,
                     "lifecycle_history": list(getattr(ag.state, "lifecycle_history", [])),
                     "legacy_artifacts": dict(getattr(ag.state, "legacy_artifacts", {})),
-                    "memory_archival_policy": dict(getattr(ag.state, "memory_archival_policy", {})),
+                    "memory_archival_policy": dict(
+                        getattr(ag.state, "memory_archival_policy", {})
+                    ),
                     "predecessor_id": getattr(ag.state, "predecessor_id", None),
                     "successor_id": getattr(ag.state, "successor_id", None),
                     "personality_transition_events": list(
@@ -1881,7 +1839,6 @@ class Simulation:
         if context is None:
             return []
         return context.planned_outputs if context.planned_outputs else context.events
-
 
     async def async_run(self: Self, num_steps: int) -> None:
         """
@@ -2122,7 +2079,10 @@ class Simulation:
                     "phase_order": normalized_phase_order,
                 }
             )
-            if isinstance(persisted_batch_hash, str) and persisted_batch_hash != computed_batch_hash:
+            if (
+                isinstance(persisted_batch_hash, str)
+                and persisted_batch_hash != computed_batch_hash
+            ):
                 raise ValueError(
                     f"Domain event batch hash mismatch at step {event.get('step')}:"
                     f" persisted {persisted_batch_hash}, computed {computed_batch_hash}"
@@ -2183,7 +2143,9 @@ class Simulation:
         sim.world_state.environment.active_global_modifiers = list(
             env_snapshot["active_global_modifiers"]
         )
-        sim.world_state.environment.council_window_active = bool(env_snapshot["council_window_active"])
+        sim.world_state.environment.council_window_active = bool(
+            env_snapshot["council_window_active"]
+        )
         snapshot_turn_quantum = int(snapshot.get("turns_per_world_tick", sim.turns_per_world_tick))
         sim.turns_per_world_tick = max(1, snapshot_turn_quantum)
         sim.environment_system.set_turns_per_world_tick(sim.turns_per_world_tick)
@@ -2210,7 +2172,9 @@ class Simulation:
                             "to_state": target_state.value,
                             "reason": "snapshot_restore",
                             "legacy_artifacts": dict(a_data.get("legacy_artifacts", {})),
-                            "memory_archival_policy": dict(a_data.get("memory_archival_policy", {})),
+                            "memory_archival_policy": dict(
+                                a_data.get("memory_archival_policy", {})
+                            ),
                         }
                         sim.population_service.apply_lifecycle_transition_event(
                             agent=ag,
@@ -2218,7 +2182,9 @@ class Simulation:
                         )
                     ag.state.lifecycle_history = list(a_data.get("lifecycle_history", []))
                     ag.state.legacy_artifacts = dict(a_data.get("legacy_artifacts", {}))
-                    ag.state.memory_archival_policy = dict(a_data.get("memory_archival_policy", {}))
+                    ag.state.memory_archival_policy = dict(
+                        a_data.get("memory_archival_policy", {})
+                    )
                     ag.state.is_alive = target_state != AgentLifecycleState.DECEASED
                     ag.state.predecessor_id = a_data.get("predecessor_id")
                     ag.state.successor_id = a_data.get("successor_id")

--- a/tests/integration/interfaces/test_canonical_command_bus_matrix.py
+++ b/tests/integration/interfaces/test_canonical_command_bus_matrix.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from src.interfaces.dashboard_backend import SimulationEvent
+from src.interfaces.interaction_schema import InteractionContext
+
+pytestmark = pytest.mark.integration
+
+
+class DummyNeo4j:
+    Driver = object
+    GraphDatabase = object
+
+
+class DummyState:
+    def __init__(self) -> None:
+        self.ip = 5.0
+        self.du = 5.0
+        self.short_term_memory = []
+        self.messages_sent_count = 0
+        self.last_message_step = None
+        self.collective_ip = 0.0
+        self.collective_du = 0.0
+
+
+class DummyAgent:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self._state = DummyState()
+        from src.infra.ledger import ledger as _ledger
+
+        _ledger.log_change(agent_id, 5.0, 5.0, "init")
+
+    def get_id(self) -> str:
+        return self.agent_id
+
+    @property
+    def state(self) -> DummyState:
+        return self._state
+
+    async def run_turn(self, *args: object, **kwargs: object) -> dict[str, object]:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_command_bus_matrix_routes_all_flows_through_canonical_dispatcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sys.modules.setdefault("neo4j", DummyNeo4j())
+    from src.sim.simulation import Simulation
+
+    sim = Simulation([DummyAgent("alpha"), DummyAgent("beta")])
+    seen: list[str] = []
+    original = sim.command_bus.dispatch_payload
+
+    async def recording_dispatch(
+        payload: dict[str, object], *, context: InteractionContext | None = None
+    ):
+        seen.append(
+            str(payload.get("intent") or payload.get("command") or payload.get("command_type"))
+        )
+        return await original(payload, context=context)
+
+    monkeypatch.setattr(sim.command_bus, "dispatch_payload", recording_dispatch)
+
+    await sim.command_bus.dispatch_payload(
+        {
+            "intent": "direct_message",
+            "text": "hi beta",
+            "recipient_id": "beta",
+            "target_agent_id": "beta",
+        },
+        context=InteractionContext(sender_id="user-dm", source="discord"),
+    )
+    await sim.command_bus.dispatch_payload(
+        {"intent": "broadcast", "text": "hello all"},
+        context=InteractionContext(sender_id="user-broadcast", source="dashboard"),
+    )
+    await sim.external_event_ingestion.route_event(
+        SimulationEvent(
+            type="control",
+            data={"intent": "inject_event", "text": "storm front", "source": "event_bus"},
+        )
+    )
+    await sim.command_bus.dispatch_payload(
+        {"intent": "moderation", "command": "mute", "agent_id": "beta"},
+        context=InteractionContext(sender_id="mod-1", source="discord", permissions={"moderator"}),
+    )
+
+    async with sim._msg_lock:
+        contents = [str(msg.get("content")) for msg in sim.pending_messages_for_next_round]
+
+    assert seen == ["direct_message", "broadcast", "inject_event", "moderation"]
+    assert any(content == "hi beta" for content in contents)
+    assert any(content == "hello all" for content in contents)
+    assert any("storm front" in content for content in contents)
+    assert "beta" in sim.muted_agents
+
+    await sim.stop_event_listener()
+    sim.close()

--- a/tests/integration/interfaces/test_discord_bot.py
+++ b/tests/integration/interfaces/test_discord_bot.py
@@ -120,6 +120,7 @@ async def test_agent_update_blocked_content_not_sent(monkeypatch: pytest.MonkeyP
         assert metrics.get_discord_agent_outputs_blocked_total() == before + 1
         bot.client.get_channel.assert_not_called()
 
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_multi_token_message_forwarding() -> None:
@@ -255,7 +256,6 @@ async def test_control_commands_require_admin_without_opa(
     await _assert_unauthorized(slash_spawn, "agent-1")
 
 
-
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_on_message_updates_agent_state(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -350,7 +350,7 @@ async def test_broadcast_command(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     agents = [DummyAgent("A"), DummyAgent("B"), DummyAgent("C")]
     sim = Simulation(agents)
 
-    await sim._handle_human_command("/broadcast hello all")
+    await sim.external_event_ingestion.handle_human_command("/broadcast hello all")
 
     async with sim._msg_lock:
         recipients = {m["recipient_id"] for m in sim.pending_messages_for_next_round}

--- a/tests/integration/interfaces/test_discord_forwarding.py
+++ b/tests/integration/interfaces/test_discord_forwarding.py
@@ -70,16 +70,18 @@ async def test_event_bus_forwarding(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     monkeypatch.setattr("src.sim.event_kernel.get_event_bus", lambda: bus)
     monkeypatch.setattr("src.sim.simulation.get_event_bus", lambda: bus)
 
+    from src.sim.runtime.external_event_ingestion_service import ExternalEventIngestionService
+
     handled: list[str] = []
-    original = Simulation._handle_human_command
+    original = ExternalEventIngestionService.handle_human_command
 
     async def wrapped(
-        self: Simulation, text: str, metadata: dict | None = None
+        self: ExternalEventIngestionService, text: str, metadata: dict | None = None
     ) -> None:
         handled.append(text)
         await original(self, text, metadata)
 
-    monkeypatch.setattr(Simulation, "_handle_human_command", wrapped)
+    monkeypatch.setattr(ExternalEventIngestionService, "handle_human_command", wrapped)
 
     with patch("src.interfaces.discord_bot.SimulationDiscordBot", AsyncMock()):
         agent = DummyAgent("A")
@@ -135,8 +137,12 @@ async def test_human_command_rate_limit_scoped_by_sender(
 
     sim = Simulation([DummyAgent("A")])
 
-    await sim._handle_human_command("hello from user 1", {"sender_id": "user-1"})
-    await sim._handle_human_command("hello from user 2", {"sender_id": "user-2"})
+    await sim.external_event_ingestion.handle_human_command(
+        "hello from user 1", {"sender_id": "user-1"}
+    )
+    await sim.external_event_ingestion.handle_human_command(
+        "hello from user 2", {"sender_id": "user-2"}
+    )
 
     assert spend_mock.await_count == 2
     assert emit_mock.await_count == 0
@@ -175,8 +181,8 @@ async def test_human_command_rate_limit_sends_feedback(
 
     sim = Simulation([DummyAgent("A")])
 
-    await sim._handle_human_command("first", {"sender_id": "user-1"})
-    await sim._handle_human_command("second", {"sender_id": "user-1"})
+    await sim.external_event_ingestion.handle_human_command("first", {"sender_id": "user-1"})
+    await sim.external_event_ingestion.handle_human_command("second", {"sender_id": "user-1"})
 
     assert spend_mock.await_count == 1
     assert emit_mock.await_count == 1

--- a/tests/integration/interfaces/test_discord_policy_blocking.py
+++ b/tests/integration/interfaces/test_discord_policy_blocking.py
@@ -107,10 +107,12 @@ async def test_blocked_messages_do_not_reach_handler(
 
     handled: list[str] = []
 
-    async def handler(self: Simulation, text: str) -> None:
+    async def handler(self: object, text: str, metadata: dict | None = None) -> None:
         handled.append(text)
 
-    monkeypatch.setattr(Simulation, "_handle_human_command", handler)
+    from src.sim.runtime.external_event_ingestion_service import ExternalEventIngestionService
+
+    monkeypatch.setattr(ExternalEventIngestionService, "handle_human_command", handler)
 
     with patch("src.interfaces.discord_bot.discord.Client", DummyDiscordClient):
         bot = await SimulationDiscordBot.create("token", 123, context=ctx)

--- a/tests/integration/sim/test_human_command_replay.py
+++ b/tests/integration/sim/test_human_command_replay.py
@@ -49,7 +49,9 @@ class RecordingAgent:
         knowledge_board: Any | None = None,
         memory_service: Any | None = None,
     ) -> dict[str, Any]:
-        perceived = environment_perception.get("perceived_messages", []) if environment_perception else []
+        perceived = (
+            environment_perception.get("perceived_messages", []) if environment_perception else []
+        )
         self.perceptions.append([dict(msg) for msg in perceived])
         return {}
 
@@ -79,7 +81,7 @@ async def test_human_command_event_replays_messages(
     ledger.log_change(agent.agent_id, agent.state.ip, agent.state.du, "init")
     sim = Simulation([agent], seed=123)
 
-    await sim._handle_human_command("hello there")
+    await sim.external_event_ingestion.handle_human_command("hello there")
     await sim.run_step()
     original_messages = agent.perceptions[-1]
 

--- a/tests/integration/simulation/test_discord_bot_integration.py
+++ b/tests/integration/simulation/test_discord_bot_integration.py
@@ -84,11 +84,15 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     q_msgs: asyncio.Queue[db.AgentMessage] = asyncio.Queue()
     handled: list[str] = []
 
-    original_handle = Simulation._handle_human_command
+    from src.sim.runtime.external_event_ingestion_service import ExternalEventIngestionService
 
-    async def wrapped(self: Simulation, text: str) -> None:
+    original_handle = ExternalEventIngestionService.handle_human_command
+
+    async def wrapped(
+        self: ExternalEventIngestionService, text: str, metadata: dict | None = None
+    ) -> None:
         handled.append(text)
-        await original_handle(self, text)
+        await original_handle(self, text, metadata)
 
     class Client(DummyDiscordClient):
         pass
@@ -98,7 +102,7 @@ async def test_simulation_bot_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         patch("src.interfaces.dashboard_backend.get_event_queue", lambda: q_events),
         patch("src.interfaces.dashboard_backend.message_sse_queue", q_msgs),
         patch("src.interfaces.discord_bot.message_sse_queue", q_msgs),
-        patch.object(Simulation, "_handle_human_command", wrapped),
+        patch.object(ExternalEventIngestionService, "handle_human_command", wrapped),
         patch("src.interfaces.dashboard_backend.EventSourceResponse", object),
     ):
         bot = await SimulationDiscordBot.create(

--- a/tests/unit/interfaces/test_discord_commands.py
+++ b/tests/unit/interfaces/test_discord_commands.py
@@ -196,8 +196,8 @@ async def test_kb_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     sim = Simulation([DummyAgent()])
     sim.knowledge_board.add_entry = MagicMock()
-    await sim._handle_human_command("/kb first")
-    await sim._handle_human_command("/kb second")
+    await sim.external_event_ingestion.handle_human_command("/kb first")
+    await sim.external_event_ingestion.handle_human_command("/kb second")
     sim.knowledge_board.add_entry.assert_called_once()
 
 
@@ -223,11 +223,9 @@ async def test_message_relay_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
         lambda: SimpleNamespace(ensure_du_budget=lambda *args, **kwargs: None),
     )
     monkeypatch.setattr(ledger_module.ledger, "spend", AsyncMock())
-    await sim._handle_human_command("hello")
-    await sim._handle_human_command("hello again")
+    await sim.external_event_ingestion.handle_human_command("hello")
+    await sim.external_event_ingestion.handle_human_command("hello again")
     ledger_module.ledger.spend.assert_awaited_once()
-
-
 
 
 @pytest.mark.unit
@@ -239,9 +237,13 @@ async def test_slash_event_enqueues_control_event(
     ctx = SimpleNamespace(get_event_queue=lambda: queue)
     bot = SimpleNamespace(context=ctx)
     monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
-    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        discord_module, "_has_control_command_permission", AsyncMock(return_value=True)
+    )
     interaction = DummyInteraction()
-    interaction.user = SimpleNamespace(id="u-1", guild_permissions=SimpleNamespace(administrator=False))
+    interaction.user = SimpleNamespace(
+        id="u-1", guild_permissions=SimpleNamespace(administrator=False)
+    )
     await discord_module.slash_event(interaction, "meteor shower")
     event = await queue.get()
     assert event.type == "control"
@@ -261,11 +263,14 @@ async def test_slash_event_requires_authorization(
     ctx = SimpleNamespace(get_event_queue=lambda: queue)
     bot = SimpleNamespace(context=ctx)
     monkeypatch.setattr(discord_module, "get_active_bot", lambda ctx=None: bot)
-    monkeypatch.setattr(discord_module, "_has_control_command_permission", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        discord_module, "_has_control_command_permission", AsyncMock(return_value=False)
+    )
     interaction = DummyInteraction()
     await discord_module.slash_event(interaction, "storm")
     assert queue.empty()
     interaction.response.send_message.assert_awaited_once_with("unauthorized", ephemeral=True)
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio

--- a/tests/unit/interfaces/test_interaction_schema_compat.py
+++ b/tests/unit/interfaces/test_interaction_schema_compat.py
@@ -21,17 +21,16 @@ def test_parse_bus_command_accepts_modern_text_payload() -> None:
     assert envelope.text == "hello"
 
 
-def test_parse_bus_command_supports_legacy_fields_with_deprecation_warning() -> None:
-    with pytest.deprecated_call(match="deprecated"):
-        envelope = parse_bus_command(
-            {
-                "command_type": "inject_event",
-                "content": "storm incoming",
-                "prompt": "global",
-                "agent_id": "mod-1",
-            },
-            context=InteractionContext(sender_id="mod-1", source="discord", permissions={"admin"}),
-        )
+def test_parse_bus_command_supports_legacy_fields_with_telemetry() -> None:
+    envelope = parse_bus_command(
+        {
+            "command_type": "inject_event",
+            "content": "storm incoming",
+            "prompt": "global",
+            "agent_id": "mod-1",
+        },
+        context=InteractionContext(sender_id="mod-1", source="discord", permissions={"admin"}),
+    )
 
     assert isinstance(envelope, InjectEventEnvelope)
     assert envelope.text == "storm incoming"

--- a/tests/unit/interfaces/test_legacy_command_adapter.py
+++ b/tests/unit/interfaces/test_legacy_command_adapter.py
@@ -1,0 +1,44 @@
+from datetime import date
+
+import pytest
+
+from src.interfaces.legacy_command_adapter import (
+    assert_no_expired_legacy_adapter_usage,
+    get_legacy_adapter_hits,
+    normalize_legacy_command_payload,
+    reset_legacy_adapter_hits,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def setup_function() -> None:
+    reset_legacy_adapter_hits()
+
+
+def teardown_function() -> None:
+    reset_legacy_adapter_hits()
+
+
+def test_legacy_adapter_emits_structured_telemetry() -> None:
+    payload = normalize_legacy_command_payload(
+        {"command_type": "inject_event", "content": "storm", "prompt": "global"},
+        adapter="test.adapter",
+        context_source="discord",
+        sender_id="user-1",
+    )
+
+    hits = get_legacy_adapter_hits()
+    assert payload["intent"] == "inject_event"
+    assert payload["text"] == "storm"
+    assert payload["scope"] == "global"
+    assert len(hits) == 1
+    assert hits[0].asdict()["adapter"] == "test.adapter"
+    assert hits[0].asdict()["fields"] == ["command_type", "content", "prompt"]
+
+
+def test_legacy_adapter_fails_after_migration_window() -> None:
+    normalize_legacy_command_payload({"command_type": "human_message", "content": "hello"})
+
+    with pytest.raises(AssertionError, match="Legacy command adapter usage remains"):
+        assert_no_expired_legacy_adapter_usage(today=date(2027, 1, 1))

--- a/tests/unit/sim/test_event_task_start.py
+++ b/tests/unit/sim/test_event_task_start.py
@@ -44,15 +44,19 @@ class DummyAgent:
 async def test_event_task_runs_without_running_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     received: list[str] = []
 
-    async def handler(self: Simulation, text: str) -> None:
+    from src.sim.runtime.external_event_ingestion_service import ExternalEventIngestionService
+
+    async def handler(
+        self: ExternalEventIngestionService, text: str, metadata: dict | None = None
+    ) -> None:
         received.append(text)
 
-    monkeypatch.setattr(Simulation, "_handle_human_command", handler)
+    monkeypatch.setattr(ExternalEventIngestionService, "handle_human_command", handler)
 
     async def dummy_listener(self: Simulation) -> None:
         await asyncio.sleep(0)
 
-    monkeypatch.setattr(Simulation, "_event_listener_loop", dummy_listener)
+    monkeypatch.setattr(ExternalEventIngestionService, "_event_listener_loop", dummy_listener)
     sim = Simulation([DummyAgent()])
     await sim.start_event_listener()
 

--- a/tests/unit/sim/test_human_command.py
+++ b/tests/unit/sim/test_human_command.py
@@ -65,7 +65,7 @@ async def test_human_command_deducts_resources(
     agent = DummyAgent("A")
     sim = Simulation([agent])
 
-    await sim._handle_human_command("hello")
+    await sim.external_event_ingestion.handle_human_command("hello")
 
     assert agent.state.ip == pytest.approx(1.0)
     assert agent.state.du == pytest.approx(1.0)
@@ -92,7 +92,7 @@ async def test_human_command_rejected_without_resources(
     agent = DummyAgent("A", ip=0.5, du=0.5)
     sim = Simulation([agent])
 
-    await sim._handle_human_command("hello")
+    await sim.external_event_ingestion.handle_human_command("hello")
 
     assert agent.state.ip == pytest.approx(0.5)
     assert agent.state.du == pytest.approx(0.5)
@@ -120,7 +120,7 @@ async def test_human_command_uses_structured_routing_metadata(
     beta = DummyAgent("beta")
     sim = Simulation([alpha, beta])
 
-    await sim._handle_human_command(
+    await sim.external_event_ingestion.handle_human_command(
         "hello beta",
         {
             "sender_id": "human-42",
@@ -157,7 +157,9 @@ async def test_human_command_broadcast_falls_back_to_current_agent(
     sim = Simulation([alpha, beta])
     sim.current_agent_index = 1
 
-    await sim._handle_human_command("hello all", {"sender_id": "human-x", "broadcast": True})
+    await sim.external_event_ingestion.handle_human_command(
+        "hello all", {"sender_id": "human-x", "broadcast": True}
+    )
 
     assert beta.state.ip == pytest.approx(1.0)
     async with sim._msg_lock:
@@ -181,7 +183,7 @@ async def test_human_command_ignores_empty_text_without_spending_resources(
     agent = DummyAgent("A")
     sim = Simulation([agent])
 
-    await sim._handle_human_command("   ")
+    await sim.external_event_ingestion.handle_human_command("   ")
 
     assert agent.state.ip == pytest.approx(2.0)
     assert agent.state.du == pytest.approx(2.0)

--- a/tests/unit/sim/test_human_command_costs.py
+++ b/tests/unit/sim/test_human_command_costs.py
@@ -96,9 +96,9 @@ async def test_handle_human_command_missing_config(
     ]:
         monkeypatch.setitem(config._CONFIG, key, None)
 
-    await sim._handle_human_command("hello")
+    await sim.external_event_ingestion.handle_human_command("hello")
     sim._last_relay_times.clear()
-    await sim._handle_human_command("/broadcast hi")
+    await sim.external_event_ingestion.handle_human_command("/broadcast hi")
 
     assert agent.state.ip == pytest.approx(2.0)
     assert agent.state.du == pytest.approx(2.0)
@@ -129,7 +129,7 @@ async def test_human_command_uses_human_budget_without_agent_state_deduction(
         lambda: types.SimpleNamespace(ensure_du_budget=lambda *_args, **_kwargs: None),
     )
 
-    await sim._handle_human_command("hello")
+    await sim.external_event_ingestion.handle_human_command("hello")
 
     assert agent.state.ip == pytest.approx(2.0)
     hip, hdu = ledger.get_balance("human")

--- a/tests/unit/sim/test_runtime_flow_architecture.py
+++ b/tests/unit/sim/test_runtime_flow_architecture.py
@@ -53,14 +53,14 @@ class DummyAgent:
 
 
 @pytest.mark.asyncio
-async def test_legacy_human_command_routes_through_command_bus() -> None:
+async def test_legacy_human_ingestion_routes_through_command_bus() -> None:
     sys.modules.setdefault("neo4j", DummyNeo4j())
     from src.sim.simulation import Simulation
 
     sim = Simulation([DummyAgent("A")])
     sim.command_bus.dispatch_payload = AsyncMock()
 
-    await sim._handle_human_command("hello", {"sender_id": "user-1"})
+    await sim.external_event_ingestion.handle_human_command("hello", {"sender_id": "user-1"})
 
     sim.command_bus.dispatch_payload.assert_awaited_once()
     await sim.stop_event_listener()

--- a/tests/unit/sim/test_simulation_inject_event.py
+++ b/tests/unit/sim/test_simulation_inject_event.py
@@ -123,7 +123,7 @@ async def test_graph_backend_kb_write_commands_use_lock(monkeypatch: pytest.Monk
     sim = Simulation([DummyAgent("A")])
     sim.event_kernel.emit_environment_event = AsyncMock()
 
-    await sim._handle_human_command("/kb graph path")
+    await sim.external_event_ingestion.handle_human_command("/kb graph path")
     await sim.handle_control_command(
         {
             "command": "post_kb",
@@ -197,7 +197,9 @@ def test_apply_event_replaces_graph_backend_kb_state(monkeypatch: pytest.MonkeyP
     from tests.integration.knowledge_board.test_graph_backend import DummyDriver
 
     monkeypatch.setattr(config, "KNOWLEDGE_BOARD_BACKEND", "graph")
-    monkeypatch.setattr("src.sim.simulation.GraphKnowledgeBoard", lambda: GraphKnowledgeBoard(driver=DummyDriver()))
+    monkeypatch.setattr(
+        "src.sim.simulation.GraphKnowledgeBoard", lambda: GraphKnowledgeBoard(driver=DummyDriver())
+    )
 
     sim = Simulation([DummyAgent("A")])
     event = {


### PR DESCRIPTION
### Motivation
- Make the `CommandBus` + envelope parsing the single canonical ingestion API for human/control/moderation commands to eliminate ad-hoc legacy paths. 
- Centralize legacy payload normalization to a single adapter so we can emit structured deprecation telemetry and enforce a migration window. 
- Prevent transports (Discord, dashboard, event routing) from calling deprecated simulation ingestion helpers directly and instead route all flows through the canonical dispatcher. 
- Provide integration test coverage for the main command flows to validate the canonical path.

### Description
- Added `src/interfaces/legacy_command_adapter.py` which normalizes legacy payload fields, records structured telemetry (`LegacyAdapterTelemetry`) for deprecated field usage, provides helpers `get_legacy_adapter_hits`, `reset_legacy_adapter_hits`, and enforces a migration-window assertion via `assert_no_expired_legacy_adapter_usage`.
- Made `src/interfaces/interaction_schema.parse_interaction_intent` and `src/interfaces/domain_command_adapters.parse_bus_command` call the legacy adapter so envelope parsing is the single place legacy normalization occurs.
- Replaced direct calls to deprecated simulation ingestion helpers: removed the deprecated `Simulation._handle_human_command*` adapters and updated the runtime to forward external events into `ExternalEventIngestionService.handle_human_command`, and wired `EventKernel.forward_external_events` to call the service method.
- Updated `src/interfaces/discord_moderation.py` and dashboard control handling to dispatch moderation/control commands through the `CommandBus` (`dispatch_payload` / envelopes) and to build an appropriate `InteractionContext` rather than enqueueing raw `SimulationEvent` objects.
- Extended `src/sim/command_service.py` to apply moderation actions (`mute`, `unmute`, `reset_memory`, `penalty`) when they arrive via the canonical envelope path.
- Adjusted transport and test code to call the canonical ingestion path (various tests now use `external_event_ingestion.handle_human_command` or `command_bus.dispatch_payload`).
- Added integration test matrix `tests/integration/interfaces/test_canonical_command_bus_matrix.py` and unit tests `tests/unit/interfaces/test_legacy_command_adapter.py` to validate telemetry and migration-window behavior.

### Testing
- Ran linters/formatters with `ruff format` and `ruff check` on modified files and fixed style issues (checks passed).
- Ran unit tests for the legacy adapter and schema adapters: `pytest -q tests/unit/interfaces/test_legacy_command_adapter.py` passed and `pytest -q tests/unit/interfaces/test_interaction_schema_compat.py tests/unit/sim/test_runtime_flow_architecture.py tests/integration/interfaces/test_canonical_command_bus_matrix.py -x` passed.
- Ran a broader suite including human-command and integration flows with `pytest -q tests/unit/sim/test_human_command.py tests/unit/sim/test_human_command_costs.py -x` and observed a failing test: `tests/unit/sim/test_human_command_costs.py::test_handle_human_command_missing_config` fails due to a changed legacy `/broadcast` compatibility behavior after canonicalizing ingestion (message-count difference). 
- Summary of test outcomes: linting passed; the new legacy-adapter unit tests and the new canonical-path integration matrix passed; most runtime and integration tests passed, with one failing human-command cost test that reflects a behavioral change in legacy compatibility which needs follow-up to reconcile exact backward-compatible semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa8c5ed908326b9c3c3cc7e38a74a)