### PR TITLE
Use documented dashboard entrypoint and add token middleware regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "lint": "pre-commit run -a",
-    "dashboard": "uvicorn src.interfaces.dashboard_backend:app --reload",
+    "dashboard": "python -m src.http_app",
     "dashboard:ui": "pnpm --filter culture-ui dev"
   },
   "pnpm": {

--- a/tests/integration/interfaces/test_dashboard_token_middleware.py
+++ b/tests/integration/interfaces/test_dashboard_token_middleware.py
@@ -1,16 +1,100 @@
 import importlib
 import sys
+import types
+from collections.abc import Callable
+from typing import Any
 
 import httpx
 import pytest
 from httpx import ASGITransport
 
-pytest.importorskip("fastapi")
+
+class _TestFastAPI:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._routes: dict[tuple[str, str], Callable[..., Any]] = {}
+        self._middleware: Callable[..., Any] | None = None
+
+    async def __call__(
+        self, scope: dict[str, Any], receive: object, send: Callable[..., Any]
+    ) -> None:
+        method = scope.get("method", "GET")
+        path = scope.get("path", "")
+
+        class Request:
+            def __init__(self) -> None:
+                self.method = method
+                self.headers = {
+                    key.decode().title(): value.decode() for key, value in scope.get("headers", [])
+                }
+
+            async def is_disconnected(self) -> bool:
+                return True
+
+        async def call_next(_: Request) -> _TestJSONResponse:
+            status = 200 if (method, path) in self._routes else 404
+            return _TestJSONResponse({}, status_code=status)
+
+        request = Request()
+        response = (
+            await self._middleware(request, call_next)
+            if self._middleware
+            else await call_next(request)
+        )
+        await send({"type": "http.response.start", "status": response.status_code, "headers": []})
+        await send({"type": "http.response.body", "body": response.body, "more_body": False})
+
+    def get(
+        self, path: str, *args: object, **kwargs: object
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._route("GET", path)
+
+    def post(
+        self, path: str, *args: object, **kwargs: object
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._route("POST", path)
+
+    def websocket(
+        self, path: str, *args: object, **kwargs: object
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        return self._route("WEBSOCKET", path)
+
+    def middleware(
+        self, *args: object, **kwargs: object
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            self._middleware = fn
+            return fn
+
+        return decorator
+
+    def _route(self, method: str, path: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            self._routes[(method, path)] = fn
+            return fn
+
+        return decorator
+
+
+class _TestJSONResponse:
+    def __init__(self, content: object = b"", *args: object, **kwargs: object) -> None:
+        self.status_code = int(kwargs.get("status_code", 200))
+        self.body = b"{}"
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_token_required(monkeypatch):
+async def test_documented_dashboard_entrypoint_requires_token_for_post(monkeypatch):
+    """The documented dashboard app entrypoint must configure token middleware."""
+    fastapi_mod = types.ModuleType("fastapi")
+    fastapi_mod.FastAPI = _TestFastAPI
+    fastapi_mod.Request = object
+    fastapi_mod.Response = object
+    fastapi_mod.WebSocket = object
+    fastapi_mod.WebSocketDisconnect = Exception
+    responses_mod = types.ModuleType("fastapi.responses")
+    responses_mod.JSONResponse = _TestJSONResponse
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_mod)
+    monkeypatch.setitem(sys.modules, "fastapi.responses", responses_mod)
     monkeypatch.setenv("DASHBOARD_API_TOKEN", "secret")
     for mod in ["src.http_app", "src.interfaces.dashboard_backend"]:
         if mod in sys.modules:


### PR DESCRIPTION
### Motivation
- Ensure the root `dashboard` npm script launches the documented configured app entry point rather than importing the backend module directly.
- Add a regression test that verifies the documented dashboard entry point enforces `DASHBOARD_API_TOKEN` for mutating (POST) endpoints.

### Description
- Update `package.json` to change the `dashboard` script from `uvicorn src.interfaces.dashboard_backend:app --reload` to `python -m src.http_app`.
- Expand the dashboard token middleware test to import `src.http_app`, set `DASHBOARD_API_TOKEN`, and assert an unauthenticated POST to `/api/governance/propose` returns `401` while a bearer token returns `200`.
- The test uses a lightweight `fastapi` stub to validate that the `src.http_app` entrypoint configures the same token middleware behavior as the backend module.
- Confirmed README already documents `python -m src.http_app` for starting the dashboard.

### Testing
- Ran `pytest -m integration tests/integration/interfaces/test_dashboard_token_middleware.py`, which passed.
- Ran `pre-commit run ruff --files tests/integration/interfaces/test_dashboard_token_middleware.py package.json`, which passed for the touched files.
- Ran `pre-commit run ruff-format --files tests/integration/interfaces/test_dashboard_token_middleware.py`, which passed and formatted the test file.
- Attempted `pnpm lint` / full repo pre-commit run which surfaced many pre-existing repository-wide lint/type/compatibility issues and failed outside the scope of this targeted change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e5f38b7488326a22a2c33b4016ebb)