### PR TITLE
feat: add explicit knowledge board capability flags and capability-aware query routing

### DIFF
--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -230,12 +230,12 @@ def _subsystem_status() -> dict[str, dict[str, str | bool]]:
 
         board = getattr(sim, "knowledge_board", None)
         board_name = type(board).__name__ if board is not None else "None"
-        if board is not None and "graph" in board_name.lower():
+        if board is not None and bool(getattr(board, "supports_graph_queries", False)):
             statuses["graph_store"] = {"ok": True, "detail": board_name}
         else:
             statuses["graph_store"] = {
                 "ok": False,
-                "detail": f"graph backend not active (current: {board_name})",
+                "detail": f"graph capability unavailable (current: {board_name})",
             }
 
     try:
@@ -916,7 +916,8 @@ async def api_knowledge_thread(root_entry_id: str, page: int = 1, page_size: int
         root_entry_id=root_entry_id,
         pagination=QueryPagination(page=page, page_size=page_size),
     )
-    return JSONResponse(service.query_thread(query).to_dict())
+    result = service.query_thread(query)
+    return JSONResponse(result.to_dict())
 
 
 @app.get("/api/knowledge/proposal/{proposal_id}")
@@ -974,6 +975,8 @@ async def api_knowledge_causal_chain(entry_id: str, depth: int = 3) -> Response:
     if service is None:
         return JSONResponse({"entry_id": entry_id, "chain": []})
     chain = service.query_causal_chain(CausalChainQueryDTO(entry_id=entry_id, depth=depth))
+    if hasattr(chain, "to_dict"):
+        return JSONResponse({"entry_id": entry_id, "chain": [], "error": chain.to_dict()})
     return JSONResponse({"entry_id": entry_id, "chain": [item.to_dict() for item in chain]})
 
 

--- a/src/sim/graph_knowledge_board.py
+++ b/src/sim/graph_knowledge_board.py
@@ -32,6 +32,11 @@ logger = logging.getLogger(__name__)
 
 
 class GraphKnowledgeBoard:
+    supports_threads = True
+    supports_causal_chain = True
+    supports_votes = True
+    supports_graph_queries = True
+
     """Knowledge Board backed by a Neo4j graph database."""
 
     def __init__(
@@ -71,7 +76,6 @@ class GraphKnowledgeBoard:
     def _count_entries(self: Self) -> int:
         res = self._run("MATCH (e:KBEntry) RETURN count(e) AS cnt")
         return int(res[0]["cnt"]) if res else 0
-
 
     def begin_transaction(self: Self) -> dict[str, Any]:
         """Capture a snapshot used for compensating rollback."""

--- a/src/sim/knowledge_board.py
+++ b/src/sim/knowledge_board.py
@@ -165,6 +165,11 @@ class LoggingList(list[T], Generic[T]):
 
 
 class KnowledgeBoard:
+    supports_threads = True
+    supports_causal_chain = True
+    supports_votes = True
+    supports_graph_queries = False
+
     """
     Represents a shared knowledge board that agents can read from and eventually write to.
     Maintains a list of knowledge entries as structured dictionaries.
@@ -263,7 +268,9 @@ class KnowledgeBoard:
         self.entries = LoggingList(self._records_from_dicts(entries))
         metrics.KNOWLEDGE_BOARD_SIZE.set(len(self.entries))
 
-    def _records_from_dicts(self: Self, entries: list[dict[str, Any]]) -> list[KnowledgeEntryRecord]:
+    def _records_from_dicts(
+        self: Self, entries: list[dict[str, Any]]
+    ) -> list[KnowledgeEntryRecord]:
         records: list[KnowledgeEntryRecord] = []
         for entry in entries:
             migrated = migrate_entry_dict(entry)
@@ -273,7 +280,9 @@ class KnowledgeBoard:
                         entry_id=str(migrated.get("entry_id") or ""),
                         step=int(migrated.get("step") or 0),
                         agent_id=str(migrated.get("agent_id") or "unknown"),
-                        entry_type=str(migrated.get("entry_type") or KnowledgeEntryType.NOTE.value),
+                        entry_type=str(
+                            migrated.get("entry_type") or KnowledgeEntryType.NOTE.value
+                        ),
                         content_full=str(migrated.get("content_full") or ""),
                         content_display=str(migrated.get("content_display") or ""),
                         content_summary=str(
@@ -438,7 +447,8 @@ class KnowledgeBoard:
         votes = [
             entry
             for entry in self.entries
-            if entry.entry_type == KnowledgeEntryType.VOTE.value and entry.parent_entry_id == proposal_id
+            if entry.entry_type == KnowledgeEntryType.VOTE.value
+            and entry.parent_entry_id == proposal_id
         ]
         approvals = 0
         rejections = 0

--- a/src/sim/knowledge_board_protocol.py
+++ b/src/sim/knowledge_board_protocol.py
@@ -55,6 +55,10 @@ class KnowledgeBoardCapabilities(Protocol):
     """Strict capability contract used by callers."""
 
     lock: Any
+    supports_threads: bool
+    supports_causal_chain: bool
+    supports_votes: bool
+    supports_graph_queries: bool
 
     def append_entry(
         self,
@@ -100,7 +104,9 @@ class KnowledgeBoardCapabilities(Protocol):
 
     def get_agent_stance_history(self, agent_id: str) -> list[dict[str, Any]]: ...
 
-    def get_active_proposal_projection(self, limit: int = 20) -> list[ActiveProposalProjection]: ...
+    def get_active_proposal_projection(
+        self, limit: int = 20
+    ) -> list[ActiveProposalProjection]: ...
 
     def get_consensus_projection(self, proposal_id: str) -> ConsensusStatusProjection: ...
 
@@ -143,20 +149,40 @@ def _require_capability(board: object, capability: type[CapabilityT], name: str)
     raise UnsupportedKnowledgeBoardCapabilityError(capability=name, board=board)
 
 
+def _coerce_board(board: object) -> KnowledgeBoardCapabilities:
+    if isinstance(board, KnowledgeBoardCapabilities):
+        return cast(KnowledgeBoardCapabilities, board)
+    if isinstance(board, GraphKnowledgeBoard):
+        return GraphKnowledgeBoardAdapter(board)
+    if isinstance(board, KnowledgeBoard):
+        return InMemoryKnowledgeBoardAdapter(board)
+    raise UnsupportedKnowledgeBoardCapabilityError(
+        capability="KnowledgeBoardCapabilities", board=board
+    )
+
+
 def as_entry_store(board: object) -> EntryStore:
-    return _require_capability(board, KnowledgeBoardCapabilities, "KnowledgeBoardCapabilities")
+    return _coerce_board(board)
 
 
 def as_relationship_store(board: object) -> RelationshipStore:
-    return _require_capability(board, KnowledgeBoardCapabilities, "KnowledgeBoardCapabilities")
+    capability_board = _coerce_board(board)
+    if not getattr(capability_board, "supports_graph_queries", False):
+        raise UnsupportedKnowledgeBoardCapabilityError(capability="RelationshipStore", board=board)
+    return capability_board
 
 
 def as_proposal_voting_store(board: object) -> ProposalVotingStore:
-    return _require_capability(board, KnowledgeBoardCapabilities, "KnowledgeBoardCapabilities")
+    capability_board = _coerce_board(board)
+    if not getattr(capability_board, "supports_votes", False):
+        raise UnsupportedKnowledgeBoardCapabilityError(
+            capability="ProposalVotingStore", board=board
+        )
+    return capability_board
 
 
 def as_semantic_query_store(board: object) -> SemanticQueryStore:
-    return _require_capability(board, KnowledgeBoardCapabilities, "KnowledgeBoardCapabilities")
+    return _coerce_board(board)
 
 
 def _normalize_entries(
@@ -217,6 +243,10 @@ class InMemoryKnowledgeBoardAdapter:
     def __init__(self, board: KnowledgeBoard | None = None) -> None:
         self._board = board or KnowledgeBoard()
         self.lock = self._board.lock
+        self.supports_threads = self._board.supports_threads
+        self.supports_causal_chain = self._board.supports_causal_chain
+        self.supports_votes = self._board.supports_votes
+        self.supports_graph_queries = self._board.supports_graph_queries
         self._links: list[dict[str, Any]] = []
 
     def add_entry(
@@ -356,9 +386,11 @@ class InMemoryKnowledgeBoardAdapter:
                 entry_type=str(item.get("entry_type", "")),
                 parent_entry_id=item.get("parent_entry_id"),
                 target_agent_id=item.get("target_agent_id"),
-                stance=(item.get("reference_metadata") or {}).get("stance")
-                if isinstance(item.get("reference_metadata"), dict)
-                else item.get("stance"),
+                stance=(
+                    (item.get("reference_metadata") or {}).get("stance")
+                    if isinstance(item.get("reference_metadata"), dict)
+                    else item.get("stance")
+                ),
             )
             for item in self.get_agent_stance_history(agent_id)
         ]
@@ -370,6 +402,10 @@ class GraphKnowledgeBoardAdapter(InMemoryKnowledgeBoardAdapter):
     def __init__(self, board: GraphKnowledgeBoard | None = None) -> None:
         self._graph = board or GraphKnowledgeBoard()
         self.lock = self._graph.lock
+        self.supports_threads = self._graph.supports_threads
+        self.supports_causal_chain = self._graph.supports_causal_chain
+        self.supports_votes = self._graph.supports_votes
+        self.supports_graph_queries = self._graph.supports_graph_queries
         self._tx_journal: dict[int, dict[str, list[dict[str, Any]]]] = {}
 
     def append_entry(
@@ -436,7 +472,21 @@ class GraphKnowledgeBoardAdapter(InMemoryKnowledgeBoardAdapter):
         )
 
     def get_proposal_support_counts(self, proposal_ids: list[str] | None = None) -> dict[str, int]:
-        return {pid: row["support"] for pid, row in self.aggregate_votes(proposal_ids).items()}
+        return self._graph.get_proposal_support_counts(proposal_ids)
+
+    def get_endorsed_ideas(
+        self,
+        *,
+        min_endorsements: int = 1,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        return self._graph.get_endorsed_ideas(
+            min_endorsements=min_endorsements,
+            limit=limit,
+        )
+
+    def get_agent_contribution_graph(self, agent_id: str | None = None) -> list[dict[str, Any]]:
+        return self._graph.get_agent_contribution_graph(agent_id=agent_id)
 
     def begin_transaction(self) -> object:
         tx_id = id(object())
@@ -547,11 +597,11 @@ class VectorAugmentedKnowledgeBoardAdapter(InMemoryKnowledgeBoardAdapter):
 
 
 def supports_voting(board: object) -> bool:
-    return hasattr(board, "record_vote") and hasattr(board, "get_proposal_support_counts")
+    return bool(getattr(board, "supports_votes", False))
 
 
 def supports_graph_queries(board: object) -> bool:
-    return hasattr(board, "get_endorsed_ideas") and hasattr(board, "get_agent_contribution_graph")
+    return bool(getattr(board, "supports_graph_queries", False))
 
 
 def supports_read_models(board: object) -> bool:

--- a/src/sim/knowledge_board_queries.py
+++ b/src/sim/knowledge_board_queries.py
@@ -112,3 +112,42 @@ class PagedQueryResultDTO:
             "page_size": self.page_size,
             "items": [item.to_dict() for item in self.items],
         }
+
+
+@dataclass(frozen=True)
+class UnsupportedCapabilityQueryResultDTO:
+    capability: str
+    message: str
+    query_type: str
+    fallback_items: tuple[RankedEntryDTO, ...] = ()
+
+    @property
+    def total(self) -> int:
+        return len(self.fallback_items)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "unsupported": True,
+            "capability": self.capability,
+            "message": self.message,
+            "query_type": self.query_type,
+            "total": self.total,
+            "items": [item.to_dict() for item in self.fallback_items],
+        }
+
+
+def unsupported_capability_result(
+    *,
+    capability: str,
+    query_type: str,
+    fallback_items: tuple[RankedEntryDTO, ...] = (),
+) -> UnsupportedCapabilityQueryResultDTO:
+    return UnsupportedCapabilityQueryResultDTO(
+        capability=capability,
+        message=(
+            f"Knowledge board backend does not support capability '{capability}' "
+            f"required for query '{query_type}'."
+        ),
+        query_type=query_type,
+        fallback_items=fallback_items,
+    )

--- a/src/sim/knowledge_board_service.py
+++ b/src/sim/knowledge_board_service.py
@@ -28,6 +28,8 @@ from src.sim.knowledge_board_queries import (
     StoryDigestDTO,
     ThreadQueryDTO,
     TimelineQueryDTO,
+    UnsupportedCapabilityQueryResultDTO,
+    unsupported_capability_result,
 )
 from src.sim.knowledge_entry import KnowledgeEntry, KnowledgeEntryType
 
@@ -66,7 +68,14 @@ class KnowledgeBoardService:
             ranked, page=query.pagination.page, page_size=query.pagination.page_size
         )
 
-    def query_thread(self, query: ThreadQueryDTO) -> PagedQueryResultDTO:
+    def query_thread(
+        self, query: ThreadQueryDTO
+    ) -> PagedQueryResultDTO | UnsupportedCapabilityQueryResultDTO:
+        if not self._board.supports_threads:
+            return unsupported_capability_result(
+                capability="supports_threads",
+                query_type="thread",
+            )
         all_entries = self._all_entries()
         children_by_parent: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for entry in all_entries:
@@ -96,6 +105,11 @@ class KnowledgeBoardService:
         )
 
     def query_proposal_status(self, query: ProposalStatusQueryDTO) -> dict[str, Any]:
+        if not self._board.supports_votes:
+            return unsupported_capability_result(
+                capability="supports_votes",
+                query_type="proposal_status",
+            ).to_dict()
         entries = self._all_entries()
         proposal = next(
             (entry for entry in entries if str(entry.get("entry_id", "")) == query.proposal_id),
@@ -116,9 +130,11 @@ class KnowledgeBoardService:
         )
         return {
             "proposal_id": query.proposal_id,
-            "proposal": self._entry_to_ranked(proposal, score=1.0, signals={}).to_dict()
-            if proposal
-            else None,
+            "proposal": (
+                self._entry_to_ranked(proposal, score=1.0, signals={}).to_dict()
+                if proposal
+                else None
+            ),
             "consensus": {
                 "approvals": consensus.approvals,
                 "rejections": consensus.rejections,
@@ -142,7 +158,14 @@ class KnowledgeBoardService:
             ranked, page=query.pagination.page, page_size=query.pagination.page_size
         )
 
-    def query_causal_chain(self, query: CausalChainQueryDTO) -> list[RankedEntryDTO]:
+    def query_causal_chain(
+        self, query: CausalChainQueryDTO
+    ) -> list[RankedEntryDTO] | UnsupportedCapabilityQueryResultDTO:
+        if not self._board.supports_causal_chain:
+            return unsupported_capability_result(
+                capability="supports_causal_chain",
+                query_type="causal_chain",
+            )
         entries = self._all_entries()
         by_id = {str(entry.get("entry_id", "")): entry for entry in entries}
         path: list[RankedEntryDTO] = []

--- a/tests/integration/knowledge_board/test_capability_matrix.py
+++ b/tests/integration/knowledge_board/test_capability_matrix.py
@@ -32,6 +32,30 @@ class DummySession:
         if "SET e = $props" in query:
             self.driver.entries.append(dict(params["props"]))
             return DummyResult([])
+        if "MATCH (a:Agent {agent_id: $agent_id})-[:AUTHORED]->(e:KBEntry)" in query:
+            agent_id = params["agent_id"]
+            rows = [
+                entry
+                for entry in self.driver.entries
+                if entry.get("agent_id") == agent_id
+                and entry.get("entry_type") in ["vote", "endorsement"]
+            ]
+            return DummyResult(
+                [
+                    {
+                        "entry_id": row["entry_id"],
+                        "step": row["step"],
+                        "entry_type": row["entry_type"],
+                        "parent_entry_id": row.get("parent_entry_id"),
+                        "target_agent_id": row.get("target_agent_id"),
+                    }
+                    for row in rows
+                ]
+            )
+        if "RETURN a.agent_id AS agent_id, e.entry_id AS entry_id" in query:
+            return DummyResult(
+                [{"agent_id": "agent-1", "entry_id": "idea-1", "entry_type": "idea", "step": 1}]
+            )
         if "ORDER BY e.step DESC" in query:
             limit = params["limit"]
             rows = sorted(self.driver.entries, key=lambda entry: entry["step"], reverse=True)[
@@ -44,15 +68,31 @@ class DummySession:
         if "DETACH DELETE" in query:
             self.driver.entries.clear()
             return DummyResult([])
+        if "MATCH (p:KBEntry {entry_type: 'proposal'})" in query:
+            proposals = [
+                entry for entry in self.driver.entries if entry.get("entry_type") == "proposal"
+            ]
+            return DummyResult([{"proposal": row} for row in proposals[: params["limit"]]])
+        if "OPTIONAL MATCH (:Agent)-[v:VOTED]->(p)" in query:
+            proposal_id = params["proposal_id"]
+            votes = [
+                entry
+                for entry in self.driver.entries
+                if entry.get("entry_type") == "vote"
+                and entry.get("parent_entry_id") == proposal_id
+            ]
+            approvals = sum(
+                1 for vote in votes if (vote.get("reference_metadata") or {}).get("approve")
+            )
+            rejections = len(votes) - approvals
+            return DummyResult(
+                [{"proposal_id": proposal_id, "approvals": approvals, "rejections": rejections}]
+            )
         if "RETURN p.entry_id AS proposal_id, count(v) AS support_count" in query:
             return DummyResult([{"proposal_id": "p-1", "support_count": 2}])
         if "RETURN i AS entry, endorsements" in query:
             return DummyResult(
                 [{"entry": {"entry_id": "idea-1", "entry_type": "idea"}, "endorsements": 2}]
-            )
-        if "RETURN a.agent_id AS agent_id, e.entry_id AS entry_id" in query:
-            return DummyResult(
-                [{"agent_id": "agent-1", "entry_id": "idea-1", "entry_type": "idea", "step": 1}]
             )
         return DummyResult([])
 
@@ -128,9 +168,9 @@ def test_capability_adapters_fail_explicitly_for_unsupported_memory_features() -
         as_relationship_store(board)
     assert relationship_error.value.capability == "RelationshipStore"
 
-    with pytest.raises(UnsupportedKnowledgeBoardCapabilityError) as voting_error:
-        as_proposal_voting_store(board)
-    assert voting_error.value.capability == "ProposalVotingStore"
+    voting_store = as_proposal_voting_store(board)
+    voting_store.record_vote(voter_agent_id="agent-1", proposal_id="p-1", approve=True)
+    assert board.supports_votes is True
 
 
 @pytest.mark.integration

--- a/tests/integration/knowledge_board/test_query_backend_parity.py
+++ b/tests/integration/knowledge_board/test_query_backend_parity.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+
+from src.sim.graph_knowledge_board import GraphKnowledgeBoard
+from src.sim.knowledge_board import KnowledgeBoard
+from src.sim.knowledge_board_queries import (
+    AgentContributionQueryDTO,
+    CausalChainQueryDTO,
+    ProposalStatusQueryDTO,
+    QueryPagination,
+    ThreadQueryDTO,
+    TimelineQueryDTO,
+)
+from src.sim.knowledge_board_service import KnowledgeBoardService
+from src.sim.knowledge_entry import KnowledgeEntry
+
+
+class DummyResult(list):
+    def single(self) -> Any:
+        return self[0]
+
+
+class DummySession:
+    def __init__(self, driver: DummyDriver) -> None:
+        self.driver = driver
+
+    def run(self, query: str, **params: Any) -> Iterable[Any]:
+        if "RETURN count(e) AS cnt" in query:
+            return DummyResult([{"cnt": len(self.driver.entries)}])
+        if "SET e = $props" in query:
+            self.driver.entries.append(dict(params["props"]))
+            return DummyResult([])
+        if "ORDER BY e.step DESC" in query:
+            limit = params["limit"]
+            rows = sorted(self.driver.entries, key=lambda entry: entry["step"], reverse=True)[
+                :limit
+            ]
+            return DummyResult([{"e": row} for row in rows])
+        if "ORDER BY e.step ASC" in query:
+            rows = sorted(self.driver.entries, key=lambda entry: entry["step"])
+            return DummyResult([{"e": row} for row in rows])
+        if "DETACH DELETE" in query:
+            self.driver.entries.clear()
+            return DummyResult([])
+        if "MATCH (p:KBEntry {entry_type: 'proposal'})" in query:
+            proposals = [
+                entry for entry in self.driver.entries if entry.get("entry_type") == "proposal"
+            ]
+            return DummyResult(
+                [
+                    {"proposal": row}
+                    for row in sorted(proposals, key=lambda entry: entry["step"], reverse=True)[
+                        : params["limit"]
+                    ]
+                ]
+            )
+        if "OPTIONAL MATCH (:Agent)-[v:VOTED]->(p)" in query:
+            proposal_id = params["proposal_id"]
+            votes = [
+                entry
+                for entry in self.driver.entries
+                if entry.get("entry_type") == "vote"
+                and entry.get("parent_entry_id") == proposal_id
+            ]
+            approvals = sum(
+                1 for vote in votes if (vote.get("reference_metadata") or {}).get("approve")
+            )
+            rejections = len(votes) - approvals
+            return DummyResult(
+                [{"proposal_id": proposal_id, "approvals": approvals, "rejections": rejections}]
+            )
+        if "MATCH (a:Agent {agent_id: $agent_id})-[:AUTHORED]->(e:KBEntry)" in query:
+            agent_id = params["agent_id"]
+            rows = [
+                entry
+                for entry in self.driver.entries
+                if entry.get("agent_id") == agent_id
+                and entry.get("entry_type") in ["vote", "endorsement"]
+            ]
+            return DummyResult(
+                [
+                    {
+                        "entry_id": row["entry_id"],
+                        "step": row["step"],
+                        "entry_type": row["entry_type"],
+                        "parent_entry_id": row.get("parent_entry_id"),
+                        "target_agent_id": row.get("target_agent_id"),
+                    }
+                    for row in rows
+                ]
+            )
+        return DummyResult([])
+
+    def __enter__(self) -> DummySession:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class DummyDriver:
+    def __init__(self) -> None:
+        self.entries: list[dict[str, Any]] = []
+
+    def session(self) -> DummySession:
+        return DummySession(self)
+
+
+def _service(board: KnowledgeBoard | GraphKnowledgeBoard) -> KnowledgeBoardService:
+    return KnowledgeBoardService(
+        board,
+        step_provider=lambda: 10,
+        vector_provider=lambda: {"sim": 10},
+    )
+
+
+def _seed(service: KnowledgeBoardService) -> str:
+    board = service._board
+    board.add_entry(
+        KnowledgeEntry(
+            content_full="proposal alpha", entry_type="proposal", tags=["governance", "proposal"]
+        ),
+        agent_id="agent-1",
+        step=1,
+    )
+    proposal_id = board.get_full_entries()[-1]["entry_id"]
+    board.add_entry(
+        KnowledgeEntry(
+            content_full="vote yes",
+            entry_type="vote",
+            parent_entry_id=proposal_id,
+            reference_metadata={"approve": True, "stance": "approve"},
+        ),
+        agent_id="agent-2",
+        step=2,
+    )
+    board.add_entry(
+        KnowledgeEntry(
+            content_full="vote no",
+            entry_type="vote",
+            parent_entry_id=proposal_id,
+            reference_metadata={"approve": False, "stance": "reject"},
+        ),
+        agent_id="agent-3",
+        step=3,
+    )
+    board.add_entry(
+        KnowledgeEntry(
+            content_full="reply to proposal",
+            entry_type="note",
+            parent_entry_id=proposal_id,
+            tags=["discussion"],
+        ),
+        agent_id="agent-4",
+        step=4,
+    )
+    board.add_entry(
+        KnowledgeEntry(
+            content_full="reply to reply",
+            entry_type="note",
+            parent_entry_id=board.get_full_entries()[-1]["entry_id"],
+            tags=["discussion"],
+        ),
+        agent_id="agent-5",
+        step=5,
+    )
+    return proposal_id
+
+
+@pytest.mark.integration
+def test_query_result_parity_for_overlapping_capabilities() -> None:
+    memory_service = _service(KnowledgeBoard())
+    graph_service = _service(GraphKnowledgeBoard(driver=DummyDriver()))
+
+    proposal_id = _seed(memory_service)
+    _seed(graph_service)
+
+    timeline_query = TimelineQueryDTO(pagination=QueryPagination(page_size=10))
+    memory_timeline = memory_service.query_timeline(timeline_query).to_dict()
+    graph_timeline = graph_service.query_timeline(timeline_query).to_dict()
+    assert memory_timeline == graph_timeline
+
+    thread_query = ThreadQueryDTO(
+        root_entry_id=proposal_id, pagination=QueryPagination(page_size=10)
+    )
+    assert (
+        memory_service.query_thread(thread_query).to_dict()
+        == graph_service.query_thread(thread_query).to_dict()
+    )
+
+    proposal_query = ProposalStatusQueryDTO(
+        proposal_id=proposal_id, pagination=QueryPagination(page_size=10)
+    )
+    assert memory_service.query_proposal_status(
+        proposal_query
+    ) == graph_service.query_proposal_status(proposal_query)
+
+    contribution_query = AgentContributionQueryDTO(
+        agent_id="agent-2", pagination=QueryPagination(page_size=10)
+    )
+    assert (
+        memory_service.query_agent_contribution(contribution_query).to_dict()
+        == graph_service.query_agent_contribution(contribution_query).to_dict()
+    )
+
+    causal_query = CausalChainQueryDTO(
+        entry_id=memory_service._board.get_full_entries()[-1]["entry_id"], depth=5
+    )
+    memory_chain = [item.to_dict() for item in memory_service.query_causal_chain(causal_query)]
+    graph_chain = [item.to_dict() for item in graph_service.query_causal_chain(causal_query)]
+    assert memory_chain == graph_chain

--- a/tests/unit/sim/test_knowledge_board_conformance.py
+++ b/tests/unit/sim/test_knowledge_board_conformance.py
@@ -30,7 +30,9 @@ class MockSession:
             return DummyResult([{"cnt": len(self.driver.entries)}])
         if "ORDER BY e.step DESC" in query:
             limit = params["limit"]
-            rows = sorted(self.driver.entries, key=lambda entry: entry["step"], reverse=True)[:limit]
+            rows = sorted(self.driver.entries, key=lambda entry: entry["step"], reverse=True)[
+                :limit
+            ]
             return DummyResult([{"e": row} for row in rows])
         if "ORDER BY e.step ASC" in query:
             rows = sorted(self.driver.entries, key=lambda entry: entry["step"])
@@ -131,14 +133,17 @@ def test_snapshot_replay_invariants(
 
 
 @pytest.mark.parametrize(
-    ("factory", "expects_extensions"),
-    [(_memory_factory, False), (_graph_factory, True)],
+    ("factory", "expects_extensions", "expects_voting"),
+    [(_memory_factory, False, True), (_graph_factory, True, True)],
 )
 def test_optional_feature_checks(
     factory: Callable[[], KnowledgeBoardProtocol],
     expects_extensions: bool,
+    expects_voting: bool,
 ) -> None:
     board = factory()
 
-    assert supports_voting(board) is expects_extensions
+    assert supports_voting(board) is expects_voting
     assert supports_graph_queries(board) is expects_extensions
+    assert board.supports_threads is True
+    assert board.supports_causal_chain is True

--- a/tests/unit/sim/test_knowledge_board_service.py
+++ b/tests/unit/sim/test_knowledge_board_service.py
@@ -137,3 +137,34 @@ async def test_query_views_and_digest_generation() -> None:
     digests = service.generate_story_digests()
     assert set(digests.keys()) == {"daily", "weekly"}
     assert digests["daily"].period == "daily"
+
+
+class _CapabilityLimitedBoard(KnowledgeBoard):
+    supports_threads = False
+    supports_causal_chain = False
+    supports_votes = False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_query_methods_return_structured_unsupported_capability_payloads() -> None:
+    board = _CapabilityLimitedBoard()
+    service = KnowledgeBoardService(
+        board,
+        step_provider=lambda: 1,
+        vector_provider=lambda: {"sim": 1},
+    )
+
+    thread = service.query_thread(
+        ThreadQueryDTO(root_entry_id="missing", pagination=QueryPagination(page_size=10))
+    )
+    assert thread.to_dict()["capability"] == "supports_threads"
+
+    proposal = service.query_proposal_status(
+        ProposalStatusQueryDTO(proposal_id="proposal-1", pagination=QueryPagination(page_size=10))
+    )
+    assert proposal["capability"] == "supports_votes"
+    assert proposal["unsupported"] is True
+
+    chain = service.query_causal_chain(CausalChainQueryDTO(entry_id="entry-1", depth=4))
+    assert chain.to_dict()["capability"] == "supports_causal_chain"


### PR DESCRIPTION
### Motivation
- Make knowledge-board feature availability explicit via capability flags instead of inferring from class names or method presence. 
- Route query features through capability checks so callers receive structured "unsupported capability" responses when a backend does not expose a requested feature. 

### Description
- Added boolean capability flags `supports_threads`, `supports_causal_chain`, `supports_votes`, and `supports_graph_queries` to the `KnowledgeBoardCapabilities` protocol and implemented them on both `KnowledgeBoard` and `GraphKnowledgeBoard`. 
- Coerced raw backends to capability-aware adapters via `_coerce_board` and populated adapter instances with the new `supports_*` attributes, and replaced `supports_voting`/`supports_graph_queries` helpers to read the flags. 
- Replaced class-name heuristics in `dashboard_backend._subsystem_status()` with capability inspection and updated API handlers to handle and serialize structured unsupported-capability payloads. 
- Introduced `UnsupportedCapabilityQueryResultDTO` and `unsupported_capability_result` in `knowledge_board_queries.py` and updated `KnowledgeBoardService` to gate `query_thread`, `query_proposal_status`, and `query_causal_chain` with capability checks that return the structured unsupported responses. 
- Added/adjusted unit and integration tests to assert capability behavior and parity between in-memory and graph backends where capabilities overlap. 

### Testing
- Ran formatting and lint checks with `black --check` and `ruff check` on modified files and fixed formatting issues; checks passed. 
- Executed unit tests `pytest tests/unit/sim/test_knowledge_board_service.py tests/unit/sim/test_knowledge_board_conformance.py` and integration tests `pytest -m integration tests/integration/knowledge_board/test_capability_matrix.py tests/integration/knowledge_board/test_query_backend_parity.py`, all selected tests passed. 
- Verified module compilation with `python -m compileall src tests` and confirmed no import/compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babd559b548326831ae9f7ce9bd90a)