### PR TITLE
Make simulation kernel the authoritative tick orchestrator and add phase-boundary invariants

### DIFF
--- a/src/sim/kernel/simulation_kernel.py
+++ b/src/sim/kernel/simulation_kernel.py
@@ -13,7 +13,7 @@ from src.sim.runtime.step_context import StepContext
 
 
 class SimulationKernel:
-    """Minimal orchestrator across deterministic kernel phases."""
+    """Authoritative tick orchestrator across deterministic kernel phases."""
 
     def __init__(self) -> None:
         self.interaction_engine = InteractionEngine()
@@ -24,14 +24,28 @@ class SimulationKernel:
         self.reducer = DomainEventReducer()
 
     async def run_tick(self, simulation: Any, context: StepContext) -> int:
+        """Run one canonical tick through the only supported phase sequence."""
+
         tick = self.world_engine.build_tick_context(simulation)
         context.tick_context = tick
+        baseline = self._phase_boundary_state(simulation, context)
+        self._assert_phase_boundary(simulation, context, baseline=baseline, phase="tick_start")
 
         context.phase_order.append(KERNEL_PHASE_SEQUENCE[0])
-        self.reducer.apply(simulation, context, await self.interaction_engine.ingress(simulation, tick))
+        self.reducer.apply(
+            simulation, context, await self.interaction_engine.ingress(simulation, tick)
+        )
+        self._assert_phase_boundary(
+            simulation, context, baseline=baseline, phase=KERNEL_PHASE_SEQUENCE[0]
+        )
 
         context.phase_order.append(KERNEL_PHASE_SEQUENCE[1])
-        self.reducer.apply(simulation, context, await self.turn_engine.plan(simulation, context, tick))
+        self.reducer.apply(
+            simulation, context, await self.turn_engine.plan(simulation, context, tick)
+        )
+        self._assert_phase_boundary(
+            simulation, context, baseline=baseline, phase=KERNEL_PHASE_SEQUENCE[1]
+        )
 
         context.phase_order.append(KERNEL_PHASE_SEQUENCE[2])
         self.reducer.apply(
@@ -39,11 +53,79 @@ class SimulationKernel:
             context,
             await self.turn_engine.prepare_commit(simulation, context, tick),
         )
-        self.reducer.apply(simulation, context, await self.turn_engine.commit(simulation, context, tick))
+        self._assert_phase_boundary(simulation, context, baseline=baseline, phase="pre_commit")
+        self.reducer.apply(
+            simulation, context, await self.turn_engine.commit(simulation, context, tick)
+        )
+        self._assert_phase_boundary(
+            simulation, context, baseline=baseline, phase=KERNEL_PHASE_SEQUENCE[2]
+        )
 
         context.phase_order.append(KERNEL_PHASE_SEQUENCE[3])
         _ = self.society_engine.snapshot(simulation, tick)
         _ = self.persistence_engine.capture_tick(simulation, tick)
+        self._assert_phase_boundary(
+            simulation, context, baseline=baseline, phase=KERNEL_PHASE_SEQUENCE[3]
+        )
 
         context.phase_order.append(KERNEL_PHASE_SEQUENCE[4])
+        self._assert_phase_boundary(
+            simulation, context, baseline=baseline, phase=KERNEL_PHASE_SEQUENCE[4]
+        )
         return len(context.planned_outputs) if context.planned_outputs else len(context.events)
+
+    @staticmethod
+    def _world_time_tuple(simulation: Any) -> tuple[int, int, int, int]:
+        temporal = simulation.world_state.temporal
+        return (
+            int(getattr(temporal, "world_season", 0) or 0),
+            int(getattr(temporal, "world_day", 0) or 0),
+            int(getattr(temporal, "world_hour", 0) or 0),
+            int(getattr(temporal, "world_tick", 0) or 0),
+        )
+
+    @classmethod
+    def _phase_boundary_state(cls, simulation: Any, context: StepContext) -> dict[str, Any]:
+        return {
+            "world_time": cls._world_time_tuple(simulation),
+            "trace_hash": getattr(simulation, "_last_trace_hash", ""),
+            "planned_count": len(context.planned_outputs),
+            "event_count": len(context.events),
+        }
+
+    @classmethod
+    def _assert_phase_boundary(
+        cls,
+        simulation: Any,
+        context: StepContext,
+        *,
+        baseline: dict[str, Any],
+        phase: str,
+    ) -> None:
+        """Validate boundary invariants shared by every kernel phase."""
+
+        planned_count = len(context.planned_outputs)
+        event_count = len(context.events)
+        if planned_count < 0 or event_count < 0:  # Defensive: list lengths cannot be negative.
+            raise AssertionError(f"Negative event count at phase {phase}")
+        if context.max_turns < 1:
+            raise AssertionError(
+                f"max_turns must be positive at phase {phase}: {context.max_turns}"
+            )
+
+        current_world_time = cls._world_time_tuple(simulation)
+        if current_world_time < baseline["world_time"]:
+            raise AssertionError(
+                f"World time moved backwards at phase {phase}: "
+                f"{current_world_time} < {baseline['world_time']}"
+            )
+
+        tick_hash = ""
+        if context.tick_context is not None:
+            tick_hash = str(context.tick_context.replay_metadata.get("trace_hash", ""))
+        current_hash = str(getattr(simulation, "_last_trace_hash", ""))
+        if tick_hash and current_hash != tick_hash:
+            raise AssertionError(
+                f"Snapshot hash continuity violated at phase {phase}: "
+                f"current={current_hash!r} tick={tick_hash!r}"
+            )

