### PR TITLE
feat: add strategic adherence scorecard and strategy test suite

### DIFF
--- a/src/sim/analytics.py
+++ b/src/sim/analytics.py
@@ -1,14 +1,18 @@
+
 """User-value analytics for simulation event streams and knowledge board data."""
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass
 from itertools import pairwise
+from pathlib import Path
 from typing import Any
 
 USER_VALUE_KPI_PAYLOAD_VERSION = 2
+STRATEGIC_ADHERENCE_PAYLOAD_VERSION = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,11 +56,147 @@ class UserValueKPIReport:
         return payload
 
 
+@dataclass(frozen=True, slots=True)
+class StrategicPillarThreshold:
+    """Pass/fail bands for a strategic pillar score."""
+
+    warning_floor: float
+    pass_floor: float
+    critical: bool = False
+
+    def as_dict(self) -> dict[str, float | bool]:
+        return {
+            "warning_floor": self.warning_floor,
+            "pass_floor": self.pass_floor,
+            "critical": self.critical,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StrategicAdherenceThresholds:
+    """Pass/fail configuration for strategic adherence evaluation."""
+
+    aggregate_regression_tolerance: float = 0.0
+    pillars: dict[str, StrategicPillarThreshold] | None = None
+
+    def __post_init__(self) -> None:
+        if self.pillars is None:
+            object.__setattr__(
+                self,
+                'pillars',
+                {
+                    'social_emergence': StrategicPillarThreshold(
+                        warning_floor=0.65, pass_floor=0.75, critical=True
+                    ),
+                    'user_intervention': StrategicPillarThreshold(
+                        warning_floor=0.65, pass_floor=0.75, critical=False
+                    ),
+                    'governance': StrategicPillarThreshold(
+                        warning_floor=0.7, pass_floor=0.8, critical=True
+                    ),
+                    'long_run_persistence': StrategicPillarThreshold(
+                        warning_floor=0.7, pass_floor=0.8, critical=True
+                    ),
+                },
+            )
+
+    def as_dict(self) -> dict[str, Any]:
+        pillars = self.pillars or {}
+        return {
+            'aggregate_regression_tolerance': self.aggregate_regression_tolerance,
+            'pillars': {name: threshold.as_dict() for name, threshold in pillars.items()},
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StrategicPillarScore:
+    """A scored strategic pillar with band evaluation metadata."""
+
+    name: str
+    score: float
+    status: str
+    threshold: StrategicPillarThreshold
+    metrics: dict[str, float | int]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'name': self.name,
+            'score': self.score,
+            'status': self.status,
+            'threshold': self.threshold.as_dict(),
+            'metrics': dict(self.metrics),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StrategicAdherenceScorecard:
+    """Aggregate strategic adherence payload for dashboards and CI gating."""
+
+    payload_version: int
+    user_value_kpis: UserValueKPIReport
+    additional_metrics: dict[str, float]
+    pillar_scores: tuple[StrategicPillarScore, ...]
+    aggregate_adherence_score: float
+    aggregate_status: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'payload_version': self.payload_version,
+            'user_value_kpis': self.user_value_kpis.as_dict(),
+            'additional_metrics': dict(self.additional_metrics),
+            'pillar_scores': [pillar.as_dict() for pillar in self.pillar_scores],
+            'aggregate_adherence_score': self.aggregate_adherence_score,
+            'aggregate_status': self.aggregate_status,
+        }
+
+    def write_json(self, path: str | Path) -> Path:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(self.as_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return target
+
+
+@dataclass(frozen=True, slots=True)
+class StrategicReleaseGateResult:
+    """Release gate outcome comparing a current scorecard to a baseline."""
+
+    passed: bool
+    aggregate_delta: float
+    critical_pillar_regressions: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'passed': self.passed,
+            'aggregate_delta': self.aggregate_delta,
+            'critical_pillar_regressions': list(self.critical_pillar_regressions),
+            'reasons': list(self.reasons),
+        }
+
+
 def _as_step(entry: Mapping[str, Any]) -> int:
     try:
         return int(entry.get("step", 0))
     except Exception:
         return 0
+
+
+def _bounded_ratio(value: float) -> float:
+    return round(min(max(value, 0.0), 1.0), 4)
+
+
+def _safe_mean(values: Iterable[float]) -> float:
+    items = [value for value in values]
+    if not items:
+        return 0.0
+    return sum(items) / len(items)
+
+
+def _step_distance(event: Mapping[str, Any], other: Mapping[str, Any]) -> int:
+    return abs(_as_step(event) - _as_step(other))
 
 
 def compute_user_value_kpis(
@@ -199,3 +339,221 @@ def compute_user_value_kpis(
         social_graph_change_count=social_graph_change_count,
         stagnation_alerts=tuple(stagnation_alerts),
     )
+
+
+def compute_strategic_adherence_scorecard(
+    *,
+    events: Iterable[Mapping[str, Any]],
+    knowledge_entries: Iterable[Mapping[str, Any]],
+    thresholds: StrategicAdherenceThresholds | None = None,
+) -> StrategicAdherenceScorecard:
+    """Compute strategic adherence scores for dashboarding and release gates."""
+
+    cfg = thresholds or StrategicAdherenceThresholds()
+    event_rows = [dict(event) for event in events]
+    entries = [dict(entry) for entry in knowledge_entries]
+    user_value_kpis = compute_user_value_kpis(events=event_rows, knowledge_entries=entries)
+
+    latency_values = [float(event['latency_ms']) for event in event_rows if 'latency_ms' in event]
+    latency_score = _bounded_ratio(1.0 - (_safe_mean(latency_values) / 1000.0)) if latency_values else 0.0
+
+    recovery_events = [event for event in event_rows if 'recovery_success' in event]
+    recovery_success = _bounded_ratio(
+        _safe_mean(float(bool(event.get('recovery_success'))) for event in recovery_events)
+    ) if recovery_events else 0.0
+
+    command_events = [event for event in event_rows if str(event.get('type')) == 'human_command']
+    command_responses = 0
+    for command in command_events:
+        if any(
+            str(event.get('type')) in {'command_ack', 'agent_action', 'governance_vote'}
+            and _step_distance(command, event) <= 1
+            for event in event_rows
+            if event is not command
+        ):
+            command_responses += 1
+    command_responsiveness = _bounded_ratio(
+        command_responses / len(command_events) if command_events else 0.0
+    )
+
+    memory_scores = [
+        float(event['memory_recall_quality'])
+        for event in event_rows
+        if 'memory_recall_quality' in event
+    ] + [
+        float(entry['memory_recall_quality'])
+        for entry in entries
+        if 'memory_recall_quality' in entry
+    ]
+    memory_recall_quality = _bounded_ratio(_safe_mean(memory_scores)) if memory_scores else 0.0
+
+    additional_metrics = {
+        'latency_score': latency_score,
+        'recovery_success': recovery_success,
+        'command_responsiveness': command_responsiveness,
+        'memory_recall_quality': memory_recall_quality,
+    }
+
+    pillar_inputs = {
+        'social_emergence': {
+            'interaction_diversity': user_value_kpis.cross_agent_interaction_diversity,
+            'novelty_score': user_value_kpis.novelty_score,
+            'social_graph_change_score': _bounded_ratio(user_value_kpis.social_graph_change_count / 3.0),
+        },
+        'user_intervention': {
+            'user_intervention_coverage': _bounded_ratio(user_value_kpis.user_intervention_rate * 4.0),
+            'command_responsiveness': command_responsiveness,
+            'latency_score': latency_score,
+        },
+        'governance': {
+            'conflict_resolution_score': _bounded_ratio(1.0 / (1 + user_value_kpis.unresolved_conflict_count)),
+            'recovery_success': recovery_success,
+            'narrative_continuity_score': user_value_kpis.narrative_continuity_score,
+        },
+        'long_run_persistence': {
+            'return_session_continuity': user_value_kpis.return_session_continuity,
+            'memory_recall_quality': memory_recall_quality,
+            'narrative_continuity_score': user_value_kpis.narrative_continuity_score,
+        },
+    }
+
+    pillar_scores: list[StrategicPillarScore] = []
+    for pillar_name, metrics in pillar_inputs.items():
+        threshold = (cfg.pillars or {})[pillar_name]
+        score = _bounded_ratio(_safe_mean(float(value) for value in metrics.values()))
+        if score >= threshold.pass_floor:
+            status = 'pass'
+        elif score >= threshold.warning_floor:
+            status = 'warning'
+        else:
+            status = 'fail'
+        pillar_scores.append(
+            StrategicPillarScore(
+                name=pillar_name,
+                score=score,
+                status=status,
+                threshold=threshold,
+                metrics={key: round(float(value), 4) for key, value in metrics.items()},
+            )
+        )
+
+    aggregate_adherence_score = _bounded_ratio(
+        _safe_mean(pillar.score for pillar in pillar_scores)
+    )
+    aggregate_status = 'pass' if all(p.status == 'pass' for p in pillar_scores) else (
+        'fail' if any(p.status == 'fail' for p in pillar_scores) else 'warning'
+    )
+    return StrategicAdherenceScorecard(
+        payload_version=STRATEGIC_ADHERENCE_PAYLOAD_VERSION,
+        user_value_kpis=user_value_kpis,
+        additional_metrics=additional_metrics,
+        pillar_scores=tuple(pillar_scores),
+        aggregate_adherence_score=aggregate_adherence_score,
+        aggregate_status=aggregate_status,
+    )
+
+
+def evaluate_release_gate(
+    current: StrategicAdherenceScorecard,
+    baseline: StrategicAdherenceScorecard,
+    *,
+    thresholds: StrategicAdherenceThresholds | None = None,
+) -> StrategicReleaseGateResult:
+    """Gate releases on aggregate regression and critical-pillar drops."""
+
+    cfg = thresholds or StrategicAdherenceThresholds()
+    aggregate_delta = round(
+        current.aggregate_adherence_score - baseline.aggregate_adherence_score,
+        4,
+    )
+    current_pillars = {pillar.name: pillar for pillar in current.pillar_scores}
+    baseline_pillars = {pillar.name: pillar for pillar in baseline.pillar_scores}
+    critical_regressions: list[str] = []
+    for name, threshold in (cfg.pillars or {}).items():
+        if not threshold.critical:
+            continue
+        current_pillar = current_pillars.get(name)
+        baseline_pillar = baseline_pillars.get(name)
+        if current_pillar is None or baseline_pillar is None:
+            continue
+        if current_pillar.score < baseline_pillar.score:
+            critical_regressions.append(name)
+
+    reasons: list[str] = []
+    if aggregate_delta < -cfg.aggregate_regression_tolerance:
+        reasons.append('aggregate_score_regressed')
+    if critical_regressions:
+        reasons.append('critical_pillar_drop')
+    return StrategicReleaseGateResult(
+        passed=not reasons,
+        aggregate_delta=aggregate_delta,
+        critical_pillar_regressions=tuple(critical_regressions),
+        reasons=tuple(reasons),
+    )
+
+
+def strategic_adherence_scorecard_from_dict(payload: Mapping[str, Any]) -> StrategicAdherenceScorecard:
+    """Rehydrate a scorecard from JSON payload data."""
+
+    user_payload = payload.get('user_value_kpis', {})
+    thresholds_payload = user_payload.get('thresholds', {})
+    user_value = UserValueKPIReport(
+        payload_version=int(user_payload.get('payload_version', USER_VALUE_KPI_PAYLOAD_VERSION)),
+        thresholds=SimulationStagnationThresholds(**thresholds_payload),
+        narrative_continuity_score=float(user_payload.get('narrative_continuity_score', 0.0)),
+        unresolved_conflict_count=int(user_payload.get('unresolved_conflict_count', 0)),
+        cross_agent_interaction_diversity=float(user_payload.get('cross_agent_interaction_diversity', 0.0)),
+        user_intervention_rate=float(user_payload.get('user_intervention_rate', 0.0)),
+        return_session_continuity=float(user_payload.get('return_session_continuity', 0.0)),
+        novelty_score=float(user_payload.get('novelty_score', 0.0)),
+        repetitive_intents_ratio=float(user_payload.get('repetitive_intents_ratio', 0.0)),
+        social_graph_change_count=int(user_payload.get('social_graph_change_count', 0)),
+        stagnation_alerts=tuple(str(value) for value in user_payload.get('stagnation_alerts', [])),
+    )
+    pillars: list[StrategicPillarScore] = []
+    for pillar in payload.get('pillar_scores', []):
+        threshold_payload = pillar.get('threshold', {})
+        pillars.append(
+            StrategicPillarScore(
+                name=str(pillar.get('name', '')),
+                score=float(pillar.get('score', 0.0)),
+                status=str(pillar.get('status', 'fail')),
+                threshold=StrategicPillarThreshold(
+                    warning_floor=float(threshold_payload.get('warning_floor', 0.0)),
+                    pass_floor=float(threshold_payload.get('pass_floor', 0.0)),
+                    critical=bool(threshold_payload.get('critical', False)),
+                ),
+                metrics={
+                    str(key): float(value)
+                    for key, value in dict(pillar.get('metrics', {})).items()
+                },
+            )
+        )
+    return StrategicAdherenceScorecard(
+        payload_version=int(payload.get('payload_version', STRATEGIC_ADHERENCE_PAYLOAD_VERSION)),
+        user_value_kpis=user_value,
+        additional_metrics={
+            str(key): float(value)
+            for key, value in dict(payload.get('additional_metrics', {})).items()
+        },
+        pillar_scores=tuple(pillars),
+        aggregate_adherence_score=float(payload.get('aggregate_adherence_score', 0.0)),
+        aggregate_status=str(payload.get('aggregate_status', 'fail')),
+    )
+
+
+__all__ = [
+    'STRATEGIC_ADHERENCE_PAYLOAD_VERSION',
+    'USER_VALUE_KPI_PAYLOAD_VERSION',
+    'SimulationStagnationThresholds',
+    'StrategicAdherenceScorecard',
+    'StrategicAdherenceThresholds',
+    'StrategicPillarScore',
+    'StrategicPillarThreshold',
+    'StrategicReleaseGateResult',
+    'UserValueKPIReport',
+    'compute_strategic_adherence_scorecard',
+    'compute_user_value_kpis',
+    'evaluate_release_gate',
+    'strategic_adherence_scorecard_from_dict',
+]

--- a/tests/strategy/fixtures/strategic_adherence_baseline.json
+++ b/tests/strategy/fixtures/strategic_adherence_baseline.json
@@ -1,0 +1,91 @@
+{
+  "additional_metrics": {
+    "command_responsiveness": 1.0,
+    "latency_score": 0.8211,
+    "memory_recall_quality": 0.8663,
+    "recovery_success": 1.0
+  },
+  "aggregate_adherence_score": 0.8808,
+  "aggregate_status": "pass",
+  "payload_version": 1,
+  "pillar_scores": [
+    {
+      "metrics": {
+        "interaction_diversity": 1.0,
+        "novelty_score": 0.9167,
+        "social_graph_change_score": 1.0
+      },
+      "name": "social_emergence",
+      "score": 0.9722,
+      "status": "pass",
+      "threshold": {
+        "critical": true,
+        "pass_floor": 0.75,
+        "warning_floor": 0.65
+      }
+    },
+    {
+      "metrics": {
+        "command_responsiveness": 1.0,
+        "latency_score": 0.8211,
+        "user_intervention_coverage": 0.6316
+      },
+      "name": "user_intervention",
+      "score": 0.8176,
+      "status": "pass",
+      "threshold": {
+        "critical": false,
+        "pass_floor": 0.75,
+        "warning_floor": 0.65
+      }
+    },
+    {
+      "metrics": {
+        "conflict_resolution_score": 1.0,
+        "narrative_continuity_score": 0.6667,
+        "recovery_success": 1.0
+      },
+      "name": "governance",
+      "score": 0.8889,
+      "status": "pass",
+      "threshold": {
+        "critical": true,
+        "pass_floor": 0.8,
+        "warning_floor": 0.7
+      }
+    },
+    {
+      "metrics": {
+        "memory_recall_quality": 0.8663,
+        "narrative_continuity_score": 0.6667,
+        "return_session_continuity": 1.0
+      },
+      "name": "long_run_persistence",
+      "score": 0.8443,
+      "status": "pass",
+      "threshold": {
+        "critical": true,
+        "pass_floor": 0.8,
+        "warning_floor": 0.7
+      }
+    }
+  ],
+  "user_value_kpis": {
+    "cross_agent_interaction_diversity": 1.0,
+    "narrative_continuity_score": 0.6667,
+    "novelty_score": 0.9167,
+    "payload_version": 2,
+    "repetitive_intents_ratio": 0.1667,
+    "return_session_continuity": 1.0,
+    "social_graph_change_count": 3,
+    "stagnation_alerts": [],
+    "thresholds": {
+      "max_repetitive_intents_ratio": 0.75,
+      "min_interaction_diversity": 0.2,
+      "min_novelty_score": 0.2,
+      "min_social_graph_change_count": 1
+    },
+    "unresolved_conflict_count": 0,
+    "user_intervention_rate": 0.1579
+  }
+}

--- a/tests/strategy/test_strategy_scorecard.py
+++ b/tests/strategy/test_strategy_scorecard.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.sim.analytics import (
+    STRATEGIC_ADHERENCE_PAYLOAD_VERSION,
+    StrategicAdherenceThresholds,
+    compute_strategic_adherence_scorecard,
+    evaluate_release_gate,
+    strategic_adherence_scorecard_from_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+
+CANONICAL_SCENARIOS: dict[str, dict[str, list[dict[str, object]]]] = {
+    "social_emergence": {
+        "events": [
+            {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "propose", "target_agent_id": "b", "content": "relationship formed", "latency_ms": 180},
+            {"type": "agent_action", "step": 2, "agent_id": "b", "action_intent": "respond", "target_agent_id": "c", "content": "ally pact", "latency_ms": 200},
+            {"type": "agent_action", "step": 3, "agent_id": "c", "action_intent": "coordinate", "target_agent_id": "a", "content": "coalition updated", "latency_ms": 220},
+            {"type": "agent_action", "step": 4, "agent_id": "a", "action_intent": "reflect", "target_agent_id": "c", "latency_ms": 210},
+        ],
+        "knowledge_entries": [
+            {"entry_id": "s1", "step": 1, "entry_type": "social_update", "content_summary": "New alliance formed", "tags": ["ally"], "memory_recall_quality": 0.84},
+        ],
+    },
+    "user_intervention": {
+        "events": [
+            {"type": "human_command", "step": 1, "content": "pause and regroup", "latency_ms": 150},
+            {"type": "command_ack", "step": 1, "agent_id": "a", "latency_ms": 140},
+            {"type": "agent_action", "step": 2, "agent_id": "a", "action_intent": "replan", "target_agent_id": "b", "latency_ms": 190},
+            {"type": "human_command", "step": 3, "content": "resume with safer routing", "latency_ms": 160},
+            {"type": "command_ack", "step": 4, "agent_id": "b", "latency_ms": 170},
+            {"type": "agent_action", "step": 4, "agent_id": "b", "action_intent": "reroute", "target_agent_id": "c", "latency_ms": 200},
+        ],
+        "knowledge_entries": [
+            {"entry_id": "u1", "step": 4, "entry_type": "operator_note", "content_summary": "Operator instructions applied", "tags": ["command"], "memory_recall_quality": 0.8},
+        ],
+    },
+    "governance": {
+        "events": [
+            {"type": "human_command", "step": 1, "content": "open vote", "latency_ms": 120},
+            {"type": "governance_vote", "step": 2, "agent_id": "a", "action_intent": "vote_yes", "target_agent_id": "proposal-1", "recovery_success": True, "latency_ms": 180},
+            {"type": "governance_vote", "step": 2, "agent_id": "b", "action_intent": "vote_yes", "target_agent_id": "proposal-1", "recovery_success": True, "latency_ms": 200},
+            {"type": "agent_action", "step": 3, "agent_id": "c", "action_intent": "implement_policy", "target_agent_id": "a", "latency_ms": 210},
+        ],
+        "knowledge_entries": [
+            {"entry_id": "g1", "step": 1, "entry_type": "conflict", "content_summary": "Conflict about resource usage", "tags": ["conflict"]},
+            {"entry_id": "g2", "step": 3, "entry_type": "resolution", "content_summary": "Resolved through governance vote", "tags": ["resolution"], "parent_entry_id": "g1", "memory_recall_quality": 0.82},
+        ],
+    },
+    "long_run_persistence": {
+        "events": [
+            {"type": "agent_action", "step": 1, "agent_id": "a", "action_intent": "document", "target_agent_id": "b", "latency_ms": 230, "memory_recall_quality": 0.86},
+            {"type": "snapshot", "step": 2, "latency_ms": 110},
+            {"type": "agent_action", "step": 3, "agent_id": "b", "action_intent": "retrieve", "target_agent_id": "a", "latency_ms": 210, "memory_recall_quality": 0.88},
+            {"type": "snapshot", "step": 5, "latency_ms": 100},
+            {"type": "agent_action", "step": 6, "agent_id": "c", "action_intent": "continue_plan", "target_agent_id": "a", "latency_ms": 220, "memory_recall_quality": 0.9},
+        ],
+        "knowledge_entries": [
+            {"entry_id": "p1", "step": 1, "entry_type": "memory", "content_summary": "Initial plan recorded", "tags": ["memory"], "memory_recall_quality": 0.91},
+            {"entry_id": "p2", "step": 6, "entry_type": "memory", "content_summary": "Plan continued after restore", "tags": ["memory"], "parent_entry_id": "p1", "memory_recall_quality": 0.92},
+        ],
+    },
+}
+
+
+def _combined_inputs() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    events: list[dict[str, object]] = []
+    knowledge_entries: list[dict[str, object]] = []
+    for scenario in CANONICAL_SCENARIOS.values():
+        events.extend(scenario["events"])
+        knowledge_entries.extend(scenario["knowledge_entries"])
+    return events, knowledge_entries
+
+
+@pytest.mark.parametrize("scenario_name", sorted(CANONICAL_SCENARIOS))
+def test_canonical_strategy_scenarios_produce_expected_pillar_signal(scenario_name: str) -> None:
+    scenario = CANONICAL_SCENARIOS[scenario_name]
+    scorecard = compute_strategic_adherence_scorecard(
+        events=scenario["events"],
+        knowledge_entries=scenario["knowledge_entries"],
+    )
+
+    assert scorecard.payload_version == STRATEGIC_ADHERENCE_PAYLOAD_VERSION
+    assert scorecard.aggregate_adherence_score > 0.0
+    targeted_pillar = next(
+        pillar for pillar in scorecard.pillar_scores if pillar.name == scenario_name
+    )
+    assert targeted_pillar.status in {"pass", "warning"}
+    assert targeted_pillar.score >= targeted_pillar.threshold.warning_floor
+
+
+def test_strategy_scorecard_writes_dashboard_json_artifact(tmp_path: Path) -> None:
+    events, knowledge_entries = _combined_inputs()
+
+    scorecard = compute_strategic_adherence_scorecard(
+        events=events,
+        knowledge_entries=knowledge_entries,
+    )
+    output_path = tmp_path / "strategic_adherence_scorecard.json"
+    scorecard.write_json(output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["aggregate_adherence_score"] == scorecard.aggregate_adherence_score
+    assert payload["aggregate_status"] == scorecard.aggregate_status
+    assert {pillar["name"] for pillar in payload["pillar_scores"]} == {
+        "social_emergence",
+        "user_intervention",
+        "governance",
+        "long_run_persistence",
+    }
+    assert set(payload["additional_metrics"]) == {
+        "latency_score",
+        "recovery_success",
+        "command_responsiveness",
+        "memory_recall_quality",
+    }
+
+
+def test_release_gate_blocks_aggregate_regression_and_critical_pillar_drop() -> None:
+    events, knowledge_entries = _combined_inputs()
+    baseline = compute_strategic_adherence_scorecard(
+        events=events,
+        knowledge_entries=knowledge_entries,
+    )
+
+    degraded_events = list(events)
+    degraded_events.extend(
+        [
+            {"type": "agent_action", "step": 20, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b", "latency_ms": 950, "memory_recall_quality": 0.2},
+            {"type": "agent_action", "step": 21, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b", "latency_ms": 980, "memory_recall_quality": 0.2},
+            {"type": "agent_action", "step": 22, "agent_id": "a", "action_intent": "idle", "target_agent_id": "b", "latency_ms": 990, "memory_recall_quality": 0.2, "recovery_success": False},
+        ]
+    )
+    degraded_knowledge = list(knowledge_entries)
+    degraded_knowledge.append(
+        {"entry_id": "g3", "step": 22, "entry_type": "conflict", "content_summary": "Conflict reopened", "tags": ["conflict"], "parent_entry_id": None}
+    )
+    current = compute_strategic_adherence_scorecard(
+        events=degraded_events,
+        knowledge_entries=degraded_knowledge,
+    )
+
+    gate = evaluate_release_gate(current, baseline)
+
+    assert not gate.passed
+    assert gate.aggregate_delta < 0
+    assert "aggregate_score_regressed" in gate.reasons
+    assert "critical_pillar_drop" in gate.reasons
+    assert {"governance", "long_run_persistence"}.intersection(gate.critical_pillar_regressions)
+
+
+def test_release_gate_accepts_current_scorecard_against_committed_baseline_fixture(tmp_path: Path) -> None:
+    fixture_path = Path("tests/strategy/fixtures/strategic_adherence_baseline.json")
+    baseline_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    baseline = strategic_adherence_scorecard_from_dict(baseline_payload)
+    events, knowledge_entries = _combined_inputs()
+
+    current = compute_strategic_adherence_scorecard(
+        events=events,
+        knowledge_entries=knowledge_entries,
+        thresholds=StrategicAdherenceThresholds(),
+    )
+    output_path = tmp_path / "strategic_adherence_scorecard.json"
+    current.write_json(output_path)
+
+    gate = evaluate_release_gate(current, baseline)
+
+    assert gate.passed
+    assert gate.aggregate_delta >= 0
+    assert gate.critical_pillar_regressions == ()


### PR DESCRIPTION
### Motivation
- Provide a single, machine-readable strategic adherence score that combines user-value KPIs with operational metrics to support dashboards, CI trend tracking, and release gating. 
- Capture canonical strategic scenarios (social emergence, user intervention, governance, long-run persistence) with an automated test harness to prevent regressions in strategic behavior.

### Description
- Add strategic scoring primitives to `src/sim/analytics.py`, including per-pillar `StrategicPillarThreshold`, `StrategicPillarScore`, `StrategicAdherenceScorecard`, JSON serialization via `write_json`, and rehydration with `strategic_adherence_scorecard_from_dict`.
- Implement `compute_strategic_adherence_scorecard()` that builds on `compute_user_value_kpis()` and incorporates additional metrics (`latency`, `recovery_success`, `command_responsiveness`, `memory_recall_quality`), computes pass/warning/fail bands for four strategic pillars, and produces a single `aggregate_adherence_score` and `aggregate_status`.
- Add `evaluate_release_gate()` to compare current vs baseline scorecards and fail releases on aggregate regression or any critical-pillar drop.
- Add `tests/strategy/test_strategy_scorecard.py` with canonical scenario inputs and a test that writes/reads the JSON artifact, and include a committed baseline artifact at `tests/strategy/fixtures/strategic_adherence_baseline.json` for CI comparisons.

### Testing
- Ran the focused pytest invocation `SKIP_DEP_INSTALL=1 python scripts/run_tests.py tests/unit/sim/test_analytics.py tests/strategy/test_strategy_scorecard.py`, and all tests passed (`13 passed, 2 warnings`).
- Ran linting with `python -m ruff check src/sim/analytics.py tests/unit/sim/test_analytics.py tests/strategy/test_strategy_scorecard.py`, which passed. 
- Ran type checks with `python -m mypy src/sim/analytics.py`, which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac1fccc408326b64c08e520cb790d)