### PR TITLE
Use deterministic Discord token hashing

### DIFF
--- a/src/interfaces/token_store.py
+++ b/src/interfaces/token_store.py
@@ -1,6 +1,7 @@
+import hashlib
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from src.infra import config
 
@@ -34,7 +35,7 @@ async def _get_pool() -> Any:
     return _pool
 
 
-async def get_token(agent_id: str) -> Optional[str]:
+async def get_token(agent_id: str) -> str | None:
     """Return the Discord token for the given agent ID if present."""
     pool = await _get_pool()
     row = await pool.fetchrow(
@@ -44,7 +45,7 @@ async def get_token(agent_id: str) -> Optional[str]:
     return row["token"] if row else None
 
 
-async def lookup_token(agent_id: str) -> Optional[str]:
+async def lookup_token(agent_id: str) -> str | None:
     """Return or automatically assign the Discord token for ``agent_id``."""
     token = await get_token(agent_id)
     if token:
@@ -57,7 +58,9 @@ async def lookup_token(agent_id: str) -> Optional[str]:
     if not tokens:
         return None
 
-    token = tokens[hash(agent_id) % len(tokens)]
+    stable_digest = hashlib.sha256(agent_id.encode("utf-8")).digest()[:8]
+    stable_hash = int.from_bytes(stable_digest, "big")
+    token = tokens[stable_hash % len(tokens)]
     try:
         await save_token(agent_id, token)
     except Exception:

--- a/tests/unit/interfaces/test_token_store.py
+++ b/tests/unit/interfaces/test_token_store.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 
 from src.interfaces import token_store
@@ -33,3 +35,31 @@ async def test_save_and_get_token(monkeypatch: pytest.MonkeyPatch) -> None:
     await token_store.save_token("agent_x", "tok_x")
     assert await token_store.get_token("agent_x") == "tok_x"
     assert await token_store.get_token("missing") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lookup_token_uses_deterministic_agent_hash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def missing_get_token(agent_id: str) -> None:
+        return None
+
+    saved_tokens: list[tuple[str, str]] = []
+
+    async def dummy_save_token(agent_id: str, token: str) -> None:
+        saved_tokens.append((agent_id, token))
+
+    monkeypatch.setattr(token_store, "get_token", missing_get_token)
+    monkeypatch.setattr(token_store, "save_token", dummy_save_token)
+    tokens = ["tok_a", "tok_b", "tok_c", "tok_d"]
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", ",".join(tokens))
+    stable_hash = int.from_bytes(hashlib.sha256(b"agent_x").digest()[:8], "big")
+    expected_token = tokens[stable_hash % len(tokens)]
+
+    first_token = await token_store.lookup_token("agent_x")
+    second_token = await token_store.lookup_token("agent_x")
+
+    assert first_token == expected_token
+    assert second_token == expected_token
+    assert saved_tokens == [("agent_x", expected_token), ("agent_x", expected_token)]


### PR DESCRIPTION
### Motivation
- Replace the non-deterministic built-in `hash()` used for picking a `DISCORD_BOT_TOKEN` so the same `agent_id` always maps to the same token across runs. 

### Description
- Import `hashlib` in `src/interfaces/token_store.py` and compute a stable digest with `hashlib.sha256(agent_id.encode("utf-8")).digest()[:8]` to derive a stable integer via `int.from_bytes(..., "big")` for modulo selection. 
- Use the stable integer (`stable_hash`) instead of `hash(agent_id)` to select the token from the `DISCORD_BOT_TOKEN` list. 
- Adjusted return type hints from `Optional[str]` to `str | None` for `get_token` and `lookup_token`. 
- Added unit test `test_lookup_token_uses_deterministic_agent_hash` in `tests/unit/interfaces/test_token_store.py` which patches `DISCORD_BOT_TOKEN`, stubs `get_token`/`save_token`, and asserts deterministic mapping for a given `agent_id`.

### Testing
- Ran `ruff format` and applied formatting, and `ruff check` on the modified files which passed. 
- Ran `pytest tests/unit/interfaces/test_token_store.py -q` and the unit tests passed (`2 passed`). 
- Ran `mypy --strict --config-file pyproject.toml src/interfaces/token_store.py` which reports failures due to pre-existing mypy errors in the repository unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e60f81fe08326938f80b99fd4704a)