--- a/src/sim/simulation_kernel.py
+++ b/src/sim/simulation_kernel.py
@@ -1,3 +1,16 @@
-from src.sim.kernel.simulation_kernel import SimulationKernel
+from __future__ import annotations
+
+import warnings
+
+from src.sim.kernel.simulation_kernel import SimulationKernel as _AuthoritativeSimulationKernel
+
+warnings.warn(
+    "src.sim.simulation_kernel is a deprecated adapter; import "
+    "src.sim.kernel.simulation_kernel.SimulationKernel instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+SimulationKernel = _AuthoritativeSimulationKernel
 
 __all__ = ["SimulationKernel"]

--- a/tests/unit/sim/test_kernel_golden_trace_parity.py
+++ b/tests/unit/sim/test_kernel_golden_trace_parity.py
@@ -57,13 +57,16 @@ async def test_golden_trace_compat_pipeline_matches_kernel_run_step() -> None:
     kernel_sim = Simulation([ScriptedAgent("A", "R"), ScriptedAgent("B", "R")], seed=123)
 
     try:
-        compat_events = await compat_sim._run_step_pipeline(max_turns=2)
+        with pytest.deprecated_call(match="compatibility adapter"):
+            compat_events = await compat_sim._run_step_pipeline(max_turns=2)
 
         _ = await kernel_sim.run_step(max_turns=2)
         kernel_context = kernel_sim.engine.last_step_context
         assert kernel_context is not None
         kernel_events = (
-            kernel_context.planned_outputs if kernel_context.planned_outputs else kernel_context.events
+            kernel_context.planned_outputs
+            if kernel_context.planned_outputs
+            else kernel_context.events
         )
 
         assert _normalize_trace(compat_events) == _normalize_trace(kernel_events)
@@ -72,3 +75,24 @@ async def test_golden_trace_compat_pipeline_matches_kernel_run_step() -> None:
         compat_sim.close()
         await kernel_sim.stop_event_listener()
         kernel_sim.close()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kernel_phase_boundaries_reject_snapshot_hash_discontinuity() -> None:
+    sim = Simulation([ScriptedAgent("A", "R")], seed=123)
+    try:
+        sim._last_trace_hash = "snapshot-before"
+        original_plan = sim.engine.kernel.turn_engine.plan
+
+        async def _mutating_plan(*args: Any, **kwargs: Any) -> Any:
+            sim._last_trace_hash = "snapshot-after"
+            return await original_plan(*args, **kwargs)
+
+        sim.engine.kernel.turn_engine.plan = _mutating_plan  # type: ignore[method-assign]
+
+        with pytest.raises(AssertionError, match="Snapshot hash continuity"):
+            await sim.run_step(max_turns=2)
+    finally:
+        await sim.stop_event_listener()
+        sim.close()


### PR DESCRIPTION
### Motivation
- Establish a single authoritative orchestration path for deterministic tick progression to simplify runtime reasoning and avoid duplicated turn branches. 
- Keep backwards compatibility with existing callers that import the legacy adapter while encouraging migration to the canonical kernel API. 
- Detect and fail fast on subtle replay/invariant violations (event counts, world-time monotonicity, snapshot hash continuity) that could corrupt deterministic replays. 

### Description
- Implemented an authoritative kernel in `src/sim/kernel/simulation_kernel.py` where `run_tick` executes the canonical phase sequence and performs boundary invariant assertions after each phase. 
- Added helper methods `_world_time_tuple`, `_phase_boundary_state`, and `_assert_phase_boundary` to capture and validate world-time monotonicity, planned/event counts, `max_turns` positivity, and snapshot trace-hash continuity. 
- Kept `src/sim/simulation_kernel.py` as a thin, deprecated adapter that imports and re-exports the authoritative `SimulationKernel` while emitting a `DeprecationWarning`. 
- Updated unit tests in `tests/unit/sim/test_kernel_golden_trace_parity.py` to assert compatibility between the deprecated pipeline adapter and the canonical kernel path and to add a test that exercises snapshot-hash continuity detection. 

### Testing
- Ran static checks with `python -m ruff check` and formatting checks with `python -m ruff format --check` against the modified files and they passed. 
- Executed the unit and targeted integration tests with `python -m pytest tests/unit/sim/test_kernel_golden_trace_parity.py tests/integration/sim/test_simulation_kernel_migration.py` and all selected tests passed. 
- Ran the integration suite subset `python -m pytest -m integration tests/integration/sim/test_simulation_kernel_migration.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3951507ac88326b632b74492b5fbbe)