### PR TITLE
Add versioned dashboard API contracts, capabilities endpoint, and deterministic UI fallbacks

### DIFF
--- a/culture-ui/src/MemoryExplorer.test.tsx
+++ b/culture-ui/src/MemoryExplorer.test.tsx
@@ -14,20 +14,24 @@ describe('MemoryExplorer', () => {
     ;(globalThis as unknown as { EventSource?: typeof EventSource }).EventSource =
       MockEventSource as unknown as typeof EventSource
     fetchMock = vi.fn((url: string) => {
+      if (url === '/api/capabilities') {
+        return Promise.resolve({
+          json: () => Promise.resolve({ schema: 'dashboard.capabilities', version: '2026-03-18', enabled: true, data: { capabilities: { memory: { enabled: true, reason: 'ok' } } } }),
+        }) as unknown as Response
+      }
       if (url === '/api/map') {
         return Promise.resolve({
-          json: () =>
-            Promise.resolve({ agents: { 'agent-1': {}, 'agent-2': {} } }),
+          json: () => Promise.resolve({ schema: 'dashboard.map_state', version: '2026-03-18', enabled: true, data: { agents: { 'agent-1': {}, 'agent-2': {} } } }),
         }) as unknown as Response
       }
       if (url === '/api/memory/agent-1') {
         return Promise.resolve({
-          json: () => Promise.resolve({ semantic: ['s1'], episodic: ['e1'] }),
+          json: () => Promise.resolve({ schema: 'dashboard.memory_views', version: '2026-03-18', enabled: true, data: { semantic: ['s1'], episodic: ['e1'] } }),
         }) as unknown as Response
       }
       if (url === '/api/memory/agent-2') {
         return Promise.resolve({
-          json: () => Promise.resolve({ semantic: ['s2'], episodic: ['e2'] }),
+          json: () => Promise.resolve({ schema: 'dashboard.memory_views', version: '2026-03-18', enabled: true, data: { semantic: ['s2'], episodic: ['e2'] } }),
         }) as unknown as Response
       }
       return Promise.resolve({ json: () => Promise.resolve({}) }) as Response
@@ -66,4 +70,3 @@ describe('MemoryExplorer', () => {
     expect(await screen.findByText('e2')).toBeInTheDocument()
   })
 })
-

--- a/culture-ui/src/MissionOverview.test.tsx
+++ b/culture-ui/src/MissionOverview.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
 import MissionOverview from './pages/MissionOverview'
 import { reorderMissions } from './lib/reorderMissions'
 
@@ -9,12 +10,16 @@ const missions = [
 ]
 
 describe('MissionOverview', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
 
-  it('renders missions table', async () => {
-
+  it('renders missions table from backend envelope', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ schema: 'dashboard.missions', version: '2026-03-18', enabled: true, data: { missions }, missions }) }) as unknown as Response))
     render(<MissionOverview />)
     expect(screen.getByRole('heading', { name: /mission overview/i })).toBeInTheDocument()
-    expect(screen.getByText('Gather Intel')).toBeInTheDocument()
+    expect(await screen.findByText('Gather Intel')).toBeInTheDocument()
     expect(screen.getByText('Prepare Brief')).toBeInTheDocument()
   })
 

--- a/culture-ui/src/Quests.test.tsx
+++ b/culture-ui/src/Quests.test.tsx
@@ -8,10 +8,14 @@ describe('Quests page', () => {
     vi.unstubAllGlobals()
   })
 
