### PR TITLE
docs: align testing docs with pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,7 @@ For more details, see [docs/architecture.md](docs/architecture.md#61-asynchronou
 Culture.ai uses pytest with marker-based test selection and parallelization for fast feedback:
 
 - **Default run** (`pytest`): Runs only unit tests (fast, no external dependencies)
-- **Full suite** (`pytest -m "slow or dspy_program or integration" -v -n auto`): Runs all slow, DSPy, and integration tests in parallel
+- **Full suite** (`pytest -m "slow or dspy or integration" -v -n auto`): Runs all slow, DSPy, and integration tests in parallel
 - ChromaDB test DBs are stored in RAM (tmpfs) on Linux for speed; see `docs/testing.md` for details
 
 `pytest` reads settings from `pytest.ini`. If you run tests with `-c /dev/null` or
@@ -1095,8 +1095,8 @@ Run the full test suite after installing development dependencies and starting a
    ```bash
    python -m pytest tests/
    ```
-`pytest-xdist` enables parallel execution via the `-n auto` option in `pytest.ini`.
-`scripts/run_tests.py` checks for this plugin and strips `-n auto` if it isn't installed, so tests still run serially without it.
+`pytest-xdist` enables parallel execution when you pass `-n auto` explicitly, such as in the full-suite command above.
+`scripts/run_tests.py` checks whether this plugin is installed before using parallel options, so tests still run serially without it.
 These tests also rely on optional packages (`chromadb`, `weaviate-client`, `langgraph`) which are included in `requirements.txt` and installed in CI.
 Generate a coverage report:
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,7 +22,7 @@ If any of these optional packages are missing, `scripts/run_tests.py` prints a
 warning and skips affected tests automatically. For example, the SQL token store
 tests require both `sqlalchemy` and `aiosqlite`; tests that patch the
 `requests` library or depend on `numpy` are treated the same way. Running
-`pytest` directly may fail because `pytest.ini` specifies `-n auto` and
+`pytest` directly uses the options in `pytest.ini`, including
 `asyncio_mode=strict`.
 
 ## Test Markers and Suite Structure
@@ -31,22 +31,22 @@ Tests are categorized using pytest markers:
 
 - `unit`: Fast, self-contained tests (default selection)
 - `integration`: Multi-component or external-service tests
-- `dspy_program`: Tests that require DSPy/Ollama/LLM
+- `dspy`: Tests that require DSPy/Ollama/LLM
 - `slow`: Tests that take >5s or require heavy resources
 - `memory`, `vector_store`, `hierarchical_memory`, `mus`, etc.: Specialized subsystems
 
 ### Default vs. Full Suite
 
-- **Default run** (`pytest`): Runs only unit tests (excludes `slow`, `dspy_program`, `integration`)
-- **Full run** (`pytest -m "slow or dspy_program or integration"`): Runs all slow, DSPy, and integration tests
+- **Default run** (`pytest`): Runs tests marked `unit` and excludes `dspy` through `pytest.ini`
+- **Full run** (`pytest -m "slow or dspy or integration"`): Runs all slow, DSPy, and integration tests
 
 ## Parallelization
 
 Culture.ai uses [pytest-xdist](https://pytest-xdist.readthedocs.io/) for parallel test execution:
 
-- All tests are run in parallel by default (`-n auto`)
-- Tests in the same file are kept on the same worker (`--dist loadscope`)
-- This reduces wall-clock time from ~40 min to ≤5 min on modern CPUs
+- Parallel execution is available when you pass `-n auto` explicitly or use a wrapper command that adds it
+- Use `--dist loadscope` to keep tests in the same file on the same worker
+- This can reduce wall-clock time significantly on modern CPUs
 
 ## ChromaDB Test DB Optimization (tmpfs)
 
@@ -63,7 +63,7 @@ Culture.ai uses [pytest-xdist](https://pytest-xdist.readthedocs.io/) for paralle
   ```
 - **Full suite (all slow/integration/DSPy):**
   ```bash
-  pytest -m "slow or dspy_program or integration" -v -n auto
+  pytest -m "slow or dspy or integration" -v -n auto
   ```
 - **Top 10 slowest tests:**
   ```bash
@@ -109,7 +109,7 @@ The CI workflow can run this suite by triggering the `run-redteam` input of the 
 
 ## Adding/Updating Markers
 
-- Add `@pytest.mark.slow`, `@pytest.mark.integration`, or `@pytest.mark.dspy_program` to slow or external-service tests
+- Add `@pytest.mark.slow`, `@pytest.mark.integration`, or `@pytest.mark.dspy` to slow or external-service tests
 - Update `pytest.ini` to register new markers
 - Document new marker usage in this file
 

--- a/docs/testing_strategy.md
+++ b/docs/testing_strategy.md
@@ -21,7 +21,7 @@ We use pytest markers to categorize tests and make it easy to run specific subse
 ### Component Areas
 
 - `memory`: Marks tests related to agent memory systems
-- `dspy_program`: Marks tests related to DSPy programs
+- `dspy`: Marks tests related to DSPy programs
 - `agent_graph`: Marks tests involving the BasicAgentGraph and its nodes
 - `simulation`: Marks tests involving the main Simulation loop or environment
 - `vector_store`: Marks tests related to vector store functionality


### PR DESCRIPTION
### Motivation

- Bring testing documentation into agreement with the current `pytest.ini` so readers get accurate instructions about markers and parallelization.

### Description

- Replace legacy `dspy_program` marker references with `dspy` in `docs/testing.md`, `docs/testing_strategy.md`, and `README.md`.
- Clarify that `-n auto` is used only when passed explicitly (or added by wrapper tooling) and is not implicitly provided by `pytest.ini`.
- Update the description of the default run to state that `pytest` runs tests marked `unit` and excludes `dspy` via `pytest.ini`, and update the full-suite command to use the `dspy` marker.
- Adjust `README.md` guidance about `pytest-xdist` and `scripts/run_tests.py` to match the current behavior of the test wrapper.

### Testing

- No automated tests were run because this is a documentation-only change, which is allowed by the repository guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e64ae86fc83268d3c40e382cb4d04)