### PR TITLE
Add WebSocket token validation for /ws/control and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,11 @@ python -m src.http_app
 
 Set `DASHBOARD_API_TOKEN` to require an access token for state-changing (POST,
 PUT, PATCH, DELETE) endpoints. Clients must include
-`Authorization: Bearer <token>` when calling those APIs.
+`Authorization: Bearer <token>` when calling those APIs. The `/ws/control`
+WebSocket also requires the same token when configured; provide it with an
+`Authorization: Bearer <token>` WebSocket handshake header or, for browser
+clients that cannot set custom WebSocket headers, a `?token=<token>` query
+parameter.
 
 You can then consume events using any SSE-capable client. Here's a minimal
 example using `httpx`:

--- a/src/interfaces/dashboard_backend.py
+++ b/src/interfaces/dashboard_backend.py
@@ -431,13 +431,28 @@ def _sim_kb_service() -> Any | None:
     return getattr(sim, "knowledge_board_service", None) if sim is not None else None
 
 
+def _valid_bearer_token(auth_header: str | None) -> bool:
+    """Return whether an Authorization header matches the configured API token."""
+    return bool(API_TOKEN and auth_header == f"Bearer {API_TOKEN}")
+
+
+def _valid_websocket_token(websocket: WebSocket) -> bool:
+    """Validate dashboard WebSocket control authentication when configured."""
+    if not API_TOKEN:
+        return True
+
+    if _valid_bearer_token(websocket.headers.get("Authorization")):
+        return True
+
+    return websocket.query_params.get("token") == API_TOKEN
+
+
 async def _require_token(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
     """Enforce bearer token for mutating requests when configured."""
     if API_TOKEN and request.method in {"POST", "PUT", "PATCH", "DELETE"}:
-        auth = request.headers.get("Authorization")
-        if auth != f"Bearer {API_TOKEN}":
+        if not _valid_bearer_token(request.headers.get("Authorization")):
             return JSONResponse({"error": "unauthorized"}, status_code=401)
     return await call_next(request)
 
@@ -1638,6 +1653,10 @@ try:
 
     @app.websocket("/ws/control")
     async def ws_control(websocket: WebSocket) -> None:
+        if not _valid_websocket_token(websocket):
+            await websocket.close(code=1008)
+            return
+
         await websocket.accept()
         try:
             while True:

--- a/tests/integration/interfaces/test_websocket_events.py
+++ b/tests/integration/interfaces/test_websocket_events.py
@@ -5,6 +5,7 @@ import socket
 import pytest
 import uvicorn
 import websockets
+from websockets import exceptions as ws_exceptions
 
 from src import http_app
 from src.interfaces import dashboard_backend as db
@@ -23,10 +24,17 @@ class DummyBus:
         self.events.append("unsubscribe")
 
 
+@pytest.fixture(autouse=True)
+def _reset_api_token() -> None:
+    db.configure_api_token(None)
+    yield
+    db.configure_api_token(None)
+
+
 async def _start_server() -> tuple[uvicorn.Server, asyncio.Task[None], int]:
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
-    host, port = sock.getsockname()
+    _host, port = sock.getsockname()
     sock.close()
     config = uvicorn.Config(
         http_app.app,
@@ -69,13 +77,59 @@ async def test_ws_events_receive_and_close(monkeypatch: pytest.MonkeyPatch) -> N
 @pytest.mark.asyncio
 async def test_ws_control_pause_and_disconnect() -> None:
     server, task, port = await _start_server()
-    async with websockets.connect(f"ws://127.0.0.1:{port}/ws/control") as ws:
-        await ws.send(json.dumps({"command": "pause"}))
-        data = await asyncio.wait_for(ws.recv(), 1)
-        payload = json.loads(data)
-        assert payload["paused"] is True
-        await ws.close()
-        with pytest.raises(websockets.ConnectionClosedOK):
-            await ws.recv()
-    server.should_exit = True
-    await task
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws/control") as ws:
+            await ws.send(json.dumps({"command": "pause"}))
+            data = await asyncio.wait_for(ws.recv(), 1)
+            payload = json.loads(data)
+            assert payload["paused"] is True
+            await ws.close()
+            with pytest.raises(websockets.ConnectionClosedOK):
+                await ws.recv()
+    finally:
+        server.should_exit = True
+        await task
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_control_rejects_missing_token() -> None:
+    db.configure_api_token("secret")
+    server, task, port = await _start_server()
+    try:
+        with pytest.raises(ws_exceptions.InvalidStatus):
+            async with websockets.connect(f"ws://127.0.0.1:{port}/ws/control"):
+                pass
+    finally:
+        server.should_exit = True
+        await task
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_control_rejects_invalid_token() -> None:
+    db.configure_api_token("secret")
+    server, task, port = await _start_server()
+    try:
+        with pytest.raises(ws_exceptions.InvalidStatus):
+            async with websockets.connect(f"ws://127.0.0.1:{port}/ws/control?token=wrong"):
+                pass
+    finally:
+        server.should_exit = True
+        await task
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ws_control_accepts_valid_token_and_processes_command() -> None:
+    db.configure_api_token("secret")
+    server, task, port = await _start_server()
+    try:
+        async with websockets.connect(f"ws://127.0.0.1:{port}/ws/control?token=secret") as ws:
+            await ws.send(json.dumps({"command": "pause"}))
+            data = await asyncio.wait_for(ws.recv(), 1)
+            payload = json.loads(data)
+            assert payload["paused"] is True
+    finally:
+        server.should_exit = True
+        await task


### PR DESCRIPTION
### Motivation
- Ensure state-changing dashboard control via WebSocket is protected by the same token-based auth as HTTP mutating endpoints when `DASHBOARD_API_TOKEN` is configured.

### Description
- Added `_valid_bearer_token` and `_valid_websocket_token` helpers and reused `_valid_bearer_token` for HTTP mutating middleware enforcement in `src/interfaces/dashboard_backend.py`.
- Enforced token validation for `/ws/control` before calling `websocket.accept()` and close unauthorized handshakes with close code `1008`.
- Added integration tests in `tests/integration/interfaces/test_websocket_events.py` to cover missing-token rejection, invalid-token rejection, and valid-token acceptance and command processing, and added an autouse fixture to reset token state between tests.
- Updated `README.md` to document WebSocket control authentication options (handshake `Authorization: Bearer <token>` header or `?token=<token>` query parameter).

### Testing
- Ran `ruff check src/interfaces/dashboard_backend.py tests/integration/interfaces/test_websocket_events.py tests/integration/interfaces/test_dashboard_token_middleware.py` which passed.
- Ran `pytest -m integration tests/integration/interfaces/test_websocket_events.py tests/integration/interfaces/test_dashboard_token_middleware.py -q` and all integration tests passed.
- Ran `mypy --strict --config-file pyproject.toml ...` which reported pre-existing project type errors unrelated to this change and therefore is not blocking this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e66cf84cc8326a626ce3746c1fe3c)