-  it('renders quests from api', async () => {
-    vi.stubGlobal('fetch', vi.fn(() =>
+  it('renders quests from versioned api envelope', async () => {
+    vi.stubGlobal('fetch', vi.fn((url: string) =>
       Promise.resolve({
-        json: () => Promise.resolve({ quests: [{ id: 1, title: 'Q1', description: '', progress: 0, status: 'pending' }] })
+        json: () => Promise.resolve(
+          url === '/api/quests'
+            ? { schema: 'dashboard.quests', version: '2026-03-18', enabled: true, data: { quests: [{ id: 1, title: 'Q1', description: '', progress: 0, status: 'pending' }] } }
+            : { schema: 'dashboard.capabilities', version: '2026-03-18', enabled: true, data: { capabilities: {} } },
+        )
       }) as unknown as Response
     ))
     render(<Quests />)

--- a/culture-ui/src/lib/api.ts
+++ b/culture-ui/src/lib/api.ts
@@ -1,5 +1,25 @@
 import type { WidgetInfo } from './widgetRegistry'
 
+export interface ApiEnvelope<T> {
+  schema: string
+  version: string
+  enabled: boolean
+  data: T
+  fallback?: {
+    reason?: string
+    action?: string
+  }
+}
+
+export interface CapabilityState {
+  enabled: boolean
+  reason: string
+}
+
+export interface CapabilitiesResponse {
+  capabilities: Record<string, CapabilityState>
+}
+
 export interface Mission {
   id: number
   name: string
@@ -15,66 +35,11 @@ export interface Quest {
   status: string
 }
 
-export async function fetchMissions(): Promise<Mission[]> {
-  const res = await fetch('/api/missions')
-  return (await res.json()) as Mission[]
-}
-
-export async function fetchQuests(): Promise<Quest[]> {
-  const res = await fetch('/api/quests')
-  const data = (await res.json()) as { quests: Quest[] }
-  return data.quests
-}
-
-export async function proposeLaw(
-  proposerId: string,
-  text: string,
-): Promise<boolean> {
-  const res = await fetch('/api/propose_law', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ proposer_id: proposerId, text }),
-  })
-  const data = (await res.json()) as { approved: boolean }
-  return data.approved
-}
-
 export interface ProposalOutcome {
   approved: boolean
   yes_weight: number
   no_weight: number
   ip_spent: number
-}
-
-export async function submitProposal(
-  proposerId: string,
-  text: string,
-): Promise<ProposalOutcome> {
-  const res = await fetch('/api/governance/propose', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ proposer_id: proposerId, text }),
-  })
-  return (await res.json()) as ProposalOutcome
-}
-
-
-export type WidgetRegistration = WidgetInfo & Record<string, unknown>
-
-export async function registerWidgetBackend(widget: WidgetRegistration): Promise<string[]> {
-  const res = await fetch('/api/register_widget', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      name: widget.name,
-      ...(widget.scriptUrl ? { script_url: widget.scriptUrl } : {}),
-      ...Object.fromEntries(
-        Object.entries(widget).filter(([k]) => k !== 'name' && k !== 'scriptUrl'),
-      ),
-    }),
-  })
-  const data = (await res.json()) as { widgets: string[] }
-  return data.widgets
 }
 
 export interface ObservabilityMetrics {
@@ -93,13 +58,86 @@ export interface ObservabilityMetrics {
   agent_llm_latency_p95_ms?: Record<string, number>
 }
 
-export async function fetchObservabilityMetrics(): Promise<ObservabilityMetrics> {
-  const res = await fetch('/api/observability_metrics')
-  return (await res.json()) as ObservabilityMetrics
+export type WidgetRegistration = WidgetInfo & Record<string, unknown>
+
+function isEnvelope<T>(value: unknown): value is ApiEnvelope<T> {
+  return typeof value === 'object' && value !== null && 'schema' in value && 'data' in value
+}
+
+export async function fetchApiEnvelope<T>(url: string): Promise<ApiEnvelope<T>> {
+  const res = await fetch(url)
+  const json = (await res.json()) as ApiEnvelope<T> | T
+  if (isEnvelope<T>(json)) {
+    return json
+  }
+  return {
+    schema: url,
+    version: 'legacy',
+    enabled: true,
+    data: json as T,
+  }
+}
+
+export async function fetchCapabilities(): Promise<ApiEnvelope<CapabilitiesResponse>> {
+  return fetchApiEnvelope<CapabilitiesResponse>('/api/capabilities')
+}
+
+export async function fetchMissions(): Promise<ApiEnvelope<{ missions: Mission[] }>> {
+  return fetchApiEnvelope<{ missions: Mission[] }>('/api/missions')
+}
+
+export async function fetchQuests(): Promise<ApiEnvelope<{ quests: Quest[] }>> {
+  return fetchApiEnvelope<{ quests: Quest[] }>('/api/quests')
+}
+
+export async function proposeLaw(
+  proposerId: string,
+  text: string,
+): Promise<boolean> {
+  const res = await fetch('/api/propose_law', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ proposer_id: proposerId, text }),
+  })
+  const data = (await res.json()) as { approved: boolean }
+  return data.approved
+}
+
+export async function submitProposal(
+  proposerId: string,
+  text: string,
+): Promise<ProposalOutcome> {
+  const res = await fetch('/api/governance/propose', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ proposer_id: proposerId, text }),
+  })
+  return (await res.json()) as ProposalOutcome
+}
+
+export async function registerWidgetBackend(widget: WidgetRegistration): Promise<string[]> {
+  const res = await fetch('/api/register_widget', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: widget.name,
+      ...(widget.scriptUrl ? { script_url: widget.scriptUrl } : {}),
+      ...Object.fromEntries(
+        Object.entries(widget).filter(([k]) => k !== 'name' && k !== 'scriptUrl'),
+      ),
+    }),
+  })
+  const data = (await res.json()) as { widgets: string[] }
+  return data.widgets
+}
+
+export async function fetchObservabilityMetrics(): Promise<ApiEnvelope<ObservabilityMetrics>> {
+  return fetchApiEnvelope<ObservabilityMetrics>('/api/observability_metrics')
 }
 
 export async function displayObservabilityMetrics(): Promise<void> {
-  const metrics = await fetchObservabilityMetrics()
+  const envelope = await fetchObservabilityMetrics()
+  const metrics = envelope.data
   console.log('DU/1k tokens:', metrics.du_per_1k_tokens)
   console.log('p95 latency (ms):', metrics.llm_latency_p95_ms)
   console.log('Coalitions:', metrics.coalition_count)
@@ -114,4 +152,3 @@ export async function displayObservabilityMetrics(): Promise<void> {
   console.log('Agent DU/1k tokens:', metrics.agent_du_per_1k_tokens)
   console.log('Agent p95 latency (ms):', metrics.agent_llm_latency_p95_ms)
 }
-

--- a/culture-ui/src/lib/useCapabilities.ts
+++ b/culture-ui/src/lib/useCapabilities.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { fetchCapabilities, type CapabilityState } from './api'
+
+export function useCapabilities() {
+  const [capabilities, setCapabilities] = useState<Record<string, CapabilityState>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const envelope = await fetchCapabilities()
+        if (!cancelled) {
+          setCapabilities(envelope.data.capabilities || {})
+        }
+      } catch {
+        if (!cancelled) {
+          setCapabilities({})
+        }
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return capabilities
+}

--- a/culture-ui/src/pages/LawProposal.tsx
+++ b/culture-ui/src/pages/LawProposal.tsx
@@ -2,14 +2,21 @@ import { useState } from 'react'
 import type { FormEvent } from 'react'
 import { registerWidget } from '../lib/widgetRegistry'
 import { proposeLaw } from '../lib/api'
+import { useCapabilities } from '../lib/useCapabilities'
 
 export default function LawProposal() {
+  const capabilities = useCapabilities()
+  const governance = capabilities.governance
   const [text, setText] = useState('')
   const [proposer, setProposer] = useState('agent_1')
   const [result, setResult] = useState<string | null>(null)
 
   async function submit(e: FormEvent) {
     e.preventDefault()
+    if (governance && !governance.enabled) {
+      setResult(governance.reason)
+      return
+    }
     setResult(null)
     try {
       const approved = await proposeLaw(proposer, text)
@@ -22,20 +29,23 @@ export default function LawProposal() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Propose Law</h1>
+      {governance && !governance.enabled && <p data-testid="governance-fallback">{governance.reason}</p>}
       <form onSubmit={submit} className="space-y-2">
         <input
           placeholder="Proposal text"
           value={text}
           onChange={(e) => setText(e.target.value)}
           className="border p-1 w-full"
+          disabled={Boolean(governance && !governance.enabled)}
         />
         <input
           placeholder="Proposer ID"
           value={proposer}
           onChange={(e) => setProposer(e.target.value)}
           className="border p-1 w-full"
+          disabled={Boolean(governance && !governance.enabled)}
         />
-        <button type="submit" className="px-2 py-1 border rounded">
+        <button type="submit" className="px-2 py-1 border rounded" disabled={Boolean(governance && !governance.enabled)}>
           Submit
         </button>
       </form>

--- a/culture-ui/src/pages/MapState.tsx
+++ b/culture-ui/src/pages/MapState.tsx
@@ -1,35 +1,36 @@
 import { useEffect, useState } from 'react'
-
-interface MapEvent {
-  type?: string
-  data?: {
-    world_map?: {
-      agents?: Record<string, [number, number]>
-    }
-  }
-}
+import { fetchApiEnvelope } from '../lib/api'
+import { useCapabilities } from '../lib/useCapabilities'
 
 export default function MapState() {
+  const capabilities = useCapabilities()
+  const mapCapability = capabilities.map
   const [positions, setPositions] = useState<Record<string, [number, number]>>({})
 
   useEffect(() => {
-    const es = new EventSource('/api/map')
-    es.onmessage = (ev) => {
+    let cancelled = false
+    async function load() {
       try {
-        const payload = JSON.parse(ev.data) as MapEvent
-        if (payload.data?.world_map?.agents) {
-          setPositions(payload.data.world_map.agents)
+        const envelope = await fetchApiEnvelope<{ world_map?: { agents?: Record<string, [number, number]> } }>('/api/map')
+        if (!cancelled && envelope.data.world_map?.agents) {
+          setPositions(envelope.data.world_map.agents)
         }
       } catch {
-        // ignore
+        if (!cancelled) {
+          setPositions({})
+        }
       }
     }
-    return () => es.close()
+    void load()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Map State</h1>
+      {mapCapability && !mapCapability.enabled && <p data-testid="map-fallback">{mapCapability.reason}</p>}
       <div data-testid="map-state">
         <ul>
           {Object.entries(positions).map(([id, [x, y]]) => (

--- a/culture-ui/src/pages/MemoryExplorer.tsx
+++ b/culture-ui/src/pages/MemoryExplorer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { fetchApiEnvelope } from '../lib/api'
+import { useCapabilities } from '../lib/useCapabilities'
 
 interface AgentInfo {
   mood?: number
@@ -11,6 +13,9 @@ interface MessagePayload {
 }
 
 export default function MemoryExplorerPage() {
+  const capabilities = useCapabilities()
+  const memoryCapability = capabilities.memory
+  const memoryEnabled = memoryCapability?.enabled ?? true
   const [agents, setAgents] = useState<string[]>([])
   const [agentId, setAgentId] = useState('')
   const [semantic, setSemantic] = useState<string[]>([])
@@ -18,15 +23,19 @@ export default function MemoryExplorerPage() {
   const [messages, setMessages] = useState<string[]>([])
 
   useEffect(() => {
+    if (!memoryEnabled) {
+      setAgents([])
+      setAgentId('')
+      setSemantic([])
+      setEpisodic([])
+      return
+    }
     let cancelled = false
     async function load() {
       try {
-        const res = await fetch('/api/map')
-        const json = (await res.json()) as {
-          agents?: Record<string, AgentInfo>
-        }
+        const envelope = await fetchApiEnvelope<{ agents?: Record<string, AgentInfo> }>('/api/map')
         if (cancelled) return
-        const ids = Object.keys(json.agents || {})
+        const ids = Object.keys(envelope.data.agents || {})
         setAgents(ids)
         if (ids.length) setAgentId(ids[0])
       } catch {
@@ -37,21 +46,20 @@ export default function MemoryExplorerPage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [memoryEnabled])
 
   useEffect(() => {
-    if (!agentId) return
+    if (!agentId || !memoryEnabled) return
     let cancelled = false
     async function load() {
       try {
-        const res = await fetch(`/api/memory/${agentId}`)
-        const json = (await res.json()) as {
+        const envelope = await fetchApiEnvelope<{
           semantic?: string[]
           episodic?: Array<{ content?: string } | string>
-        }
+        }>(`/api/memory/${agentId}`)
         if (cancelled) return
-        setSemantic(json.semantic || [])
-        const eps = (json.episodic || []).map((m) =>
+        setSemantic(envelope.data.semantic || [])
+        const eps = (envelope.data.episodic || []).map((m) =>
           typeof m === 'string' ? m : m.content || String(m),
         )
         setEpisodic(eps)
@@ -63,10 +71,10 @@ export default function MemoryExplorerPage() {
     return () => {
       cancelled = true
     }
-  }, [agentId])
+  }, [agentId, memoryEnabled])
 
   useEffect(() => {
-    if (!agentId) return
+    if (!agentId || !memoryEnabled) return
     const es = new EventSource('/stream/messages')
     es.onmessage = (ev) => {
       try {
@@ -79,11 +87,12 @@ export default function MemoryExplorerPage() {
       }
     }
     return () => es.close()
-  }, [agentId])
+  }, [agentId, memoryEnabled])
 
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Memory Explorer</h1>
+      {!memoryEnabled && memoryCapability && <p data-testid="memory-fallback">{memoryCapability.reason}</p>}
       <label className="block">
         Agent:
         <select
@@ -91,6 +100,7 @@ export default function MemoryExplorerPage() {
           value={agentId}
           onChange={(e) => setAgentId(e.target.value)}
           className="border p-1 ml-2"
+          disabled={!memoryEnabled}
         >
           {agents.map((id) => (
             <option key={id} value={id}>
@@ -99,22 +109,9 @@ export default function MemoryExplorerPage() {
           ))}
         </select>
       </label>
-      <div data-testid="summaries">
-        {semantic.map((s, i) => (
-          <div key={i}>{s}</div>
-        ))}
-      </div>
-      <div data-testid="memories">
-        {episodic.map((m, i) => (
-          <div key={i}>{m}</div>
-        ))}
-      </div>
-      <div data-testid="messages">
-        {messages.map((m, i) => (
-          <div key={i}>{m}</div>
-        ))}
-      </div>
+      <div data-testid="summaries">{semantic.map((s, i) => <div key={i}>{s}</div>)}</div>
+      <div data-testid="memories">{episodic.map((m, i) => <div key={i}>{m}</div>)}</div>
+      <div data-testid="messages">{messages.map((m, i) => <div key={i}>{m}</div>)}</div>
     </div>
   )
 }
-

--- a/culture-ui/src/pages/MissionOverview.tsx
+++ b/culture-ui/src/pages/MissionOverview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { registerWidget } from '../lib/widgetRegistry'
 import clsx from 'clsx'
 import type { ColumnDef, Row } from '@tanstack/react-table'
@@ -8,7 +8,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import type { Mission } from '../lib/api'
-import missionsData from '../mock/missions.json'
+import { fetchMissions } from '../lib/api'
 import {
   DndContext,
   KeyboardSensor,
@@ -26,7 +26,6 @@ import { CSS } from '@dnd-kit/utilities'
 
 import { reorderMissions } from '../lib/reorderMissions'
 
-export { reorderMissions }
 
 function DraggableRow({ row }: { row: Row<Mission> }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -56,7 +55,29 @@ function DraggableRow({ row }: { row: Row<Mission> }) {
 }
 
 export default function MissionOverview() {
-  const [data, setData] = useState<Mission[]>(missionsData as Mission[])
+  const [data, setData] = useState<Mission[]>([])
+  const [fallback, setFallback] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const envelope = await fetchMissions()
+        if (cancelled) return
+        setData(envelope.data.missions || [])
+        setFallback(envelope.enabled ? null : envelope.fallback?.reason || 'Missions unavailable.')
+      } catch {
+        if (!cancelled) {
+          setData([])
+          setFallback('Missions unavailable.')
+        }
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const columns: ColumnDef<Mission>[] = [
     {
@@ -95,6 +116,7 @@ export default function MissionOverview() {
   return (
     <div className="p-4">
       <h2 className="mb-4 text-xl font-bold">Mission Overview</h2>
+      {fallback && <p data-testid="missions-fallback">{fallback}</p>}
       <DndContext
         sensors={sensors}
         onDragEnd={({ active, over }) => {

--- a/culture-ui/src/pages/Proposals.tsx
+++ b/culture-ui/src/pages/Proposals.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { registerWidget } from '../lib/widgetRegistry'
 import { submitProposal } from '../lib/api'
+import { useCapabilities } from '../lib/useCapabilities'
 
 interface Proposal {
   proposer_id: string
@@ -13,6 +14,9 @@ interface Proposal {
 }
 
 export default function Proposals() {
+  const capabilities = useCapabilities()
+  const governance = capabilities.governance
+  const governanceEnabled = governance?.enabled ?? true
   const [data, setData] = useState<Proposal[]>([])
   const [text, setText] = useState('')
   const [proposer, setProposer] = useState('agent_1')
@@ -24,16 +28,24 @@ export default function Proposals() {
       const json = (await res.json()) as { proposals: Proposal[] }
       setData(json.proposals || [])
     } catch {
-      /* ignore */
+      setData([])
     }
   }
 
   useEffect(() => {
+    if (!governanceEnabled) {
+      setData([])
+      return
+    }
     void load()
-  }, [])
+  }, [governanceEnabled])
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
+    if (!governanceEnabled) {
+      setResult(governance.reason)
+      return
+    }
     setResult(null)
     try {
       const outcome = await submitProposal(proposer, text)
@@ -47,47 +59,20 @@ export default function Proposals() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Recent Proposals</h1>
+      {!governanceEnabled && governance && <p data-testid="governance-fallback">{governance.reason}</p>}
       <form onSubmit={submit} className="space-y-2">
-        <input
-          placeholder="Proposal text"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          className="border p-1 w-full"
-        />
-        <input
-          placeholder="Proposer ID"
-          value={proposer}
-          onChange={(e) => setProposer(e.target.value)}
-          className="border p-1 w-full"
-        />
-        <button type="submit" className="px-2 py-1 border rounded">
+        <input placeholder="Proposal text" value={text} onChange={(e) => setText(e.target.value)} className="border p-1 w-full" disabled={!governanceEnabled} />
+        <input placeholder="Proposer ID" value={proposer} onChange={(e) => setProposer(e.target.value)} className="border p-1 w-full" disabled={!governanceEnabled} />
+        <button type="submit" className="px-2 py-1 border rounded" disabled={!governanceEnabled}>
           Submit
         </button>
         {result && <div data-testid="result">Result: {result}</div>}
       </form>
       <table className="min-w-full border" data-testid="proposal-table">
-        <thead>
-          <tr>
-            <th className="border px-2">Time</th>
-            <th className="border px-2">Proposer</th>
-            <th className="border px-2">Text</th>
-            <th className="border px-2">Yes</th>
-            <th className="border px-2">No</th>
-            <th className="border px-2">IP Spent</th>
-            <th className="border px-2">Approved</th>
-          </tr>
-        </thead>
+        <thead><tr><th className="border px-2">Time</th><th className="border px-2">Proposer</th><th className="border px-2">Text</th><th className="border px-2">Yes</th><th className="border px-2">No</th><th className="border px-2">IP Spent</th><th className="border px-2">Approved</th></tr></thead>
         <tbody>
           {data.map((p, idx) => (
-            <tr key={idx}>
-              <td className="border px-2">{new Date(p.ts).toLocaleString()}</td>
-              <td className="border px-2">{p.proposer_id}</td>
-              <td className="border px-2">{p.text}</td>
-              <td className="border px-2">{p.yes_weight}</td>
-              <td className="border px-2">{p.no_weight}</td>
-              <td className="border px-2">{p.ip_spent}</td>
-              <td className="border px-2">{p.approved ? 'Yes' : 'No'}</td>
-            </tr>
+            <tr key={idx}><td className="border px-2">{new Date(p.ts).toLocaleString()}</td><td className="border px-2">{p.proposer_id}</td><td className="border px-2">{p.text}</td><td className="border px-2">{p.yes_weight}</td><td className="border px-2">{p.no_weight}</td><td className="border px-2">{p.ip_spent}</td><td className="border px-2">{p.approved ? 'Yes' : 'No'}</td></tr>
           ))}
         </tbody>
       </table>

--- a/culture-ui/src/pages/Quests.tsx
+++ b/culture-ui/src/pages/Quests.tsx
@@ -1,26 +1,24 @@
 import { useEffect, useState } from 'react'
 import { registerWidget } from '../lib/widgetRegistry'
-
-interface Quest {
-  id: number
-  title: string
-  description: string
-  progress: number
-  status: string
-}
+import { fetchQuests, type Quest } from '../lib/api'
 
 export default function Quests() {
   const [quests, setQuests] = useState<Quest[]>([])
+  const [fallback, setFallback] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     async function load() {
       try {
-        const res = await fetch('/api/quests')
-        const json = (await res.json()) as { quests: Quest[] }
-        if (!cancelled) setQuests(json.quests || [])
+        const envelope = await fetchQuests()
+        if (!cancelled) {
+          setQuests(envelope.data.quests || [])
+          setFallback(envelope.enabled ? null : envelope.fallback?.reason || 'Quests unavailable.')
+        }
       } catch {
-        /* ignore */
+        if (!cancelled) {
+          setFallback('Quests unavailable.')
+        }
       }
     }
     void load()
@@ -32,6 +30,7 @@ export default function Quests() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Quests</h1>
+      {fallback && <p data-testid="quests-fallback">{fallback}</p>}
       <table className="min-w-full border" data-testid="quest-table">
         <thead>
           <tr>

--- a/scripts/seed_dashboard_dev.py
+++ b/scripts/seed_dashboard_dev.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_MISSIONS = [
+    {"id": 1, "name": "Bootstrap Dashboard", "status": "seeded", "progress": 100},
+    {"id": 2, "name": "Verify Capabilities", "status": "ready", "progress": 25},
+    {"id": 3, "name": "Exercise Fallback States", "status": "pending", "progress": 0},
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Seed explicit development data for dashboard APIs."
+    )
+    parser.add_argument(
+        "--missions-path",
+        type=Path,
+        default=Path(__file__).resolve().parents[1]
+        / "data"
+        / "dev"
+        / "dashboard"
+        / "missions.json",
+    )
+    args = parser.parse_args()
+
+    args.missions_path.parent.mkdir(parents=True, exist_ok=True)
+    args.missions_path.write_text(json.dumps(DEFAULT_MISSIONS, indent=2) + "\n", encoding="utf-8")
+    print(f"Seeded missions fixture at {args.missions_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -172,10 +172,36 @@ BREAKPOINT_TAGS: set[str] = {"violence", "nsfw"}
 # Registry of widgets registered by the UI or plugins
 WIDGET_REGISTRY = WidgetRegistry()
 
-# Path to the initial missions data bundled with the front-end
-MISSIONS_PATH = (
-    Path(__file__).resolve().parents[2] / "culture-ui" / "src" / "mock" / "missions.json"
-)
+API_SCHEMA_VERSION = "2026-03-18"
+DEV_DATA_DIR = Path(__file__).resolve().parents[2] / "data" / "dev" / "dashboard"
+MISSIONS_PATH = DEV_DATA_DIR / "missions.json"
+
+
+class CapabilityInfo(BaseModel):
+    enabled: bool
+    reason: str
+
+
+class ApiSchemaEnvelope(BaseModel):
+    schema: str
+    version: str = API_SCHEMA_VERSION
+    enabled: bool = True
+    data: Any
+    fallback: dict[str, Any] | None = None
+
+
+def _schema_payload(
+    schema: str,
+    data: Any,
+    *,
+    enabled: bool = True,
+    fallback: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    envelope = ApiSchemaEnvelope(schema=schema, data=data, enabled=enabled, fallback=fallback)
+    payload = envelope.model_dump()
+    if isinstance(data, dict):
+        payload.update(data)
+    return payload
 
 
 def _subsystem_status() -> dict[str, dict[str, str | bool]]:
@@ -230,6 +256,72 @@ def _subsystem_status() -> dict[str, dict[str, str | bool]]:
         }
 
     return statuses
+
+
+def _dashboard_capabilities() -> dict[str, CapabilityInfo]:
+    statuses = _subsystem_status()
+    sim = DEFAULT_CONTEXT.sim_state.get("simulation")
+    return {
+        "missions": CapabilityInfo(
+            enabled=MISSIONS_PATH.exists(),
+            reason=(
+                f"development seed available at {MISSIONS_PATH}"
+                if MISSIONS_PATH.exists()
+                else "No development mission seed found. Run scripts/seed_dashboard_dev.py."
+            ),
+        ),
+        "quests": CapabilityInfo(
+            enabled=True,
+            reason="Quest data served from the runtime ledger.",
+        ),
+        "governance": CapabilityInfo(
+            enabled=bool(sim is not None),
+            reason=(
+                "Governance endpoints require an initialized simulation."
+                if sim is None
+                else "Governance service available."
+            ),
+        ),
+        "observability": CapabilityInfo(
+            enabled=True,
+            reason="Observability metrics are always exposed with zero/default fallbacks.",
+        ),
+        "map": CapabilityInfo(
+            enabled=bool(sim is not None and getattr(sim, "world_map", None) is not None),
+            reason=(
+                "Map endpoints require a simulation world map."
+                if sim is None or getattr(sim, "world_map", None) is None
+                else "World map available."
+            ),
+        ),
+        "memory": CapabilityInfo(
+            enabled=bool(sim is not None),
+            reason=(
+                "Memory views require an initialized simulation."
+                if sim is None
+                else "Memory services available with empty fallback responses."
+            ),
+        ),
+        "graph_kb": CapabilityInfo(
+            enabled=bool(statuses.get("graph_store", {}).get("ok")),
+            reason=str(statuses.get("graph_store", {}).get("detail", "graph backend unavailable")),
+        ),
+        "moderation": CapabilityInfo(
+            enabled=True,
+            reason="Moderation controls are routed through dashboard/Discord policies.",
+        ),
+    }
+
+
+def _capability_enabled(name: str) -> bool:
+    capability = _dashboard_capabilities().get(name)
+    return bool(capability.enabled) if capability is not None else False
+
+
+def _capability_fallback(name: str) -> dict[str, Any]:
+    capability = _dashboard_capabilities().get(name)
+    reason = capability.reason if capability is not None else "Capability unavailable."
+    return {"reason": reason, "action": "Show deterministic empty state in the UI."}
 
 
 class AgentMessage(BaseModel):
@@ -520,7 +612,15 @@ async def api_map() -> Response:
                 except Exception:  # pragma: no cover - defensive
                     logger.exception("Failed to load summary for %s", ag.agent_id)
             agents[ag.agent_id] = {"mood": mood, "summary": summary}
-    return JSONResponse({"world_map": world_map, "agents": agents})
+    enabled = _capability_enabled("map")
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.map_state",
+            {"world_map": world_map, "agents": agents},
+            enabled=enabled,
+            fallback=None if enabled else _capability_fallback("map"),
+        )
+    )
 
 
 @app.get("/api/agent_stats")
@@ -588,19 +688,47 @@ async def readiness() -> Response:
     return JSONResponse(payload, status_code=200 if not missing else 503)
 
 
+@app.get("/api/capabilities")
+async def api_capabilities() -> Response:
+    capabilities = {key: value.model_dump() for key, value in _dashboard_capabilities().items()}
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.capabilities",
+            {"capabilities": capabilities},
+        )
+    )
+
+
 @app.get("/api/missions")
 async def get_missions() -> Response:
-    """Return the list of missions from the bundled JSON file."""
-    with open(MISSIONS_PATH, encoding="utf-8") as f:
-        missions = json.load(f)
-    return JSONResponse(missions)
+    """Return missions seeded explicitly for development environments."""
+    missions: list[dict[str, Any]] = []
+    enabled = MISSIONS_PATH.exists()
+    if enabled:
+        with open(MISSIONS_PATH, encoding="utf-8") as f:
+            missions = json.load(f)
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.missions",
+            {"missions": missions},
+            enabled=enabled,
+            fallback=None if enabled else _capability_fallback("missions"),
+        )
+    )
 
 
 @app.get("/api/quests")
 async def get_quests_api() -> Response:
     """Return the list of generated quests."""
     quests = ledger.get_quests()
-    return JSONResponse({"quests": quests})
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.quests",
+            {"quests": quests},
+            enabled=_capability_enabled("quests"),
+            fallback=None if _capability_enabled("quests") else _capability_fallback("quests"),
+        )
+    )
 
 
 @app.get("/api/agents/{agent_id}/semantic_summaries")
@@ -738,7 +866,15 @@ async def api_memory(agent_id: str, limit: int = 5) -> Response:
             except Exception:  # pragma: no cover - defensive
                 episodic = []
 
-    return JSONResponse({"semantic": semantic, "episodic": episodic})
+    enabled = _capability_enabled("memory")
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.memory_views",
+            {"semantic": semantic, "episodic": episodic},
+            enabled=enabled,
+            fallback=None if enabled else _capability_fallback("memory"),
+        )
+    )
 
 
 @app.get("/api/knowledge/timeline")
@@ -946,15 +1082,33 @@ async def api_get_gov() -> Response:
     sim = SIM_STATE.get("simulation")
     if sim is not None and hasattr(sim, "get_governance_read_model"):
         model = cast(dict[str, Any], sim.get_governance_read_model())
-        return JSONResponse(model)
+        return JSONResponse(
+            _schema_payload(
+                "dashboard.governance",
+                model,
+                enabled=_capability_enabled("governance"),
+                fallback=(
+                    None
+                    if _capability_enabled("governance")
+                    else _capability_fallback("governance")
+                ),
+            )
+        )
     return JSONResponse(
-        {
-            "rules": governance_rules_engine.current_rules(),
-            "current_rules": governance_rules_engine.current_rules(),
-            "pending_votes": governance_rules_engine.pending_votes(),
-            "active_offices": governance_rules_engine.active_offices(),
-            "sanctions": governance_rules_engine.sanctions(),
-        }
+        _schema_payload(
+            "dashboard.governance",
+            {
+                "rules": governance_rules_engine.current_rules(),
+                "current_rules": governance_rules_engine.current_rules(),
+                "pending_votes": governance_rules_engine.pending_votes(),
+                "active_offices": governance_rules_engine.active_offices(),
+                "sanctions": governance_rules_engine.sanctions(),
+            },
+            enabled=_capability_enabled("governance"),
+            fallback=(
+                None if _capability_enabled("governance") else _capability_fallback("governance")
+            ),
+        )
     )
 
 
@@ -1097,7 +1251,18 @@ async def api_cost_metrics() -> Response:
 
     payload = _cost_metrics_data()
     payload["user_value_kpis"] = _user_value_metrics_data()
-    return JSONResponse(payload)
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.observability",
+            payload,
+            enabled=_capability_enabled("observability"),
+            fallback=(
+                None
+                if _capability_enabled("observability")
+                else _capability_fallback("observability")
+            ),
+        )
+    )
 
 
 @app.get("/api/observability_metrics")
@@ -1106,7 +1271,18 @@ async def api_observability_metrics() -> Response:
 
     payload = _cost_metrics_data()
     payload["user_value_kpis"] = _user_value_metrics_data()
-    return JSONResponse(payload)
+    return JSONResponse(
+        _schema_payload(
+            "dashboard.observability",
+            payload,
+            enabled=_capability_enabled("observability"),
+            fallback=(
+                None
+                if _capability_enabled("observability")
+                else _capability_fallback("observability")
+            ),
+        )
+    )
 
 
 @app.get("/api/user_value_metrics")

--- a/tests/unit/interfaces/test_dashboard_backend_contracts.py
+++ b/tests/unit/interfaces/test_dashboard_backend_contracts.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+
+from src.interfaces import dashboard_backend as db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_api_capabilities_reports_expected_subsystems(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(db, "MISSIONS_PATH", db.DEV_DATA_DIR / "missing.json")
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "simulation", None)
+
+    response = await db.api_capabilities()
+    payload = json.loads(response.body)
+
+    assert payload["schema"] == "dashboard.capabilities"
+    assert set(payload["capabilities"]).issuperset(
+        {"graph_kb", "governance", "map", "memory", "moderation"}
+    )
+    assert payload["capabilities"]["governance"]["enabled"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_versioned_endpoint_contracts_embed_data_and_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(db.DEFAULT_CONTEXT.sim_state, "simulation", None)
+
+    map_payload = json.loads((await db.api_map()).body)
+    memory_payload = json.loads((await db.api_memory("agent-1")).body)
+    gov_payload = json.loads((await db.api_get_gov()).body)
+    observability_payload = json.loads((await db.api_observability_metrics()).body)
+
+    assert map_payload["schema"] == "dashboard.map_state"
+    assert map_payload["enabled"] is False
+    assert map_payload["data"]["world_map"] == {}
+
+    assert memory_payload["schema"] == "dashboard.memory_views"
+    assert memory_payload["episodic"] == []
+    assert memory_payload["fallback"]["action"]
+
+    assert gov_payload["schema"] == "dashboard.governance"
+    assert gov_payload["enabled"] is False
+    assert "rules" in gov_payload["data"]
+
+    assert observability_payload["schema"] == "dashboard.observability"
+    assert "du_per_1k_tokens" in observability_payload["data"]

--- a/tests/unit/interfaces/test_dashboard_backend_missions.py
+++ b/tests/unit/interfaces/test_dashboard_backend_missions.py
@@ -7,11 +7,27 @@ from src.interfaces import dashboard_backend as db
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_get_missions_returns_data(tmp_path, monkeypatch):
+async def test_get_missions_returns_versioned_schema(tmp_path, monkeypatch):
     missions = [{"id": 1, "name": "Test", "status": "Pending", "progress": 0}]
     path = tmp_path / "missions.json"
     path.write_text(json.dumps(missions))
     monkeypatch.setattr(db, "MISSIONS_PATH", path)
 
     response = await db.get_missions()
-    assert json.loads(response.body) == missions
+    payload = json.loads(response.body)
+    assert payload["schema"] == "dashboard.missions"
+    assert payload["enabled"] is True
+    assert payload["missions"] == missions
+    assert payload["data"]["missions"] == missions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_missions_returns_deterministic_fallback_when_unseeded(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "MISSIONS_PATH", tmp_path / "missing.json")
+
+    response = await db.get_missions()
+    payload = json.loads(response.body)
+    assert payload["enabled"] is False
+    assert payload["missions"] == []
+    assert "Run scripts/seed_dashboard_dev.py" in payload["fallback"]["reason"]

--- a/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
+++ b/tests/unit/interfaces/test_dashboard_backend_observability_metrics.py
@@ -83,9 +83,10 @@ async def test_api_observability_metrics_serializes_extended_payload(
         "llm_error_rate",
     }
 
-    assert expected_keys.issubset(payload.keys())
-    assert payload["memory_retrieval_errors_total"] == 20
-    assert payload["llm_errors_total"] == 5
+    assert payload["schema"] == "dashboard.observability"
+    assert expected_keys.issubset(payload["data"].keys())
+    assert payload["data"]["memory_retrieval_errors_total"] == 20
+    assert payload["data"]["llm_errors_total"] == 5
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Motivation
- Provide stable, versioned API envelopes for dashboard endpoints so the UI can detect schema versions and adapt to enabled/disabled subsystems.
- Move bundled demo fixture loading out of runtime code into an explicit development seed script to avoid hidden runtime data dependencies.
- Expose runtime capability information so the frontend can render deterministic fallbacks when a subsystem is unavailable.

### Description
- Add `ApiSchemaEnvelope`, `_schema_payload`, capability discovery helpers, and a new `/api/capabilities` endpoint, and apply the envelope to missions, quests, map state, memory views, governance, and observability responses in `src/interfaces/dashboard_backend.py`.
- Replace the previous in-repo UI mock missions path with a development seed file and `scripts/seed_dashboard_dev.py` that writes `data/dev/dashboard/missions.json` for local/dev seeding.
- Update frontend API client to parse envelopes (`fetchApiEnvelope`) and add `useCapabilities` hook, and update UI pages (`MissionOverview`, `Quests`, `MapState`, `MemoryExplorer`, `LawProposal`, `Proposals`, etc.) to consume envelope data and render deterministic fallback messages and disabled controls.
- Add unit contract tests for backend envelopes and fallbacks and update frontend tests to assert the new envelope shapes and fallback UI behavior.

### Testing
- Ran focused style checks `ruff` and `black --check` against modified files (`src/interfaces/dashboard_backend.py`, `scripts/seed_dashboard_dev.py`, and new/updated tests`) which passed for the changed files; a repository-wide `./scripts/lint.sh` initially flagged unrelated Ruff findings outside this change set.
- Executed Python unit tests `python -m pytest tests/unit/interfaces/test_dashboard_backend_missions.py tests/unit/interfaces/test_dashboard_backend_contracts.py tests/unit/interfaces/test_dashboard_backend_observability_metrics.py` and they passed.
- Installed frontend deps with `pnpm --dir culture-ui install --frozen-lockfile`, ran `eslint` on the changed frontend files which completed (with a small number of non-blocking warnings), and ran `vitest` for the updated tests (`MissionOverview.test.tsx`, `Quests.test.tsx`, `MemoryExplorer.test.tsx`) which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab99f5fc08326917a9efea7879fc7)