### PR TITLE
Add per-metric stagnation thresholds, KPI payload versioning, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,45 @@ See [culture-ui/README.md](culture-ui/README.md) for additional details.
 UI requirements are summarized in [docs/culture_ui_requirements.md](docs/culture_ui_requirements.md).
 Steps for launching the Memory Explorer are in [docs/memory_explorer.md](docs/memory_explorer.md).
 
+
+## User Value KPI Reference
+
+The canonical user-value KPI contract is exposed in two places:
+
+- the dashboard KPI Card page (`/kpi-card`) for product-facing reference, and
+- this README for engineering-facing implementation details.
+
+The `/api/user_value_metrics` payload is currently versioned as `payload_version = 2`.
+Consumers should branch on `payload_version` before assuming metric semantics.
+
+### KPI definitions
+
+| Field | Definition |
+| --- | --- |
+| `payload_version` | Schema/semantics version for the KPI payload. Increment this whenever field meaning or alert behavior changes. |
+| `thresholds.min_novelty_score` | Minimum acceptable `novelty_score` before raising `low_novelty`. |
+| `thresholds.min_interaction_diversity` | Minimum acceptable `cross_agent_interaction_diversity` before raising `low_interaction_diversity`. |
+| `thresholds.max_repetitive_intents_ratio` | Maximum acceptable `repetitive_intents_ratio` before raising `repetitive_intents`. |
+| `thresholds.min_social_graph_change_count` | Minimum acceptable `social_graph_change_count` before raising `no_social_graph_change`. |
+| `narrative_continuity_score` | Average of knowledge-board continuation coverage and contiguous event-step continuity. |
+| `unresolved_conflict_count` | Conflict entries without linked resolution entries on the knowledge board. |
+| `cross_agent_interaction_diversity` | Observed directed interaction pairs divided by the total possible directed agent pairs. |
+| `user_intervention_rate` | Fraction of sampled events triggered by `human_command`. |
+| `return_session_continuity` | Continuity of snapshot/resume progression across snapshot steps. |
+| `novelty_score` | Unique action intents divided by total action intents. |
+| `repetitive_intents_ratio` | Frequency of the dominant action intent divided by total action intents. |
+| `social_graph_change_count` | Count of events mentioning relationship, coalition, ally, or rival changes. |
+| `stagnation_alerts` | Independent alerts emitted when a single KPI crosses its dedicated threshold. |
+
+### Stagnation alerts
+
+The stagnation alerts are intentionally independent so dashboards can explain *which* signal regressed:
+
+- `low_novelty` → `novelty_score < thresholds.min_novelty_score`
+- `low_interaction_diversity` → `cross_agent_interaction_diversity < thresholds.min_interaction_diversity`
+- `repetitive_intents` → `repetitive_intents_ratio > thresholds.max_repetitive_intents_ratio`
+- `no_social_graph_change` → `social_graph_change_count < thresholds.min_social_graph_change_count`
+
 ## Extensions and Plug-ins
 
 Culture exposes simple hooks for registering dashboard widgets and agent behaviors.

--- a/culture-ui/README.md
+++ b/culture-ui/README.md
@@ -113,3 +113,12 @@ Run the development server and navigate to `/storyboard` to see it in action.
 latest agent positions. The widget also displays each agent's mood and a recent
 one-line summary. Register it in your dashboard layout using the widget name
 `LiveMap`.
+
+
+## User Value KPI reference
+
+The KPI Card page (`/kpi-card`) includes the canonical field definitions for the
+`/api/user_value_metrics` payload. Treat the repository root README
+(`../README.md#user-value-kpi-reference`) as the engineering source of truth and
+this page as the in-dashboard companion reference for product reviews.
+

--- a/culture-ui/src/pages/KpiCard.tsx
+++ b/culture-ui/src/pages/KpiCard.tsx
@@ -1,14 +1,83 @@
 import KpiCard from '../widgets/KpiCard'
 import { registerWidget } from '../lib/widgetRegistry'
 
+const KPI_DOCS = [
+  {
+    name: 'payload_version',
+    meaning: 'Schema version for /api/user_value_metrics. Increment when KPI semantics or field contracts change.',
+  },
+  {
+    name: 'narrative_continuity_score',
+    meaning: 'Average of knowledge-board continuation links and contiguous event steps; higher means the story progresses coherently across turns.',
+  },
+  {
+    name: 'unresolved_conflict_count',
+    meaning: 'Conflicts detected on the knowledge board that do not yet have a linked resolution entry.',
+  },
+  {
+    name: 'cross_agent_interaction_diversity',
+    meaning: 'Observed directed agent-to-agent interaction pairs divided by the total possible directed pairs.',
+  },
+  {
+    name: 'user_intervention_rate',
+    meaning: 'Share of logged simulation events that were initiated by human commands.',
+  },
+  {
+    name: 'return_session_continuity',
+    meaning: 'Continuity of snapshot/resume progression across recorded snapshot steps.',
+  },
+  {
+    name: 'novelty_score',
+    meaning: 'Unique action intents divided by total action intents for the sampled window.',
+  },
+  {
+    name: 'repetitive_intents_ratio',
+    meaning: 'Frequency of the most common action intent divided by total action intents; higher means more repetition.',
+  },
+  {
+    name: 'social_graph_change_count',
+    meaning: 'Count of events whose payload indicates relationship, coalition, ally, or rival changes.',
+  },
+  {
+    name: 'stagnation_alerts',
+    meaning: 'Independent alerts emitted when novelty, interaction diversity, repetitive intent, or social-graph metrics cross their dedicated thresholds.',
+  },
+]
+
 export default function KpiCardPage() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">KPI Card</h1>
+      <p className="max-w-3xl text-sm text-gray-700">
+        Canonical KPI definitions live here and in the repository README so product and
+        engineering interpret the dashboard consistently.
+      </p>
       <KpiCard />
+      <section aria-labelledby="kpi-definitions" className="max-w-4xl space-y-3">
+        <h2 id="kpi-definitions" className="text-lg font-semibold">
+          User value KPI definitions
+        </h2>
+        <div className="overflow-x-auto rounded border">
+          <table className="min-w-full border-collapse text-left text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="border-b px-3 py-2 font-semibold">Field</th>
+                <th className="border-b px-3 py-2 font-semibold">Definition</th>
+              </tr>
+            </thead>
+            <tbody>
+              {KPI_DOCS.map((doc) => (
+                <tr key={doc.name}>
+                  <td className="border-b px-3 py-2 font-mono">{doc.name}</td>
+                  <td className="border-b px-3 py-2">{doc.meaning}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
     </div>
   )
 }
 
 registerWidget('KpiCard', KpiCardPage)
-

--- a/src/sim/analytics.py
+++ b/src/sim/analytics.py
@@ -4,24 +4,37 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from itertools import pairwise
 from typing import Any
+
+USER_VALUE_KPI_PAYLOAD_VERSION = 2
 
 
 @dataclass(frozen=True, slots=True)
 class SimulationStagnationThresholds:
     """Alert limits for detecting simulation stagnation signals."""
 
-    min_cross_agent_interaction_diversity: float = 0.2
+    min_novelty_score: float = 0.2
+    min_interaction_diversity: float = 0.2
     max_repetitive_intents_ratio: float = 0.75
     min_social_graph_change_count: int = 1
+
+    def as_dict(self) -> dict[str, float | int]:
+        return {
+            "min_novelty_score": self.min_novelty_score,
+            "min_interaction_diversity": self.min_interaction_diversity,
+            "max_repetitive_intents_ratio": self.max_repetitive_intents_ratio,
+            "min_social_graph_change_count": self.min_social_graph_change_count,
+        }
 
 
 @dataclass(frozen=True, slots=True)
 class UserValueKPIReport:
     """Canonical user-value KPI payload consumed by dashboards and summaries."""
 
+    payload_version: int
+    thresholds: SimulationStagnationThresholds
     narrative_continuity_score: float
     unresolved_conflict_count: int
     cross_agent_interaction_diversity: float
@@ -33,17 +46,10 @@ class UserValueKPIReport:
     stagnation_alerts: tuple[str, ...]
 
     def as_dict(self) -> dict[str, Any]:
-        return {
-            "narrative_continuity_score": self.narrative_continuity_score,
-            "unresolved_conflict_count": self.unresolved_conflict_count,
-            "cross_agent_interaction_diversity": self.cross_agent_interaction_diversity,
-            "user_intervention_rate": self.user_intervention_rate,
-            "return_session_continuity": self.return_session_continuity,
-            "novelty_score": self.novelty_score,
-            "repetitive_intents_ratio": self.repetitive_intents_ratio,
-            "social_graph_change_count": self.social_graph_change_count,
-            "stagnation_alerts": list(self.stagnation_alerts),
-        }
+        payload = asdict(self)
+        payload["stagnation_alerts"] = list(self.stagnation_alerts)
+        payload["thresholds"] = self.thresholds.as_dict()
+        return payload
 
 
 def _as_step(entry: Mapping[str, Any]) -> int:
@@ -171,14 +177,18 @@ def compute_user_value_kpis(
             social_graph_change_count += 1
 
     stagnation_alerts: list[str] = []
-    if novelty_score < cfg.min_cross_agent_interaction_diversity:
+    if novelty_score < cfg.min_novelty_score:
         stagnation_alerts.append("low_novelty")
+    if cross_agent_interaction_diversity < cfg.min_interaction_diversity:
+        stagnation_alerts.append("low_interaction_diversity")
     if repetitive_intents_ratio > cfg.max_repetitive_intents_ratio:
         stagnation_alerts.append("repetitive_intents")
     if social_graph_change_count < cfg.min_social_graph_change_count:
         stagnation_alerts.append("no_social_graph_change")
 
     return UserValueKPIReport(
+        payload_version=USER_VALUE_KPI_PAYLOAD_VERSION,
+        thresholds=cfg,
         narrative_continuity_score=round(narrative_continuity_score, 4),
         unresolved_conflict_count=unresolved_conflict_count,
         cross_agent_interaction_diversity=round(cross_agent_interaction_diversity, 4),
@@ -189,4 +199,3 @@ def compute_user_value_kpis(
         social_graph_change_count=social_graph_change_count,
         stagnation_alerts=tuple(stagnation_alerts),
     )
-

--- a/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
+++ b/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
@@ -10,7 +10,15 @@ from tests.unit.interfaces.test_dashboard_backend_control import load_dashboard_
 def _prepare_dashboard_backend(monkeypatch: pytest.MonkeyPatch) -> None:
     if "src.sim.resource_manager" not in sys.modules:
         resource_manager = types.ModuleType("src.sim.resource_manager")
+        resource_manager.BudgetCharger = object
+        resource_manager.BudgetChecker = object
+        resource_manager.HasResources = object
+        resource_manager.ResourceManager = object
+        resource_manager.TickCapper = object
+        resource_manager.get_budget_charger = lambda: None
+        resource_manager.get_budget_checker = lambda: None
         resource_manager.get_resource_manager = lambda: None
+        resource_manager.get_tick_capper = lambda: None
         monkeypatch.setitem(sys.modules, "src.sim.resource_manager", resource_manager)
 
 
@@ -221,6 +229,13 @@ async def test_api_user_value_metrics_includes_kpis_and_periodic_summary(
     resp = await db.api_user_value_metrics()
     payload = json.loads(resp.body)
 
+    assert payload["payload_version"] == 2
+    assert payload["thresholds"] == {
+        "min_novelty_score": 0.2,
+        "min_interaction_diversity": 0.2,
+        "max_repetitive_intents_ratio": 0.75,
+        "min_social_graph_change_count": 1,
+    }
     assert "narrative_continuity_score" in payload
     assert "unresolved_conflict_count" in payload
     assert "stagnation_alerts" in payload

--- a/tests/unit/sim/test_analytics.py
+++ b/tests/unit/sim/test_analytics.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from src.sim.analytics import compute_user_value_kpis
+from src.sim.analytics import (
+    USER_VALUE_KPI_PAYLOAD_VERSION,
+    SimulationStagnationThresholds,
+    compute_user_value_kpis,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -22,6 +26,8 @@ def test_compute_user_value_kpis_from_events_and_board_entries() -> None:
 
     report = compute_user_value_kpis(events=events, knowledge_entries=entries)
 
+    assert report.payload_version == USER_VALUE_KPI_PAYLOAD_VERSION
+    assert report.thresholds == SimulationStagnationThresholds()
     assert report.narrative_continuity_score >= 0
     assert report.unresolved_conflict_count == 0
     assert report.cross_agent_interaction_diversity > 0
@@ -29,14 +35,74 @@ def test_compute_user_value_kpis_from_events_and_board_entries() -> None:
     assert report.return_session_continuity == 1.0
 
 
-def test_compute_user_value_kpis_emits_stagnation_alerts() -> None:
-    events = [
-        {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "idle"},
-        {"type": "agent_action", "step": 2, "agent_id": "a", "action_intent": "idle"},
-        {"type": "agent_action", "step": 3, "agent_id": "a", "action_intent": "idle"},
-    ]
+@pytest.mark.parametrize(
+    ("thresholds", "events", "expected_alert", "unexpected_alerts"),
+    [
+        (
+            SimulationStagnationThresholds(min_novelty_score=0.6, min_interaction_diversity=0.0, max_repetitive_intents_ratio=1.0, min_social_graph_change_count=0),
+            [
+                {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 2, "agent_id": "b", "action_intent": "idle", "target_agent_id": "a"},
+                {"type": "agent_action", "step": 3, "agent_id": "a", "action_intent": "explore", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 4, "agent_id": "b", "action_intent": "explore", "target_agent_id": "a", "content": "relationship formed"},
+            ],
+            "low_novelty",
+            {"low_interaction_diversity", "repetitive_intents", "no_social_graph_change"},
+        ),
+        (
+            SimulationStagnationThresholds(min_novelty_score=0.0, min_interaction_diversity=0.6, max_repetitive_intents_ratio=1.0, min_social_graph_change_count=0),
+            [
+                {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "propose", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 2, "agent_id": "a", "action_intent": "explore", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 3, "agent_id": "c", "action_intent": "respond", "target_agent_id": "a", "content": "ally shift"},
+                {"type": "agent_action", "step": 4, "agent_id": "b", "action_intent": "reflect", "target_agent_id": "a"},
+            ],
+            "low_interaction_diversity",
+            {"low_novelty", "repetitive_intents", "no_social_graph_change"},
+        ),
+        (
+            SimulationStagnationThresholds(min_novelty_score=0.0, min_interaction_diversity=0.0, max_repetitive_intents_ratio=0.6, min_social_graph_change_count=0),
+            [
+                {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 2, "agent_id": "b", "action_intent": "idle", "target_agent_id": "a"},
+                {"type": "agent_action", "step": 3, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b", "content": "coalition updated"},
+                {"type": "agent_action", "step": 4, "agent_id": "b", "action_intent": "explore", "target_agent_id": "a"},
+            ],
+            "repetitive_intents",
+            {"low_novelty", "low_interaction_diversity", "no_social_graph_change"},
+        ),
+        (
+            SimulationStagnationThresholds(min_novelty_score=0.0, min_interaction_diversity=0.0, max_repetitive_intents_ratio=1.0, min_social_graph_change_count=1),
+            [
+                {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "propose", "target_agent_id": "b"},
+                {"type": "agent_action", "step": 2, "agent_id": "b", "action_intent": "respond", "target_agent_id": "a"},
+            ],
+            "no_social_graph_change",
+            {"low_novelty", "low_interaction_diversity", "repetitive_intents"},
+        ),
+    ],
+)
+def test_compute_user_value_kpis_threshold_crossings_are_independent(
+    thresholds: SimulationStagnationThresholds,
+    events: list[dict[str, object]],
+    expected_alert: str,
+    unexpected_alerts: set[str],
+) -> None:
+    report = compute_user_value_kpis(events=events, knowledge_entries=[], thresholds=thresholds)
 
-    report = compute_user_value_kpis(events=events, knowledge_entries=[])
+    assert expected_alert in report.stagnation_alerts
+    assert unexpected_alerts.isdisjoint(report.stagnation_alerts)
 
-    assert "repetitive_intents" in report.stagnation_alerts
-    assert "no_social_graph_change" in report.stagnation_alerts
+
+def test_compute_user_value_kpis_serializes_payload_version_and_thresholds() -> None:
+    report = compute_user_value_kpis(events=[], knowledge_entries=[])
+
+    payload = report.as_dict()
+
+    assert payload["payload_version"] == USER_VALUE_KPI_PAYLOAD_VERSION
+    assert payload["thresholds"] == {
+        "min_novelty_score": 0.2,
+        "min_interaction_diversity": 0.2,
+        "max_repetitive_intents_ratio": 0.75,
+        "min_social_graph_change_count": 1,
+    }


### PR DESCRIPTION
### Motivation

- Make stagnation detection explicit and debuggable by giving each signal its own threshold field and emitting independent alerts. 
- Version the KPI payload so dashboards and downstream consumers can evolve safely when metric semantics change. 
- Provide a single canonical place (dashboard + README) documenting KPI fields so product and engineering share the same contract. 

### Description

- Introduces `SimulationStagnationThresholds` with explicit fields (`min_novelty_score`, `min_interaction_diversity`, `max_repetitive_intents_ratio`, `min_social_graph_change_count`) and an `as_dict()` serializer. 
- Adds `USER_VALUE_KPI_PAYLOAD_VERSION` and extends `UserValueKPIReport` to include `payload_version` and `thresholds`, and updates `as_dict()` to serialize both. 
- Updates `compute_user_value_kpis()` to evaluate each stagnation signal against its dedicated threshold and adds a `low_interaction_diversity` alert; rounding/formatting retained for existing KPIs. 
- Adds unit tests that assert independent threshold-crossing behavior and payload version/threshold serialization; updates dashboard observability tests to assert the new payload fields and adjusts test fixtures to satisfy imports. 
- Documents the KPI contract in the dashboard KPI Card (`culture-ui/src/pages/KpiCard.tsx`) and in the repository README (and links the UI README to the canonical README section). 

### Testing

- Ran static checks with `ruff` against modified files via `ruff check src/sim/analytics.py src/interfaces/dashboard_backend.py tests/unit/sim/test_analytics.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py`, which passed. 
- Ran unit tests with `pytest tests/unit/sim/test_analytics.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py`, and all exercised tests passed. 
- Attempted `pnpm --filter culture-ui lint` and `pnpm --filter culture-ui type-check` in this environment but those failed due to missing UI workspace dependencies (these failures are environmental and not related to the Python changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab1976f14832686f85b6566fed658)